### PR TITLE
Bugfix observer initialization in `gptq_wrapper`

### DIFF
--- a/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py
@@ -10,6 +10,7 @@ from compressed_tensors.quantization.lifecycle.forward import fake_quantize
 
 from llmcompressor.modifiers.utils import SPARSITY_THRESHOLD
 from llmcompressor.modifiers.utils.compression_wrapper import ModuleCompressionWrapper
+from llmcompressor.observers import Observer
 from llmcompressor.pytorch.utils.helpers import tensor_sparsity
 from llmcompressor.utils import getattr_chain
 from llmcompressor.utils.metric_logging import (
@@ -303,6 +304,7 @@ class GPTQWrapper(ModuleCompressionWrapper):
         :param W: weight to calculate quantization parameters from
         """
         observer = args.get_observer()
+        observer = Observer.load_from_registry(observer, quantization_args=args)
         _scale, _zero_point = observer(W, g_idx=None)
         update_parameter_data(self.layer, _scale, "weight_scale")
         update_parameter_data(self.layer, _zero_point, "weight_zero_point")


### PR DESCRIPTION
This PR addresses a missing initialization step in the `gptq` wrapper, which previously raised an error when attempting to initialize an observer object by name. 

The issue arose after the recent Observers refactor, where `QuantizationArgs.get_observer()` now returns an observer name instead of an object. This name must be used to initialize an observer on the `llm-compressor` side.

<details>
<summary>Test Script and Output</summary>

#### Test Script

```python
from llmcompressor.transformers import oneshot
from llmcompressor.transformers import SparseAutoModelForCausalLM
from llmcompressor.modifiers.quantization.gptq import GPTQModifier

hf_model_stub = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
calibration_dataset = "open_platypus"
output_directory = f"{hf_model_stub.split('/')[-1]}-pruned_50.2of4-uncompressed"

model = SparseAutoModelForCausalLM.from_pretrained(hf_model_stub, torch_dtype="auto", device_map="auto")

recipe = [
    GPTQModifier(scheme="W8A8", targets="Linear", ignore=["lm_head"]),
]

oneshot(
    model=model,
    dataset=calibration_dataset,
    recipe=recipe,
    output_dir=output_directory,
)
```

#### Output Summary (Truncated)

```plaintext
100%|█████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:01<00:00, 269.43it/s]
2024-10-31T20:44:55.692830+0000 | apply_compression | INFO - Mean output error from quantization: 0.002
2024-10-31T20:44:55.693904+0000 | apply_compression | INFO - 
===== Compressing layer 22/22  =====
2024-10-31T20:44:55.694095+0000 | apply_compression | INFO - Calibrating model.layers.21...
100%|██████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:06<00:00, 82.01it/s]
2024-10-31T20:45:02.531663+0000 | compress_module | INFO - Compressing model.layers.21.model.layers.21.self_attn.q_proj...
2024-10-31T20:45:03.258442+0000 | compress | METRIC - time 0.73
2024-10-31T20:45:03.259133+0000 | compress | METRIC - error 12.22
2024-10-31T20:45:03.259514+0000 | compress | METRIC - GPU 0 | usage: 0.70% | total memory: 79 GB
2024-10-31T20:45:03.259598+0000 | compress | METRIC - GPU 1 | usage: 0.61% | total memory: 79 GB
2024-10-31T20:45:03.259666+0000 | compress | METRIC - GPU 2 | usage: 0.68% | total memory: 79 GB
2024-10-31T20:45:03.259727+0000 | compress | METRIC - GPU 3 | usage: 0.59% | total memory: 79 GB
2024-10-31T20:45:03.259785+0000 | compress | METRIC - GPU 4 | usage: 89.85% | total memory: 79 GB
2024-10-31T20:45:03.259842+0000 | compress | METRIC - GPU 5 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:03.259899+0000 | compress | METRIC - GPU 6 | usage: 4.99% | total memory: 79 GB
2024-10-31T20:45:03.259954+0000 | compress | METRIC - GPU 7 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:03.260144+0000 | compress | METRIC - Compressed layer size: 8.005859375 MB
2024-10-31T20:45:03.260499+0000 | compress_module | INFO - Compressing model.layers.21.model.layers.21.self_attn.k_proj...
2024-10-31T20:45:03.792801+0000 | compress | METRIC - time 0.53
2024-10-31T20:45:03.793563+0000 | compress | METRIC - error 3.49
2024-10-31T20:45:04.020150+0000 | compress | METRIC - GPU 0 | usage: 0.70% | total memory: 79 GB
2024-10-31T20:45:04.020406+0000 | compress | METRIC - GPU 1 | usage: 0.61% | total memory: 79 GB
2024-10-31T20:45:04.020490+0000 | compress | METRIC - GPU 2 | usage: 0.68% | total memory: 79 GB
2024-10-31T20:45:04.020565+0000 | compress | METRIC - GPU 3 | usage: 0.59% | total memory: 79 GB
2024-10-31T20:45:04.020645+0000 | compress | METRIC - GPU 4 | usage: 89.85% | total memory: 79 GB
2024-10-31T20:45:04.020723+0000 | compress | METRIC - GPU 5 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:04.020824+0000 | compress | METRIC - GPU 6 | usage: 4.99% | total memory: 79 GB
2024-10-31T20:45:04.020901+0000 | compress | METRIC - GPU 7 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:04.021158+0000 | compress | METRIC - Compressed layer size: 1.000732421875 MB
2024-10-31T20:45:04.021783+0000 | compress_module | INFO - Compressing model.layers.21.model.layers.21.self_attn.v_proj...
2024-10-31T20:45:04.565787+0000 | compress | METRIC - time 0.54
2024-10-31T20:45:04.566422+0000 | compress | METRIC - error 0.87
2024-10-31T20:45:04.566814+0000 | compress | METRIC - GPU 0 | usage: 0.70% | total memory: 79 GB
2024-10-31T20:45:04.566899+0000 | compress | METRIC - GPU 1 | usage: 0.61% | total memory: 79 GB
2024-10-31T20:45:04.566965+0000 | compress | METRIC - GPU 2 | usage: 0.68% | total memory: 79 GB
2024-10-31T20:45:04.567028+0000 | compress | METRIC - GPU 3 | usage: 0.59% | total memory: 79 GB
2024-10-31T20:45:04.567088+0000 | compress | METRIC - GPU 4 | usage: 89.85% | total memory: 79 GB
2024-10-31T20:45:04.567146+0000 | compress | METRIC - GPU 5 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:04.567203+0000 | compress | METRIC - GPU 6 | usage: 4.99% | total memory: 79 GB
2024-10-31T20:45:04.567261+0000 | compress | METRIC - GPU 7 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:04.567450+0000 | compress | METRIC - Compressed layer size: 1.000732421875 MB
2024-10-31T20:45:04.567791+0000 | compress_module | INFO - Compressing model.layers.21.model.layers.21.self_attn.o_proj...
2024-10-31T20:45:05.116289+0000 | compress | METRIC - time 0.55
2024-10-31T20:45:05.117008+0000 | compress | METRIC - error 0.38
2024-10-31T20:45:05.117407+0000 | compress | METRIC - GPU 0 | usage: 0.70% | total memory: 79 GB
2024-10-31T20:45:05.117493+0000 | compress | METRIC - GPU 1 | usage: 0.61% | total memory: 79 GB
2024-10-31T20:45:05.117559+0000 | compress | METRIC - GPU 2 | usage: 0.68% | total memory: 79 GB
2024-10-31T20:45:05.117618+0000 | compress | METRIC - GPU 3 | usage: 0.59% | total memory: 79 GB
2024-10-31T20:45:05.117676+0000 | compress | METRIC - GPU 4 | usage: 89.85% | total memory: 79 GB
2024-10-31T20:45:05.117731+0000 | compress | METRIC - GPU 5 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:05.117786+0000 | compress | METRIC - GPU 6 | usage: 4.99% | total memory: 79 GB
2024-10-31T20:45:05.117841+0000 | compress | METRIC - GPU 7 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:05.118025+0000 | compress | METRIC - Compressed layer size: 8.005859375 MB
2024-10-31T20:45:05.118433+0000 | compress_module | INFO - Compressing model.layers.21.model.layers.21.mlp.gate_proj...
2024-10-31T20:45:05.698811+0000 | compress | METRIC - time 0.58
2024-10-31T20:45:05.699419+0000 | compress | METRIC - error 21.34
2024-10-31T20:45:05.805179+0000 | compress | METRIC - GPU 0 | usage: 0.70% | total memory: 79 GB
2024-10-31T20:45:05.805401+0000 | compress | METRIC - GPU 1 | usage: 0.61% | total memory: 79 GB
2024-10-31T20:45:05.805482+0000 | compress | METRIC - GPU 2 | usage: 0.68% | total memory: 79 GB
2024-10-31T20:45:05.805546+0000 | compress | METRIC - GPU 3 | usage: 0.59% | total memory: 79 GB
2024-10-31T20:45:05.805608+0000 | compress | METRIC - GPU 4 | usage: 89.85% | total memory: 79 GB
2024-10-31T20:45:05.805667+0000 | compress | METRIC - GPU 5 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:05.805727+0000 | compress | METRIC - GPU 6 | usage: 5.17% | total memory: 79 GB
2024-10-31T20:45:05.805786+0000 | compress | METRIC - GPU 7 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:05.805983+0000 | compress | METRIC - Compressed layer size: 22.01611328125 MB
2024-10-31T20:45:05.806458+0000 | compress_module | INFO - Compressing model.layers.21.model.layers.21.mlp.up_proj...
2024-10-31T20:45:06.373694+0000 | compress | METRIC - time 0.57
2024-10-31T20:45:06.374177+0000 | compress | METRIC - error 13.03
2024-10-31T20:45:06.622400+0000 | compress | METRIC - GPU 0 | usage: 0.70% | total memory: 79 GB
2024-10-31T20:45:06.622647+0000 | compress | METRIC - GPU 1 | usage: 0.61% | total memory: 79 GB
2024-10-31T20:45:06.622730+0000 | compress | METRIC - GPU 2 | usage: 0.68% | total memory: 79 GB
2024-10-31T20:45:06.622797+0000 | compress | METRIC - GPU 3 | usage: 0.59% | total memory: 79 GB
2024-10-31T20:45:06.622859+0000 | compress | METRIC - GPU 4 | usage: 90.15% | total memory: 79 GB
2024-10-31T20:45:06.622918+0000 | compress | METRIC - GPU 5 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:06.622978+0000 | compress | METRIC - GPU 6 | usage: 5.17% | total memory: 79 GB
2024-10-31T20:45:06.623038+0000 | compress | METRIC - GPU 7 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:06.623279+0000 | compress | METRIC - Compressed layer size: 22.01611328125 MB
2024-10-31T20:45:06.623825+0000 | compress_module | INFO - Compressing model.layers.21.model.layers.21.mlp.down_proj...
2024-10-31T20:45:07.833507+0000 | compress | METRIC - time 1.21
2024-10-31T20:45:07.834566+0000 | compress | METRIC - error 3.55
2024-10-31T20:45:07.835334+0000 | compress | METRIC - GPU 0 | usage: 0.70% | total memory: 79 GB
2024-10-31T20:45:07.835395+0000 | compress | METRIC - GPU 1 | usage: 0.61% | total memory: 79 GB
2024-10-31T20:45:07.835443+0000 | compress | METRIC - GPU 2 | usage: 0.68% | total memory: 79 GB
2024-10-31T20:45:07.835484+0000 | compress | METRIC - GPU 3 | usage: 0.59% | total memory: 79 GB
2024-10-31T20:45:07.835524+0000 | compress | METRIC - GPU 4 | usage: 89.85% | total memory: 79 GB
2024-10-31T20:45:07.835564+0000 | compress | METRIC - GPU 5 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:07.835603+0000 | compress | METRIC - GPU 6 | usage: 5.47% | total memory: 79 GB
2024-10-31T20:45:07.835641+0000 | compress | METRIC - GPU 7 | usage: 0.55% | total memory: 79 GB
2024-10-31T20:45:07.835805+0000 | compress | METRIC - Compressed layer size: 22.005859375 MB
100%|█████████████████████████████████████████████████████████████████████████████████████████████| 512/512 [00:01<00:00, 298.51it/s]
2024-10-31T20:45:10.265503+0000 | apply_compression | INFO - Mean output error from quantization: 0.002
manager stage: Modifiers initialized
2024-10-31T20:45:10.287094+0000 | initialize | INFO - Compression lifecycle initialized for 1 modifiers
manager stage: Modifiers finalized
2024-10-31T20:45:10.287513+0000 | finalize | INFO - Compression lifecycle finalized for 1 modifiers
2024-10-31T20:45:10.302305+0000 | save_pretrained_wrapper | INFO - Inferring a sparsity configuration requires a global sparsity calculation. This can be costly for large models. To skip the calculation of compression statistics set skip_compression_stats=True
Calculating model sparsity: 100%|████████████████████████████████████████████████████████████████| 509/509 [00:00<00:00, 1327.55it/s]
Calculating quantization compression ratio: 246it [00:02, 99.96it/s] 
Quantized Compression: 100%|██████████████████████████████████████████████████████████████████████| 509/509 [00:00<00:00, 870.29it/s]
2024-10-31T20:45:15.194607+0000 | save_model_and_recipe | INFO - Saving output to /home/rahul/llm-compressor/TinyLlama-1.1B-Chat-v1.0-pruned_50.2of4-uncompressed
```

</details>

<details>
<summary>Error (Before this PR)</summary>

#### Error Message

```plaintext
self._update_quantization_parameters(weight_quant_args, W)
  File "/root/.clearml/venvs-builds/3.10/lib/python3.10/site-packages/llmcompressor/modifiers/quantization/gptq/utils/gptq_wrapper.py", line 306, in _update_quantization_parameters
    _scale, _zero_point = observer(W, g_idx=None)
TypeError: 'str' object is not callable
```



</details>

@anmarques originally reported this issue 
