### PR TITLE
Move config["testconfig_path"] assignment

### DIFF
--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -83,9 +83,10 @@ def parse_params(
         for file in os.listdir(current_config_dir):
             config_path = os.path.join(current_config_dir, file)
             config = _load_yaml(config_path)
-            config["testconfig_path"] = config_path
             if not config:
                 continue
+
+            config["testconfig_path"] = config_path
 
             cadence = os.environ.get("CADENCE", "commit")
             expected_cadence = config.get("cadence")


### PR DESCRIPTION
SUMMARY:
This PR provides a fix for the recently merged #892. This fix moves the dict-key `testconfig_path` to after an `if` conditional that checks whether `config` is truthy or not.


TEST PLAN:
Using `pytest --co` to collect test cases across the repo. It now works on files where it was broken before, as well as still includes the updated naming for the e2e test cases.