### PR TITLE
[MOE Quantization] Warn against "undercalibrated" modules 

### DIFF
--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Optional, Union
-from compressed_tensors.quantization.observers.helpers import get_observer_token_count
+
 from compressed_tensors.quantization import (
     QuantizationConfig,
     QuantizationScheme,
@@ -10,6 +10,7 @@ from compressed_tensors.quantization import (
     preset_name_to_scheme,
     set_module_for_calibration,
 )
+from compressed_tensors.quantization.observers.helpers import get_observer_token_count
 from loguru import logger
 from pydantic import Field
 from torch.nn import Module
@@ -205,7 +206,6 @@ class QuantizationModifier(Modifier):
         if module_training:
             module.train()
 
-
     def _check_token_distribution(
         self, model: Module, threshold: Optional[float] = None
     ):
@@ -220,7 +220,7 @@ class QuantizationModifier(Modifier):
             receive during calibration
         """
         if threshold is None:
-            _LOGGER.debug("Skipping token distribution check. threshold is None.")
+            logger.debug("Skipping token distribution check. threshold is None.")
             return
 
         all_tokens = self.calibration_dataloader_.dataset["input_ids"]
@@ -234,7 +234,7 @@ class QuantizationModifier(Modifier):
                 # implementation in the source code)
                 continue
             if token_count / total_token_count < threshold:
-                _LOGGER.warning(
+                logger.warning(
                     f"The module_name: {module_name} "
                     f"received less than {int(threshold * 100)}% "
                     "of calibration batch tokens "

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Optional, Union
-
+from compressed_tensors.quantization.observers.helpers import get_observer_token_count
 from compressed_tensors.quantization import (
     QuantizationConfig,
     QuantizationScheme,
@@ -76,6 +76,9 @@ class QuantizationModifier(Modifier):
         if self.calculate_start() == -1:  # one-shot
             module.apply(set_module_for_calibration)
             self._calibrate_if_possible(module)
+            self._check_token_distribution(
+                module, threshold=kwargs.get("min_tokens_per_module")
+            )
             module.apply(freeze_module_quantization)
 
         return True
@@ -201,3 +204,40 @@ class QuantizationModifier(Modifier):
 
         if module_training:
             module.train()
+
+
+    def _check_token_distribution(
+        self, model: Module, threshold: Optional[float] = None
+    ):
+        """
+        A helper function that warns when a module has seen
+        fewer than threshold % of all the tokens throughout
+        the calibration process.
+        Checks are only triggered if threshold is not None.
+        :param model: the model to validate
+        :param threshold: the minimum percentage of tokens
+            (out of all the tokens in a batch) a module should
+            receive during calibration
+        """
+        if threshold is None:
+            _LOGGER.debug("Skipping token distribution check. threshold is None.")
+            return
+
+        all_tokens = self.calibration_dataloader_.dataset["input_ids"]
+        total_token_count = sum(len(sample) for sample in all_tokens)
+        counter = get_observer_token_count(model)
+        for module_name, token_count in counter.items():
+            if token_count is None:
+                # the module has not been observed
+                # or its token_count is not being recorded
+                # by the observer (refer to the observer's
+                # implementation in the source code)
+                continue
+            if token_count / total_token_count < threshold:
+                _LOGGER.warning(
+                    f"The module_name: {module_name} "
+                    f"received less than {int(threshold * 100)}% "
+                    "of calibration batch tokens "
+                    f"({token_count}/{total_token_count} tokens). "
+                    "This could result may harm the quantization quality."
+                )

--- a/src/llmcompressor/transformers/finetune/data/data_args.py
+++ b/src/llmcompressor/transformers/finetune/data/data_args.py
@@ -153,3 +153,14 @@ class DataTrainingArguments(CustomDataTrainingArguments):
             ),
         },
     )
+    min_tokens_per_module: Optional[float] = field(
+        default=0.2,
+        metadata={
+            "help": (
+                "The minimum percentage of tokens (out of the total number) "
+                "that the module should 'receive' throughout the forward "
+                "pass of the calibration. If a module receives fewer tokens, "
+                "a warning will be logged."
+            ),
+        },
+    )

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -107,6 +107,8 @@ class SessionManagerMixIn:
         if self.is_fsdp_enabled:
             self._prepare_model_for_fsdp()
 
+        self.min_tokens_per_module = data_args.min_tokens_per_module
+
     def initialize_session(
         self,
         epoch: float,
@@ -402,6 +404,7 @@ class SessionManagerMixIn:
             start=-1,
             copy_data=False,
             accelerator=self.accelerator,
+            min_tokens_per_module=self.min_tokens_per_module,
         )
 
         # log model sparsity


### PR DESCRIPTION
Note: this branch requires this PR: https://github.com/neuralmagic/compressed-tensors/pull/46 to land in `compressed-tensors`.

## Example Use:

```python
from llmcompressor.transformers import oneshot
from llmcompressor.modifiers.quantization.gptq import GPTQModifier

# Sets parameters for the GPTQ algorithms - target Linear layer weights at 4 bits
recipe = GPTQModifier(scheme="FP8", targets="Linear", ignore=["lm_head"])

# Apply GPTQ algorithm using open_platypus dataset for calibration.
oneshot(
    model="Isotonic/TinyMixtral-4x248M-MoE",
    dataset="open_platypus",
    recipe=recipe,
    save_compressed=True,
    output_dir="llama-compressed-quickstart",
    overwrite_output_dir=True,
    max_seq_length=128,
    num_calibration_samples=2,
)
```

```bash
...
2024-07-10T21:33:18.273943+0200 | _build_quant_modifier | INFO - Building quantization modifier with args: {'targets': 'Linear', 'scheme': 'FP8', 'ignore': ['lm_head']}
2024-07-10T21:33:18.299325+0200 | _calibrate | INFO - Running QuantizationModifier calibration with 2 samples...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:09<00:00,  4.53s/it]
2024-07-10T21:33:27.368876+0200 | _check_token_distribution | WARNING - The module_name: model.layers.0.block_sparse_moe.experts.1.w1 received less than 20% of calibration batch tokens (35/256 tokens). This could result may harm the quantization quality.
2024-07-10T21:33:27.369534+0200 | _check_token_distribution | WARNING - The module_name: model.layers.0.block_sparse_moe.experts.1.w2 received less than 20% of calibration batch tokens (35/256 tokens). This could result may harm the quantization quality.
2024-07-10T21:33:27.369577+0200 | _check_token_distribution | WARNING - The module_name: model.layers.0.block_sparse_moe.experts.1.w3 received less than 20% of calibration batch tokens (35/256 tokens). This could result may harm the quantization quality.
...
```
