### PR TITLE
Offloading Bug Fix

### DIFF
--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -199,7 +199,7 @@ def calculate_offload_device_map(
     available_gpus = torch.cuda.device_count()
     if available_gpus < num_gpus:
         raise ValueError(
-            "Requested {num_gpus} GPUs but only {available_gpus} are available."
+            f"Requested {num_gpus} GPUs but only {available_gpus} are available."
         )
     max_gpu_memory = [max_gpu_memory] * num_gpus
 


### PR DESCRIPTION
SUMMARY:
Fixes for two issues that came up during testing
* Missing fstring for an assertion being raised
* sparsity structure calculation fails for offloaded models. We missed this bug because this check gets skipped for models with < 5% sparsity


TEST PLAN:
Manual testing
