### PR TITLE
[Bugfix] Add fix to preserve modifier order when passed as a list

### DIFF
--- a/src/llmcompressor/recipe/recipe.py
+++ b/src/llmcompressor/recipe/recipe.py
@@ -672,7 +672,7 @@ def create_recipe_string_from_modifiers(
             }
         }
     }
-    recipe_str: str = yaml.dump(recipe_dict)
+    recipe_str: str = yaml.dump(recipe_dict, sort_keys=False)
     return recipe_str
 
 

--- a/tests/llmcompressor/recipe/test_recipe.py
+++ b/tests/llmcompressor/recipe/test_recipe.py
@@ -3,8 +3,10 @@ import tempfile
 import pytest
 import yaml
 
+from llmcompressor.modifiers import Modifier
 from llmcompressor.modifiers.obcq.base import SparseGPTModifier
 from llmcompressor.recipe import Recipe
+from llmcompressor.recipe.recipe import create_recipe_string_from_modifiers
 from tests.llmcompressor.helpers import valid_recipe_strings
 
 
@@ -96,3 +98,45 @@ def test_recipe_can_be_created_from_modifier_instances():
     ):
         assert isinstance(actual_modifier, type(expected_modifier))
         assert actual_modifier.dict() == expected_modifier.dict()
+
+
+class A_FirstDummyModifier(Modifier):
+    def model_dump(self):
+        return {}
+
+
+class B_SecondDummyModifier(Modifier):
+    def model_dump(self):
+        return {}
+
+
+def test_create_recipe_string_from_modifiers_with_default_group_name():
+    modifiers = [B_SecondDummyModifier(), A_FirstDummyModifier()]
+    expected_recipe_str = (
+        "DEFAULT_stage:\n"
+        "  DEFAULT_modifiers:\n"
+        "    B_SecondDummyModifier: {}\n"
+        "    A_FirstDummyModifier: {}\n"
+    )
+    actual_recipe_str = create_recipe_string_from_modifiers(modifiers)
+    assert actual_recipe_str == expected_recipe_str
+
+
+def test_create_recipe_string_from_modifiers_with_custom_group_name():
+    modifiers = [B_SecondDummyModifier(), A_FirstDummyModifier()]
+    group_name = "custom"
+    expected_recipe_str = (
+        "custom_stage:\n"
+        "  DEFAULT_modifiers:\n"
+        "    B_SecondDummyModifier: {}\n"
+        "    A_FirstDummyModifier: {}\n"
+    )
+    actual_recipe_str = create_recipe_string_from_modifiers(modifiers, group_name)
+    assert actual_recipe_str == expected_recipe_str
+
+
+def test_create_recipe_string_from_modifiers_with_empty_modifiers():
+    modifiers = []
+    expected_recipe_str = "DEFAULT_stage:\n" "  DEFAULT_modifiers: {}\n"
+    actual_recipe_str = create_recipe_string_from_modifiers(modifiers)
+    assert actual_recipe_str == expected_recipe_str

--- a/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
+++ b/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
@@ -2,7 +2,7 @@ import unittest
 from pathlib import Path
 
 import pytest
-from compressed_tensors.compressors.utils import tensor_follows_mask_structure
+from compressed_tensors.utils import tensor_follows_mask_structure
 from parameterized import parameterized_class
 
 from llmcompressor.core import reset_session


### PR DESCRIPTION
Summary:

A bug was identified by @robertgshaw2-neuralmagic during testing of SmoothQuant with GPTQ. When these modifiers were passed as a list, the SmoothQuant modifier was not being applied. This issue only occurred when a list of modifier objects was passed and did not affect cases where a recipe string was provided.

Reason:

The error occurred during the list of modifiers -> recipe string creation phase. The use of yaml.dump() was not respecting the order of modifiers in the dictionary, as it was internally sorting the keys. This caused the GPTQ modifier to be applied before SmoothQuant, which led to the GPTQ modifier inferring its own QuantizationModifier and ignoring the passed-in SmoothQuant modifier.

Fix:

The fix was to pass sort_keys=False during the yaml.dump() process. This preserves the order of the modifiers, ensuring they are applied in the correct sequence.

 
Resources: https://github.com/yaml/pyyaml/issues/110

TEST PLAN:
Automated tests added to ensure order is preserved; this test fails on main but passes with current diff:

