### PR TITLE
Move Weight Update Out Of Loop

### DIFF
--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -95,6 +95,18 @@ class GPTQWrapper(ModuleCompressionWrapper):
 
         tick = time.time()
 
+        if hasattr(self.layer, "quantization_scheme"):
+            quant_scheme = self.layer.quantization_scheme
+            if quant_scheme.weights is not None:
+                # fetch latest correct scale and ZP relevant for any changes
+                # such as activation reordering
+                from compressed_tensors.quantization import (
+                    update_layer_weight_quant_params,
+                )
+
+                update_layer_weight_quant_params(self.layer)
+
+
         dead = torch.diag(self.H) == 0
         self.H[dead, dead] = 1
         W[:, dead] = 0
@@ -141,14 +153,6 @@ class GPTQWrapper(ModuleCompressionWrapper):
                 elif hasattr(self.layer, "quantization_scheme"):
                     quant_scheme = self.layer.quantization_scheme
                     if quant_scheme.weights is not None:
-                        # fetch latest correct scale and ZP relevant for any changes
-                        # such as activation reordering
-                        from compressed_tensors.quantization import (
-                            update_layer_weight_quant_params,
-                        )
-
-                        update_layer_weight_quant_params(self.layer)
-
                         scale = self.layer.weight_scale
                         zero_point = self.layer.weight_zero_point
                         from compressed_tensors.quantization import QuantizationStrategy


### PR DESCRIPTION
SUMMARY:
Recent change for activation reordering was updating the scale/zp each block of GPTQ, it only needs to be updated once layer. Moving this line out of the loop sped things up by 20x

TEST PLAN:
Manual testing

Before:
```
===== Compressing layer 1/1  =====
2024-07-25T14:21:48.809433+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.self_attn.q_proj...
2024-07-25T14:22:11.727413+0000 | compress | INFO - time 22.87
2024-07-25T14:22:11.727872+0000 | compress | INFO - error 1503.34
2024-07-25T14:22:11.728176+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.self_attn.k_proj...
2024-07-25T14:22:34.115003+0000 | compress | INFO - time 22.39
2024-07-25T14:22:34.115453+0000 | compress | INFO - error 798.58
2024-07-25T14:22:34.115750+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.self_attn.v_proj...
2024-07-25T14:22:56.367681+0000 | compress | INFO - time 22.25
2024-07-25T14:22:56.367947+0000 | compress | INFO - error 19.61
2024-07-25T14:22:56.368194+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.self_attn.o_proj...
2024-07-25T14:23:19.128502+0000 | compress | INFO - time 22.76
2024-07-25T14:23:19.128925+0000 | compress | INFO - error 0.29
2024-07-25T14:23:19.129270+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.mlp.gate_proj...
2024-07-25T14:23:41.729422+0000 | compress | INFO - time 22.60
2024-07-25T14:23:41.729671+0000 | compress | INFO - error 507.43
2024-07-25T14:23:41.729919+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.mlp.up_proj...
2024-07-25T14:24:04.349380+0000 | compress | INFO - time 22.62
2024-07-25T14:24:04.349802+0000 | compress | INFO - error 400.27
2024-07-25T14:24:04.350086+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.mlp.down_proj...
2024-07-25T14:28:23.691902+0000 | compress | INFO - time 259.34
2024-07-25T14:28:23.692347+0000 | compress | INFO - error 1.29
```

After:
```
===== Compressing layer 1/1  =====
2024-07-25T14:42:37.554267+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.self_attn.q_proj...
2024-07-25T14:42:38.702161+0000 | compress | INFO - time 1.10
2024-07-25T14:42:38.702430+0000 | compress | INFO - error 1503.34
2024-07-25T14:42:38.702674+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.self_attn.k_proj...
2024-07-25T14:42:39.747094+0000 | compress | INFO - time 1.04
2024-07-25T14:42:39.747477+0000 | compress | INFO - error 798.58
2024-07-25T14:42:39.747755+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.self_attn.v_proj...
2024-07-25T14:42:40.791669+0000 | compress | INFO - time 1.04
2024-07-25T14:42:40.791917+0000 | compress | INFO - error 19.61
2024-07-25T14:42:40.792149+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.self_attn.o_proj...
2024-07-25T14:42:41.844949+0000 | compress | INFO - time 1.05
2024-07-25T14:42:41.845229+0000 | compress | INFO - error 0.29
2024-07-25T14:42:41.845500+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.mlp.gate_proj...
2024-07-25T14:42:42.947179+0000 | compress | INFO - time 1.10
2024-07-25T14:42:42.947426+0000 | compress | INFO - error 507.43
2024-07-25T14:42:42.947678+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.mlp.up_proj...
2024-07-25T14:42:44.051472+0000 | compress | INFO - time 1.10
2024-07-25T14:42:44.051754+0000 | compress | INFO - error 400.27
2024-07-25T14:42:44.052022+0000 | compress_module | INFO - Compressing model.layers.0.model.layers.0.mlp.down_proj...
2024-07-25T14:42:48.255730+0000 | compress | INFO - time 4.20
2024-07-25T14:42:48.255968+0000 | compress | INFO - error 1.29
```
