### PR TITLE
Update Quantization Save Defaults

### DIFF
--- a/src/llmcompressor/transformers/compression/quantization_format.py
+++ b/src/llmcompressor/transformers/compression/quantization_format.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from compressed_tensors import CompressionFormat
+from compressed_tensors.config import SparsityCompressionConfig
 from compressed_tensors.quantization.utils import (
     is_model_quantized,
     is_module_quantized,
@@ -11,7 +12,10 @@ __all__ = ["infer_quantization_format"]
 
 
 def infer_quantization_format(
-    model, quantization_format: Optional[str] = None, save_compressed: bool = False
+    model,
+    quantization_format: Optional[str] = None,
+    save_compressed: bool = False,
+    sparsity_config: Optional[SparsityCompressionConfig] = None,
 ) -> str:
     """
     Infers a quantization format based on model state and compression args
@@ -30,32 +34,38 @@ def infer_quantization_format(
         return quantization_format
 
     if save_compressed:
-        quant_types = _get_quant_types(model)
-        if quant_types == ["int4"]:  # save packed if everything is int4
-            return CompressionFormat.pack_quantized
-        elif quant_types == ["float8"]:
-            return CompressionFormat.float_quantized
+        weight_schemes, input_schemes = _get_unique_quant_args(model)
+        is_24_structure = (
+            sparsity_config and sparsity_config.sparsity_structure == "2:4"
+        )
+        is_weight_only = len(input_schemes) == 0 and len(weight_schemes) > 0
 
-        # otherwise just quantize to int8
-        return CompressionFormat.int_quantized
+        if is_weight_only:  # w4a16 and w8a16
+            if is_24_structure:
+                return CompressionFormat.marlin_24
+            return CompressionFormat.pack_quantized
+        else:  # w8a8 float and int
+            return CompressionFormat.naive_quantized
     else:
         # format will be inferred from config
         return None
 
 
-def _get_quant_types(model):
+def _get_unique_quant_args(model):
     """
-    Gets a list of all the quantized types present in model
+    Gets a list of all the unique quantization settings present in model
     """
-    quant_info = []
+    quant_info_weight = []
+    quant_info_inputs = []
     for _, submodule in iter_named_leaf_modules(model):
         if is_module_quantized(submodule):
             weight_scheme = submodule.quantization_scheme.weights
+            input_scheme = submodule.quantization_scheme.input_activations
             if weight_scheme is not None:
-                weight_bit_depth = weight_scheme.num_bits
-                weight_type = weight_scheme.type
-                weight_info = f"{weight_type}{weight_bit_depth}"
-                if weight_info not in quant_info:
-                    quant_info.append(weight_info)
+                if weight_scheme not in quant_info_weight:
+                    quant_info_weight.append(weight_scheme)
+            if input_scheme is not None:
+                if input_scheme not in quant_info_inputs:
+                    quant_info_inputs.append(input_scheme)
 
-    return quant_info
+    return quant_info_weight, quant_info_inputs

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -107,7 +107,8 @@ class SessionManagerMixIn:
         if self.is_fsdp_enabled:
             self._prepare_model_for_fsdp()
 
-        self.min_tokens_per_module = data_args.min_tokens_per_module
+        if data_args is not None:
+            self.min_tokens_per_module = data_args.min_tokens_per_module
 
     def initialize_session(
         self,

--- a/src/llmcompressor/transformers/finetune/training_args.py
+++ b/src/llmcompressor/transformers/finetune/training_args.py
@@ -33,7 +33,7 @@ class TrainingArguments(HFTrainingArgs):
         },
     )
     save_compressed: Optional[bool] = field(
-        default=False,
+        default=True,
         metadata={"help": "Whether to compress sparse models during save"},
     )
     do_oneshot: Optional[bool] = field(

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -39,7 +39,7 @@ def modify_save_pretrained(model: PreTrainedModel):
             save_directory: str,
             sparsity_config: Optional[SparsityCompressionConfig] = None,
             quantization_format: Optional[str] = None,
-            save_compressed: bool = False,
+            save_compressed: bool = True,
             skip_compression_stats: bool = False,
             **kwargs,
         ):
@@ -88,6 +88,7 @@ def modify_save_pretrained(model: PreTrainedModel):
                 model=model,
                 quantization_format=quantization_format,
                 save_compressed=save_compressed,
+                sparsity_config=sparsity_config,
             )
             compressor = ModelCompressor.from_pretrained_model(
                 model,

--- a/tests/llmcompressor/transformers/compression/test_infer_quant_format.py
+++ b/tests/llmcompressor/transformers/compression/test_infer_quant_format.py
@@ -1,0 +1,35 @@
+import pytest
+from compressed_tensors.config import SparsityCompressionConfig
+from compressed_tensors.quantization import preset_name_to_scheme
+
+from llmcompressor.transformers.compression.quantization_format import (
+    infer_quantization_format,
+)
+from tests.llmcompressor.pytorch.helpers import LinearNet
+
+
+@pytest.mark.parametrize(
+    "preset,sparsity_structure,expected_format",
+    [
+        ["W8A8", "unstructured", "naive-quantized"],
+        ["W8A16", "unstructured", "pack-quantized"],
+        ["W8A16", "2:4", "marlin-24"],
+        ["W4A16", "unstructured", "pack-quantized"],
+        ["W4A16", "2:4", "marlin-24"],
+        ["FP8", "unstructured", "naive-quantized"],
+    ],
+)
+def test_infer_quant_format(preset, sparsity_structure, expected_format):
+    sparsity_config = SparsityCompressionConfig(
+        format="dense", sparsity_structure=sparsity_structure
+    )
+    quant_scheme = preset_name_to_scheme(preset, targets=["Linear"])
+
+    dummy_model = LinearNet()
+    for _, module in dummy_model.named_modules():
+        module.quantization_scheme = quant_scheme
+
+    inferred_format = infer_quantization_format(
+        dummy_model, save_compressed=True, sparsity_config=sparsity_config
+    )
+    assert inferred_format.value == expected_format

--- a/tests/llmcompressor/transformers/compression/test_quantization.py
+++ b/tests/llmcompressor/transformers/compression/test_quantization.py
@@ -70,6 +70,7 @@ class TestQuantizationMatches(unittest.TestCase):
             pad_to_max_length=pad_to_max_length,
             clear_sparse_session=True,
             splits={"calibration": "train_gen[:5%]"},
+            save_compressed=False,
         )
 
     def _get_quant_info(self, model):

--- a/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
+++ b/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
@@ -64,6 +64,7 @@ class TestMaskStructurePreserved(unittest.TestCase):
             output_dir=self.output_first,
             oneshot_device=self.device,
             clear_sparse_session=False,
+            save_compressed=False,
         )
         first_tiny_model = get_session_model()
         targetted_layer = first_tiny_model.model.layers[0].self_attn.k_proj
@@ -87,6 +88,7 @@ class TestMaskStructurePreserved(unittest.TestCase):
             output_dir=self.output_second,
             oneshot_device=self.device,
             clear_sparse_session=False,
+            save_compressed=False,
         )
 
         second_tiny_model = get_session_model()


### PR DESCRIPTION
SUMMARY:
We now default to `save_compressed=True` when running `oneshot()` or `save_pretrained()` so quantized models are compressed automatically. Also updated the default save formats as follows
* w4a16 - packed-quantized
* w8a16 - packed-quantized
* w8a8 - int8 - int-quantized
* w8a8 - fp8 - float-quantized
* w4a16 2:4 - marlin-24
* w8a16 2:4 - marlin-24

TEST PLAN:
Added unit test for default save formats
