### PR TITLE
Remove FP8 hack, bump transformers version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "tqdm>=4.0.0",
         "click>=7.1.2,!=8.0.0",  # 8.0.0 blocked due to reported bug
         "torch>=1.7.0",
-        "transformers>4.0,<5.0",
+        "transformers>=4.41.0,<5.0",
         "datasets",
         "accelerate>=0.20.3",
         "pynvml==11.5.3",


### PR DESCRIPTION
## Purpose ##
* Remove fp8 hack which is merged into transformers as of release `v4.41.0`

## Changes ##
* Remove hack
* Bump transformers version. This is acceptable because the version will be bumped for HFQuantizer anyways

## Testing ##
* on commit tests