### PR TITLE
demote recipe string initialization to debug and make more descriptive

### DIFF
--- a/src/llmcompressor/recipe/recipe.py
+++ b/src/llmcompressor/recipe/recipe.py
@@ -118,9 +118,9 @@ class Recipe(RecipeBase):
         if not os.path.isfile(path_or_modifiers):
             # not a local file
             # assume it's a string
-            logger.warning(
-                "Could not process input as a file path or zoo stub, "
-                "attempting to process it as a string."
+            logger.debug(
+                "Could not initialize recipe as a file path or zoo stub, "
+                "attempting to process as a string."
             )
             logger.debug(f"Input string: {path_or_modifiers}")
             obj = _load_json_or_yaml_string(path_or_modifiers)


### PR DESCRIPTION
```
2024-08-26T19:43:23.486418+0000 | create_instance | WARNING - Could not process input as a file path or zoo stub, attempting to process it as a string.
```

This message appears when compressing a model from a recipe string. As this is a common and well supported use case, this message should be on the debug level rather than warning level.

Additionally, this message appears without much context as to what "instance", "input", or "it" is.


Now:
```
2024-08-26T19:43:23.486418+0000 | create_instance | DEBUG - Could not initialize recipe as a file path or zoo stub, attempting to process as a string.
```