### PR TITLE
SmoothQuant Mapping Defaults

### DIFF
--- a/src/llmcompressor/modifiers/smoothquant/base.py
+++ b/src/llmcompressor/modifiers/smoothquant/base.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple
+from pydantic import field_validator
 
 import torch
 from loguru import logger
@@ -13,7 +14,13 @@ from llmcompressor.utils.pytorch.module import get_layers, get_matching_layer
 
 MINIMUM_SMOOTHING_SCALE = 1e-5
 
+DEFAULT_SMOOTHQUANT_MAPPINGS = [
+    [["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"], "re:.*input_layernorm"],
+    [["re:.*gate_proj", "re:.*up_proj"], "re:.*post_attention_layernorm"]
+]
+
 __all__ = ["SmoothQuantScale", "SmoothQuantMapping", "SmoothQuantModifier"]
+
 
 
 @dataclass
@@ -47,7 +54,7 @@ class SmoothQuantMapping:
     balance_layers: List[Module]
 
 
-class SmoothQuantModifier(Modifier):
+class SmoothQuantModifier(Modifier, validate_assignment = True):
     """
      Implements the SmoothQuant algorithm from https://arxiv.org/abs/2211.10438. This
      modifier performs a channel-wise smoothing of outliers in activations, making them
@@ -88,7 +95,7 @@ class SmoothQuantModifier(Modifier):
     """
 
     smoothing_strength: float = 0.5
-    mappings: List[Tuple]
+    mappings: List[Tuple] = DEFAULT_SMOOTHQUANT_MAPPINGS
     ignore: Optional[List[str]] = None
     num_calibration_steps: Optional[int] = None
     calibration_function: Optional[Callable] = None

--- a/src/llmcompressor/modifiers/smoothquant/base.py
+++ b/src/llmcompressor/modifiers/smoothquant/base.py
@@ -52,7 +52,7 @@ class SmoothQuantMapping:
     balance_layers: List[Module]
 
 
-class SmoothQuantModifier(Modifier, validate_assignment=True):
+class SmoothQuantModifier(Modifier):
     """
      Implements the SmoothQuant algorithm from https://arxiv.org/abs/2211.10438. This
      modifier performs a channel-wise smoothing of outliers in activations, making them

--- a/src/llmcompressor/modifiers/smoothquant/base.py
+++ b/src/llmcompressor/modifiers/smoothquant/base.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple
-from pydantic import field_validator
 
 import torch
 from loguru import logger
@@ -16,11 +15,10 @@ MINIMUM_SMOOTHING_SCALE = 1e-5
 
 DEFAULT_SMOOTHQUANT_MAPPINGS = [
     [["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"], "re:.*input_layernorm"],
-    [["re:.*gate_proj", "re:.*up_proj"], "re:.*post_attention_layernorm"]
+    [["re:.*gate_proj", "re:.*up_proj"], "re:.*post_attention_layernorm"],
 ]
 
 __all__ = ["SmoothQuantScale", "SmoothQuantMapping", "SmoothQuantModifier"]
-
 
 
 @dataclass
@@ -54,7 +52,7 @@ class SmoothQuantMapping:
     balance_layers: List[Module]
 
 
-class SmoothQuantModifier(Modifier, validate_assignment = True):
+class SmoothQuantModifier(Modifier, validate_assignment=True):
     """
      Implements the SmoothQuant algorithm from https://arxiv.org/abs/2211.10438. This
      modifier performs a channel-wise smoothing of outliers in activations, making them

--- a/tests/llmcompressor/modifiers/smoothquant/test_base.py
+++ b/tests/llmcompressor/modifiers/smoothquant/test_base.py
@@ -3,7 +3,10 @@ import unittest
 import pytest
 
 from llmcompressor.modifiers.factory import ModifierFactory
-from llmcompressor.modifiers.smoothquant.base import SmoothQuantModifier, DEFAULT_SMOOTHQUANT_MAPPINGS
+from llmcompressor.modifiers.smoothquant.base import (
+    DEFAULT_SMOOTHQUANT_MAPPINGS,
+    SmoothQuantModifier,
+)
 from tests.llmcompressor.modifiers.conf import setup_modifier_factory
 
 
@@ -33,6 +36,7 @@ class TestSmoothQuantIsRegistered(unittest.TestCase):
         self.assertEqual(modifier.smoothing_strength, self.kwargs["smoothing_strength"])
         self.assertEqual(modifier.mappings, self.kwargs["mappings"])
 
+
 @pytest.mark.unit
 class TestSmoothQuantDefaults(unittest.TestCase):
     def setUp(self):
@@ -46,7 +50,9 @@ class TestSmoothQuantDefaults(unittest.TestCase):
     def test_override_defaults(self):
         strength = 0.7
         dummy_map = [(["layer1", "layer2"], "layer3")]
-        non_default_sq = SmoothQuantModifier(smoothing_strength=strength, mappings=dummy_map)
+        non_default_sq = SmoothQuantModifier(
+            smoothing_strength=strength, mappings=dummy_map
+        )
 
         assert non_default_sq.smoothing_strength == strength
         assert non_default_sq.mappings == dummy_map

--- a/tests/llmcompressor/modifiers/smoothquant/test_base.py
+++ b/tests/llmcompressor/modifiers/smoothquant/test_base.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 
 from llmcompressor.modifiers.factory import ModifierFactory
-from llmcompressor.modifiers.smoothquant.base import SmoothQuantModifier
+from llmcompressor.modifiers.smoothquant.base import SmoothQuantModifier, DEFAULT_SMOOTHQUANT_MAPPINGS
 from tests.llmcompressor.modifiers.conf import setup_modifier_factory
 
 
@@ -32,3 +32,21 @@ class TestSmoothQuantIsRegistered(unittest.TestCase):
 
         self.assertEqual(modifier.smoothing_strength, self.kwargs["smoothing_strength"])
         self.assertEqual(modifier.mappings, self.kwargs["mappings"])
+
+@pytest.mark.unit
+class TestSmoothQuantDefaults(unittest.TestCase):
+    def setUp(self):
+        setup_modifier_factory()
+
+    def test_defaults(self):
+        default_sq = SmoothQuantModifier()
+        assert default_sq.smoothing_strength == 0.5
+        assert default_sq.mappings == DEFAULT_SMOOTHQUANT_MAPPINGS
+
+    def test_override_defaults(self):
+        strength = 0.7
+        dummy_map = [(["layer1", "layer2"], "layer3")]
+        non_default_sq = SmoothQuantModifier(smoothing_strength=strength, mappings=dummy_map)
+
+        assert non_default_sq.smoothing_strength == strength
+        assert non_default_sq.mappings == dummy_map

--- a/tests/llmcompressor/transformers/obcq/recipes/quant.yaml
+++ b/tests/llmcompressor/transformers/obcq/recipes/quant.yaml
@@ -1,11 +1,7 @@
 test_stage:
   obcq_modifiers:
     SmoothQuantModifier:
-      smoothing_strength: 0.5
-      mappings: [
-        [["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"], "re:.*input_layernorm"],
-        [["re:.*gate_proj", "re:.*up_proj"], "re:.*post_attention_layernorm"]
-      ]
+      smoothing_strength: 0.6
     GPTQModifier:
       block_size: 128
       sequential_update: False


### PR DESCRIPTION
SUMMARY:
Previously users were required to manually enter mappings for `SmoothQuant`, adding in a default that should work for most models.


TEST PLAN:
Added unit test for default, updated one of the integration tests to use the default and confirmed it passes on the nightly tests
