### PR TITLE
[Bugfix] Correct metrics calculations

### DIFF
--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -12,10 +12,7 @@ from llmcompressor.modifiers.utils import SPARSITY_THRESHOLD
 from llmcompressor.modifiers.utils.compression_wrapper import ModuleCompressionWrapper
 from llmcompressor.pytorch.utils.helpers import tensor_sparsity
 from llmcompressor.utils import getattr_chain
-from llmcompressor.utils.metric_logging import (
-    get_GPU_memory_usage,
-    get_layer_size_bytes,
-)
+from llmcompressor.utils.metric_logging import get_GPU_memory_usage, get_layer_size_mb
 
 try:
     import transformers
@@ -344,5 +341,5 @@ class GPTQWrapper(ModuleCompressionWrapper):
 
         patch.log(
             "METRIC",
-            f"Compressed layer size: {get_layer_size_bytes(self.layer)} MB",
+            f"Compressed layer size: {get_layer_size_mb(self.layer)} MB",
         )

--- a/src/llmcompressor/utils/metric_logging.py
+++ b/src/llmcompressor/utils/metric_logging.py
@@ -3,6 +3,8 @@ from typing import List, Tuple
 from loguru import logger
 from torch.nn import Module
 
+__all__ = ["get_GPU_memory_usage", "get_layer_size_mb"]
+
 
 def get_GPU_memory_usage() -> List[Tuple]:
     try:
@@ -23,7 +25,7 @@ def get_GPU_memory_usage() -> List[Tuple]:
             handle = pynvml.nvmlDeviceGetHandleByIndex(i)
             mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
             memory_usage_percentage = mem_info.used / mem_info.total
-            total_memory_gb = mem_info.total / (1024**3)
+            total_memory_gb = mem_info.total / (1e9)
             usage.append(
                 (memory_usage_percentage, total_memory_gb),
             )
@@ -35,7 +37,7 @@ def get_GPU_memory_usage() -> List[Tuple]:
         return []
 
 
-def get_layer_size_bytes(module: Module) -> float:
+def get_layer_size_mb(module: Module) -> float:
     param_size = 0
     buffer_size = 0
 
@@ -46,6 +48,6 @@ def get_layer_size_bytes(module: Module) -> float:
         buffer_size += buffer.nelement() * buffer.element_size()
 
     total_size = param_size + buffer_size
-    total_size_mb = total_size / (1024**2)  # Convert bytes to MB
+    total_size_mb = total_size / (1e6)  # Convert bytes to MB
 
     return total_size_mb


### PR DESCRIPTION
## Purpose ##
* Fix metrics calculations to use gigabytes and megabytes rather than gibibytes and mebibytes

## Changes ##
* Use correct gigabyte and megabyte sizes in metrics calculations
* Rename `get_layer_size_bytes` to `get_layer_size_mb`