### PR TITLE
Propagate `trust_remote_code` Argument

### DIFF
--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -165,7 +165,7 @@ def custom_offload_device_map(
     :param max_memory_per_gpu: Max memory to allocate on each GPU, as either a string
         such as "10GB" or an integer number of bytes
     :param num_gpus: number of gpus to utilize
-    :param \**model_kwargs: keyword arguments to pass to model initializer
+    :param **model_kwargs: keyword arguments to pass to model initializer
     :return: memory mapping for layers of model_stub to be passed to from_pretrained()
     """
     max_cpu_memory = psutil.virtual_memory().available
@@ -174,9 +174,7 @@ def custom_offload_device_map(
 
     device_map = {}
     with init_empty_weights():
-        dummy_model = AutoModelForCausalLM.from_pretrained(
-            model_stub, **model_kwargs
-        )
+        dummy_model = AutoModelForCausalLM.from_pretrained(model_stub, **model_kwargs)
         device_map = infer_auto_device_map(
             dummy_model,
             max_memory=memory_limits,
@@ -200,7 +198,7 @@ def calculate_offload_device_map(
     :param model_stub: local path or HF stub to calculate mapping for
     :param reserve_for_hessians: whether to reserve memory for GPTQ
     :param num_gpus: number of gpus to utilize
-    :param \**model_kwargs: keyword arguments to pass to model initializer
+    :param **model_kwargs: keyword arguments to pass to model initializer
     :return: memory mapping for layers of model_stub to be passed to from_pretrained()
     """
     max_cpu_memory = psutil.virtual_memory().available
@@ -214,9 +212,7 @@ def calculate_offload_device_map(
 
     device_map = {}
     with init_empty_weights():
-        dummy_model = AutoModelForCausalLM.from_pretrained(
-            model_stub, **model_kwargs
-        )
+        dummy_model = AutoModelForCausalLM.from_pretrained(model_stub, **model_kwargs)
 
         reserved_memory = 0
         if reserve_for_hessians:

--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -165,7 +165,7 @@ def custom_offload_device_map(
     :param max_memory_per_gpu: Max memory to allocate on each GPU, as either a string
         such as "10GB" or an integer number of bytes
     :param num_gpus: number of gpus to utilize
-    :param **model_kwargs: keyword arguments to pass to model initializer
+    :param model_kwargs: keyword arguments to pass to model initializer
     :return: memory mapping for layers of model_stub to be passed to from_pretrained()
     """
     max_cpu_memory = psutil.virtual_memory().available
@@ -198,7 +198,7 @@ def calculate_offload_device_map(
     :param model_stub: local path or HF stub to calculate mapping for
     :param reserve_for_hessians: whether to reserve memory for GPTQ
     :param num_gpus: number of gpus to utilize
-    :param **model_kwargs: keyword arguments to pass to model initializer
+    :param model_kwargs: keyword arguments to pass to model initializer
     :return: memory mapping for layers of model_stub to be passed to from_pretrained()
     """
     max_cpu_memory = psutil.virtual_memory().available

--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -155,7 +155,7 @@ def custom_offload_device_map(
     model_stub: str,
     max_memory_per_gpu: Union[str, int],
     num_gpus: int = 1,
-    torch_dtype: torch.dtype = torch.float16,
+    **model_kwargs,
 ) -> Dict[Union[int, str], Union[int, str]]:
     """
     Calculates the optimal gpu mappings for model_stub stored as torch_dtype, where
@@ -165,7 +165,7 @@ def custom_offload_device_map(
     :param max_memory_per_gpu: Max memory to allocate on each GPU, as either a string
         such as "10GB" or an integer number of bytes
     :param num_gpus: number of gpus to utilize
-    :param torch_dtype: dtype model will be loaded as
+    :param \**model_kwargs: keyword arguments to pass to model initializer
     :return: memory mapping for layers of model_stub to be passed to from_pretrained()
     """
     max_cpu_memory = psutil.virtual_memory().available
@@ -175,7 +175,7 @@ def custom_offload_device_map(
     device_map = {}
     with init_empty_weights():
         dummy_model = AutoModelForCausalLM.from_pretrained(
-            model_stub, torch_dtype=torch_dtype
+            model_stub, **model_kwargs
         )
         device_map = infer_auto_device_map(
             dummy_model,
@@ -191,7 +191,7 @@ def calculate_offload_device_map(
     model_stub: str,
     reserve_for_hessians=False,
     num_gpus: int = 1,
-    torch_dtype: torch.dtype = torch.float16,
+    **model_kwargs,
 ) -> Dict[Union[int, str], Union[int, str]]:
     """
     Calculates the optimal gpu mappings for model_stub stored as torch_dtype. Takes
@@ -200,7 +200,7 @@ def calculate_offload_device_map(
     :param model_stub: local path or HF stub to calculate mapping for
     :param reserve_for_hessians: whether to reserve memory for GPTQ
     :param num_gpus: number of gpus to utilize
-    :param torch_dtype: dtype model will be loaded as
+    :param \**model_kwargs: keyword arguments to pass to model initializer
     :return: memory mapping for layers of model_stub to be passed to from_pretrained()
     """
     max_cpu_memory = psutil.virtual_memory().available
@@ -215,7 +215,7 @@ def calculate_offload_device_map(
     device_map = {}
     with init_empty_weights():
         dummy_model = AutoModelForCausalLM.from_pretrained(
-            model_stub, torch_dtype=torch_dtype
+            model_stub, **model_kwargs
         )
 
         reserved_memory = 0

--- a/src/llmcompressor/transformers/finetune/model_args.py
+++ b/src/llmcompressor/transformers/finetune/model_args.py
@@ -69,3 +69,11 @@ class ModelArguments:
             "model has a output word embedding layer."
         },
     )
+    trust_remote: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether or not to allow for custom models to execute their "
+            "own modeling files. This option should only be set to True for "
+            "repositories you trust and in which you have read the code"
+        },
+    )

--- a/src/llmcompressor/transformers/finetune/model_args.py
+++ b/src/llmcompressor/transformers/finetune/model_args.py
@@ -69,7 +69,7 @@ class ModelArguments:
             "model has a output word embedding layer."
         },
     )
