### PR TITLE
Fix for issue #43 -- starcoder model

### DIFF
--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -138,7 +138,13 @@ def quantization_memory_requirement(model: torch.nn.Module) -> int:
             for param in module.parameters():
                 # assume the max of group 128 and static scale/zp
                 # TODO: base this on the recipe instead instead of assuming max
-                max_quant_shape = param.shape[0] * param.shape[1] // 128
+
+                # potentially just bias term
+                max_quant_shape = param.shape[0] // 128
+
+                if len(param.size()) > 1:  # weights
+                    max_quant_shape *= param.shape[1]
+
                 total_elements += max_quant_shape * 4
 
     bytes_ratio = 32 // 16  # assuming float16


### PR DESCRIPTION
SUMMARY:
FIx for issue
https://github.com/vllm-project/llm-compressor/issues/43

Culprit in `quantization_memory_requirement`, where the params of the module is assumed to be >1 Dimension. Bias term only has 1. 


TEST PLAN:
Startcoder model, so used sample code gen prompt in the oneshot-ed model
```
input_ids = tokenizer("Self attention in python", return_tensors="pt").input_ids.to(
    "cuda"
)
output = model.generate(input_ids, max_new_tokens=100)
print(tokenizer.decode(output[0]))
```
Output
```
import numpy as np
import torch
import torch.nn as nn
import torch.nn.functional as F

class SelfAttention(nn.Module):
    def __init__(self, embed_size, heads):
        super(SelfAttention, self).__init__()
        self.embed_size = embed_size
        self.heads = heads
        self.head_dim = embed_size // heads
        
        assert (self.head_dim * heads ==
```
