### PR TITLE
[ DOC ] Remove version restrictions in W8A8 exmaple

### DIFF
--- a/examples/big_models_with_accelerate/README.md
+++ b/examples/big_models_with_accelerate/README.md
@@ -66,7 +66,7 @@ We will show working examples for each use case:
 Install `llmcompressor`:
 
 ```bash
-pip install llmcompressor==0.1.0
+pip install llmcompressor
 ```
 
 ### CPU Offloading: `FP8` Quantization with `PTQ`

--- a/examples/quantization_w8a8_fp8/README.md
+++ b/examples/quantization_w8a8_fp8/README.md
@@ -9,7 +9,7 @@
 To get started, install:
 
 ```bash
-pip install llmcompressor==0.1.0
+pip install llmcompressor
 ```
 
 ## Quickstart

--- a/examples/quantization_w8a8_int8/README.md
+++ b/examples/quantization_w8a8_int8/README.md
@@ -9,7 +9,7 @@
 To get started, install:
 
 ```bash
-pip install llmcompressor==0.1.0
+pip install llmcompressor
 ```
 
 ## Quickstart


### PR DESCRIPTION
SUMMARY:
The latest compressored-tensor 0.8.0 removed some API, https://github.com/neuralmagic/compressed-tensors/pull/156/files If installed the older llmcompressor from pip, it would throw the error like:
```
ImportError: cannot import name 'update_layer_weight_quant_params' from 'compressed_tensors.quantization'
```


TEST PLAN:
already tested locally
