### PR TITLE
Clarify Function Names for Logging

### DIFF
--- a/src/llmcompressor/modifiers/obcq/utils/sgpt_wrapper.py
+++ b/src/llmcompressor/modifiers/obcq/utils/sgpt_wrapper.py
@@ -23,7 +23,7 @@ class SparseGptWrapper(ModuleCompressionWrapper):
 
     Lifecycle:
         - add_batch
-        - fasterprune
+        - compress
         - free
 
     :param name: name of module to run compression on
@@ -59,7 +59,7 @@ class SparseGptWrapper(ModuleCompressionWrapper):
         inp = math.sqrt(2 / self.nsamples) * inp.float()
         self.H += inp.matmul(inp.t()).to(self.dev)
 
-    def fasterprune(
+    def compress(
         self,
         sparsity: float,
         prunen: int = 0,

--- a/src/llmcompressor/modifiers/pruning/wanda/utils/wanda_wrapper.py
+++ b/src/llmcompressor/modifiers/pruning/wanda/utils/wanda_wrapper.py
@@ -29,7 +29,7 @@ class WandaWrapper(ModuleCompressionWrapper):
 
     Lifecycle:
         - add_batch
-        - fasterprune
+        - compress
         - free
 
     :param name: name of module to run compression on
@@ -60,7 +60,7 @@ class WandaWrapper(ModuleCompressionWrapper):
         inp = inp.type(torch.float32)
         self.scaler_row += torch.norm(inp, p=2, dim=1) ** 2 / self.nsamples
 
-    def fasterprune(
+    def compress(
         self,
         sparsity: float,
         prunen: int = 0,

--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -25,7 +25,7 @@ class GPTQWrapper(ModuleCompressionWrapper):
 
     Lifecycle:
         - add_batch
-        - fasterprune
+        - compress
         - free
 
     :param name: name of module to run compression on
@@ -61,7 +61,7 @@ class GPTQWrapper(ModuleCompressionWrapper):
         inp = math.sqrt(2 / self.nsamples) * inp.float()
         self.H += inp.matmul(inp.t()).to(self.dev)
 
-    def fasterprune(
+    def compress(
         self,
         blocksize: int = 128,
         percdamp: float = 0.01,

--- a/src/llmcompressor/modifiers/utils/compression_wrapper.py
+++ b/src/llmcompressor/modifiers/utils/compression_wrapper.py
@@ -24,7 +24,7 @@ class ModuleCompressionWrapper(Module, ABC):
 
     Lifecycle:
         - add_batch
-        - fasterprune
+        - compress
         - free
 
     :param name: name of module to run compression on
@@ -75,11 +75,11 @@ class ModuleCompressionWrapper(Module, ABC):
         """
         raise NotImplementedError("Child class must implement `add_batch`")
 
-    def fasterprune(self, *args, **kwargs):
+    def compress(self, *args, **kwargs):
         """
         Run pruning on the layer up to the target sparsity
         """
-        raise NotImplementedError("Child class must implement `fasterprune`")
+        raise NotImplementedError("Child class must implement `compress`")
 
     def state_dict(self, destination=None, prefix="", keep_vars=False, **kwargs):
         """

--- a/src/llmcompressor/modifiers/utils/layer_compressor.py
+++ b/src/llmcompressor/modifiers/utils/layer_compressor.py
@@ -27,7 +27,7 @@ class LayerCompressor:
             - compressible_modules()
             - module_compressor_class.register_forward_hook()
         - compress()
-            - module_compressor_class.fasterprune()
+            - module_compressor_class.compress()
         - post_compress()
         - revert_layer_wrappers()
 
@@ -123,13 +123,13 @@ class LayerCompressor:
         """
 
         @torch.no_grad()
-        def prune(module):
+        def compress_module(module):
             if isinstance(module, self.module_compressor_class):
                 full_name = self._get_full_submodule_name(module.name)
                 logger.info(f"Compressing {full_name}...")
-                module.fasterprune(**self.args)
+                module.compress(**self.args)
 
-        self.layer.apply(prune)
+        self.layer.apply(compress_module)
 
     def _get_full_submodule_name(self, name):
         full_name = ".".join(x for x in [self.name, name] if len(x) > 0)


### PR DESCRIPTION
SUMMARY:
* Each module compressor(sparseGPT, WANDA, GPTQ) implemented a `fasterprune` method, but this is misleading for GPTQ which does quantization only. Renaming `fasterprune->compress`
* Rename `LayerCompressor.prune()` to `LayerCompressor.compress_module()` for the same reason

TEST PLAN:
Manually tested a w4a16 quantization example to confirm the logging change:

Before
```
2024-07-02T14:15:00.233030+0000 | prune | INFO - Compressing model.layers.11.self_attn.q_proj.model.layers.11.self_attn.q_proj...
2024-07-02T14:15:01.061103+0000 | fasterprune | INFO - time 0.83
2024-07-02T14:15:01.061573+0000 | fasterprune | INFO - error 6155.81
```

After
```
2024-07-02T14:31:16.224969+0000 | compress_module | INFO - Compressing model.layers.20.model.layers.20.self_attn.q_proj...
2024-07-02T14:31:17.100250+0000 | compress | INFO - time 0.87
2024-07-02T14:31:17.100596+0000 | compress | INFO - error 4623.34
```
