### PR TITLE
[Bugfix] Use weight parameter of linear layer

### DIFF
--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -126,7 +126,7 @@ def hessian_memory_requirements(model: torch.nn.Module) -> int:
         total_hessian_elems[no_split_name] = 0
         max_column_size[no_split_name] = 0
         for _name, module in no_split_layer.named_modules():
-            if isinstance(module, Linear):
+            if isinstance(module, Linear) and hasattr(module, "weight"):
                 column_size = module.weight.shape[1]
                 total_hessian_elems[no_split_name] += column_size * column_size
                 if column_size > max_column_size[no_split_name]:

--- a/src/llmcompressor/transformers/compression/helpers.py
+++ b/src/llmcompressor/transformers/compression/helpers.py
@@ -125,14 +125,13 @@ def hessian_memory_requirements(model: torch.nn.Module) -> int:
     for no_split_name, no_split_layer in transformer_layers.items():
         total_hessian_elems[no_split_name] = 0
         max_column_size[no_split_name] = 0
-        for name, module in no_split_layer.named_modules():
+        for _name, module in no_split_layer.named_modules():
             if isinstance(module, Linear):
-                for param in module.parameters():
-                    column_size = param.shape[1]
-                    total_hessian_elems[no_split_name] += column_size * column_size
-                    if column_size > max_column_size[no_split_name]:
-                        # max extra memory for inverse calculation
-                        max_column_size[no_split_name] = column_size
+                column_size = module.weight.shape[1]
+                total_hessian_elems[no_split_name] += column_size * column_size
+                if column_size > max_column_size[no_split_name]:
+                    # max extra memory for inverse calculation
+                    max_column_size[no_split_name] = column_size
 
     max_total_hessian_elems = max(total_hessian_elems.values())
     overall_max_column_size = max(max_column_size.values())


### PR DESCRIPTION
## Purpose ##
* Fixes #106 where some Linear (potentially subclassed) layers have parameters which are not two dimensional, namely bias parameters

```
Traceback (most recent call last):
  File "/root/.clearml/venvs-builds/3.10/code/llmcompressor_oneshot_base.py", line 90, in <module>
    device_map = calculate_offload_device_map(
  File "/root/.clearml/venvs-builds/3.10/lib/python3.10/site-packages/llmcompressor/transformers/compression/helpers.py", line 239, in calculate_offload_device_map
    reserved_memory = hessian_memory_requirements(dummy_model)
  File "/root/.clearml/venvs-builds/3.10/lib/python3.10/site-packages/llmcompressor/transformers/compression/helpers.py", line 131, in hessian_memory_requirements
    column_size = param.shape[1]
IndexError: tuple index out of range

1728512138021 oneshot-a100-single-clearml-agent:46dc5f512eb64c9dbf7f58d0c9786b61 DEBUG Process failed, exit code 1
```

## Changes ##
* Only calculate hessians w.r.t. Linear.weight Since `Linear` layers are guaranteed to have a `weight` parameter, and hessians are only interested in the weight parameter

## Testing ##
* `cognitivecomputations/dolphin-2.9.2-qwen2-7b` used to error, now properly computes device map
* `hessian_memory_requirements` yields same result with  both on main and in this branch
  * `deepseek-ai/DeepSeek-V2.5` -> `37679529984`
  * `meta-llama/Meta-Llama-3-8B-Instruct` -> `2046820352`