### PR TITLE
Add: Wrapper flow for W8A8 quantization

### DIFF
--- a/src/llmcompressor/flows.py
+++ b/src/llmcompressor/flows.py
@@ -1,0 +1,60 @@
+from typing import Dict, Optional, Union
+
+
+def quantize_w8a8(
+    model_id: str,
+    dataset: str,
+    output_dir: str,
+    splits: Dict[str, str],
+    max_seq_length: int,
+    pad_to_max_length: bool,
+    num_calibration_samples: int,
+    smoothquant_kwargs: Optional[Dict[str, Union[int, float, str]]] = None,
+    gptq_kwargs: Optional[Dict[str, Union[int, float, str]]] = None,
+) -> None:
+    """
+    Apply W8A8 and SmoothQuant + GPTQ quantization to a model using the oneshot method.
+
+    :param model_id: The HF model id, or local path to the model to be quantized.
+    :param dataset: The dataset to be used for calibration.
+    :param output_dir: The directory where the quantized model will be saved.
+    :param splits: The data splits to be used for calibration
+        ex. {"calibration": "train_gen[:5%]"}
+    :param max_seq_length: The maximum sequence length for the model.
+    :param pad_to_max_length: Whether to pad sequences to the maximum length.
+    :param num_calibration_samples: The number of samples to be used for calibration.
+    :param smoothquant_kwargs: Optional dictionary of keyword arguments for
+        the SmoothQuantModifier.
+    :param gptq_kwargs: Optional dictionary of keyword arguments for the GPTQModifier.
+    """
+    from llmcompressor.modifiers.quantization.gptq import GPTQModifier
+    from llmcompressor.modifiers.smoothquant import SmoothQuantModifier
+    from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot
+
+    default_gptq_kwargs = dict(
+        targets="Linear", scheme="W8A8", ignore=["lm_head"], sequential_update=False
+    )
+    gptq_kwargs = {**default_gptq_kwargs, **(gptq_kwargs or {})}
+    # Define the quantization recipe with SmoothQuant and GPTQ
+    recipe = [
+        SmoothQuantModifier(**(smoothquant_kwargs or {})),
+        GPTQModifier(**gptq_kwargs),
+    ]
+
+    # Load the model
+    model = SparseAutoModelForCausalLM.from_pretrained(
+        model_id, device_map="auto", torch_dtype="auto"
+    )
+
+    # Apply the quantization
+    oneshot(
+        model=model,
+        dataset=dataset,
+        recipe=recipe,
+        output_dir=output_dir,
+        splits=splits,
+        max_seq_length=max_seq_length,
+        pad_to_max_length=pad_to_max_length,
+        num_calibration_samples=num_calibration_samples,
+        save_compressed=True,
+    )

--- a/src/llmcompressor/recipe/modifier.py
+++ b/src/llmcompressor/recipe/modifier.py
@@ -83,13 +83,14 @@ class RecipeModifier(RecipeBase):
     @model_validator(mode="before")
     @classmethod
     def extract_modifier_type(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        modifier = {"group": values.pop("group")}
-        assert len(values) == 1, "multiple key pairs found for modifier"
-        modifier_type, args = list(values.items())[0]
+        if len(values) == 2:
+            # values contains only group and the Modifier type as keys
+            group = values.pop("group")
+            modifier_type, args = values.popitem()
+            return {"group": group, "type": modifier_type, "args": args}
 
-        modifier["type"] = modifier_type
-        modifier["args"] = args
-        return modifier
+        # values already in the correct format
+        return values
 
     def dict(self, *args, **kwargs) -> Dict[str, Any]:
         """

--- a/src/llmcompressor/recipe/stage.py
+++ b/src/llmcompressor/recipe/stage.py
@@ -161,26 +161,26 @@ class RecipeStage(RecipeBase):
         """
 
         modifiers = []
-        remove_keys = []
 
-        if "modifiers" in values and values["modifiers"]:
-            remove_keys.append("modifiers")
-            for mod_key, mod_value in values["stages"].items():
-                modifier = {mod_key: mod_value}
-                modifier["group"] = "default"
-                modifiers.append(modifier)
+        if "modifiers" in values:
+            modifier_values = values.pop("modifiers")
+            if "stages" in values:
+                for mod_key, mod_value in values.pop("stages").items():
+                    modifiers.append({mod_key: mod_value, "group": "default"})
+            else:
+                values["default_stage"] = {
+                    "default_modifiers": {mod.type: mod.args for mod in modifier_values}
+                }
+                modifiers.extend(
+                    {mod.type: mod.args, "group": "default"} for mod in modifier_values
+                )
 
-        for key, value in list(values.items()):
-            if key.endswith("_modifiers"):
-                remove_keys.append(key)
-                group = key.rsplit("_modifiers", 1)[0]
-                for mod_key, mod_value in value.items():
-                    modifier = {mod_key: mod_value}
-                    modifier["group"] = group
-                    modifiers.append(modifier)
-
-        for key in remove_keys:
-            del values[key]
+        for key in [k for k in values if k.endswith("_modifiers")]:
+            group = key.rsplit("_modifiers", 1)[0]
+            modifiers.extend(
+                {mod_key: mod_value, "group": group}
+                for mod_key, mod_value in values.pop(key).items()
+            )
 
         return modifiers
 

--- a/tests/llmcompressor/recipe/test_recipe.py
+++ b/tests/llmcompressor/recipe/test_recipe.py
@@ -3,10 +3,8 @@ import tempfile
 import pytest
 import yaml
 
-from llmcompressor.modifiers import Modifier
 from llmcompressor.modifiers.obcq.base import SparseGPTModifier
 from llmcompressor.recipe import Recipe
-from llmcompressor.recipe.recipe import create_recipe_string_from_modifiers
 from tests.llmcompressor.helpers import valid_recipe_strings
 
 
@@ -97,44 +95,4 @@ def test_recipe_can_be_created_from_modifier_instances():
         actual_modifiers[0].modifiers, expected_modifiers[0].modifiers
     ):
         assert isinstance(actual_modifier, type(expected_modifier))
