### PR TITLE
fix build error for nightly

### DIFF
--- a/src/llmcompressor/version.py
+++ b/src/llmcompressor/version.py
@@ -5,7 +5,6 @@ This module provides functionality for creating semantic version strings based o
 version base and build type. It supports `release`, `nightly`, and `dev` build types.
 """
 
-from datetime import datetime
 from typing import Optional, Tuple
 
 # Define the base version and build type
@@ -16,6 +15,8 @@ build_type = "dev"  # can be 'release', 'nightly', 'dev', or 'dev' with a dev nu
 def _generate_version_attributes(
     base, type_
 ) -> Tuple[str, int, int, int, Optional[str]]:
+    from datetime import datetime
+
     parts = base.split(".")
     major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
 


### PR DESCRIPTION
SUMMARY:
To fix following error:

$ make build
python3 setup.py sdist bdist_wheel 
Extracting version info from /home/dhuang/llm-compressor/src/llmcompressor
Traceback (most recent call last):
  File "/home/dhuang/llm-compressor/setup.py", line 13, in <module>
    version_info = extract_version_info(package_path)
  File "/home/dhuang/llm-compressor/utils/version_extractor.py", line 38, in extract_version_info
    exec(open(version_path).read(), globals(), locals_dict)
  File "<string>", line 39, in <module>
  File "<string>", line 25, in _generate_version_attributes
NameError: name 'datetime' is not defined
make: *** [Makefile:38: build] Error 1


TEST PLAN:
workflow to automate nightly build
