### PR TITLE
Fix 2/4 GPTQ Model Tests

### DIFF
--- a/tests/llmcompressor/transformers/gptq/test_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_oneshot.py
@@ -107,5 +107,5 @@ class TestGPTQOneShotWithFullScheme(unittest.TestCase):
         not_targetted = model_loaded.lm_head
         assert not hasattr(not_targetted, "quantization_scheme")
 
-    # def tearDown(self):
-    #    shutil.rmtree(self.output)
+    def tearDown(self):
+        shutil.rmtree(self.output)


### PR DESCRIPTION
SUMMARY:
-The `quantization_config` that is attached to the model is attached to a slightly different location using the loaded `quantization_config` compared to `compression_config`
- This updates the test based on this change + adds a comment explaining the difference
