### PR TITLE
Bug starcoder issue 43

### DIFF
--- a/examples/big_model_offloading/big_model_fp8.py
+++ b/examples/big_model_offloading/big_model_fp8.py
@@ -1,0 +1,59 @@
+import torch
+from transformers import AutoTokenizer
+
+from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot
+from llmcompressor.transformers.compression.helpers import (  # noqa
+    calculate_offload_device_map,
+    custom_offload_device_map,
+)
+
+# define a llmcompressor recipe for FP8 quantization
+# this recipe requires no calibration data since inputs are dynamically quantized
+recipe = """
+quant_stage:
+    quant_modifiers:
+        QuantizationModifier:
+            ignore: ["lm_head"]
+            config_groups:
+                group_0:
+                    weights:
+                        num_bits: 8
+                        type: float
+                        strategy: channel
+                        dynamic: false
+                        symmetric: true
+                    input_activations:
+                        num_bits: 8
+                        type: float
+                        strategy: token
+                        dynamic: true
+                        symmetric: true
+                    targets: ["Linear"]
+"""
+
+model_stub = "meta-llama/Meta-Llama-3-70B-Instruct"
+
+# determine which layers to offload to cpu based on available resources
+device_map = calculate_offload_device_map(
+    model_stub, reserve_for_hessians=False, num_gpus=1, torch_dtype=torch.float16
+)
+
+# alternatively, specify the maximum memory to allocate per GPU directly
+# device_map = custom_offload_device_map(
+#    model_stub, max_memory_per_gpu="10GB", num_gpus=2, torch_dtype=torch.float16
+# )
+
+model = SparseAutoModelForCausalLM.from_pretrained(
+    model_stub, torch_dtype=torch.float16, device_map=device_map
+)
+
+output_dir = "./test_output_llama3b_70b_fp8"
+
+
+oneshot(
+    model=model,
+    recipe=recipe,
+    output_dir=output_dir,
+    save_compressed=True,
+    tokenizer=AutoTokenizer.from_pretrained(model_stub),
+)

--- a/examples/big_model_offloading/big_model_w8a8_calibrate.py
+++ b/examples/big_model_offloading/big_model_w8a8_calibrate.py
@@ -1,0 +1,99 @@
+import torch
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot
+from llmcompressor.transformers.compression.helpers import (  # noqa
+    calculate_offload_device_map,
+    custom_offload_device_map,
+)
+
+# define a llmcompressor recipe for FP8 quantization
+# this recipe requires calibration
+recipe = """
+quant_stage:
+    quant_modifiers:
+        GPTQModifier:
+            sequential_update: true
+            ignore: ["lm_head"]
+            config_groups:
+                group_0:
+                    weights:
+                        num_bits: 8
+                        type: int
+                        strategy: tensor
+                        dynamic: false
+                        symmetric: true
+                    input_activations:
+                        num_bits: 8
+                        type: float
+                        strategy: tensor
+                        dynamic: false
+                        symmetric: true
+                    targets: ["Linear"]
+"""
+
+model_stub = "meta-llama/Meta-Llama-3-70B-Instruct"
+
+# determine which layers to offload to cpu based on available resources
+# since we are running GPTQ, reserve memory upfront for the hessian calculation
+device_map = calculate_offload_device_map(
+    model_stub, reserve_for_hessians=True, num_gpus=1, torch_dtype=torch.float16
+)
+
+# alternatively, specify the maximum memory to allocate per GPU directly
+# device_map = custom_offload_device_map(
+#    model_stub, max_memory_per_gpu="30GB", num_gpus=2, torch_dtype=torch.float16
+# )
+
+model = SparseAutoModelForCausalLM.from_pretrained(
+    model_stub, torch_dtype=torch.float16, device_map=device_map
+)
+tokenizer = AutoTokenizer.from_pretrained(model_stub)
+output_dir = "./test_output_llama3b_70b_fp8"
+
+# Select calibration dataset.
+DATASET_ID = "HuggingFaceH4/ultrachat_200k"
+DATASET_SPLIT = "train_sft"
+NUM_CALIBRATION_SAMPLES = 32
+MAX_SEQUENCE_LENGTH = 512
+
+# Load dataset and preprocess.
+ds = load_dataset(DATASET_ID, split=DATASET_SPLIT)
+ds = ds.shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))
+
+
+def preprocess(example):
+    return {
+        "text": tokenizer.apply_chat_template(
+            example["messages"],
+            tokenize=False,
+        )
+    }
+
+
+ds = ds.map(preprocess)
+
+
+# Tokenize inputs.
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    save_compressed=True,
+)

