### PR TITLE
Cap accelerate version to avoid bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "torch>=1.7.0",
         "transformers>4.0,<5.0",
         "datasets",
-        "accelerate>=0.20.3",
+        "accelerate>=0.20.3,<1.1.0",
         "pynvml==11.5.3",
         "compressed-tensors"
         if version_info.build_type == "release"


### PR DESCRIPTION
## Purpose ##
* A bug introduced in accelerate v1.1.0 breaks loading state_dicts of offloaded models. Until https://github.com/huggingface/accelerate/pull/3217 lands, accelerate's version should be capped to avoid this error