### PR TITLE
Fix help dialogue

### DIFF
--- a/src/llmcompressor/transformers/finetune/data/data_args.py
+++ b/src/llmcompressor/transformers/finetune/data/data_args.py
@@ -45,9 +45,8 @@ class CustomDataTrainingArguments(DVCDatasetTrainingArguments):
         default=None,
         metadata={
             "help": (
-                "The preprocessing function to apply ",
-                "or the preprocessing func name in "
-                "src/llmcompressor/transformers/utils/preprocessing_functions.py",
+                "The preprocessing function to apply or the preprocessing func name in "
+                "src/llmcompressor/transformers/utils/preprocessing_functions.py"
             )
         },
     )


### PR DESCRIPTION
## Purpose ##
* Fix bug where value error would be thrown if user tried to use any entrypoint with the `--help` flag
```
AttributeError: 'tuple' object has no attribute 'strip'
```

## Changes ##
* Replace the tuple which was giving the error with a string

## Testing ##
Running these commands now properly shows the help dialogue
```bash
llmcompressor.transformers.text_generation.oneshot -h
llmcompressor.transformers.text_generation.finetune -h
llmcompressor.transformers.text_generation.oneshot --help
llmcompressor.transformers.text_generation.finetune --help
```