### PR TITLE
Fix layerwise targets

### DIFF
--- a/src/llmcompressor/modifiers/quantization/gptq/base.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/base.py
@@ -94,6 +94,7 @@ class GPTQModifier(Modifier):
 
     sequential_update: Optional[bool] = False
     targets: Union[str, List[str], None] = None
+    sequential_targets: Union[str, List[str], None] = None
     block_size: int = 128
     quantize: Union[bool, Dict] = True
     dampening_frac: Optional[float] = 0.01
@@ -177,11 +178,11 @@ class GPTQModifier(Modifier):
         modifiable_model = state.model
         calibration_dataloader = state.data.calib
 
-        if self.targets is None:
+        if self.sequential_targets is None:
             # if no targets are provided, default to the modules that shouldn't be
             # split by FSDP. For Transformers models this is equivalent to the
             # decoder layers (ie LlamaDecoderLayer)
-            self.targets = get_no_split_params(modifiable_model)
+            self.sequential_targets = get_no_split_params(modifiable_model)
 
         self.initialize_compression(modifiable_model, calibration_dataloader)
         self.apply_compression(calibration_dataloader)
@@ -215,7 +216,7 @@ class GPTQModifier(Modifier):
                 f"{type(self.model)} instead"
             )
 
-        return get_layers(self.targets, self.model)
+        return get_layers(self.sequential_targets, self.model)
 
     def initialize_compression(
         self,


### PR DESCRIPTION
SUMMARY:
When we previously added in support for the targets/scheme UX to GPTQModifier, this overwrote an existing attribute also named targets that stored the names of the transformer layers (used for sequential updates). This PR renames targets to restore the original functionality


TEST PLAN:
Manual testing. Previously `GPTQModifier(targets="Linear", scheme="W8A8", ignore=["lm_head"], sequential_update=True)` would run calibration for every linear layer rather than every transformer layer. After the fix we get the correct number of layers
