### PR TITLE
Bug Fix: recipe stages were not being concatenated

### DIFF
--- a/src/llmcompressor/transformers/sparsification/sparse_model.py
+++ b/src/llmcompressor/transformers/sparsification/sparse_model.py
@@ -146,7 +146,6 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
                 compressor.decompress(
                     model_path=pretrained_model_name_or_path, model=model
                 )
-        # if recipe:
         recipe = resolve_recipe(recipe=recipe, model_path=pretrained_model_name_or_path)
 
         if recipe:

--- a/src/llmcompressor/transformers/sparsification/sparse_model.py
+++ b/src/llmcompressor/transformers/sparsification/sparse_model.py
@@ -14,10 +14,14 @@ from loguru import logger
 from torch.nn import Module
 from transformers import AutoModelForCausalLM, PreTrainedModel
 
+from llmcompressor.pytorch.model_load.helpers import initialize_recipe
 from llmcompressor.transformers.sparsification.compressed_tensors_utils import (
     modify_save_pretrained,
 )
-from llmcompressor.transformers.utils.helpers import download_model_directory
+from llmcompressor.transformers.utils.helpers import (
+    download_model_directory,
+    resolve_recipe,
+)
 
 __all__ = ["SparseAutoModel", "SparseAutoModelForCausalLM", "get_shared_tokenizer_src"]
 
@@ -142,6 +146,11 @@ class SparseAutoModelForCausalLM(AutoModelForCausalLM):
                 compressor.decompress(
                     model_path=pretrained_model_name_or_path, model=model
                 )
+        # if recipe:
+        recipe = resolve_recipe(recipe=recipe, model_path=pretrained_model_name_or_path)
+
+        if recipe:
+            initialize_recipe(model=model, recipe_path=recipe)
 
         return model
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -104,6 +104,7 @@ def parse_params(
                 logging.info(
                     f"Skipping testing model: {file} for cadence: {expected_cadence}"
                 )
+
     if isinstance(configs_directory, list):
         for config in configs_directory:
             _parse_configs_dir(config)


### PR DESCRIPTION
SUMMARY:
The recipe stages weren't being concatenated on consecutive runs leading to failures while running tests such as `tests/llmcompressor/transformers/obcq/test_consecutive_runs.py::TestConsecutiveRunsSmall_0_commit::test_consecutive_runs_small - AssertionError: 1 != 2`


TEST PLAN:
The failing test now passes
