### PR TITLE
Add: targets and ignore inference for sparse compression

### DIFF
--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -1,14 +1,17 @@
-from typing import Dict, List, Optional, Union
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple, Union
 
 import psutil
 import torch
 from accelerate import infer_auto_device_map, init_empty_weights
 from accelerate.accelerator import get_state_dict_offloaded_model
+from compressed_tensors.quantization.utils import iter_named_leaf_modules, module_type
 from torch.nn.modules import Linear
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM
 
 from llmcompressor.pytorch.utils import get_linear_layers
+from llmcompressor.pytorch.utils.helpers import tensor_sparsity
 from llmcompressor.utils.pytorch import get_layers, get_no_split_params
 
 __ALL__ = [
@@ -18,6 +21,8 @@ __ALL__ = [
     "hessian_memory_requirements",
     "custom_offload_device_map",
     "calculate_offload_device_map",
+    "infer_sparse_targets_and_ignores",
+    "is_sparse_compression_target",
 ]
 
 
@@ -29,6 +34,9 @@ def tensor_follows_mask_structure(tensor, mask: str = "2:4") -> bool:
         Note, some weights can incidentally be zero, so we check for
         atleast n zeros in each chunk of size m
     """
+
+    if mask.lower().strip() == "unstructured":
+        return True
 
     n, m = tuple(map(int, mask.split(":")))
     # Reshape the tensor into chunks of size m
@@ -240,3 +248,104 @@ def calculate_offload_device_map(
         del dummy_model
 
     return device_map
+
+
+def infer_sparse_targets_and_ignores(
+    model: torch.nn.Module,
+    sparsity_structure: str,
+    sparsity_threshold: float,
+) -> Tuple[List[str], List[str]]:
+    """
+    Infers the target and ignore layers in the given model
+    to be used for sparsity compression
+
+    :param model: model to check
+    :param sparsity_structure: sparsity structure to check against
+    :param sparsity_threshold: threshold for sparsity
+    :return: tuple of target and ignore layers
+    """
+
+    exhaustive_targets, exhaustive_ignore = _get_sparse_targets_ignore_dicts(
+        module=model,
+        sparsity_structure=sparsity_structure,
+        sparsity_threshold=sparsity_threshold,
+    )
+
+    return _reduce_targets_and_ignores_into_lists(
+        exhaustive_targets=exhaustive_targets,
+        exhaustive_ignore=exhaustive_ignore,
+    )
+
+
+def is_sparse_compression_target(
+    module: torch.nn.Module, sparsity_threshold: float, sparsity_structure: str
+) -> bool:
+    """
+    :param module: module to check
+    :param sparsity_threshold: threshold for sparsity
+    :param sparsity_structure: sparsity structure to check against
+    :return: whether or not the module is a target for sparsity compression,
+        i.e True if it is sparse and follows the sparsity structure, else False
+    """
+    return (
+        hasattr(module, "weight")
+        and tensor_sparsity(module.weight) >= sparsity_threshold
+        and tensor_follows_mask_structure(tensor=module.weight, mask=sparsity_structure)
+    )
+
+
+def _get_sparse_targets_ignore_dicts(
+    module: torch.nn.Module, sparsity_structure: str, sparsity_threshold: float
+) -> Tuple[Dict[str, List[str]], Dict[str, List[str]]]:
+    """
+    Get sparse targets and ignore dictionaries
+
+    :param module: module to check
+    :param sparsity_structure: sparsity structure to check against
+    :param sparsity_threshold: threshold for sparsity
+    :return: tuple of exhaustive targets and ignore dictionaries
+    """
+    exhaustive_targets = defaultdict(list)
+    exhaustive_ignore = defaultdict(list)
+
+    for name, submodule in iter_named_leaf_modules(module):
+        layer_type = module_type(submodule)
+        is_target = is_sparse_compression_target(
+            module=submodule,
+            sparsity_threshold=sparsity_threshold,
+            sparsity_structure=sparsity_structure,
+        )
+        target_dict = exhaustive_targets if is_target else exhaustive_ignore
+        target_dict[layer_type].append(name)
+    return exhaustive_targets, exhaustive_ignore
+
+
+def _reduce_targets_and_ignores_into_lists(
+    exhaustive_targets: Dict[str, List[str]], exhaustive_ignore: Dict[str, List[str]]
+) -> Tuple[List[str], List[str]]:
+    """
+    Reduces the targets and ignores dictionaries into lists
+
+    :param exhaustive_targets: dictionary of target layers, must contain all
+        targetted layers in the model
+    :param exhaustive_ignore: dictionary of ignore layers, must contain all
+        ignored layers in the model
+    :return: tuple of reduced target and ignore layers
+    """
+
+    targets, ignore = [], []
+    all_layer_types = set(exhaustive_targets.keys()).union(
+        set(exhaustive_ignore.keys())
+    )
+    for layer_type in all_layer_types:
+        curr_targets = exhaustive_targets.get(layer_type, [])
+        curr_ignores = exhaustive_ignore.get(layer_type, [])
+
+        if len(curr_targets) > len(curr_ignores):
+            targets.append(layer_type)
+            ignore.extend(curr_ignores)
+        else:
+            ignore.append(layer_type)
+            targets.extend(curr_targets)
+
+    return targets, ignore

--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -342,11 +342,12 @@ def _reduce_targets_and_ignores_into_lists(
         curr_targets = exhaustive_targets.get(submodule_type, [])
         curr_ignores = exhaustive_ignore.get(submodule_type, [])
 
-        if len(curr_targets) > len(curr_ignores):
+        if len(curr_targets) >= len(curr_ignores):
             targets.append(submodule_type)
             ignore.extend(curr_ignores)
-        else:
-            ignore.append(submodule_type)
+        elif len(curr_targets) > 0:
+            # only add ignore layers if
+            # there are targetted
             targets.extend(curr_targets)
-
+            ignore.extend(curr_ignores)
     return targets, ignore

--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -40,6 +40,10 @@ def tensor_follows_mask_structure(tensor: torch.Tensor, mask: str = "2:4") -> bo
         return True
 
     n, m = tuple(map(int, mask.split(":")))
+
+    # If n or m is 0, then the tensor follows the mask structure
+    if n == 0 or m == 0:
+        return True
     # Reshape the tensor into chunks of size m
     tensor = tensor.view(-1, m)
 

--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -347,7 +347,7 @@ def _reduce_targets_and_ignores_into_lists(
             ignore.extend(curr_ignores)
         elif len(curr_targets) > 0:
             # only add ignore layers if
-            # there are targetted
+            # they are targetted
             targets.extend(curr_targets)
             ignore.extend(curr_ignores)
     return targets, ignore

--- a/src/llmcompressor/transformers/compression/sparsity_config.py
+++ b/src/llmcompressor/transformers/compression/sparsity_config.py
@@ -8,6 +8,7 @@ from torch.nn import Module
 from llmcompressor.core import active_session
 from llmcompressor.pytorch.utils import ModuleSparsificationInfo
 from llmcompressor.transformers.compression.helpers import (
+    infer_sparse_targets_and_ignores,
     infer_sparsity_structure_from_model,
     infer_sparsity_structure_from_stage_modifiers,
 )
@@ -18,6 +19,8 @@ class SparsityConfigMetadata:
     Class of helper functions for filling out a SparsityCompressionConfig with readable
     metadata from the model
     """
+
+    SPARSITY_THRESHOLD: float = 0.2
 
     @staticmethod
     def infer_global_sparsity(
@@ -100,10 +103,18 @@ class SparsityConfigMetadata:
         else:
             format = CompressionFormat.dense.value
 
+        targets, ignores = infer_sparse_targets_and_ignores(
+            model,
+            sparsity_structure=sparsity_structure,
+            sparsity_threshold=SparsityConfigMetadata.SPARSITY_THRESHOLD,
+        )
+
         return SparsityCompressionConfig.load_from_registry(
             format,
             global_sparsity=global_sparsity,
             sparsity_structure=sparsity_structure,
+            targets=targets,
+            ignore=ignores,
         )
 
     @staticmethod

--- a/tests/llmcompressor/transformers/compression/test_helpers.py
+++ b/tests/llmcompressor/transformers/compression/test_helpers.py
@@ -1,0 +1,69 @@
+import pytest
+
+from llmcompressor.transformers.compression.helpers import (
+    _reduce_targets_and_ignores_into_lists,
+)
+
+
+@pytest.mark.parametrize(
+    "exhaustive_targets, exhaustive_ignore, expected_targets, expected_ignore",
+    [
+        # Test case 1: when exhaustive_targets has more elements
+        # than exhaustive_ignore for a given key
+        (
+            {"type1": ["target1", "target2"], "type2": ["target3"]},
+            {"type1": ["ignore1"], "type2": ["ignore2", "ignore3"]},
+            ["type1", "target3"],
+            ["ignore1", "ignore2", "ignore3"],
+        ),
+        # Test case 2: when exhaustive_ignore has more elements
+        # than exhaustive_targets for a given key
+        (
+            {"type1": ["target1"], "type2": ["target3", "target4"]},
+            {"type1": ["ignore1", "ignore2"], "type2": ["ignore3"]},
+            ["target1", "type2"],
+            ["ignore1", "ignore2", "ignore3"],
+        ),
+        # Test case 3: when exhaustive_targets and exhaustive_ignore
+        # have the same number of elements for a given key
+        (
+            {"type1": ["target1", "target2"], "type2": ["target3", "target4"]},
+            {"type1": ["ignore1", "ignore2"], "type2": ["ignore3", "ignore4"]},
+            ["type1", "type2"],
+            ["ignore1", "ignore2", "ignore3", "ignore4"],
+        ),
+        # Test case 4: when exhaustive_targets
+        # and exhaustive_ignore are empty
+        ({}, {}, [], []),
+        # Test case 5: when exhaustive_targets has
+        # keys not present in exhaustive_ignore
+        (
+            {"type1": ["target1", "target2"], "type3": ["target3", "target4"]},
+            {"type1": ["ignore1", "ignore2"], "type2": ["ignore3", "ignore4"]},
+            ["type1", "type3"],
+            ["ignore1", "ignore2"],
+        ),
+        # Test case 6: when exhaustive_ignore has keys
+        # not present in exhaustive_targets
+        (
+            {"type1": ["target1", "target2"], "type2": ["target3", "target4"]},
+            {"type1": ["ignore1", "ignore2"], "type3": ["ignore3", "ignore4"]},
+            ["type1", "type2"],
+            ["ignore1", "ignore2"],
+        ),
+    ],
+)
+def test_reduce_targets_and_ignores_into_lists(
+    exhaustive_targets, exhaustive_ignore, expected_targets, expected_ignore
+):
+    targets, ignore = _reduce_targets_and_ignores_into_lists(
+        exhaustive_targets, exhaustive_ignore
+    )
+    _assert_list_contents_match(targets, expected_targets)
+    _assert_list_contents_match(ignore, expected_ignore)
+
+
+def _assert_list_contents_match(list1, list2):
+    assert len(list1) == len(list2)
+    for item in list1:
+        assert item in list2


### PR DESCRIPTION
This PR adds support to automatically infer targets and ignore lists for sparse compression

The lists thus generated will be used to to ignore things like layernorms, and embeddings

The logic for adding to targets:
- layer must have sparsity > threshold (set to 20% for now) 
- layer must follow the sparsity structure defined

Otherwise it's added to the ignore list

Note: We also perform a reduction of the targets, and ignore list to make them cleaner and easily readable inside `config.json`

The compression_config inside `config.json` will now look like:
```json
"compression_config": {
    "sparsity_config": {
      "format": "sparse-bitmask",
      "global_sparsity": 0.12233772669884009,
      "ignore": [
        "Embedding",
        "lm_head",
        "LlamaRotaryEmbedding",
        "SiLU",
        "LlamaRMSNorm"
      ],
      "registry_requires_subclass": false,
      "sparsity_structure": "2:4",
      "targets": [
        "Linear"
      ]
    }
  },
```

After review comments we were able to further simplify compression_config, now we only include modules in ignore list if they are targetted, now the compression config looks like:
```json
  "compression_config": {
    "sparsity_config": {
      "format": "dense",
      "global_sparsity": 0.12233772669884009,
      "ignore": [
        "lm_head"
      ],
      "registry_requires_subclass": false,
      "sparsity_structure": "2:4",
      "targets": [
        "Linear"
      ]
    }
  }
```

Note: relies on https://github.com/neuralmagic/compressed-tensors/pull/159
