### PR TITLE
Update workflows/actions

### DIFF
--- a/.github/workflows/build-and-publish-release-images.yaml
+++ b/.github/workflows/build-and-publish-release-images.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get Tag
         id: extract_tag
-        run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF_NAME#*/})"
+        run: echo "tag=${GITHUB_REF_NAME#*/}" >> $GITHUB_OUTPUT
 
       - name: Current Version Name
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build-and-publish-release-images.yaml
+++ b/.github/workflows/build-and-publish-release-images.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Checkout code
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,7 +15,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: umbrelladocs/action-linkspector@v1
       with:
         github_token: ${{ secrets.github_token }}

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -12,7 +12,7 @@ jobs:
   quality-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - uses: actions/checkout@v4

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -16,9 +16,6 @@ jobs:
         with:
           python-version: '3.9'
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{needs.test-setup.outputs.branch}}
       - name: "⚙️ Install dependencies"
         run: pip3 install .[dev]
       - name: "🧹 Running quality checks"

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -1,5 +1,5 @@
 name: Quality Checks
-on: 
+on:
   push:
     branches:
       - main
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{needs.test-setup.outputs.branch}}
       - name: "⚙️ Install dependencies"

--- a/.github/workflows/set-comment.yaml
+++ b/.github/workflows/set-comment.yaml
@@ -1,5 +1,5 @@
 name: PR Reminder Comment Bot
-on: 
+on:
   pull_request:
     branches:
       - main
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remind to add ready label
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: test-setup
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: test-setup
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: test-setup
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - uses: actions/checkout@v4
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: test-setup
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - uses: actions/checkout@v4

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -1,5 +1,5 @@
 name: Test Checks
-on: 
+on:
   push:
     branches:
       - main
@@ -27,7 +27,7 @@ jobs:
       pytorch: ${{ steps.pytorch-check.outputs.output }}
       transformers: ${{ steps.transformers-check.outputs.output }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       # TODO: for @DanH what is this supposed to be doing?
@@ -46,8 +46,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
@@ -67,8 +67,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
@@ -89,8 +89,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
@@ -111,8 +111,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
@@ -129,7 +129,7 @@ jobs:
         run: |
           pytest tests/llmcompressor/transformers/compression -v
       - name: Run Finetune Tests
-        if: always() && steps.install.outcome == 'success'       
+        if: always() && steps.install.outcome == 'success'
         run: |
           pytest -v tests/llmcompressor/transformers/finetune -m unit
       - name: Running GPTQ Tests

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -19,29 +19,8 @@ env:
   CLEARML_API_SECRET_KEY:  ${{ secrets.CLEARML_API_SECRET_KEY }}
 
 jobs:
-  test-setup:
-    runs-on: ubuntu-22.04
-    outputs:
-      branch: ${{ steps.get-branch.outputs.branch }}
-      base: ${{ steps.base-check.outputs.output }}
-      pytorch: ${{ steps.pytorch-check.outputs.output }}
-      transformers: ${{ steps.transformers-check.outputs.output }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      # TODO: for @DanH what is this supposed to be doing?
-      # The way it was being used before was only testing code on main,
-      # not on the current PR. git branch --show current does not work
-      - name: Get current branch
-        id: get-branch
-        run: >
-          (git branch --show-current | grep -E "release/")
-          && echo "::set-output name=branch::$(git branch --show-current)"
-          || echo "::set-output name=branch::main"
   base-tests:
     runs-on: ubuntu-22.04
-    needs: test-setup
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -51,7 +30,6 @@ jobs:
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
-          ref: ${{needs.test-setup.outputs.branch}}
       - name: "⚙️ Install compressed-tensors dependencies"
         run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
       - name: "Clean compressed-tensors directory"
@@ -62,7 +40,6 @@ jobs:
         run: make test
   pytorch-tests:
     runs-on: ubuntu-22.04
-    needs: test-setup
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -72,7 +49,6 @@ jobs:
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
-          ref: ${{needs.test-setup.outputs.branch}}
       - name: "⚙️ Install compressed-tensors dependencies"
         run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
       - name: "Clean compressed-tensors directory"
@@ -84,7 +60,6 @@ jobs:
           pytest tests/llmcompressor/pytorch -v
   compat-pytorch-1_9-pytorch-tests:
     runs-on: ubuntu-22.04
-    needs: test-setup
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -94,7 +69,6 @@ jobs:
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
-          ref: ${{needs.test-setup.outputs.branch}}
       - name: "⚙️ Install compressed-tensors dependencies"
         run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
       - name: "Clean compressed-tensors directory"
@@ -106,7 +80,6 @@ jobs:
           pytest tests/llmcompressor/pytorch -v
   transformers-tests:
     runs-on: ubuntu-22.04
-    needs: test-setup
     steps:
       - uses: actions/setup-python@v5
         with:
@@ -116,7 +89,6 @@ jobs:
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
-          ref: ${{needs.test-setup.outputs.branch}}
       - name: "⚙️ Install compressed-tensors dependencies"
         run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
       - name: "Clean compressed-tensors directory"


### PR DESCRIPTION
SUMMARY:
These changes perform some cleanup in the existing workflows in advance of looking at adding GPU support:

* The `actions/checkout`, `actions/setup-python`, and `actions/github-script` usages have been updated to the latest version
* The use of the deprecated `set-output` has been replaced with the current standard
* Some redundancies have been cleaned up

The first two points will reduce a lot of noise in the runs as there were messages for each usage of the outdated actions due to their age/using outdated Node.js (internally to the actions).

The final point is a general cleanup to keep things simple.


TEST PLAN:
The runs for this PR should have the expected outcomes, but without the various warnings/etc. about the outdated actions.
