### PR TITLE
Fix Sparsity Unit Test

### DIFF
--- a/src/llmcompressor/modifiers/obcq/utils/sgpt_wrapper.py
+++ b/src/llmcompressor/modifiers/obcq/utils/sgpt_wrapper.py
@@ -124,7 +124,6 @@ class SparseGptWrapper(ModuleCompressionWrapper):
                 torch.tensor(0, dtype=torch.bool),
             )
             current_sparsity = mask.sum() / W.numel()
-            print(current_sparsity, sparsity)
             if current_sparsity > sparsity:
                 raise ValueError(
                     "The target sparsity is lower than the sparsity "

--- a/tests/llmcompressor/transformers/obcq/recipes/quant_and_sparse.yaml
+++ b/tests/llmcompressor/transformers/obcq/recipes/quant_and_sparse.yaml
@@ -1,11 +1,5 @@
 test_stage:
   obcq_modifiers:
-    SmoothQuantModifier:
-      smoothing_strength: 0.5
-      mappings: [
-        [["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"], "re:.*input_layernorm"],
-        [["re:.*gate_proj", "re:.*up_proj"], "re:.*post_attention_layernorm"]
-      ]
     QuantizationModifier:
       ignore: ["lm_head"]
       config_groups:
@@ -13,12 +7,13 @@ test_stage:
           weights:
             num_bits: 8
           targets: ["Linear"]
+    GPTQModifier:
+      block_size: 128
+      sequential_update: True
     SparseGPTModifier:
       sparsity: 0.5
       block_size: 128
       sequential_update: False
       percdamp: 0.01
       mask_structure: "0:0"
-    GPTQModifier:
-      block_size: 128
-      sequential_update: False
+      targets: ["model.layers.0"]

--- a/tests/llmcompressor/transformers/obcq/recipes/quant_and_sparse.yaml
+++ b/tests/llmcompressor/transformers/obcq/recipes/quant_and_sparse.yaml
@@ -1,5 +1,11 @@
 test_stage:
   obcq_modifiers:
+    SmoothQuantModifier:
+      smoothing_strength: 0.5
+      mappings: [
+        [["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"], "re:.*input_layernorm"],
+        [["re:.*gate_proj", "re:.*up_proj"], "re:.*post_attention_layernorm"]
+      ]
     QuantizationModifier:
       ignore: ["lm_head"]
       config_groups:


### PR DESCRIPTION
SUMMARY:
Fix for failing test detailed in https://app.asana.com/0/1208216504433080/1208216504433083/f. The issue was the quantization modifier was affecting the sparsity, and we weren't checking the mask in the appropriate location. 

TEST PLAN:
Failing nightly test now passes, confirmed locally on janice
