### PR TITLE
Patch log function name in gptq

### DIFF
--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -314,15 +314,16 @@ class GPTQWrapper(ModuleCompressionWrapper):
         :param start_tick: time when algorithm started"
         :param losses: loss as result of algorithm
         """
-        logger.log("METRIC", "time %.2f" % (time.time() - start_tick))
-        logger.log("METRIC", "error %.2f" % torch.sum(losses).item())
+        patch = logger.patch(lambda r: r.update(function="compress"))
+        patch.log("METRIC", "time %.2f" % (time.time() - start_tick))
+        patch.log("METRIC", "error %.2f" % torch.sum(losses).item())
 
         gpu_usage = get_GPU_memory_usage()
         if len(gpu_usage) > 0:
             for i in range(len(gpu_usage)):
                 perc = gpu_usage[i][0] * 100
                 total_memory = int(gpu_usage[i][1])  # GB
-                logger.log(
+                patch.log(
                     "METRIC",
                     (
                         f"GPU {i} | usage: {perc:.2f}%"
@@ -330,7 +331,7 @@ class GPTQWrapper(ModuleCompressionWrapper):
                     ),
                 )
 
-        logger.log(
+        patch.log(
             "METRIC",
             f"Compressed layer size: {get_layer_size_bytes(self.layer)} MB",
         )


### PR DESCRIPTION
## Purpose ##
* Revert logging changes introduced by #120 
* Make log messages nicer by changing the name of the function that is calling them

Before
```
2024-09-12T03:12:20.499337+0000 | compress_module | INFO - Compressing model.layers.23.model.layers.23.mlp.down_proj...
2024-09-12T03:12:22.485596+0000 | _log_metrics | METRIC - time 1.99
2024-09-12T03:12:22.486285+0000 | _log_metrics | METRIC - error 312.77
2024-09-12T03:12:22.486857+0000 | _log_metrics | METRIC - GPU 0 | usage: 7.72% | total memory: 15 GB
2024-09-12T03:12:22.486891+0000 | _log_metrics | METRIC - GPU 1 | usage: 8.17% | total memory: 15 GB
2024-09-12T03:12:22.486945+0000 | _log_metrics | METRIC - Compressed layer size: 8.428466796875 MB
```
After
```
2024-09-12T03:22:18.627134+0000 | compress_module | INFO - Compressing model.layers.23.model.layers.23.mlp.down_proj...
2024-09-12T03:22:20.484464+0000 | compress | METRIC - time 1.86
2024-09-12T03:22:20.485176+0000 | compress | METRIC - error 312.77
2024-09-12T03:22:20.485331+0000 | compress | METRIC - GPU 0 | usage: 7.72% | total memory: 15 GB
2024-09-12T03:22:20.485368+0000 | compress | METRIC - GPU 1 | usage: 8.17% | total memory: 15 GB
2024-09-12T03:22:20.485426+0000 | compress | METRIC - Compressed layer size: 8.428466796875 MB
```

## Changes ##
* Used logaru patching to change function name in logs 

## Testing ##
* gptq compression was run to completion