### PR TITLE
Fix Failing Transformers Tests

### DIFF
--- a/examples/big_model_offloading/big_model_w8a8_calibrate.py
+++ b/examples/big_model_offloading/big_model_w8a8_calibrate.py
@@ -30,7 +30,7 @@ quant_stage:
                     targets: ["Linear"]
 """
 
-model_stub = "meta-llama/Meta-Llama-3-70B"
+model_stub = "meta-llama/Meta-Llama-3-70B-Instruct"
 
 device_map = calculate_offload_device_map(
     model_stub, reserve_for_hessians=True, num_gpus=2, torch_dtype=torch.float16
@@ -86,4 +86,5 @@ oneshot(
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     save_compressed=True,
+    output_dir=output_dir,
 )

--- a/examples/big_model_offloading/big_model_w8a8_calibrate.py
+++ b/examples/big_model_offloading/big_model_w8a8_calibrate.py
@@ -3,10 +3,7 @@ from datasets import load_dataset
 from transformers import AutoTokenizer
 
 from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot
-from llmcompressor.transformers.compression.helpers import (  # noqa
-    calculate_offload_device_map,
-    custom_offload_device_map,
-)
+from llmcompressor.transformers.compression.helpers import calculate_offload_device_map
 
 # define a llmcompressor recipe for FP8 quantization
 # this recipe requires calibration
@@ -35,8 +32,8 @@ quant_stage:
 
 model_stub = "meta-llama/Meta-Llama-3-70B-Instruct"
 
-device_map = custom_offload_device_map(
-    model_stub, max_memory_per_gpu="74GB", num_gpus=1, torch_dtype=torch.float16
+device_map = calculate_offload_device_map(
+    model_stub, reserve_for_hessians=True, num_gpus=1, torch_dtype=torch.float16
 )
 
 model = SparseAutoModelForCausalLM.from_pretrained(

--- a/examples/big_model_offloading/big_model_w8a8_calibrate.py
+++ b/examples/big_model_offloading/big_model_w8a8_calibrate.py
@@ -30,10 +30,10 @@ quant_stage:
                     targets: ["Linear"]
 """
 
