### PR TITLE
Install compressed-tensors after llm-compressor

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -26,16 +26,18 @@ jobs:
         with:
           python-version: '3.11'
       - uses: actions/checkout@v4
+      - name: "⚙️ Install dependencies"
+        run: pip3 install -U pip setuptools && pip3 install .[dev]
       - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
       - name: "⚙️ Install compressed-tensors dependencies"
-        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+        run: |
+          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
+          pip3 install ./compressed-tensors/
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
-      - name: "⚙️ Install dependencies"
-        run: pip3 install .[dev]
       - name: "🔬 Running base tests"
         run: make test
   pytorch-tests:
@@ -45,16 +47,18 @@ jobs:
         with:
           python-version: '3.11'
       - uses: actions/checkout@v4
+      - name: "⚙️ Install dependencies"
+        run: pip3 install -U pip setuptools && pip3 install .[dev]
       - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
       - name: "⚙️ Install compressed-tensors dependencies"
-        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+        run: |
+          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
+          pip3 install ./compressed-tensors/
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
-      - name: "⚙️ Install dependencies"
-        run: pip3 install .[dev]
       - name: "🔬 Running pytorch tests"
         run: |
           pytest tests/llmcompressor/pytorch -v
@@ -65,16 +69,18 @@ jobs:
         with:
           python-version: '3.9'
       - uses: actions/checkout@v4
+      - name: "⚙️ Install dependencies"
+        run: pip3 install -U pip setuptools && pip3 install .[dev]
       - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
       - name: "⚙️ Install compressed-tensors dependencies"
-        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+        run: |
+          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
+          pip3 install ./compressed-tensors/
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
-      - name: "⚙️ Install dependencies"
-        run: pip3 install .[dev]
       - name: "🔬 Running pytorch tests"
         run: |
           pytest tests/llmcompressor/pytorch -v
@@ -85,17 +91,19 @@ jobs:
         with:
           python-version: '3.11'
       - uses: actions/checkout@v4
+      - name: "⚙️ Install dependencies"
+        run: pip3 install -U pip setuptools && pip3 install .[dev]
       - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
       - name: "⚙️ Install compressed-tensors dependencies"
-        run: pip3 install -U pip && pip3 install setuptools compressed-tensors/
+        id: install
+        run: |
+          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
+          pip3 install ./compressed-tensors/
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
-      - name: "⚙️ Install dependencies"
-        id: install
-        run: pip3 install .[dev]
       - name: "🔬 Running transformers tests"
         if: always() && steps.install.outcome == 'success'
         run: |

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -61,7 +61,7 @@ jobs:
         run: rm -r compressed-tensors/
       - name: "🔬 Running pytorch tests"
         run: |
-          pytest tests/llmcompressor/pytorch -v
+          pytest -v tests/llmcompressor/pytorch
   compat-pytorch-1_9-pytorch-tests:
     runs-on: ubuntu-22.04
     steps:
@@ -83,7 +83,7 @@ jobs:
         run: rm -r compressed-tensors/
       - name: "🔬 Running pytorch tests"
         run: |
-          pytest tests/llmcompressor/pytorch -v
+          pytest -v tests/llmcompressor/pytorch
   transformers-tests:
     runs-on: ubuntu-22.04
     steps:
@@ -107,7 +107,7 @@ jobs:
       - name: "🔬 Running transformers tests"
         if: always() && steps.install.outcome == 'success'
         run: |
-          pytest tests/llmcompressor/transformers/compression -v
+          pytest -v tests/llmcompressor/transformers/compression
       - name: Run Finetune Tests
         if: always() && steps.install.outcome == 'success'
         run: |
@@ -115,17 +115,17 @@ jobs:
       - name: Running GPTQ Tests
         if: always() && steps.install.outcome == 'success'
         run: |
-          pytest tests/llmcompressor/transformers/gptq -v
+          pytest -v tests/llmcompressor/transformers/gptq
       - name: Running ONESHOT Tests
         if: always() && steps.install.outcome == 'success'
         run: |
-          pytest tests/llmcompressor/transformers/oneshot -v
+          pytest -v tests/llmcompressor/transformers/oneshot
       - name: Running Sparsification Tests
         if: always() && steps.install.outcome == 'success'
         run: |
-          pytest tests/llmcompressor/transformers/sparsification -v
-          ptyest tests/llmcompressor/transformers/test_clear_ml.py -v
+          pytest -v tests/llmcompressor/transformers/sparsification
+          ptyest -v tests/llmcompressor/transformers/test_clear_ml.py
       - name: Running OBCQ Tests
         if: always() && steps.install.outcome == 'success'
         run: |
-          pytest -v tests/llmcompressor/transformers/obcq -v
+          pytest -v tests/llmcompressor/transformers/obcq

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -15,8 +15,8 @@ env:
   CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
   CLEARML_API_HOST: ${{ secrets.CLEARML_API_HOST }}
   CLEARML_API_ACCESS_KEY: ${{ secrets.CLEARML_API_ACCESS_KEY }}
-  CLEARML_FILES_HOST:  ${{ secrets.CLEARML_FILES_HOST }}
-  CLEARML_API_SECRET_KEY:  ${{ secrets.CLEARML_API_SECRET_KEY }}
+  CLEARML_FILES_HOST: ${{ secrets.CLEARML_FILES_HOST }}
+  CLEARML_API_SECRET_KEY: ${{ secrets.CLEARML_API_SECRET_KEY }}
 
 jobs:
   base-tests:
@@ -105,27 +105,27 @@ jobs:
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
       - name: "🔬 Running transformers tests"
-        if: always() && steps.install.outcome == 'success'
+        if: (success() || failure()) && steps.install.outcome == 'success'
         run: |
           pytest -v tests/llmcompressor/transformers/compression
       - name: Run Finetune Tests
-        if: always() && steps.install.outcome == 'success'
+        if: (success() || failure()) && steps.install.outcome == 'success'
         run: |
           pytest -v tests/llmcompressor/transformers/finetune -m unit
       - name: Running GPTQ Tests
-        if: always() && steps.install.outcome == 'success'
+        if: (success() || failure()) && steps.install.outcome == 'success'
         run: |
           pytest -v tests/llmcompressor/transformers/gptq
       - name: Running ONESHOT Tests
-        if: always() && steps.install.outcome == 'success'
+        if: (success() || failure()) && steps.install.outcome == 'success'
         run: |
           pytest -v tests/llmcompressor/transformers/oneshot
       - name: Running Sparsification Tests
-        if: always() && steps.install.outcome == 'success'
+        if: (success() || failure()) && steps.install.outcome == 'success'
         run: |
           pytest -v tests/llmcompressor/transformers/sparsification
           ptyest -v tests/llmcompressor/transformers/test_clear_ml.py
       - name: Running OBCQ Tests
-        if: always() && steps.install.outcome == 'success'
+        if: (success() || failure()) && steps.install.outcome == 'success'
         run: |
           pytest -v tests/llmcompressor/transformers/obcq


### PR DESCRIPTION
SUMMARY:
These changes move the separate `compressed-tensors` installation to after `llm-compressor` is installed, as well as uninstall any existing version first.

There is also some very minor cleanup:
* Refactor some `pytest` commands so the flag ordering is consistent between them
* Replace the use of `always()` to allow jobs to be cancelable without affecting existing logic/intentions


TEST PLAN:
Branch/PR checks should have the same outcome as `main` (unless some of the existing failure are related to `transformers` specifically requiring a non-nightly install of `compressed-tensors`).
