### PR TITLE
[Bugfix] Fix saving offloaded state dict

### DIFF
--- a/src/llmcompressor/transformers/__init__.py
+++ b/src/llmcompressor/transformers/__init__.py
@@ -7,5 +7,9 @@ Tools for integrating LLM Compressor with transformers training flows
 # isort: skip_file
 # (import order matters for circular import avoidance)
 from .utils import *
-from .sparsification import SparseAutoModel, SparseAutoModelForCausalLM, wrap_hf_model_class
+from .sparsification import (
+    SparseAutoModel,
+    SparseAutoModelForCausalLM,
+    wrap_hf_model_class,
+)
 from .finetune import *

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -73,6 +73,10 @@ def modify_save_pretrained(model: PreTrainedModel):
             # state_dict gets passed in as a kwarg for FSDP models
             state_dict = kwargs.get("state_dict", None)
 
+            # find offloaded state dict
+            if state_dict is None:
+                state_dict = get_state_dict_offloaded_model(model)
+
             if sparsity_config is not None:
                 sparsity_config.global_sparsity = (
                     SparsityConfigMetadata.infer_global_sparsity(
@@ -112,12 +116,6 @@ def modify_save_pretrained(model: PreTrainedModel):
                     save_directory, **kwargs
                 )
                 return
-
-            # if we've gotten to this point we have a config so we can run compression
-            # default safe serialization to True if not explicitly set
-            kwargs["safe_serialization"] = kwargs.get("safe_serialization", True)
-            if state_dict is None:
-                state_dict = get_state_dict_offloaded_model(model)
 
             # make sure we're on the main process when saving
             if state_dict is not None and len(state_dict) > 0:

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -119,10 +119,11 @@ def modify_save_pretrained(model: PreTrainedModel):
 
             # make sure we're on the main process when saving
             if state_dict is not None and len(state_dict) > 0:
-                state_dict = compressor.compress(model, state_dict)
+                compressed_state_dict = compressor.compress(model, state_dict)
 
+                kwargs["safe_serialization"] = kwargs.get("safe_serialization", True)
                 original_save_pretrained.__get__(model, model_class)(
-                    save_directory, state_dict=state_dict, **kwargs
+                    save_directory, state_dict=compressed_state_dict, **kwargs
                 )
                 compressor.update_config(save_directory)
 

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -73,11 +73,7 @@ def modify_save_pretrained(model: PreTrainedModel):
             # state_dict gets passed in as a kwarg for FSDP models
             state_dict = kwargs.pop("state_dict", None)
 
-            # if not passed, load (potentially offloaded) model
-            if state_dict is None:
-                state_dict = get_state_dict_offloaded_model(model)
-
-            # find offloaded state dict
+            # find offloaded state dict if none is provided
             if state_dict is None:
                 state_dict = get_state_dict_offloaded_model(model)
 

--- a/src/llmcompressor/transformers/sparsification/sparse_model.py
+++ b/src/llmcompressor/transformers/sparsification/sparse_model.py
@@ -27,7 +27,7 @@ __all__ = [
     "wrap_hf_model_class",
     "SparseAutoModel",
     "SparseAutoModelForCausalLM",
-    "get_shared_tokenizer_src"
+    "get_shared_tokenizer_src",
 ]
 
 
@@ -61,6 +61,7 @@ def wrap_hf_model_class(hf_model_class: PreTrainedModel) -> PreTrainedModel:
             pretrained_model_name_or_path directory and applied if found
         :return the created model for causal language modeling
         """
+
         def skip(*args, **kwargs):
             pass
 
@@ -156,11 +157,7 @@ def wrap_hf_model_class(hf_model_class: PreTrainedModel) -> PreTrainedModel:
 
     # Add the wrapped methods to the new class
     wrapped_model_class = type(
-        hf_model_class.__name__,
-        (hf_model_class,),
-        {
-            "from_pretrained": from_pretrained
-        }
+        hf_model_class.__name__, (hf_model_class,), {"from_pretrained": from_pretrained}
     )
 
     return wrapped_model_class

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_then_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_then_finetune.py
@@ -8,7 +8,7 @@ import pytest
 from tests.testing_utils import requires_torch
 
 
-@pytest.mark.integration
+@pytest.mark.unit
 @requires_torch
 @pytest.mark.skipif(
     "CADENCE" in os.environ

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -213,36 +213,51 @@ def test_quant_model_reload(format, dtype, tmp_path):
     shutil.rmtree(tmp_path)
 
 
+# technically only tie_word_embeddings=False is supported right now
+# setting to True is discouraged
 @pytest.mark.parametrize(
-    "safe_serialization,tie_word_embeddings",
+    "offload,torch_dtype,tie_word_embeddings,device_map",
     [
-        (True, False),
-        (False, False),
-        #(False, True),
-        #(False, True),
+        # dtype
+        # (False, torch.float16, False, "cpu"),     # passes
+        # (False, torch.float16, True, "cpu"),      # passes    (discouraged)
+        # (False, torch.float32, False, "cpu"),     # fails, https://github.com/huggingface/transformers/issues/33688
+        # (False, torch.float32, True, "cpu"),      # passes    (discouraged)
+
+        # offloading
+        (True, torch.float16, False, "cpu"),      # passes
+        (True, torch.float32, False, "cpu"),      # fails
+        (True, torch.float16, True, "cpu"),       # fails     (discouraged)
+        (True, torch.float32, True, "cpu"),       # fails     (discouraged)
+
+        # gpu
+        (False, torch.float32, False, "cuda:0"),    # passes
+        (True, torch.float32, False, "cuda:0"),     # passes
+        (True, torch.float16, True, "cuda:0"),      # passes    (discouraged)
+        (True, torch.float32, True, "cuda:0"),      # passes    (discouraged)
     ],
 )
-def test_offloaded_model_reload(safe_serialization, tie_word_embeddings, tmp_path):
+def test_model_reload(offload, torch_dtype, tie_word_embeddings, device_map, tmp_path):
     model_path = "Xenova/llama2.c-stories15M"
     save_path = tmp_path / "save_path"
 
     model = SparseAutoModelForCausalLM.from_pretrained(
         model_path,
-        torch_dtype=torch.float16,
-        device_map="cpu",
         tie_word_embeddings=tie_word_embeddings,
+        torch_dtype=torch_dtype,
+        device_map=device_map,
     )
-    model = cpu_offload(model)
+    if offload:
+        model = cpu_offload(model)
 
-    model.save_pretrained(save_path, safe_serialization=safe_serialization)
+    model.save_pretrained(save_path, safe_serialization=True)
 
     reloaded = SparseAutoModelForCausalLM.from_pretrained(
-        save_path, torch_dtype=torch.float16, device_map="cpu"
+        save_path, torch_dtype="auto", device_map="cpu"
     )
 
     model_dict = get_state_dict_offloaded_model(model)
     reloaded_dict = get_state_dict_offloaded_model(reloaded)
     assert model_dict.keys() == reloaded_dict.keys()
     for key in model_dict:
-        assert torch.equal(model_dict[key], reloaded_dict[key])
-        assert model_dict[key].device == reloaded_dict[key].device
+        assert torch.equal(model_dict[key].cpu(), reloaded_dict[key].cpu())

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -9,16 +9,15 @@ from compressed_tensors import COMPRESSION_CONFIG_NAME
 from compressed_tensors.compressors import ModelCompressor
 from compressed_tensors.config import BitmaskConfig, DenseSparsityConfig
 from compressed_tensors.quantization import QuantizationStatus
-from transformers import AutoConfig, LlamaConfig
+from transformers import AutoConfig
 
 from llmcompressor.core import reset_session
-from llmcompressor.pytorch.model_load.helpers import parse_dtype
 from llmcompressor.pytorch.utils.helpers import tensor_sparsity
 from llmcompressor.transformers import SparseAutoModelForCausalLM, oneshot
 from llmcompressor.transformers.compression.sparsity_config import (
     SparsityConfigMetadata,
 )
-from llmcompressor.transformers.finetune.model_args import ModelArguments
+
 
 @pytest.mark.parametrize(
     "compressed,config,dtype",
@@ -219,22 +218,20 @@ def test_quant_model_reload(format, dtype, tmp_path):
     "offload,torch_dtype,tie_word_embeddings,device_map",
     [
         # dtype
-        (False, torch.float16, False, "cpu"),     # passes
-        (False, torch.float16, True, "cpu"),      # passes    (discouraged)
-        # (False, torch.float32, False, "cpu"),   # fails, to be fixed in #659
-        (False, torch.float32, True, "cpu"),      # passes    (discouraged)
-
+        (False, torch.float16, False, "cpu"),
+        (False, torch.float16, True, "cpu"),
+        # (False, torch.float32, False, "cpu"),  # fails, to be fixed in #659
+        (False, torch.float32, True, "cpu"),
         # offloading
-        (True, torch.float16, False, "cpu"),      # passes
-        # (True, torch.float32, False, "cpu"),      # fails, to be fixed in #659
-        # (True, torch.float16, True, "cpu"),       # fails     (discouraged), to be fixed in #659
-        # (True, torch.float32, True, "cpu"),       # fails     (discouraged), to be fixed in #659
-
+        (True, torch.float16, False, "cpu"),
+        # (True, torch.float32, False, "cpu"),  # fails, to be fixed in #659
+        # (True, torch.float16, True, "cpu"),   # fails, to be fixed in #659
+        # (True, torch.float32, True, "cpu"),  # fails, to be fixed in #659
         # gpu
-        (False, torch.float32, False, "cuda:0"),    # passes
-        (True, torch.float32, False, "cuda:0"),     # passes
-        (True, torch.float16, True, "cuda:0"),      # passes    (discouraged)
-        (True, torch.float32, True, "cuda:0"),      # passes    (discouraged)
+        (False, torch.float32, False, "cuda:0"),
+        (True, torch.float32, False, "cuda:0"),
+        (True, torch.float16, True, "cuda:0"),
+        (True, torch.float32, True, "cuda:0"),
     ],
 )
 def test_model_reload(offload, torch_dtype, tie_word_embeddings, device_map, tmp_path):

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -219,16 +219,16 @@ def test_quant_model_reload(format, dtype, tmp_path):
     "offload,torch_dtype,tie_word_embeddings,device_map",
     [
         # dtype
-        # (False, torch.float16, False, "cpu"),     # passes
-        # (False, torch.float16, True, "cpu"),      # passes    (discouraged)
-        # (False, torch.float32, False, "cpu"),     # fails, https://github.com/huggingface/transformers/issues/33688
-        # (False, torch.float32, True, "cpu"),      # passes    (discouraged)
+        (False, torch.float16, False, "cpu"),     # passes
+        (False, torch.float16, True, "cpu"),      # passes    (discouraged)
+        # (False, torch.float32, False, "cpu"),   # fails, to be fixed in #659
+        (False, torch.float32, True, "cpu"),      # passes    (discouraged)
 
         # offloading
         (True, torch.float16, False, "cpu"),      # passes
-        (True, torch.float32, False, "cpu"),      # fails
-        (True, torch.float16, True, "cpu"),       # fails     (discouraged)
-        (True, torch.float32, True, "cpu"),       # fails     (discouraged)
+        # (True, torch.float32, False, "cpu"),      # fails, to be fixed in #659
+        # (True, torch.float16, True, "cpu"),       # fails     (discouraged), to be fixed in #659
+        # (True, torch.float32, True, "cpu"),       # fails     (discouraged), to be fixed in #659
 
         # gpu
         (False, torch.float32, False, "cuda:0"),    # passes

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -223,11 +223,6 @@ def test_quant_model_reload(format, dtype, tmp_path):
         (False, torch.float32, True, "cpu"),
         # offloading
         (True, torch.float16, False, "cpu"),
-        # gpu
-        (False, torch.float32, False, "cuda:0"),
-        (True, torch.float32, False, "cuda:0"),
-        (True, torch.float16, True, "cuda:0"),
-        (True, torch.float32, True, "cuda:0"),
     ],
 )
 def test_model_reload(offload, torch_dtype, tie_word_embeddings, device_map, tmp_path):
@@ -254,3 +249,19 @@ def test_model_reload(offload, torch_dtype, tie_word_embeddings, device_map, tmp
     assert model_dict.keys() == reloaded_dict.keys()
     for key in model_dict:
         assert torch.equal(model_dict[key].cpu(), reloaded_dict[key].cpu())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires gpu")
+@pytest.mark.parametrize(
+    "offload,torch_dtype,tie_word_embeddings,device_map",
+    [
+        (False, torch.float32, False, "cuda:0"),
+        (True, torch.float32, False, "cuda:0"),
+        (True, torch.float16, True, "cuda:0"),
+        (True, torch.float32, True, "cuda:0"),
+    ],
+)
+def test_model_reload_gpu(
+    offload, torch_dtype, tie_word_embeddings, device_map, tmp_path
+):
+    test_model_reload(offload, torch_dtype, tie_word_embeddings, device_map, tmp_path)

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -220,13 +220,9 @@ def test_quant_model_reload(format, dtype, tmp_path):
         # dtype
         (False, torch.float16, False, "cpu"),
         (False, torch.float16, True, "cpu"),
-        # (False, torch.float32, False, "cpu"),  # fails, to be fixed in #659
         (False, torch.float32, True, "cpu"),
         # offloading
         (True, torch.float16, False, "cpu"),
-        # (True, torch.float32, False, "cpu"),  # fails, to be fixed in #659
-        # (True, torch.float16, True, "cpu"),   # fails, to be fixed in #659
-        # (True, torch.float32, True, "cpu"),  # fails, to be fixed in #659
         # gpu
         (False, torch.float32, False, "cuda:0"),
         (True, torch.float32, False, "cuda:0"),


### PR DESCRIPTION
## Purpose ##
* Fix bug with saving the entire state dict of an offloaded model, even if it does not have a compressor
* Properly infer sparsity and quantization of offloaded models

## Changes ##
* Load the entire offloaded state dict before checking for a compressor and before inferring global sparsity
* Remove explicit override of `save_safetensors` kwarg, since the original `save_pretrained` function already defaults its value to `True`

## Testing ##
* Added test which throws error when trying to save an offloaded model without compression. This test fails on main but passes on this branch

Main
```
FAILED tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_model_reload[True-torch_dtype3-False-cpu] - NotImplementedError: Cannot copy out of meta tensor; no data!
FAILED tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_model_reload[True-torch_dtype5-False-cuda:0] - NotImplementedError: Cannot copy out of meta tensor; no data!
FAILED tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_model_reload[True-torch_dtype6-True-cuda:0] - NotImplementedError: Cannot copy out of meta tensor; no data!
FAILED tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py::test_model_reload[True-torch_dtype7-True-cuda:0] - NotImplementedError: Cannot copy out of meta tensor; no data!
======================================= 4 failed, 4 passed, 12 deselected in 9.03s =======================================

```

This branch
```
============================================ 8 passed, 12 deselected in 8.89s ============================================

```


