### PR TITLE
BugFix: Update TRL example scripts to point to the right SFTTrainer

### DIFF
--- a/examples/trl_mixin/README.md
+++ b/examples/trl_mixin/README.md
@@ -5,6 +5,8 @@ The `SessionManagerMixin` can be added to other Trainer classes that inherit fro
 
 For example, we can add LLM Compressor support to TRL's SFTTrainer like so: 
 
+Note: install `trl` using `pip install trl`
+
 ```python
 from trl import SFTTrainer as TRLSFTTrainer
 

--- a/examples/trl_mixin/ex_trl_constant.py
+++ b/examples/trl_mixin/ex_trl_constant.py
@@ -1,12 +1,9 @@
 from datasets import load_dataset
+from sft_trainer import SFTTrainer
 from transformers import AutoTokenizer
 from trl import DataCollatorForCompletionOnlyLM
 
-from llmcompressor.transformers import (
-    SFTTrainer,
-    SparseAutoModelForCausalLM,
-    TrainingArguments,
-)
+from llmcompressor.transformers import SparseAutoModelForCausalLM, TrainingArguments
 
 model_path = "neuralmagic/Llama-2-7b-pruned50-retrained"
 output_dir = "./output_trl_sft_test_7b_gsm8k_sft_data"

--- a/examples/trl_mixin/ex_trl_distillation.py
+++ b/examples/trl_mixin/ex_trl_distillation.py
@@ -1,8 +1,8 @@
+from sft_trainer import SFTTrainer
 from transformers import AutoTokenizer, DefaultDataCollator
 
 from llmcompressor.transformers import (
     DataTrainingArguments,
-    SFTTrainer,
     SparseAutoModelForCausalLM,
     TextGenerationDataset,
     TrainingArguments,


### PR DESCRIPTION
Updates the TRL example to point to the correct `SFTTrainer`

The example TRL scripts were importing SFTTrainer from the `llm-compressor` source (updating the import was probably missed when the scripts were moved to the examples directory), now they point to the correct trainer in examples directory

Test plan:

Ran both the scripts updated in this PR and they kickstarted just fine

Test commands:
- `python3 examples/trl_mixin/ex_trl_constant.py`
- `python3 examples/trl_mixin/ex_trl_distillation.py`

Note: also updates the readme to install trl