--- a/examples/big_model_offloading/big_model_w8a8_calibrate.py
+++ b/examples/big_model_offloading/big_model_w8a8_calibrate.py
@@ -50,12 +50,12 @@ model = SparseAutoModelForCausalLM.from_pretrained(
     model_stub, torch_dtype=torch.float16, device_map=device_map
 )
 tokenizer = AutoTokenizer.from_pretrained(model_stub)
-output_dir = "./test_output_llama3b_70b_fp8"
+output_dir = "./output_llama3b_70b_w8a8"
 
 # Select calibration dataset.
 DATASET_ID = "HuggingFaceH4/ultrachat_200k"
 DATASET_SPLIT = "train_sft"
-NUM_CALIBRATION_SAMPLES = 32
+NUM_CALIBRATION_SAMPLES = 4
 MAX_SEQUENCE_LENGTH = 512
 
 # Load dataset and preprocess.

--- a/examples/big_model_offloading/big_model_w8a8_calibrate.py
+++ b/examples/big_model_offloading/big_model_w8a8_calibrate.py
@@ -35,16 +35,9 @@ quant_stage:
 
 model_stub = "meta-llama/Meta-Llama-3-70B-Instruct"
 
-# determine which layers to offload to cpu based on available resources
-# since we are running GPTQ, reserve memory upfront for the hessian calculation
-device_map = calculate_offload_device_map(
-    model_stub, reserve_for_hessians=True, num_gpus=1, torch_dtype=torch.float16
+device_map = custom_offload_device_map(
+    model_stub, max_memory_per_gpu="74GB", num_gpus=1, torch_dtype=torch.float16
 )
-
-# alternatively, specify the maximum memory to allocate per GPU directly
-# device_map = custom_offload_device_map(
-#    model_stub, max_memory_per_gpu="30GB", num_gpus=2, torch_dtype=torch.float16
-# )
 
 model = SparseAutoModelForCausalLM.from_pretrained(
     model_stub, torch_dtype=torch.float16, device_map=device_map

--- a/src/llmcompressor/modifiers/quantization/gptq/base.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/base.py
@@ -89,6 +89,7 @@ class GPTQModifier(Modifier):
 
     sequential_update: Optional[bool] = False
     targets: Union[str, List[str], None] = None
+    sequential_targets: Union[str, List[str], None] = None
     block_size: int = 128
     quantize: Union[bool, Dict] = True
     dampening_frac: Optional[float] = 0.01
@@ -170,11 +171,11 @@ class GPTQModifier(Modifier):
         modifiable_model = state.model
         calibration_dataloader = state.data.calib
 
-        if self.targets is None:
+        if self.sequential_targets is None:
             # if no targets are provided, default to the modules that shouldn't be
             # split by FSDP. For Transformers models this is equivalent to the
             # decoder layers (ie LlamaDecoderLayer)
-            self.targets = get_no_split_params(modifiable_model)
+            self.sequential_targets = get_no_split_params(modifiable_model)
 
         self.initialize_compression(modifiable_model, calibration_dataloader)
         self.apply_compression(calibration_dataloader)
@@ -207,7 +208,7 @@ class GPTQModifier(Modifier):
                 f"{type(self.model)} instead"
             )
 
-        return get_layers(self.targets, self.model)
+        return get_layers(self.sequential_targets, self.model)
 
     def initialize_compression(
         self,

--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -74,7 +74,8 @@ class GPTQWrapper(ModuleCompressionWrapper):
         :param percdamp: Amount of dampening to apply to H, as a fraction of the
             diagonal norm
         """
-        self.layer._hf_hook.pre_forward(self.layer)
+        if hasattr(self.layer, "_hf_hook") and self.layer._hf_hook.offload:
+            self.layer._hf_hook.pre_forward(self.layer)
 
         final_shape = self.layer.weight.shape
         final_dtype = self.layer.weight.dtype
@@ -217,7 +218,8 @@ class GPTQWrapper(ModuleCompressionWrapper):
         self.layer.weight -= self.layer.weight
         self.layer.weight += W
 
-        self.layer._hf_hook.post_forward(self.layer, None)
+        if hasattr(self.layer, "_hf_hook") and self.layer._hf_hook.offload:
+            self.layer._hf_hook.post_forward(self.layer, None)
 
     def free(self):
         """

--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -74,6 +74,8 @@ class GPTQWrapper(ModuleCompressionWrapper):
         :param percdamp: Amount of dampening to apply to H, as a fraction of the
             diagonal norm
         """
+        self.layer._hf_hook.pre_forward(self.layer)
+
         final_shape = self.layer.weight.shape
         final_dtype = self.layer.weight.dtype
         W = self.layer.weight.data.clone()
@@ -214,6 +216,8 @@ class GPTQWrapper(ModuleCompressionWrapper):
         # place, clone() or direct assignment won't work
         self.layer.weight -= self.layer.weight
         self.layer.weight += W
+
+        self.layer._hf_hook.post_forward(self.layer, None)
 
     def free(self):
         """

--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -219,6 +219,8 @@ class GPTQWrapper(ModuleCompressionWrapper):
         self.layer.weight += W
 
         if hasattr(self.layer, "_hf_hook") and self.layer._hf_hook.offload:
+            mappings = self.layer._hf_hook.weights_map
+            mappings["weight"].data = self.layer.weight.to(mappings["weight"].device)
             self.layer._hf_hook.post_forward(self.layer, None)
 
     def free(self):

--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -228,6 +228,12 @@ class GPTQWrapper(ModuleCompressionWrapper):
             update_prefix_dict(self.layer, "weight", self.layer.weight.to(device))
             self.layer._hf_hook.post_forward(self.layer, None)
 
+        del W
+        del Losses
+        del diag
+        self.free()
+        print("compressed")
+
     def free(self):
         """
         Free the Hessian memory after the layer is complete

--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -239,8 +239,6 @@ class GPTQWrapper(ModuleCompressionWrapper):
         del W
         del Losses
         del diag
-        self.free()
-        print("compressed")
 
     def free(self):
         """

--- a/src/llmcompressor/modifiers/utils/compression_wrapper.py
+++ b/src/llmcompressor/modifiers/utils/compression_wrapper.py
@@ -38,7 +38,10 @@ class ModuleCompressionWrapper(Module, ABC):
 
         self.name = name
         self.layer = layer
+
         self.dev = self.layer.weight.device
+        if hasattr(self.layer, "_hf_hook") and self.layer._hf_hook.offload:
+            self.dev = self.layer._hf_hook.execution_device
 
         # Calculate weight shape to use during pruning
         W = self.layer.weight

--- a/src/llmcompressor/modifiers/utils/layer_compressor.py
+++ b/src/llmcompressor/modifiers/utils/layer_compressor.py
@@ -114,7 +114,7 @@ class LayerCompressor:
                     set_layer(full_name, module_wrapper.layer, self.model)
             else:
                 set_layer(name, module_wrapper.layer, self.layer)
-            # module_wrapper.free()
+            torch.cuda.empty_cache()
         self.modules = None
 
     def compress(self):

--- a/src/llmcompressor/modifiers/utils/layer_compressor.py
+++ b/src/llmcompressor/modifiers/utils/layer_compressor.py
@@ -128,6 +128,8 @@ class LayerCompressor:
                 full_name = self._get_full_submodule_name(module.name)
                 logger.info(f"Compressing {full_name}...")
                 module.compress(**self.args)
+                module.free()
+                print("done")
 
         self.layer.apply(compress_module)
         torch.cuda.empty_cache()

--- a/src/llmcompressor/modifiers/utils/layer_compressor.py
+++ b/src/llmcompressor/modifiers/utils/layer_compressor.py
@@ -114,7 +114,7 @@ class LayerCompressor:
                     set_layer(full_name, module_wrapper.layer, self.model)
             else:
                 set_layer(name, module_wrapper.layer, self.layer)
-            module_wrapper.free()
+            # module_wrapper.free()
         self.modules = None
 
     def compress(self):
@@ -130,6 +130,7 @@ class LayerCompressor:
                 module.compress(**self.args)
 
         self.layer.apply(compress_module)
+        torch.cuda.empty_cache()
 
     def _get_full_submodule_name(self, name):
         full_name = ".".join(x for x in [self.name, name] if len(x) > 0)

--- a/src/llmcompressor/modifiers/utils/pytorch_helpers.py
+++ b/src/llmcompressor/modifiers/utils/pytorch_helpers.py
@@ -73,3 +73,4 @@ def run_calibration_forward(
         # TODO: not ideal, figure out where we aren't freeing memory instead
         # currently without this we run OOM on the 2nd forward pass
         torch.cuda.empty_cache()
+    torch.cuda.empty_cache()

--- a/src/llmcompressor/modifiers/utils/pytorch_helpers.py
+++ b/src/llmcompressor/modifiers/utils/pytorch_helpers.py
@@ -70,3 +70,6 @@ def run_calibration_forward(
         batch = tensors_to_device(batch, model_device)
         with torch.no_grad():
             forward_fn(batch, module=model)
+        # TODO: not ideal, figure out where we aren't freeing memory instead
+        # currently without this we run OOM on the 2nd forward pass
+        torch.cuda.empty_cache()

--- a/src/llmcompressor/pytorch/utils/helpers.py
+++ b/src/llmcompressor/pytorch/utils/helpers.py
@@ -543,7 +543,7 @@ def tensor_sparsity(
     :return: the sparsity of the input tens, ie the fraction of numbers that are zero
     """
     if dim is None:
-        zeros = (tens == 0).sum()
+        zeros = (tens.cpu() == 0).sum()
         total = tens.numel()
 
         return zeros.float() / float(total)

--- a/src/llmcompressor/pytorch/utils/sparsification.py
+++ b/src/llmcompressor/pytorch/utils/sparsification.py
@@ -17,16 +17,12 @@ from typing import (
 )
 
 import torch
+from accelerate.accelerator import get_state_dict_offloaded_model
 from loguru import logger
 from torch.nn import Module
 from tqdm import tqdm
 
-from llmcompressor.pytorch.utils.helpers import (
-    get_prunable_layers,
-    get_quantizable_layers,
-    get_quantized_layers,
-    tensor_sparsity,
-)
+from llmcompressor.pytorch.utils.helpers import get_quantized_layers, tensor_sparsity
 
 __all__ = [
     "ModuleSparsificationInfo",
@@ -49,18 +45,20 @@ class ModuleSparsificationInfo:
         self, module: Module, state_dict: Optional[Dict[str, torch.Tensor]] = None
     ):
         self.module = module
-        self.state_dict = state_dict
 
-        if self.state_dict is not None:
+        if state_dict is not None:
             # when analyzing an FSDP model, the state_dict does not differentiate
             # between trainable and non-trainable parameters
             # (e.g. it can contain buffers) this means that the
             # self.trainable_parameters may be overestimated
-            self.trainable_params = [param for _, param in state_dict.items()]
+            self.trainable_params = state_dict
         else:
-            self.trainable_params = list(
-                filter(lambda param: param.requires_grad, self.module.parameters())
-            )
+            if hasattr(module, "_hf_hook"):
+                self.trainable_params = get_state_dict_offloaded_model(module)
+            else:
+                self.trainable_params = list(
+                    filter(lambda param: param.requires_grad, self.module.parameters())
+                )
 
     def __str__(self):
         return json.dumps(
@@ -69,10 +67,6 @@ class ModuleSparsificationInfo:
                     "total": self.params_total,
                     "sparse": self.params_sparse,
                     "sparsity_percent": self.params_sparse_percent,
-                    "prunable": self.params_prunable_total,
-                    "prunable_sparse": self.params_prunable_sparse,
-                    "prunable_sparsity_percent": self.params_prunable_sparse_percent,
-                    "quantizable": self.params_quantizable,
                     "quantized": self.params_quantized,
                     "quantized_percent": self.params_quantized_percent,
                 },
@@ -85,7 +79,7 @@ class ModuleSparsificationInfo:
         """
         :return: total number of trainable parameters in the model
         """
-        return sum(torch.numel(param) for param in self.trainable_params)
+        return sum(torch.numel(param) for param in self.trainable_params.values())
 
     @property
     def params_sparse(self) -> int:
@@ -94,7 +88,9 @@ class ModuleSparsificationInfo:
         """
         return sum(
             round(tensor_sparsity(param).item() * torch.numel(param))
-            for param in tqdm(self.trainable_params, desc="Calculating model sparsity")
+            for param in tqdm(
+                self.trainable_params.values(), desc="Calculating model sparsity"
+            )
         )
 
     @property
@@ -105,58 +101,14 @@ class ModuleSparsificationInfo:
         return self.params_sparse / float(self.params_total) * 100
 
     @property
-    def params_prunable_total(self) -> int:
-        """
-        :return: total number of parameters across prunable layers
-        """
-        return sum(
-            torch.numel(layer.weight)
-            for (name, layer) in get_prunable_layers(self.module)
-        )
-
-    @property
-    def params_prunable_sparse(self) -> int:
-        """
-        :return: total number of sparse (0) parameters across prunable lauyers
-        """
-        return sum(
-            round(tensor_sparsity(layer.weight).item() * torch.numel(layer.weight))
-            for (name, layer) in tqdm(
-                get_prunable_layers(self.module), desc="Calculating model sparsity"
-            )
-        )
-
-    @property
-    def params_prunable_sparse_percent(self) -> float:
-        """
-        :return: percent of prunable parameters that have been pruned
-        """
-        return self.params_prunable_sparse / float(self.params_prunable_total) * 100
-
-    @property
-    def params_quantizable(self) -> int:
-        """
-        :return: number of parameters that are included in quantizable layers
-        """
-        return sum(
-            torch.numel(layer.weight)
-            + (
-                torch.numel(layer.bias)
-                if hasattr(layer, "bias") and layer.bias is not None
-                else 0
-            )
-            for (name, layer) in get_quantizable_layers(self.module)
-        )
-
-    @property
     def params_quantized(self) -> int:
         """
         :return: number of parameters across quantized layers
         """
         return sum(
-            torch.numel(layer.weight)
+            torch.numel(self.trainable_params[f"{name}.weight"])
             + (
-                torch.numel(layer.bias)
+                torch.numel(self.trainable_params[f"{name}.bias"])
                 if hasattr(layer, "bias") and layer.bias is not None
                 else 0
             )
@@ -168,21 +120,7 @@ class ModuleSparsificationInfo:
         """
         :return: percentage of parameters that have been quantized
         """
-        return self.params_quantized / float(self.params_quantizable) * 100
-
-    @property
-    def params_info(self) -> Dict[str, Dict]:
-        """
-        :return: dict of parameter name to its sparsification information
-        """
-        return {
-            f"{name}.weight": {
-                "numel": torch.numel(layer.weight),
-                "sparsity": tensor_sparsity(layer.weight).item(),
-                "quantized": hasattr(layer, "weight_fake_quant"),
-            }
-            for (name, layer) in get_prunable_layers(self.module)
-        }
+        return self.params_quantized / float(self.params_total) * 100
 
 
 class GradSampler:

--- a/src/llmcompressor/pytorch/utils/sparsification.py
+++ b/src/llmcompressor/pytorch/utils/sparsification.py
@@ -56,9 +56,9 @@ class ModuleSparsificationInfo:
             if hasattr(module, "_hf_hook"):
                 self.trainable_params = get_state_dict_offloaded_model(module)
             else:
-                self.trainable_params = list(
-                    filter(lambda param: param.requires_grad, self.module.parameters())
-                )
+                self.trainable_params = {
+                    k: v for k, v in self.module.named_parameters() if v.requires_grad
+                }
 
     def __str__(self):
         return json.dumps(

--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -107,7 +107,7 @@ def hessian_memory_requirements(model: torch.nn.Module):
                     # max extra memory for inverse calculation
                     max_column_size = column_size
 
-    bytes_per_weight = 32 // 4  # hessians are float32
+    bytes_per_weight = 32 // 8  # hessians are float32
     inverse_reserved = max_column_size * max_column_size
     return (total_hessian_elems + inverse_reserved) * bytes_per_weight
 

--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -135,7 +135,13 @@ def quantization_memory_requirement(model: torch.nn.Module) -> int:
             for param in module.parameters():
                 # assume the max of group 128 and static scale/zp
                 # TODO: base this on the recipe instead instead of assuming max
-                max_quant_shape = param.shape[0] * param.shape[1] // 128
+
+                # potentially just bias term
+                max_quant_shape = param.shape[0] // 128
+
+                if len(param.size()) > 1:  # weights
+                    max_quant_shape *= param.shape[1]
+
                 total_elements += max_quant_shape * 4
 
     bytes_ratio = 32 // 16  # assuming float16

--- a/src/llmcompressor/transformers/compression/sparsity_config.py
+++ b/src/llmcompressor/transformers/compression/sparsity_config.py
@@ -33,7 +33,7 @@ class SparsityConfigMetadata:
         """
 
         info = ModuleSparsificationInfo(model, state_dict=state_dict)
-        global_sparsity = info.params_sparse_percent
+        global_sparsity = info.params_sparse_percent / 100.0  # convert % to float
         return global_sparsity
 
     @staticmethod

--- a/src/llmcompressor/transformers/finetune/data/base.py
+++ b/src/llmcompressor/transformers/finetune/data/base.py
@@ -182,17 +182,28 @@ class TextGenerationDataset(RegistryMixin):
         column_names = dataset.column_names
         if isinstance(column_names, dict):
             column_names = column_names[list(column_names)[0]]
-        dataset = self.map(
-            dataset,
-            function=label_fn,
-            batched=False,  # not compatible with batching due to needing row lengths
-            remove_columns=[self.PROMPT_KEY]
-            if self.PROMPT_KEY in column_names
-            else None,
-            num_proc=self.data_args.preprocessing_num_workers,
-            load_from_cache_file=not self.data_args.overwrite_cache,
-            desc="Adding labels",
-        )
+
+        add_labels = False
+        if add_labels:
+            dataset = self.map(
+                dataset,
+                function=label_fn,
+                batched=False,  # not compatible with batching, need row lengths
+                remove_columns=[self.PROMPT_KEY]
+                if self.PROMPT_KEY in column_names
+                else None,
+                num_proc=self.data_args.preprocessing_num_workers,
+                load_from_cache_file=not self.data_args.overwrite_cache,
+                desc="Adding labels",
+            )
+        else:
+            dataset = self.map(
+                dataset,
+                batched=False,  # not compatible with batching, need row lengths
+                remove_columns=[self.PROMPT_KEY]
+                if self.PROMPT_KEY in column_names
+                else None,
+            )
 
         return dataset
 

--- a/src/llmcompressor/transformers/finetune/data/base.py
+++ b/src/llmcompressor/transformers/finetune/data/base.py
@@ -94,12 +94,15 @@ class TextGenerationDataset(RegistryMixin):
             **self.raw_kwargs,
         )
 
-    def tokenize_and_process(self, raw_dataset: Optional[Dataset] = None) -> Dataset:
+    def tokenize_and_process(
+        self, raw_dataset: Optional[Dataset] = None, add_labels: Optional[bool] = False
+    ) -> Dataset:
         """
         Sets up the raw dataset for finetuning, performs tokenization, concatenates
         entries to max sequence length if desired, and adds labels to each entry
 
         :param raw_dataset: dataset to process
+        :param add_labels: whether to include labels in tokenized output
         """
 
         # helper fn for tokenizing text column
@@ -183,7 +186,6 @@ class TextGenerationDataset(RegistryMixin):
         if isinstance(column_names, dict):
             column_names = column_names[list(column_names)[0]]
 
-        add_labels = False
         if add_labels:
             dataset = self.map(
                 dataset,

--- a/src/llmcompressor/transformers/finetune/data/base.py
+++ b/src/llmcompressor/transformers/finetune/data/base.py
@@ -95,7 +95,7 @@ class TextGenerationDataset(RegistryMixin):
         )
 
     def tokenize_and_process(
-        self, raw_dataset: Optional[Dataset] = None, add_labels: Optional[bool] = False
+        self, raw_dataset: Optional[Dataset] = None, add_labels: Optional[bool] = True
     ) -> Dataset:
         """
         Sets up the raw dataset for finetuning, performs tokenization, concatenates

--- a/src/llmcompressor/transformers/finetune/runner.py
+++ b/src/llmcompressor/transformers/finetune/runner.py
@@ -65,7 +65,7 @@ class StageRunner:
         self.parent_output_dir = self._training_args.output_dir
         self._output_dir = self._training_args.output_dir
 
-    def populate_datasets(self, tokenizer: "AutoTokenizer"):
+    def populate_datasets(self, tokenizer: "AutoTokenizer", add_labels: bool = False):
         """
         Loads datasets for each flow based on data_args, stores a Dataset for each
         enabled flow in self.datasets
@@ -117,7 +117,9 @@ class StageRunner:
             else:
                 # dataset needs to be tokenized
                 raw_dataset = dataset_manager.get_raw_dataset()
-                tokenized_dataset = dataset_manager.tokenize_and_process(raw_dataset)
+                tokenized_dataset = dataset_manager.tokenize_and_process(
+                    raw_dataset, add_labels=add_labels
+                )
                 tokenized_datasets[split_name] = tokenized_dataset
 
         self.datasets = make_dataset_splits(

--- a/src/llmcompressor/transformers/finetune/runner.py
+++ b/src/llmcompressor/transformers/finetune/runner.py
@@ -65,7 +65,7 @@ class StageRunner:
         self.parent_output_dir = self._training_args.output_dir
         self._output_dir = self._training_args.output_dir
 
-    def populate_datasets(self, tokenizer: "AutoTokenizer", add_labels: bool = False):
+    def populate_datasets(self, tokenizer: "AutoTokenizer", add_labels: bool = True):
         """
         Loads datasets for each flow based on data_args, stores a Dataset for each
         enabled flow in self.datasets

--- a/src/llmcompressor/transformers/finetune/runner.py
+++ b/src/llmcompressor/transformers/finetune/runner.py
@@ -73,6 +73,7 @@ class StageRunner:
         :param tokenizer: tokenizer to use for dataset tokenization
         """
         if self._data_args.dataset is None:
+            self.tokenizer = self._model_args.tokenizer
             logger.info(
                 "Running oneshot without calibration data. This is expected for "
                 "weight-only and dynamic quantization"

--- a/src/llmcompressor/transformers/finetune/runner.py
+++ b/src/llmcompressor/transformers/finetune/runner.py
@@ -147,11 +147,12 @@ class StageRunner:
 
         # if we don't run a forward pass after initializing the FSDP model for the
         # first time, calls to summon_full_params will fail ¯\_(ツ)_/¯
-        dummy_inp = dict(next(iter(calib_data)))
-        model_device = next(self.trainer.model.parameters()).device
-        dummy_inp = tensors_to_device(dummy_inp, model_device)
-        with torch.no_grad():
-            self.trainer.model(**dummy_inp)
+        if is_fsdp_model(self.trainer.model):
+            dummy_inp = dict(next(iter(calib_data)))
+            model_device = next(self.trainer.model.parameters()).device
+            dummy_inp = tensors_to_device(dummy_inp, model_device)
+            with torch.no_grad():
+                self.trainer.model(**dummy_inp)
         self.trainer.accelerator.wait_for_everyone()
 
         self.trainer.one_shot(calib_data, stage=stage)

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -492,10 +492,10 @@ class SessionManagerMixIn:
             f"{sparsification_info.params_total} total params. "
         )
         sparsity_percent_formatted = "{:.2f}".format(
-            sparsification_info.params_prunable_sparse_percent
+            sparsification_info.params_sparse_percent
         )
         logger.info(
-            f"There are {sparsification_info.params_prunable_total} prunable "
+            f"There are {sparsification_info.params_total} prunable "
             f"params which have {sparsity_percent_formatted}% "
             "avg sparsity."
         )
@@ -504,7 +504,7 @@ class SessionManagerMixIn:
             sparsification_info.params_quantized_percent
         )
         logger.info(
-            f"There are {sparsification_info.params_quantizable} quantizable "
+            f"There are {sparsification_info.params_total} quantizable "
             f"params, with a quantization percentage of "
             f"{quant_percent_formatted}%."
         )

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -107,7 +107,8 @@ class SessionManagerMixIn:
         if self.is_fsdp_enabled:
             self._prepare_model_for_fsdp()
 
-        self.min_tokens_per_module = data_args.min_tokens_per_module
+        if data_args is not None:
+            self.min_tokens_per_module = data_args.min_tokens_per_module
 
     def initialize_session(
         self,

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -411,7 +411,7 @@ class SessionManagerMixIn:
         )
 
         # log model sparsity
-        self.maybe_log_model_sparsification()
+        # self.maybe_log_model_sparsification()
         self.accelerator.wait_for_everyone()
 
     def save_model(

--- a/src/llmcompressor/transformers/finetune/text_generation.py
+++ b/src/llmcompressor/transformers/finetune/text_generation.py
@@ -313,7 +313,8 @@ def main(
     stage_runner = StageRunner(
         model_args=model_args, data_args=data_args, training_args=training_args
     )
-    stage_runner.populate_datasets(tokenizer=tokenizer)
+    add_labels = training_args.do_train or training_args.run_stages
+    stage_runner.populate_datasets(tokenizer=tokenizer, add_labels=add_labels)
     train_dataset = stage_runner.get_dataset_split("train")
     eval_dataset = stage_runner.get_dataset_split("validation")
     calib_dataset = stage_runner.get_dataset_split("calibration")

--- a/src/llmcompressor/transformers/finetune/training_args.py
+++ b/src/llmcompressor/transformers/finetune/training_args.py
@@ -65,7 +65,3 @@ class TrainingArguments(HFTrainingArgs):
             "checkpoints will be written."
         },
     )
-
-    @property
-    def place_model_on_device(self):
-        return False

--- a/src/llmcompressor/transformers/finetune/training_args.py
+++ b/src/llmcompressor/transformers/finetune/training_args.py
@@ -65,3 +65,7 @@ class TrainingArguments(HFTrainingArgs):
             "checkpoints will be written."
         },
     )
+
+    @property
+    def place_model_on_device(self):
+        return False

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import torch
 import transformers
-from accelerate import Accelerator
 from accelerate.accelerator import get_state_dict_offloaded_model
 from compressed_tensors import ModelCompressor, SparsityCompressionConfig
 from loguru import logger
@@ -106,10 +105,11 @@ def modify_save_pretrained(model: PreTrainedModel):
                 quantization_format=quantization_format,
             )
 
-            accelerator = Accelerator()
             if compressor is None:
                 # model is not compressed or quantized, save as normal
-                accelerator.save_model(model, save_directory=save_directory, **kwargs)
+                original_save_pretrained.__get__(model, model_class)(
+                    save_directory, **kwargs
+                )
                 return
 
             # if we've gotten to this point we have a config so we can run compression

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -1,7 +1,12 @@
+import re
 import weakref
 from functools import wraps
 from typing import Optional
 
+import torch
+import transformers
+from accelerate import Accelerator
+from accelerate.accelerator import get_state_dict_offloaded_model
 from compressed_tensors import ModelCompressor, SparsityCompressionConfig
 from loguru import logger
 from transformers import PreTrainedModel
@@ -59,6 +64,12 @@ def modify_save_pretrained(model: PreTrainedModel):
             saving a model in dense format
             :param kwargs: additional kwargs to pass on to model.save_pretrained
             """
+
+            # HACK: Override the dtype_byte_size function in transformers to
+            # support float8 types. Fix is posted upstream
+            # https://github.com/huggingface/transformers/pull/30488
+            transformers.modeling_utils.dtype_byte_size = new_dtype_byte_size
+
             model = model_ref()
             # state_dict gets passed in as a kwarg for FSDP models
             state_dict = kwargs.get("state_dict", None)
@@ -94,16 +105,16 @@ def modify_save_pretrained(model: PreTrainedModel):
                 sparsity_config=sparsity_config,
                 quantization_format=quantization_format,
             )
+
+            accelerator = Accelerator()
             if compressor is None:
                 # model is not compressed or quantized, save as normal
-                return original_save_pretrained.__get__(model, model_class)(
-                    save_directory, **kwargs
-                )
+                accelerator.save_model(model, save_directory=save_directory, **kwargs)
 
             # if we've gotten to this point we have a config so we can run compression
             kwargs["safe_serialization"] = True
             if state_dict is None:
-                state_dict = model.state_dict()
+                state_dict = get_state_dict_offloaded_model(model)
 
             # make sure we're on the main process when saving
             if state_dict is not None and len(state_dict) > 0:
@@ -120,3 +131,15 @@ def modify_save_pretrained(model: PreTrainedModel):
 
     # wrap save_pretrained
     model.save_pretrained = save_pretrained_compressed(model.save_pretrained)
+
+
+# HACK: Override the dtype_byte_size function in transformers to support float8 types
+# Fix is posted upstream https://github.com/huggingface/transformers/pull/30488
+def new_dtype_byte_size(dtype):
+    if dtype == torch.bool:
+        return 1 / 8
+    bit_search = re.search(r"[^\d](\d+)_?", str(dtype))
+    if bit_search is None:
+        raise ValueError(f"`dtype` is not a valid dtype: {dtype}.")
+    bit_size = int(bit_search.groups()[0])
+    return bit_size // 8

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -110,6 +110,7 @@ def modify_save_pretrained(model: PreTrainedModel):
             if compressor is None:
                 # model is not compressed or quantized, save as normal
                 accelerator.save_model(model, save_directory=save_directory, **kwargs)
+                return
 
             # if we've gotten to this point we have a config so we can run compression
             kwargs["safe_serialization"] = True

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -44,7 +44,7 @@ def modify_save_pretrained(model: PreTrainedModel):
             sparsity_config: Optional[SparsityCompressionConfig] = None,
             quantization_format: Optional[str] = None,
             save_compressed: bool = True,
-            skip_compression_stats: bool = False,
+            skip_compression_stats: bool = True,
             **kwargs,
         ):
             """

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -44,7 +44,7 @@ def modify_save_pretrained(model: PreTrainedModel):
             sparsity_config: Optional[SparsityCompressionConfig] = None,
             quantization_format: Optional[str] = None,
             save_compressed: bool = True,
-            skip_compression_stats: bool = True,
+            skip_compression_stats: bool = False,
             **kwargs,
         ):
             """

--- a/src/llmcompressor/transformers/sparsification/sparse_model.py
+++ b/src/llmcompressor/transformers/sparsification/sparse_model.py
@@ -74,7 +74,9 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
         )
 
         # instantiate compressor from model config
-        compressor = ModelCompressor.from_pretrained(pretrained_model_name_or_path)
+        compressor = ModelCompressor.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
 
         # temporarily set the log level to error, to ignore printing out long missing
         # and unexpected key error messages (these are EXPECTED for quantized models)
@@ -82,9 +84,19 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
         restore_log_level = transformers_logger.getEffectiveLevel()
         transformers_logger.setLevel(level=logging.ERROR)
 
+        if kwargs.get("trust_remote_code"):
+            # By artifically aliasing
+            # class name SparseAutoModelForCausallLM to
+            # AutoModelForCausalLM we can "trick" the
+            # `from_pretrained` method into properly
+            # resolving the logic when
+            # (has_remote_code and trust_remote_code) == True
+            cls.__name__ = AutoModelForCausalLM.__name__
+
         model = super(AutoModelForCausalLM, cls).from_pretrained(
             pretrained_model_name_or_path, *model_args, **kwargs
         )
+
         if model.dtype != model.config.torch_dtype:
             logger.warning(
                 f"The dtype of the loaded model: {model.dtype} is different "

--- a/tests/llmcompressor/transformers/finetune/test_session_mixin.py
+++ b/tests/llmcompressor/transformers/finetune/test_session_mixin.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional, Union
 
 import pytest
-from datasets import load_dataset
 from torch.nn import Module
 from transformers import AutoModelForCausalLM, Trainer
 
@@ -44,8 +43,8 @@ def mixin_trainer():
     model_state_path = "Xenova/llama2.c-stories15M"
     model = AutoModelForCausalLM.from_pretrained(model_state_path)
     recipe = "tests/llmcompressor/transformers/finetune/test_quantization.yaml"
-    train_dataset = load_dataset("garage-bAInd/Open-Platypus", split="train[:5%]")
-    eval_dataset = load_dataset("garage-bAInd/Open-Platypus", split="train[5%:6%]")
+    train_dataset = "open-platypus"
+    eval_dataset = "open-platypus"
 
     return MixInTest(
         model=model,


### PR DESCRIPTION
SUMMARY:
Fix for https://github.com/vllm-project/llm-compressor/issues/43
Bug came from `quantization_memory_requirement`, where code assumed the shape of module's param were always >2 dimensions. One dimension can happen just for the bias term. 


TEST PLAN:
Sample code generation. Model was star coder. 

Output: 
```
```
