### PR TITLE
Use float32 for Hessian dtype

### DIFF
--- a/src/llmcompressor/modifiers/obcq/utils/sgpt_wrapper.py
+++ b/src/llmcompressor/modifiers/obcq/utils/sgpt_wrapper.py
@@ -40,7 +40,10 @@ class SparseGptWrapper(ModuleCompressionWrapper):
 
         # for Hessian calculation
         self.register_buffer(
-            "H", torch.zeros((self.columns, self.columns), device=self.dev)
+            "H",
+            torch.zeros(
+                (self.columns, self.columns), device=self.dev, dtype=torch.float32
+            ),
         )
 
     def add_batch(self, inp: torch.Tensor, out: torch.Tensor):
@@ -61,7 +64,8 @@ class SparseGptWrapper(ModuleCompressionWrapper):
             inp = inp.t()
         self.H *= self.nsamples / (self.nsamples + tmp)
         self.nsamples += tmp
-        inp = math.sqrt(2 / self.nsamples) * inp.float()
+        inp = inp.to(dtype=self.H.dtype)
+        inp = math.sqrt(2 / self.nsamples) * inp
         self.H += inp.matmul(inp.t()).to(self.dev)
 
     def compress(

--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -81,7 +81,8 @@ class GPTQWrapper(ModuleCompressionWrapper):
             inp = inp.t()
         self.H *= self.nsamples / (self.nsamples + tmp)
         self.nsamples += tmp
-        inp = math.sqrt(2 / self.nsamples) * inp.float()
+        inp = inp.to(dtype=self.H.dtype)
+        inp = math.sqrt(2 / self.nsamples) * inp
         self.H += inp.matmul(inp.t())
 
     def compress(

--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -57,7 +57,10 @@ class GPTQWrapper(ModuleCompressionWrapper):
 
         # for Hessian calculation
         self.register_buffer(
-            "H", torch.zeros((self.columns, self.columns), device=self.dev)
+            "H",
+            torch.zeros(
+                (self.columns, self.columns), device=self.dev, dtype=torch.float32
+            ),
         )
 
     def add_batch(self, inp: torch.Tensor, out: torch.Tensor):


### PR DESCRIPTION
## Purpose ##
* Fix failing tests `RuntimeError: "cholesky_cusolver" not implemented for 'BFloat16'`

## Changes ##
* Explicitly set hessian dtype to float32 (an assumption made by other functions such as cpu_offloading)
** This change guards against changes to the pytorch default dtype

## Testing ##
* TODO