### PR TITLE
Increase Sparsity Threshold for compressors

### DIFF
--- a/src/llmcompressor/transformers/compression/sparsity_config.py
+++ b/src/llmcompressor/transformers/compression/sparsity_config.py
@@ -20,7 +20,7 @@ class SparsityConfigMetadata:
     metadata from the model
     """
 
-    SPARSITY_THRESHOLD: float = 0.3
+    SPARSITY_THRESHOLD: float = 0.4
 
     @staticmethod
     def infer_global_sparsity(

--- a/src/llmcompressor/transformers/compression/sparsity_config.py
+++ b/src/llmcompressor/transformers/compression/sparsity_config.py
@@ -20,7 +20,7 @@ class SparsityConfigMetadata:
     metadata from the model
     """
 
-    SPARSITY_THRESHOLD: float = 0.2
+    SPARSITY_THRESHOLD: float = 0.3
 
     @staticmethod
     def infer_global_sparsity(


### PR DESCRIPTION
During internal testing, it was found that a sparsity threshold of 0.2 is insufficient. In some cases, applying quantization alone can naturally lead to a 20% sparsity level. To address this, this PR increases the sparsity threshold to 0.3.

Please note that this adjustment specifically pertains to sparse compression.