-    trust_remote: bool = field(
+    trust_remote_code: bool = field(
         default=False,
         metadata={
             "help": "Whether or not to allow for custom models to execute their "

--- a/src/llmcompressor/transformers/finetune/text_generation.py
+++ b/src/llmcompressor/transformers/finetune/text_generation.py
@@ -146,12 +146,14 @@ def intialize_model_from_path(
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
         tie_word_embeddings=model_args.tie_word_embeddings,
+        trust_remote_code=model_args.trust_remote_code,
     )
     teacher_config = (
         AutoConfig.from_pretrained(
             model_args.distill_teacher,
             use_auth_token=True if model_args.use_auth_token else None,
             tie_word_embeddings=model_args.tie_word_embeddings,
+            trust_remote_code=model_args.trust_remote_code,
         )
         if model_args.distill_teacher
         else None

--- a/src/llmcompressor/transformers/finetune/text_generation.py
+++ b/src/llmcompressor/transformers/finetune/text_generation.py
@@ -185,6 +185,7 @@ def intialize_model_from_path(
         "use_auth_token": True if model_args.use_auth_token else None,
         "torch_dtype": parse_dtype(model_args.precision),
         "device_map": device_map,
+        "trust_remote_code": model_args.trust_remote_code,
     }
     teacher_device_map = None if fsdp_enabled else "auto"
     teacher_kwargs = {
@@ -193,6 +194,7 @@ def intialize_model_from_path(
         "use_auth_token": True if model_args.use_auth_token else None,
         "torch_dtype": parse_dtype(model_args.precision),
         "device_map": teacher_device_map,
+        "trust_remote_code": model_args.trust_remote_code,
     }
     # this calls from_pretrained under the hood so should be FSDP safe
     model = SparseAutoModel.text_generation_from_pretrained(
@@ -223,6 +225,7 @@ def initialize_tokenizer_from_path(model_args, model, teacher):
         use_fast=True,
         revision=model_args.model_revision,
         use_auth_token=True if model_args.use_auth_token else None,
+        trust_remote_code=model_args.trust_remote_code,
     )
 
     return tokenizer


### PR DESCRIPTION
SUMMARY:
FIX #89

The `trust_remote_code` argument is propagated to the following class initializers
* tokenizer
* model
* teacher model
>! Note that `trust_remote_code` is already propagated to compressor from model

Model kwargs are added to functions which construct models to allow for the `trust_remote_code` argument to be passed
* `custom_offload_device_map`
* `calculate_offload_device_map`

TEST PLAN:
The tokenizer and model propagations were both tested using `microsoft/Phi-3-small-128k-instruct`, which requires the trust remote code option. One regression test of the one_shot function was performed.