### PR TITLE
Cleanse state dict of shared pointers before save

### DIFF
--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -28,7 +28,7 @@ def cleanse_shard(
     A function to cleanse a state_dict of shared pointers.
     Adapted from safetensors.torch.save_model method.
 
-    
+
     :param state_dict: the state_dict to cleanse
     :param force_contiguous: whether to force the tensors to be contiguous
     :param metadata: a dictionary to store the mapping of removed names to kept names


### PR DESCRIPTION
SUMMARY:
Adapts code from https://github.com/huggingface/safetensors/blob/5db3b92c76ba293a0715b916c16b113c0b3551e9/bindings/python/py_src/safetensors/torch.py#L155 to cleanse state dict of shared pointers before saving. 

Also check: https://huggingface.co/docs/safetensors/en/torch_shared_tensors


TEST PLAN:
The tests now pass on cpu and gpu

```bash
(.venv) ➜  llm-compressor git:(main) ✗ CUDA_VISIBLE_DEVICES="" pytest "tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_sparse_model_reload[True-None-dtype0]" -v
====================================================================== test session starts =======================================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0 -- /home/rahul/llm-compressor/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/rahul/llm-compressor
configfile: pyproject.toml
plugins: rerunfailures-14.0, mock-3.14.0
collected 1 item                                                                                                                                                 

tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_sparse_model_reload[True-None-dtype0] PASSED                           [100%]

======================================================================= 1 passed in 13.02s =======================================================================
(.venv) ➜  llm-compressor git:(main) ✗ CUDA_VISIBLE_DEVICES="" pytest "tests/llmcompressor/transformers/sparsification" -v                                     
====================================================================== test session starts =======================================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0 -- /home/rahul/llm-compressor/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/rahul/llm-compressor
configfile: pyproject.toml
plugins: rerunfailures-14.0, mock-3.14.0
collected 12 items                                                                                                                                               

tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_sparse_model_reload[True-None-dtype0] PASSED                           [  8%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_sparse_model_reload[False-config1-dtype1] PASSED                       [ 16%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_sparse_model_reload[True-config2-dtype2] PASSED                        [ 25%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_sparse_model_reload[False-config3-dtype3] PASSED                       [ 33%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_sparse_model_reload[False-None-dtype4] PASSED                          [ 41%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_dense_model_save[True-True] PASSED                                     [ 50%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_dense_model_save[True-False] PASSED                                    [ 58%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_dense_model_save[False-True] PASSED                                    [ 66%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_dense_model_save[False-False] PASSED                                   [ 75%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[dense-dtype0] PASSED                                [ 83%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[dense-dtype1] PASSED                                [ 91%]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[int_quantized-dtype2] PASSED                        [100%]

======================================================================== warnings summary ========================================================================
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[dense-dtype0]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[dense-dtype0]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[dense-dtype1]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[dense-dtype1]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[int_quantized-dtype2]
tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_quant_model_reload[int_quantized-dtype2]
  /home/rahul/llm-compressor/.venv/lib/python3.10/site-packages/pydantic/main.py:1156: PydanticDeprecatedSince20: The `parse_obj` method is deprecated; use `model_validate` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 12 passed, 6 warnings in 87.25s (0:01:27) ============================================================
```

Also fixes the shared tensors issue seen in  ex_trl_distillation 