### PR TITLE
Fix filename in example command

### DIFF
--- a/examples/quantizing_moe/README.md
+++ b/examples/quantizing_moe/README.md
@@ -17,7 +17,7 @@ pip install -e .
 The provided example script demonstrates an end-to-end process for applying the quantization algorithm:
 
 ```bash
-python3 mixtral_moe.py
+python3 mixtral_moe_fp8.py
 ```
 
 ## Creating a Quantized MoE Model


### PR DESCRIPTION
SUMMARY:
This fixes the filename in one of the example commands from the "quantizing_moe" example. The file was changed in #160 but the filename change was missed in this code block.


TEST PLAN:
Ran the updated command from the `examples/quantizing_moe` folder.
