### PR TITLE
Add Group Quantization Test Case

### DIFF
--- a/tests/llmcompressor/transformers/compression/configs/group_1.1b.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/group_1.1b.yaml
@@ -1,0 +1,5 @@
+cadence: "nightly"
+test_type: "regression"
+model_stub: "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
+new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_group.yaml"
+ppl_threshold: 20

--- a/tests/llmcompressor/transformers/compression/recipes/new_quant_group.yaml
+++ b/tests/llmcompressor/transformers/compression/recipes/new_quant_group.yaml
@@ -8,11 +8,11 @@ test_stage:
                         num_bits: 4
                         type: "int"
                         symmetric: False
-                        strategy: "channel"
+                        strategy: "group"
+                        group_size: 128
                     input_activations: null
                     output_activations: null
                     targets: ["Linear"]
         GPTQModifier:
             block_size: 128
             sequential_update: False
-            


### PR DESCRIPTION
Adding W4A16 group 128 test case for tinyllama 1.1b, also fixing an issue with the channel test where it was only quantizing the first 3 layers.

Confirmed this passes locally with `export CADENCE="nightly"`