### PR TITLE
Fix: Error during model saving with shared tensors

### DIFF
--- a/examples/trl_mixin/ex_trl_distillation.py
+++ b/examples/trl_mixin/ex_trl_distillation.py
@@ -58,6 +58,7 @@ training_args = TrainingArguments(
     logging_steps=50,
     gradient_checkpointing=True,
     bf16=True,
+    save_safetensors=False,  # workaround for shared tensors
 )
 trainer = SFTTrainer(
     model=model,

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -114,7 +114,8 @@ def modify_save_pretrained(model: PreTrainedModel):
                 return
 
             # if we've gotten to this point we have a config so we can run compression
-            kwargs["safe_serialization"] = True
+            # default safe serialization to True if not explicitly set
+            kwargs["safe_serialization"] = kwargs.get("safe_serialization", True)
             if state_dict is None:
                 state_dict = get_state_dict_offloaded_model(model)
 


### PR DESCRIPTION
SUMMARY:
Shared pointers cannot be directly saved using safetensors: https://huggingface.co/docs/safetensors/en/torch_shared_tensors


TEST PLAN:

`examples/trl_mixin/ex_trl_distillation.py` was executed e2e and completed w/o errors

```bash
.
.
.
                                                         
{'step_loss': 0.611039400100708, 'perplexity': 1.8423453569412231, 'distill_step_loss': 1.0392448902130127, 'epoch': 0.48}                                        
{'loss': 1.402, 'grad_norm': 5.75, 'learning_rate': 5.436720142602496e-06, 'epoch': 0.53}                                                                         
 89%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████▋             | 500/561 [14:27<01:45,  1.73s/it]2024-09-10T10:30:43.584831-0400 | save_pretrained_wrapper | INFO - Inferring a sparsity configuration requires a global sparsity calculation. This can be costly for large models. To skip the calculation of compression statistics set skip_compression_stats=True
Calculating model sparsity: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 579/579 [00:32<00:00, 17.81it/s]
Checking whether model follows 2:4 sparsity structure: 100%|██████████████████████████████████████████████████████████████████| 225/225 [00:00<00:00, 1295.42it/s]
2024-09-10T10:34:21.677614-0400 | save_model | INFO - Saved LLM Compressor recipe with model state to ./output_trl_sft_test_7b_gsm8k/checkpoint-500/recipe.yaml/s]
/home/rahul/llm-compressor/.venv/lib/python3.10/site-packages/torch/_dynamo/eval_frame.py:600: UserWarning: torch.utils.checkpoint: the use_reentrant parameter should be passed explicitly. In version 2.4 we will raise an exception if use_reentrant is not passed. use_reentrant=False is recommended, but if you need to preserve the current default behavior, you can pass use_reentrant=True. Refer to docs for more details on the differences between the two variants.
  return fn(*args, **kwargs)
{'step_loss': 0.4017972946166992, 'perplexity': 1.4945083856582642, 'distill_step_loss': 0.9399058818817139, 'epoch': 0.53}                                       
 89%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████▋             | 500/561 [18:35<01:45,  1.73s/it]/home/rahul/llm-compressor/.venv/lib/python3.10/site-packages/torch/utils/checkpoint.py:295: FutureWarning: `torch.cpu.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cpu', args...)` instead.
  with torch.enable_grad(), device_autocast_ctx, torch.cpu.amp.autocast(**ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
{'loss': 1.373, 'grad_norm': 4.65625, 'learning_rate': 9.80392156862745e-07, 'epoch': 0.59}                                                                       
{'step_loss': 0.4461307227611542, 'perplexity': 1.562255620956421, 'distill_step_loss': 0.8857428133487701, 'epoch': 0.59}                                        
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 561/561 [20:20<00:00,  1.72s/it]2024-09-10T10:36:36.477850-0400 | save_pretrained_wrapper | INFO - Inferring a sparsity configuration requires a global sparsity calculation. This can be costly for large models. To skip the calculation of compression statistics set skip_compression_stats=True
Calculating model sparsity: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 579/579 [00:33<00:00, 17.38it/s]
Checking whether model follows 2:4 sparsity structure: 100%|██████████████████████████████████████████████████████████████████| 225/225 [00:00<00:00, 1376.88it/s]
2024-09-10T10:37:25.394329-0400 | save_model | INFO - Saved LLM Compressor recipe with model state to ./output_trl_sft_test_7b_gsm8k/checkpoint-561/recipe.yaml/s]
{'train_runtime': 1299.3001, 'train_samples_per_second': 3.451, 'train_steps_per_second': 0.432, 'train_loss': 1.513728000688468, 'epoch': 0.6}                   
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 561/561 [21:39<00:00,  2.32s/it]
manager stage: Modifiers finalized
2024-09-10T10:38:00.823363-0400 | finalize | INFO - Compression lifecycle finalized for 1 modifiers
2024-09-10T10:38:00.823646-0400 | finalize_session | INFO - Finalized LLM Compressor session
2024-09-10T10:38:01.000345-0400 | log_model_sparsification | INFO - Sparsification info for LlamaForCausalLM: 6738415616 total params. 
Calculating model sparsity: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 291/291 [00:15<00:00, 18.46it/s]
2024-09-10T10:38:16.772877-0400 | log_model_sparsification | INFO - There are 6738415616 prunable params which have 48.05% avg sparsity.
2024-09-10T10:38:16.786934-0400 | log_model_sparsification | INFO - There are 6738415616 quantizable params, with a quantization percentage of 0.00%.
```