### PR TITLE
Move config["testconfig_path"] assignment

### DIFF
--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -1,10 +1,9 @@
 import shutil
 import unittest
-from typing import Callable
 
 import pytest
 from datasets import load_dataset
-from parameterized import parameterized, parameterized_class
+from parameterized import parameterized_class
 from transformers import AutoTokenizer
 
 from llmcompressor.modifiers.quantization import QuantizationModifier
@@ -33,22 +32,10 @@ WNA16_2of4 = "tests/e2e/vLLM/configs/WNA16_2of4"
 CONFIGS = [WNA16, FP8, INT8, ACTORDER, WNA16_2of4]
 
 
-def gen_test_name(testcase_func: Callable, param_num: int, param: dict) -> str:
-    return "_".join(
-        [
-            testcase_func.__name__,
-            parameterized.to_safe_name(
-                param.get("testconfig_path", "").split("configs/")[-1]
-            ),
-            param.get("cadence", "").lower(),
-        ]
-    )
-
-
 @requires_gpu
 @requires_torch
 @pytest.mark.skipif(not vllm_installed, reason="vLLM is not installed, skipping test")
-@parameterized_class(parse_params(CONFIGS), class_name_func=gen_test_name)
+@parameterized_class(parse_params(CONFIGS))
 class TestvLLM(unittest.TestCase):
     """
     The following test quantizes a model using a preset scheme or recipe,

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -1,9 +1,10 @@
 import shutil
 import unittest
+from typing import Callable
 
 import pytest
 from datasets import load_dataset
-from parameterized import parameterized_class
+from parameterized import parameterized, parameterized_class
 from transformers import AutoTokenizer
 
 from llmcompressor.modifiers.quantization import QuantizationModifier
@@ -32,10 +33,22 @@ WNA16_2of4 = "tests/e2e/vLLM/configs/WNA16_2of4"
 CONFIGS = [WNA16, FP8, INT8, ACTORDER, WNA16_2of4]
 
 
+def gen_test_name(testcase_func: Callable, param_num: int, param: dict) -> str:
+    return "_".join(
+        [
+            testcase_func.__name__,
+            parameterized.to_safe_name(
+                param.get("testconfig_path", "").split("configs/")[-1]
+            ),
+            param.get("cadence", "").lower(),
+        ]
+    )
+
+
 @requires_gpu
 @requires_torch
 @pytest.mark.skipif(not vllm_installed, reason="vLLM is not installed, skipping test")
-@parameterized_class(parse_params(CONFIGS))
+@parameterized_class(parse_params(CONFIGS), class_name_func=gen_test_name)
 class TestvLLM(unittest.TestCase):
     """
     The following test quantizes a model using a preset scheme or recipe,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -81,9 +81,7 @@ def parse_params(
         ), f"Config_directory {current_config_dir} is not a directory"
 
         for file in os.listdir(current_config_dir):
-            config_path = os.path.join(current_config_dir, file)
-            config = _load_yaml(config_path)
-            config["testconfig_path"] = config_path
+            config = _load_yaml(os.path.join(current_config_dir, file))
             if not config:
                 continue
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -81,9 +81,12 @@ def parse_params(
         ), f"Config_directory {current_config_dir} is not a directory"
 
         for file in os.listdir(current_config_dir):
-            config = _load_yaml(os.path.join(current_config_dir, file))
+            config_path = os.path.join(current_config_dir, file)
+            config = _load_yaml(config_path)
             if not config:
                 continue
+
+            config["testconfig_path"] = config_path
 
             cadence = os.environ.get("CADENCE", "commit")
             expected_cadence = config.get("cadence")

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -81,7 +81,9 @@ def parse_params(
         ), f"Config_directory {current_config_dir} is not a directory"
 
         for file in os.listdir(current_config_dir):
-            config = _load_yaml(os.path.join(current_config_dir, file))
+            config_path = os.path.join(current_config_dir, file)
+            config = _load_yaml(config_path)
+            config["testconfig_path"] = config_path
             if not config:
                 continue
 


### PR DESCRIPTION
SUMMARY:
This PR provides a fixed version of the recently merged and reverted #892. The fix is to move the dict-key `testconfig_path` to after an `if` conditional that checks whether `config` is truthy or not.


TEST PLAN:
Using `pytest --co` to collect test cases across the repo using nightly, weekly, and commit cadence values. It now works on files where it was broken before, as well as maintains the originally added functionality.