### PR TITLE
Add pile eval dataset

### DIFF
--- a/src/llmcompressor/transformers/finetune/data/__init__.py
+++ b/src/llmcompressor/transformers/finetune/data/__init__.py
@@ -8,6 +8,7 @@ from .data_args import DataTrainingArguments
 from .evolcodealpaca import EvolCodeAlpacaDataset
 from .gsm8k import GSM8KDataset
 from .open_platypus import OpenPlatypusDataset
+from .pile import PileEvalDataset
 from .ptb import PtbDataset
 from .ultrachat_200k import UltraChatDataset
 from .wikitext import WikiTextDataset

--- a/src/llmcompressor/transformers/finetune/data/pile.py
+++ b/src/llmcompressor/transformers/finetune/data/pile.py
@@ -7,7 +7,7 @@ from llmcompressor.transformers.finetune.data import TextGenerationDataset
 @TextGenerationDataset.register(name="pile_eval")
 class PileEvalDataset(TextGenerationDataset):
     """
-    Child text generation class for the Open Platypus dataset
+    Child text generation class for the PileEval dataset
 
     :param data_args: configuration settings for dataset loading
     :param split: split from dataset to load, for instance `test` or `train[:5%]`

--- a/src/llmcompressor/transformers/finetune/data/pile.py
+++ b/src/llmcompressor/transformers/finetune/data/pile.py
@@ -1,0 +1,44 @@
+from typing import Optional
+
+from llmcompressor.transformers.finetune.data import TextGenerationDataset
+
+
+@TextGenerationDataset.register(name="mit-han-lab/pile-val-backup", alias=["pile-eval"])
+class PileEvalDataset(TextGenerationDataset):
+    """
+    Child text generation class for the Open Platypus dataset
+
+    :param data_args: configuration settings for dataset loading
+    :param split: split from dataset to load, for instance `test` or `train[:5%]`
+    :param tokenizer: tokenizer to use on dataset
+    """
+
+    def __init__(self, data_args, split, tokenizer):
+        super().__init__(
+            text_column="text", data_args=data_args, split=split, tokenizer=tokenizer
+        )
+
+    def get_raw_dataset(self, cache_dir: Optional[str] = None):
+        """
+        Load the raw dataset from Hugging Face, using cached copy if available.
+        Additionally reformats the entries to fit the template.
+
+        :param cache_dir: disk location to search for cached dataset
+        :return: the requested dataset
+        """
+        raw_dataset = super().get_raw_dataset(cache_dir=cache_dir)
+
+        def restructure_fn(sample):
+            sample["text"] = sample["text"].strip()
+            return sample
+
+        raw_dataset = self.map(
+            raw_dataset,
+            function=restructure_fn,
+            batched=False,
+            remove_columns=["meta"],
+            num_proc=self.data_args.preprocessing_num_workers,
+            load_from_cache_file=not self.data_args.overwrite_cache,
+            desc="Restructuring Pile Dataset",
+        )
+        return raw_dataset

--- a/src/llmcompressor/transformers/finetune/data/pile.py
+++ b/src/llmcompressor/transformers/finetune/data/pile.py
@@ -1,9 +1,10 @@
+from copy import deepcopy
 from typing import Optional
 
 from llmcompressor.transformers.finetune.data import TextGenerationDataset
 
 
-@TextGenerationDataset.register(name="mit-han-lab/pile-val-backup", alias=["pile-eval"])
+@TextGenerationDataset.register(name="pile_eval")
 class PileEvalDataset(TextGenerationDataset):
     """
     Child text generation class for the Open Platypus dataset
@@ -14,6 +15,8 @@ class PileEvalDataset(TextGenerationDataset):
     """
 
     def __init__(self, data_args, split, tokenizer):
+        data_args = deepcopy(data_args)
+        data_args.dataset = "mit-han-lab/pile-val-backup"
         super().__init__(
             text_column="text", data_args=data_args, split=split, tokenizer=tokenizer
         )

--- a/tests/llmcompressor/transformers/finetune/data/test_registry.py
+++ b/tests/llmcompressor/transformers/finetune/data/test_registry.py
@@ -3,6 +3,7 @@ import pytest
 from llmcompressor.transformers.finetune.data import (
     C4Dataset,
     OpenPlatypusDataset,
+    PileEvalDataset,
     TextGenerationDataset,
     WikiTextDataset,
 )
@@ -57,3 +58,19 @@ def test_open_platypus_initializes(tiny_llama_tokenizer):
     assert op_manager.text_column == "text"
     assert not op_manager.padding
     assert op_manager.max_seq_length == data_args.max_seq_length
+
+
+@pytest.mark.usefixtures("tiny_llama_tokenizer")
+def test_pile_eval_initializes(tiny_llama_tokenizer):
+    data_args = DataTrainingArguments(dataset="pile-eval", pad_to_max_length=False)
+    pile_eval_manager = TextGenerationDataset.load_from_registry(
+        data_args.dataset,
+        data_args=data_args,
+        split=None,
+        tokenizer=tiny_llama_tokenizer,
+    )
+    assert isinstance(pile_eval_manager, TextGenerationDataset)
+    assert isinstance(pile_eval_manager, PileEvalDataset)
+    assert pile_eval_manager.text_column == "text"
+    assert not pile_eval_manager.padding
+    assert pile_eval_manager.max_seq_length == data_args.max_seq_length

--- a/tests/llmcompressor/transformers/finetune/data/test_registry.py
+++ b/tests/llmcompressor/transformers/finetune/data/test_registry.py
@@ -62,7 +62,7 @@ def test_open_platypus_initializes(tiny_llama_tokenizer):
 
 @pytest.mark.usefixtures("tiny_llama_tokenizer")
 def test_pile_eval_initializes(tiny_llama_tokenizer):
-    data_args = DataTrainingArguments(dataset="pile-eval", pad_to_max_length=False)
+    data_args = DataTrainingArguments(dataset="pile_eval", pad_to_max_length=False)
     pile_eval_manager = TextGenerationDataset.load_from_registry(
         data_args.dataset,
         data_args=data_args,


### PR DESCRIPTION
SUMMARY:
This PR adds the pile eval dataset to llmcompressor


TEST PLAN:
Added unit test for loading + ran the following script to verify

```python
from llmcompressor.transformers import TextGenerationDataset, DataTrainingArguments
from transformers import AutoTokenizer

data_args = DataTrainingArguments(
            dataset="pile-eval",
            concatenate_data=True,
            splits={"calibration" : "validation[:1%]"},
        )
tokenizer = AutoTokenizer.from_pretrained("Xenova/llama2.c-stories15M")
dataset_manager = TextGenerationDataset.load_from_registry(
            data_args.dataset,
            data_args=data_args,
            split=data_args.splits,
            tokenizer=tokenizer,
        )


raw_dataset = dataset_manager.get_raw_dataset()
tokenized_dataset = dataset_manager.tokenize_and_process(
    raw_dataset, add_labels=True
)


```
