### PR TITLE
[DO NOT MERGE] Increase Sparsity Threshold to 50% for sparse compression

### DIFF
--- a/src/llmcompressor/transformers/compression/sparsity_config.py
+++ b/src/llmcompressor/transformers/compression/sparsity_config.py
@@ -20,7 +20,7 @@ class SparsityConfigMetadata:
     metadata from the model
     """
 
-    SPARSITY_THRESHOLD: float = 0.4
+    SPARSITY_THRESHOLD: float = 0.5
 
     @staticmethod
     def infer_global_sparsity(


### PR DESCRIPTION
#### Background
We have observed instances where accidental sparsity induced by W4-style quantization exceeds 40%. These modules are being identified during the population of `sparsity_config`.

#### Changes
As discussed in our offline conversations, this PR increases the sparsity threshold to 50%.

#### Summary
- Increased the sparsity threshold from 40% to 50% to better handle cases of accidental sparsity induced by W4-style quantization.
