### PR TITLE
Set `ready` label for transformer tests; add message reminder on PR opened

### DIFF
--- a/.github/workflows/set-comment.yaml
+++ b/.github/workflows/set-comment.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   pr_reminder:
-    if: contains(github.event.pull_request.labels.*.name, 'ready')
     runs-on: ubuntu-latest
     steps:
       - name: Remind to run full CI on PR

--- a/.github/workflows/set-comment.yaml
+++ b/.github/workflows/set-comment.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - main
-    types: [labeled]
+    types: [opened, synchronize]
 
 jobs:
   pr_reminder:

--- a/.github/workflows/set-comment.yaml
+++ b/.github/workflows/set-comment.yaml
@@ -1,0 +1,24 @@
+name: PR Reminder Comment Bot
+on: 
+  pull_request:
+    branches:
+      - main
+    types: [labeled]
+
+jobs:
+  pr_reminder:
+    if: contains(github.event.pull_request.labels.*.name, 'ready')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remind to run full CI on PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '👋 Hi! Thank you for contributing to llm-compressors. Please add the ready label when the PR is ready for review.'
+            })
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/set-comment.yaml
+++ b/.github/workflows/set-comment.yaml
@@ -3,13 +3,13 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   pr_reminder:
     runs-on: ubuntu-latest
     steps:
-      - name: Remind to run full CI on PR
+      - name: Remind to add ready label
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/set-comment.yaml
+++ b/.github/workflows/set-comment.yaml
@@ -17,7 +17,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '👋 Hi! Thank you for contributing to llm-compressors. Please add the ready label when the PR is ready for review.'
+              body: '👋 Hi! Thank you for contributing to llm-compressor. Please add the ready label when the PR is ready for review.'
             })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -95,6 +95,7 @@ jobs:
         run: |
           pytest tests/llmcompressor/pytorch -v
   transformers-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'ready')
     runs-on: ubuntu-22.04
     needs: test-setup
     steps:

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - 'release/*'
+    types: [labeled]
 
 env:
   CADENCE: "commit"

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
       - 'release/*'
-    types: [labeled]
+    types: [labeled, opened, synchronize]
 
 env:
   CADENCE: "commit"


### PR DESCRIPTION
SUMMARY:
- Update such that a `ready` label is required before the transformer tests can run
- Post a reminder on PR opened about the `ready` label