On Current Branch:
```bash
(venv) ➜  llm-compressor git:(fix-order-of-modifiers) ✗ pytest tests/llmcompressor/recipe/test_recipe.py 
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.10.12, pytest-8.2.2, pluggy-1.5.0
rootdir: /root/llm-compressor
configfile: pyproject.toml
plugins: mock-3.14.0, rerunfailures-14.0
collected 17 items                                                                                                                                                         

tests/llmcompressor/recipe/test_recipe.py .................                                                                                                          [100%]
====================================================================== 17 passed, 3 warnings in 2.34s ======================================================================
```
On Main:
```bash
(venv) ➜  llm-compressor git:(fix-order-of-modifiers) ✗ gco -b main-copy main
M       .gitignore
Switched to a new branch 'main-copy'
(venv) ➜  llm-compressor git:(main-copy) ✗ git cherry-pick 487e19f2
[main-copy 3ab2dae0] Add automated unit tests
 Date: Thu Jul 18 18:45:19 2024 +0000
 1 file changed, 44 insertions(+)
(venv) ➜  llm-compressor git:(main-copy) ✗ pytest tests/llmcompressor/recipe/test_recipe.py
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.10.12, pytest-8.2.2, pluggy-1.5.0
rootdir: /root/llm-compressor
configfile: pyproject.toml
plugins: mock-3.14.0, rerunfailures-14.0
collected 17 items                                                                                                                                                         

tests/llmcompressor/recipe/test_recipe.py ..............FF.                                                                                                          [100%]

================================================================================= FAILURES =================================================================================
_____________________________________________________ test_create_recipe_string_from_modifiers_with_default_group_name _____________________________________________________

    def test_create_recipe_string_from_modifiers_with_default_group_name():
        modifiers = [B_SecondDummyModifier(), A_FirstDummyModifier()]
        expected_recipe_str = (
            "DEFAULT_stage:\n"
            "  DEFAULT_modifiers:\n"
            "    B_SecondDummyModifier: {}\n"
            "    A_FirstDummyModifier: {}\n"
        )
        actual_recipe_str = create_recipe_string_from_modifiers(modifiers)
>       assert actual_recipe_str == expected_recipe_str
E       AssertionError: assert 'DEFAULT_stag...odifier: {}\n' == 'DEFAULT_stag...odifier: {}\n'
E         
E           DEFAULT_stage:
E             DEFAULT_modifiers:
E         +     A_FirstDummyModifier: {}
E               B_SecondDummyModifier: {}
E         -     A_FirstDummyModifier: {}

tests/llmcompressor/recipe/test_recipe.py:122: AssertionError
-------------------------------------------------------------------------- Captured stdout setup ---------------------------------------------------------------------------
2024-07-18T18:51:19.067980+0000 | reset | INFO - Compression lifecycle reset
------------------------------------------------------------------------- Captured stdout teardown -------------------------------------------------------------------------
2024-07-18T18:51:19.070596+0000 | reset | INFO - Compression lifecycle reset
_____________________________________________________ test_create_recipe_string_from_modifiers_with_custom_group_name ______________________________________________________

    def test_create_recipe_string_from_modifiers_with_custom_group_name():
        modifiers = [B_SecondDummyModifier(), A_FirstDummyModifier()]
        group_name = "custom"
        expected_recipe_str = (
            "custom_stage:\n"
            "  DEFAULT_modifiers:\n"
            "    B_SecondDummyModifier: {}\n"
            "    A_FirstDummyModifier: {}\n"
        )
        actual_recipe_str = create_recipe_string_from_modifiers(modifiers, group_name)
>       assert actual_recipe_str == expected_recipe_str
E       AssertionError: assert 'custom_stage...odifier: {}\n' == 'custom_stage...odifier: {}\n'
E         
E           custom_stage:
E             DEFAULT_modifiers:
E         +     A_FirstDummyModifier: {}
E               B_SecondDummyModifier: {}
E         -     A_FirstDummyModifier: {}

tests/llmcompressor/recipe/test_recipe.py:135: AssertionError
-------------------------------------------------------------------------- Captured stdout setup ---------------------------------------------------------------------------
2024-07-18T18:51:19.070960+0000 | reset | INFO - Compression lifecycle reset
------------------------------------------------------------------------- Captured stdout teardown -------------------------------------------------------------------------
2024-07-18T18:51:19.073142+0000 | reset | INFO - Compression lifecycle reset
============================================================================= warnings summary =============================================================================
venv/lib/python3.10/site-packages/compressed_tensors/quantization/quant_args.py:108
  /root/llm-compressor/venv/lib/python3.10/site-packages/compressed_tensors/quantization/quant_args.py:108: PydanticDeprecatedSince20: Pydantic V1 style `@validator` validators are deprecated. You should migrate to Pydantic V2 style `@field_validator` validators, see the migration guide for more details. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.8/migration/
    @validator("strategy", pre=True, always=True)

tests/llmcompressor/recipe/test_recipe.py::test_recipe_can_be_created_from_modifier_instances
tests/llmcompressor/recipe/test_recipe.py::test_recipe_can_be_created_from_modifier_instances
  /root/llm-compressor/venv/lib/python3.10/site-packages/pydantic/main.py:1087: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.8/migration/
    warnings.warn('The `dict` method is deprecated; use `model_dump` instead.', category=PydanticDeprecatedSince20)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================= short test summary info ==========================================================================
FAILED tests/llmcompressor/recipe/test_recipe.py::test_create_recipe_string_from_modifiers_with_default_group_name - AssertionError: assert 'DEFAULT_stag...odifier: {}\n' == 'DEFAULT_stag...odifier: {}\n'
FAILED tests/llmcompressor/recipe/test_recipe.py::test_create_recipe_string_from_modifiers_with_custom_group_name - AssertionError: assert 'custom_stage...odifier: {}\n' == 'custom_stage...odifier: {}\n'
================================================================= 2 failed, 15 passed, 3 warnings in 2.39s =================================================================
```
