### PR TITLE
Add descriptions for pytest marks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,7 @@ extend-ignore = 'E203'
 markers = [
     "smoke: quick tests to check basic functionality",
     "sanity: tests to ensure that new changes do not break existing functionality",
-    "regression: detailed tests to ensure major functions work correctly"
+    "regression: detailed tests to ensure major functions work correctly",
+    "integration: tests which integrate with a third party service such as HF",
+    "unit: tests to ensure code correctness and regression test functionality",
 ]


### PR DESCRIPTION
## Purpose ##
* Reduce the number of warnings when running tests

## Changes ##
* Add test mark descriptions in the project toml

## Testing ##
* I grepped the codebase for `pytest.mark.` and found that the added flags cover all the flags used
