### PR TITLE
BugFix: Fix Sparsity Reload Testing

### DIFF
--- a/src/llmcompressor/pytorch/model_load/helpers.py
+++ b/src/llmcompressor/pytorch/model_load/helpers.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 from loguru import logger
@@ -142,17 +142,18 @@ def fallback_to_cpu(device: str) -> str:
     return device
 
 
-def parse_dtype(dtype_arg: str) -> torch.dtype:
+def parse_dtype(dtype_arg: Union[str, torch.dtype]) -> torch.dtype:
     """
-    :param dtype_arg: dtype string to parse
+    :param dtype_arg: dtype or string to parse
     :return: torch.dtype parsed from input string
     """
+    dtype_arg = str(dtype_arg)
     dtype = "auto"  # get precision from model by default
-    if dtype_arg == "half" or dtype_arg == "float16":
+    if dtype_arg in ("half", "float16", "torch.float16"):
         dtype = torch.float16
-    elif dtype_arg == "bfloat16":
+    elif dtype_arg in ("torch.bfloat16", "bfloat16"):
         dtype = torch.bfloat16
-    elif dtype_arg == "full" or dtype_arg == "float32":
+    elif dtype_arg in ("full", "float32", "torch.float32"):
         dtype = torch.float32
 
     return dtype

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -139,9 +139,9 @@ def test_dense_model_save(tmp_path, skip_compression_stats, save_compressed):
 @pytest.mark.parametrize(
     "format,dtype",
     [
-        #["dense", torch.float32],
+        ["dense", torch.float32],
         ["dense", torch.float16],
-        #["int_quantized", torch.float32],
+        ["int_quantized", torch.float32],
         # [True, "int_quantized", torch.float16],
     ],
 )
@@ -159,7 +159,7 @@ def test_quant_model_reload(format, dtype, tmp_path):
     concatenate_data = False
     num_calibration_samples = 64
     splits = {"calibration": "train[:10%]"}
-    empty_model = AutoModelForCausalLM.from_pretrained(model_path)
+    empty_model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=dtype)
 
     # create a quantized model
     oneshot(
@@ -193,9 +193,7 @@ def test_quant_model_reload(format, dtype, tmp_path):
     quant_config = ModelCompressor.parse_quantization_config(compression_config)
     assert quant_config["format"] == format
 
-    compressor = ModelCompressor.from_compression_config(
-        compression_config
-    )
+    compressor = ModelCompressor.from_compression_config(compression_config)
     compressor.quantization_config.quantization_status = QuantizationStatus.FROZEN
     compressor.decompress(model_path="compress_out", model=empty_model)
 

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -10,7 +10,7 @@ from compressed_tensors.compressors import ModelCompressor
 from compressed_tensors.config import BitmaskConfig, DenseSparsityConfig
 from compressed_tensors.quantization import QuantizationStatus
 from compressed_tensors.utils import get_offloaded_device, update_prefix_dict
-from transformers import AutoConfig
+from transformers import AutoConfig, AutoModelForCausalLM
 
 from llmcompressor.core import reset_session
 from llmcompressor.pytorch.utils.helpers import tensor_sparsity
@@ -139,13 +139,15 @@ def test_dense_model_save(tmp_path, skip_compression_stats, save_compressed):
 @pytest.mark.parametrize(
     "format,dtype",
     [
-        ["dense", torch.float32],
+        #["dense", torch.float32],
         ["dense", torch.float16],
-        ["int_quantized", torch.float32],
+        #["int_quantized", torch.float32],
         # [True, "int_quantized", torch.float16],
     ],
 )
 def test_quant_model_reload(format, dtype, tmp_path):
+    from llmcompressor.pytorch.model_load.helpers import get_session_model
+
     recipe_str = (
         "tests/llmcompressor/transformers/compression/recipes/new_quant_simple.yaml"
     )
@@ -156,25 +158,24 @@ def test_quant_model_reload(format, dtype, tmp_path):
     dataset = "open_platypus"
     concatenate_data = False
     num_calibration_samples = 64
-    output_dir = tmp_path / "oneshot_out"
     splits = {"calibration": "train[:10%]"}
+    empty_model = AutoModelForCausalLM.from_pretrained(model_path)
 
     # create a quantized model
     oneshot(
         model=model_path,
         dataset=dataset,
-        output_dir=output_dir,
         num_calibration_samples=num_calibration_samples,
         recipe=recipe_str,
         concatenate_data=concatenate_data,
         splits=splits,
         oneshot_device=device,
+        clear_sparse_session=False,
         precision=dtype,
     )
 
-    model = SparseAutoModelForCausalLM.from_pretrained(
-        tmp_path / "oneshot_out", torch_dtype=dtype
-    )
+    model = get_session_model()
+    og_state_dict = model.state_dict()
 
     for _, module in model.named_modules():
         if hasattr(module, "quantization_scheme"):
@@ -182,26 +183,33 @@ def test_quant_model_reload(format, dtype, tmp_path):
             assert module.quantization_status == QuantizationStatus.FROZEN
 
     model.save_pretrained(
-        tmp_path / "compress_out",
+        "compress_out",
         quantization_format=format,
         save_compressed=True,
     )
 
-    config = AutoConfig.from_pretrained(tmp_path / "compress_out")
+    config = AutoConfig.from_pretrained("compress_out")
     compression_config = getattr(config, QUANTIZATION_CONFIG_NAME, None)
     quant_config = ModelCompressor.parse_quantization_config(compression_config)
     assert quant_config["format"] == format
 
-    dense_model = SparseAutoModelForCausalLM.from_pretrained(
-        tmp_path / "compress_out", torch_dtype="auto"
+    compressor = ModelCompressor.from_compression_config(
+        compression_config
     )
+    compressor.quantization_config.quantization_status = QuantizationStatus.FROZEN
+    compressor.decompress(model_path="compress_out", model=empty_model)
 
-    og_state_dict = model.state_dict()
-    reconstructed_state_dict = dense_model.state_dict()
+    """
+    dense_model = SparseAutoModelForCausalLM.from_pretrained(
+        "compress_out", torch_dtype="auto", device_map=device
+    )
+    """
+
+    reconstructed_state_dict = empty_model.state_dict()
     assert len(og_state_dict) == len(reconstructed_state_dict)
     for key in og_state_dict.keys():
-        dense_tensor = og_state_dict[key]
-        reconstructed_tensor = reconstructed_state_dict[key]
+        dense_tensor = og_state_dict[key].to(device)
+        reconstructed_tensor = reconstructed_state_dict[key].to(device)
         assert dense_tensor.dtype == reconstructed_tensor.dtype
         if key.endswith("weight") and format != "dense":
             # we don't expect an exact match for compressed
@@ -209,7 +217,6 @@ def test_quant_model_reload(format, dtype, tmp_path):
             assert not torch.any(diff > 0.01).item()
         else:
             assert torch.equal(dense_tensor, reconstructed_tensor)
-
     shutil.rmtree(tmp_path)
 
 


### PR DESCRIPTION
# SUMMARY:
- Fix previously failing reload test case 
- This was failing as the lifecycle had changed but the test case was never updated
- As HFQuantizer currently does not support decompressing the entire model on load (only layer by layer) on the forward pass, temporarily commented out that pathway until it is supported and currently using the  model compressor to decompress the model on disk
- HFQuantizer also in general does not support decompressing the embedding layer, even on a layer by layer case.