-        assert actual_modifier.dict() == expected_modifier.dict()
-
-
-class A_FirstDummyModifier(Modifier):
-    pass
-
-
-class B_SecondDummyModifier(Modifier):
-    pass
-
-
-def test_create_recipe_string_from_modifiers_with_default_group_name():
-    modifiers = [B_SecondDummyModifier(), A_FirstDummyModifier()]
-    expected_recipe_str = (
-        "DEFAULT_stage:\n"
-        "  DEFAULT_modifiers:\n"
-        "    B_SecondDummyModifier: {}\n"
-        "    A_FirstDummyModifier: {}\n"
-    )
-    actual_recipe_str = create_recipe_string_from_modifiers(modifiers)
-    assert actual_recipe_str == expected_recipe_str
-
-
-def test_create_recipe_string_from_modifiers_with_custom_group_name():
-    modifiers = [B_SecondDummyModifier(), A_FirstDummyModifier()]
-    group_name = "custom"
-    expected_recipe_str = (
-        "custom_stage:\n"
-        "  DEFAULT_modifiers:\n"
-        "    B_SecondDummyModifier: {}\n"
-        "    A_FirstDummyModifier: {}\n"
-    )
-    actual_recipe_str = create_recipe_string_from_modifiers(modifiers, group_name)
-    assert actual_recipe_str == expected_recipe_str
-
-
-def test_create_recipe_string_from_modifiers_with_empty_modifiers():
-    modifiers = []
-    expected_recipe_str = "DEFAULT_stage:\n" "  DEFAULT_modifiers: {}\n"
-    actual_recipe_str = create_recipe_string_from_modifiers(modifiers)
-    assert actual_recipe_str == expected_recipe_str
+        assert actual_modifier.model_dump() == expected_modifier.model_dump()


### PR DESCRIPTION
Adds a wrapper function to apply `W8A8` quantization using `SmoothQuant` and `GPTQ`

Usage:
```python
from llmcompressor.flows import quantize_w8a8


smoothquant_kwargs = {"smoothing_strength": 0.8}
gptq_kwargs = {"targets": "Linear", "scheme": "W8A8", "ignore": ["lm_head"], "sequential_update": False}

quantize_w8a8(
    model_id="Xenova/llama2.c-stories15M",
    dataset="ultrachat-200k",
    output_dir="./test_output",
    splits={"calibration": "train_gen[:5%]"},
    max_seq_length=2048,
    pad_to_max_length=False,
    num_calibration_samples=8,
    smoothquant_kwargs=smoothquant_kwargs,
    gptq_kwargs=gptq_kwargs
)
```

Truncated Output:
```bash
done
2024-08-01T16:17:16.370529+0000 | compress_module | INFO - Compressing model.layers.5.model.layers.5.mlp.down_proj...
2024-08-01T16:17:16.704587+0000 | compress | INFO - time 0.33
2024-08-01T16:17:16.704723+0000 | compress | INFO - error 1.58
done
manager stage: Modifiers initialized
2024-08-01T16:17:16.708711+0000 | initialize | INFO - Compression lifecycle initialized for 1 modifiers
manager stage: Modifiers finalized
2024-08-01T16:17:16.708925+0000 | finalize | INFO - Compression lifecycle finalized for 1 modifiers
2024-08-01T16:17:16.709005+0000 | save_pretrained_wrapper | INFO - Inferring a sparsity configuration requires a global sparsity calculation. This can be costly for large models. To skip the calculation of compression statistics set skip_compression_stats=True
Calculating model sparsity: 100%|█████████████████████████████████████████████████████████████████████████████████████| 141/141 [00:00<00:00, 2253.45it/s]
Calculating quantization compression ratio: 111it [00:00, 2465.75it/s]
Compressing model: 100%|██████████████████████████████████████████████████████████████████████████████████████████████| 141/141 [00:00<00:00, 3498.23it/s]
2024-08-01T16:17:17.142808+0000 | save_model_and_recipe | INFO - Saving output to /root/llm-compressor/test_output
```
