### PR TITLE
Add Scheme UX for QuantizationModifier

### DIFF
--- a/examples/quantization/llama7b_fp8_quantization.py
+++ b/examples/quantization/llama7b_fp8_quantization.py
@@ -5,8 +5,8 @@ from transformers import AutoTokenizer
 from llmcompressor.modifiers.quantization import QuantizationModifier
 from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot
 
-model_stub = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
-output_dir = "/cache/llm-compressor/tiny_fp8_test"
+model_stub = "meta-llama/Meta-Llama-3-8B-Instruct"
+output_dir = "Meta-Llama-3-8B-Instruct-FP8-Compressed"
 num_calibration_samples = 512
 
 tokenizer = AutoTokenizer.from_pretrained(model_stub, use_fast=True)

--- a/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
+++ b/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
@@ -81,6 +81,7 @@ class TestCreateDefaultQuantModifier(unittest.TestCase):
         modifier.on_initialize_structure(testing_harness.get_state())
         assert modifier.quantize
         assert isinstance(modifier.quantization_modifier_, QuantizationModifier)
+        modifier.quantization_modifier_.create_init_config()
         default_config_group_name = "group_0"
         should_be_default_quant_scheme = modifier.quantization_modifier_.config_groups[
             default_config_group_name


### PR DESCRIPTION
Previously only GPTQModifier supported scheme presets: `GPTQModifier(targets="Linear", scheme="FP8")`. This PR moves the logic for resolving schemes to the QuantizationModifier, so we can now call `QuantizationModifier(targets="Linear", scheme="FP8")` rather than using the config_groups parameter