### PR TITLE
Fix HFTrainer overloads

### DIFF
--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -297,7 +297,7 @@ class SessionManagerMixIn:
             model,
             inputs,
             return_outputs=return_outputs,
-            num_items_in_batch=num_items_in_batch
+            num_items_in_batch=num_items_in_batch,
         )
 
         # take the mean across multiple GPUs

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -293,7 +293,12 @@ class SessionManagerMixIn:
 
         # TODO: do we need these model signature columns?
         inputs = {k: inputs[k] for k in inputs if k in self._signature_columns}
-        loss = super().compute_loss(model, inputs, return_outputs, num_items_in_batch)
+        loss = super().compute_loss(
+            model,
+            inputs,
+            return_outputs=return_outputs,
+            num_items_in_batch=num_items_in_batch
+        )
 
         # take the mean across multiple GPUs
         # this is done outside the compute_loss function in the parent, replicating it

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -249,7 +249,9 @@ class SessionManagerMixIn:
 
         # TODO: we don't currently have a LR scheduler in the new modifier framework
         self._check_super_defined("create_scheduler")
-        return super().create_scheduler(num_training_steps, optimizer)
+        return super().create_scheduler(
+            num_training_steps=num_training_steps, optimizer=optimizer
+        )
 
     def training_step(
         self,
@@ -268,7 +270,9 @@ class SessionManagerMixIn:
         self._check_super_defined("training_step")
 
         callbacks.batch_start(batch_data=inputs)
-        model_outputs = super().training_step(model, inputs, num_items_in_batch)
+        model_outputs = super().training_step(
+            model=model, inputs=inputs, num_items_in_batch=num_items_in_batch
+        )
 
         return model_outputs
 
@@ -294,8 +298,8 @@ class SessionManagerMixIn:
         # TODO: do we need these model signature columns?
         inputs = {k: inputs[k] for k in inputs if k in self._signature_columns}
         loss = super().compute_loss(
-            model,
-            inputs,
+            model=model,
+            inputs=inputs,
             return_outputs=return_outputs,
             num_items_in_batch=num_items_in_batch,
         )
@@ -344,7 +348,10 @@ class SessionManagerMixIn:
         inputs = {k: inputs[k] for k in inputs if k in self._model_signature_columns}
 
         model_outputs = super().prediction_step(
-            model, inputs, prediction_loss_only, ignore_keys
+            model=model,
+            inputs=inputs,
+            prediction_loss_only=prediction_loss_only,
+            ignore_keys=ignore_keys,
         )
         return model_outputs
 


### PR DESCRIPTION
## Purpose ##
* Fix failing tests in `tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py`

## Background ##
* The HFTrainer function contracts were changed in the most recent transformers release 4.46.0 ([offending commit](https://github.com/huggingface/transformers/commit/6ba31a8a94bf7cfeaf59ffc3bc9e0b0cd3e25788#diff-ed55888e6665791fe92cc8fc0c499da54f4ace6738551cd9a2591881cda076deR3603))

## Changes ##
* Change mixin overloads to use the same function contract as the original functions
* This change is backwards compatible with earlier versions of transformers since the new arguments are kwargs

## Testing ##
* `tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py` now passes