### PR TITLE
Set Sparse compression to save_compressed

### DIFF
--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -95,7 +95,7 @@ def modify_save_pretrained(model: PreTrainedModel):
                     "skip_compression_stats=True"
                 )
                 sparsity_config = SparsityConfigMetadata.from_pretrained(
-                    model, state_dict=state_dict, compress=False
+                    model, state_dict=state_dict, compress=save_compressed
                 )
 
             quantization_format = infer_quantization_format(


### PR DESCRIPTION
PR Description: Before this PR, sparse compression was not being utilized since it was explicitly set to False in the codebase. This PR enables sparse compression, allowing us to take advantage of its benefits for reduced memory on disk
