### PR TITLE
compressed-tensors main dependency for base-tests

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -46,6 +46,7 @@ jobs:
         with:
           python-version: '3.11'
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
@@ -65,6 +66,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
           repository: "neuralmagic/compressed-tensors"
@@ -87,6 +89,7 @@ jobs:
         with:
           python-version: '3.9'
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
@@ -107,6 +110,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
           repository: "neuralmagic/compressed-tensors"

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -46,6 +46,14 @@ jobs:
         with:
           python-version: '3.11'
       - uses: actions/checkout@v2
+        with:
+          repository: "neuralmagic/compressed-tensors"
+          path: "compressed-tensors"
+          ref: ${{needs.test-setup.outputs.branch}}
+      - name: "⚙️ Install compressed-tensors dependencies"
+        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+      - name: "Clean compressed-tensors directory"
+        run: rm -r compressed-tensors/
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev]
       - name: "🔬 Running base tests"
@@ -57,7 +65,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
           repository: "neuralmagic/compressed-tensors"
@@ -80,7 +87,6 @@ jobs:
         with:
           python-version: '3.9'
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
@@ -101,7 +107,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
           repository: "neuralmagic/compressed-tensors"


### PR DESCRIPTION
SUMMARY:
* Add `compressed-tensors` checkout and build to `base-tests` gha

TEST PLAN:
* See below tests
