### PR TITLE
Disable Default Bitmask Compression

### DIFF
--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -1,8 +1,9 @@
 from typing import Dict, List, Optional, Union
-from accelerate.accelerator import get_state_dict_offloaded_model
+
 import psutil
 import torch
 from accelerate import infer_auto_device_map, init_empty_weights
+from accelerate.accelerator import get_state_dict_offloaded_model
 from torch.nn.modules import Linear
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -91,7 +91,7 @@ def modify_save_pretrained(model: PreTrainedModel):
                     "skip_compression_stats=True"
                 )
                 sparsity_config = SparsityConfigMetadata.from_pretrained(
-                    model, state_dict=state_dict, compress=save_compressed
+                    model, state_dict=state_dict, compress=False
                 )
 
             quantization_format = infer_quantization_format(


### PR DESCRIPTION
SUMMARY:
This issue came up a few days ago where a user tried to run a sparsified model in vLLM: https://github.com/vllm-project/llm-compressor/issues/45. We compress sparse models into the "sparse-bitmask" compression format by default on save, however this format isn't yet supported in vLLM. I'm updating the save logic to disable automatic sparse compression for now, we can re-enable once this is supported in vLLM


TEST PLAN:
Manual test to confirm sparse models are saved as dense by default:
```
import torch
from llmcompressor.modifiers.obcq import SparseGPTModifier
from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot

recipe = SparseGPTModifier(sparsity=0.5)

model_stub = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
model = SparseAutoModelForCausalLM.from_pretrained(model_stub, torch_dtype=torch.float16, device_map="auto")

dataset = "ultrachat-200k"

output_dir = "./test_output_sparse"

splits = {"calibration": "train_gen[:5%]"}
max_seq_length = 512
pad_to_max_length = False
num_calibration_samples = 32

oneshot(
    model=model,
    dataset=dataset,
    recipe=recipe,
    output_dir=output_dir,
    splits=splits,
    max_seq_length=max_seq_length,
    pad_to_max_length=pad_to_max_length,
    num_calibration_samples=num_calibration_samples,
)
```
Output `config.json` shows the expected dense format:
```
  "compression_config": {
    "sparsity_config": {
      "format": "dense",
      "global_sparsity": 0.44059220580610386,
      "registry_requires_subclass": false,
      "sparsity_structure": "0:0"
    }
  },
```