### PR TITLE
Support Model Offloading Tied Tensors Patch

### DIFF
--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -152,7 +152,7 @@ def new_dtype_byte_size(dtype):
     return bit_size // 8
 
 
-def patch_tied_tensors_bug(model: torch.nn.Module) -> torch.nn.Module:
+def patch_tied_tensors_bug(model: torch.nn.Module):
     """
     Patches bug where HF transformers will fail to untie weights under specific
     circumstances (https://github.com/huggingface/transformers/issues/33689).
@@ -160,7 +160,6 @@ def patch_tied_tensors_bug(model: torch.nn.Module) -> torch.nn.Module:
     This function detects those cases and unties the tensors if applicable
 
     :param model: model to fix
-    :return: model with fixed parameters
     """
     if (
         hasattr(model.config, "tie_word_embeddings")
@@ -179,5 +178,3 @@ def patch_tied_tensors_bug(model: torch.nn.Module) -> torch.nn.Module:
 
                 if offloaded:
                     module._hf_hook.post_forward(module, None)
-
-    return model

--- a/src/llmcompressor/transformers/sparsification/sparse_model.py
+++ b/src/llmcompressor/transformers/sparsification/sparse_model.py
@@ -108,7 +108,7 @@ def wrap_hf_model_class(hf_model_class: PreTrainedModel) -> PreTrainedModel:
 
         # patch a shared tensor bug in HF transformers
         # https://github.com/huggingface/transformers/issues/33689
-        model = patch_tied_tensors_bug(model)
+        patch_tied_tensors_bug(model)
 
         if model.dtype != model.config.torch_dtype:
             logger.warning(


### PR DESCRIPTION
## Purpose ##
* Support calling the tied tensors bug patch for offloaded modules
  * This is a precursor to supporting #832

## Changes ##
* Write untied tensors to offloaded state dict in addition to module parameter
* Make `patch_tied_tensors_bug` an in-place function to reflect how the function cannot be used in an out-of-place way

## Testing ##
```python3
import torch
from transformers import AutoModel
from accelerate import cpu_offload
from llmcompressor.transformers.sparsification.compressed_tensors_utils import patch_tied_tensors_bug

@pytest.mark.parametrize(
    "offload,torch_dtype,tie_word_embeddings,device_map",
    [
        (False, torch.float16, False, "cpu"),
        (False, torch.float32, False, "cpu"),
        (True, torch.float32, False, "cpu"),
        (False, torch.float16, True, "cpu"),
        (False, torch.float32, True, "cpu"),
        (True, torch.float16, True, "cpu"),
        (True, torch.float32, True, "cpu"),
    ],
)
def test_model_shared_tensors(
    offload, torch_dtype, tie_word_embeddings, device_map, tmp_path
):
    # load model
    model = AutoModel.from_pretrained(
        "Xenova/llama2.c-stories15M",
        torch_dtype=torch_dtype,
        tie_word_embeddings=tie_word_embeddings,
        device_map=device_map,
    )
    if offload:
        model = cpu_offload(model)
    
    patch_tied_tensors_bug(model)

    # modify lm head
    with torch.no_grad():
        if offload:
            model.lm_head._hf_hook.pre_forward(model.lm_head)

        model.lm_head.weight += 1

        if offload:
            device = get_offloaded_device(model.lm_head)
            update_prefix_dict(model.lm_head, "weight", model.lm_head.weight.to(device))
            model.lm_head._hf_hook.post_forward(model.lm_head, None)

    # check that embed_tokens is not modified
    model_dict = get_state_dict_offloaded_model(model)
    lm_head = model_dict["lm_head.weight"]
    embed_tokens = model_dict["model.embed_tokens.weight"]
    if tie_word_embeddings:
        assert torch.equal(lm_head, embed_tokens)
    else:
        assert not torch.equal(lm_head, embed_tokens)
```