-model_stub = "meta-llama/Meta-Llama-3-70B-Instruct"
+model_stub = "meta-llama/Meta-Llama-3-70B"
 
 device_map = calculate_offload_device_map(
-    model_stub, reserve_for_hessians=True, num_gpus=1, torch_dtype=torch.float16
+    model_stub, reserve_for_hessians=True, num_gpus=2, torch_dtype=torch.float16
 )
 
 model = SparseAutoModelForCausalLM.from_pretrained(

--- a/src/llmcompressor/modifiers/utils/pytorch_helpers.py
+++ b/src/llmcompressor/modifiers/utils/pytorch_helpers.py
@@ -73,4 +73,3 @@ def run_calibration_forward(
         # TODO: not ideal, figure out where we aren't freeing memory instead
         # currently without this we run OOM on the 2nd forward pass
         torch.cuda.empty_cache()
-    torch.cuda.empty_cache()

--- a/tests/llmcompressor/transformers/compression/configs/channelwise_15m.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/channelwise_15m.yaml
@@ -2,4 +2,4 @@ cadence: "commit"
 test_type: "regression"
 model_stub: "Xenova/llama2.c-stories15M"
 new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_channel.yaml"
-ppl_threshold: 5000
+ppl_threshold: 30000

--- a/tests/llmcompressor/transformers/compression/configs/fp8_15m.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/fp8_15m.yaml
@@ -2,4 +2,4 @@ cadence: "commit"
 test_type: "regression"
 model_stub: "Xenova/llama2.c-stories15M"
 new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_fp8.yaml"
-ppl_threshold: 21000
+ppl_threshold: 30000

--- a/tests/llmcompressor/transformers/compression/configs/inputs_15m.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/inputs_15m.yaml
@@ -2,4 +2,4 @@ cadence: "commit"
 test_type: "regression"
 model_stub: "Xenova/llama2.c-stories15M"
 new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_full.yaml"
-ppl_threshold: 5000
+ppl_threshold: 30000

--- a/tests/llmcompressor/transformers/compression/configs/weights_only_15m.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/weights_only_15m.yaml
@@ -2,4 +2,4 @@ cadence: "commit"
 test_type: "regression"
 model_stub: "Xenova/llama2.c-stories15M"
 new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_weight.yaml"
-ppl_threshold: 5000
+ppl_threshold: 30000

--- a/tests/llmcompressor/transformers/finetune/finetune_custom/gpu/gpu_config.yaml
+++ b/tests/llmcompressor/transformers/finetune/finetune_custom/gpu/gpu_config.yaml
@@ -1,4 +1,4 @@
-cadence: "nightly"
+cadence: "weekly"
 test_type: "regression"
 model: “neuralmagic/Llama-2-7b-ultrachat200k”
 file_extension: json

--- a/tests/llmcompressor/transformers/finetune/test_alternate_recipe.yaml
+++ b/tests/llmcompressor/transformers/finetune/test_alternate_recipe.yaml
@@ -6,9 +6,6 @@ test_oneshot_stage:
       sequential_update: False
       percdamp: 0.01
       mask_structure: "0:0"
-      targets: [
-        "model.layers.0"
-      ]
       target_ids: ["attention_mask", "position_ids"]  
 test_train_stage:
   pruning_modifiers:

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py
@@ -22,13 +22,15 @@ class TestOneshotAndFinetuneWithTokenizer(unittest.TestCase):
         recipe_str = (
             "tests/llmcompressor/transformers/finetune/test_alternate_recipe.yaml"
         )
-        model = SparseAutoModelForCausalLM.from_pretrained("Xenova/llama2.c-stories15M")
         tokenizer = AutoTokenizer.from_pretrained(
             "Xenova/llama2.c-stories15M",
         )
         device = "cuda:0"
         if not torch.cuda.is_available():
             device = "cpu"
+        model = SparseAutoModelForCausalLM.from_pretrained(
+            "Xenova/llama2.c-stories15M", device_map=device
+        )
 
         dataset_config_name = "wikitext-2-raw-v1"
         dataset = load_dataset("wikitext", dataset_config_name, split="train[:50%]")
@@ -48,7 +50,6 @@ class TestOneshotAndFinetuneWithTokenizer(unittest.TestCase):
             max_steps=max_steps,
             concatenate_data=concatenate_data,
             splits=splits,
-            oneshot_device=device,
             tokenizer=tokenizer,
         )
 

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/consec_runs/gpu/llama_consec_runs.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/consec_runs/gpu/llama_consec_runs.yaml
@@ -1,4 +1,4 @@
-cadence: "nightly"
+cadence: "weekly"
 test_type: "regression"
 model: "meta-llama/Llama-2-7b-hf"
 dataset: open_platypus

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse.yaml
@@ -1,4 +1,4 @@
-cadence: "nightly"
+cadence: "weekly"
 test_type: "regression"
 model: "meta-llama/Llama-2-7b-hf"
 dataset: open_platypus

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse_auto.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/sparse/gpu/llama_7b_sparse_auto.yaml
@@ -1,4 +1,4 @@
-cadence: "nightly"
+cadence: "weekly"
 test_type: "regression"
 model: "meta-llama/Llama-2-7b-hf"
 dataset: open_platypus

--- a/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
+++ b/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
@@ -104,6 +104,7 @@ class TestConsecutiveRunsSmall(TestConsecutiveRuns):
         self._test_consecutive_runs(tolerance=1e-3)
 
 
+# TODO: @Satrat and @dsikka, revisit if we want these nightly or weekly
 @requires_gpu
 @requires_torch
 @pytest.mark.integration

--- a/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
@@ -57,6 +57,7 @@ class TestSparsities(unittest.TestCase):
         torch.cuda.empty_cache()
 
 
+# TODO: @Satrat and @dsikka, revisit if we want these nightly or weekly
 @requires_gpu
 @requires_torch
 @pytest.mark.integration


### PR DESCRIPTION
SUMMARY:
We've missed a few test failures with GHA being broken in this repo.
* Upping the perplexity threshold for 15M models, this was required due to a GPTQ fix
* Fixing a test recipe that was only sparsifying one layer to sparsify all layers
* Fixing a device assignment issue in a finetuning test
* Setting all the 7b parameter tests to be weekly instead of nightly


TEST PLAN:
Updated and reran the unit tests locally to confirm they're fixed
