### PR TITLE
Fix import in ModelCompressor

### DIFF
--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
@@ -3,7 +3,7 @@ import shutil
 import unittest
 
 import pytest
-from compressed_tensors.compressors.model_compressor import ModelCompressor
+from compressed_tensors.compressors import ModelCompressor
 from parameterized import parameterized_class
 from transformers import AutoConfig
 


### PR DESCRIPTION
This PR updates the import statement in one of the tests to align with recent changes introduced in PR #166 of the compressed-tensors repository.


It's worth noting that tests importing directly from compressed_tensors.compressors stays unaffected, which is why only this particular test required modification.