### PR TITLE
Add marlin-24 recipe/configs for e2e testing

### DIFF
--- a/tests/e2e/vLLM/configs/WNA16_2of4/w4a16_2of4_channel_quant.yaml
+++ b/tests/e2e/vLLM/configs/WNA16_2of4/w4a16_2of4_channel_quant.yaml
@@ -1,0 +1,7 @@
+cadence: "nightly"
+test_type: "regression"
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+scheme: W4A16_2of4_channel
+dataset_id: HuggingFaceH4/ultrachat_200k
+dataset_split: train_sft
+recipe: tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_recipe.yaml

--- a/tests/e2e/vLLM/configs/WNA16_2of4/w4a16_2of4_grouped_quant.yaml
+++ b/tests/e2e/vLLM/configs/WNA16_2of4/w4a16_2of4_grouped_quant.yaml
@@ -1,0 +1,7 @@
+cadence: "nightly"
+test_type: "regression"
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+scheme: W4A16_2of4
+dataset_id: HuggingFaceH4/ultrachat_200k
+dataset_split: train_sft
+recipe: tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_group-128_recipe.yaml

--- a/tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_group-128_recipe.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_group-128_recipe.yaml
@@ -1,0 +1,21 @@
+sparsity_stage:
+  run_type: oneshot
+  sparsity_modifiers:
+    SparseGPTModifier:
+      sparsity: 0.5
+      mask_structure: "2:4"
+      sequential_update: false
+quantization_stage:
+  run_type: oneshot
+  quantization_modifiers:
+    GPTQModifier:
+      ignore: ["lm_head"]
+      config_groups:
+        group_0:
+          weights:
+            num_bits: 4
+            type: "int"
+            symmetric: true
+            strategy: "group"
+            group_size: 128
+          targets: ["Linear"]

--- a/tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_recipe.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_recipe.yaml
@@ -1,0 +1,20 @@
+sparsity_stage:
+  run_type: oneshot
+  sparsity_modifiers:
+    SparseGPTModifier:
+      sparsity: 0.5
+      mask_structure: "2:4"
+      sequential_update: false
+quantization_stage:
+  run_type: oneshot
+  quantization_modifiers:
+    GPTQModifier:
+      ignore: ["lm_head"]
+      config_groups:
+        group_0:
+          weights:
+            num_bits: 4
+            type: "int"
+            symmetric: true
+            strategy: "channel"
+          targets: ["Linear"]

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -28,7 +28,8 @@ WNA16 = "tests/e2e/vLLM/configs/WNA16"
 FP8 = "tests/e2e/vLLM/configs/FP8"
 INT8 = "tests/e2e/vLLM/configs/INT8"
 ACTORDER = "tests/e2e/vLLM/configs/actorder"
-CONFIGS = [WNA16, FP8, INT8, ACTORDER]
+WNA16_2of4 = "tests/e2e/vLLM/configs/WNA16_2of4"
+CONFIGS = [WNA16, FP8, INT8, ACTORDER, WNA16_2of4]
 
 
 @requires_gpu

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -69,7 +69,7 @@ class TestvLLM(unittest.TestCase):
         self.device = "cuda:0"
         self.oneshot_kwargs = {}
         self.num_calibration_samples = 256
-        self.max_seq_length = 1048
+        self.max_seq_length = 2048
         self.prompts = [
             "The capital of France is",
             "The president of the US is",
@@ -77,6 +77,8 @@ class TestvLLM(unittest.TestCase):
         ]
 
     def test_vllm(self):
+        import torch
+
         # Load model.
         loaded_model = SparseAutoModelForCausalLM.from_pretrained(
             self.model, device_map=self.device, torch_dtype="auto"
@@ -120,7 +122,11 @@ class TestvLLM(unittest.TestCase):
         # Run vLLM with saved model
         print("================= RUNNING vLLM =========================")
         sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
-        llm = LLM(model=self.save_dir)
+        if "W4A16_2of4" in self.scheme:
+            # required by the kernel
+            llm = LLM(model=self.save_dir, dtype=torch.float16)
+        else:
+            llm = LLM(model=self.save_dir)
         outputs = llm.generate(self.prompts, sampling_params)
         print("================= vLLM GENERATION ======================")
         for output in outputs:
@@ -129,7 +135,6 @@ class TestvLLM(unittest.TestCase):
             generated_text = output.outputs[0].text
             print("PROMPT", prompt)
             print("GENERATED TEXT", generated_text)
-
         print("================= UPLOADING TO HUB ======================")
         self.oneshot_kwargs["model"].push_to_hub(f"nm-testing/{self.save_dir}-e2e")
         tokenizer.push_to_hub(f"nm-testing/{self.save_dir}-e2e")


### PR DESCRIPTION
SUMMARY:
- No e2e testing is yet enabled for marlin-2:4 models
- Adds to the vLLM testing such that a grouped and channel quant model is tested on a nightly cadence
- Will also ensure accuracy as we expand our 2:4 support