### PR TITLE
update accelerate version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "torch>=1.7.0",
         "transformers>4.0,<5.0",
         "datasets",
-        "accelerate>=0.20.3,<1.1.0",
+        "accelerate>=0.20.3,!=1.1.0",
         "pynvml==11.5.3",
         "compressed-tensors"
         if version_info.build_type == "release"


### PR DESCRIPTION
## Purpose ##
* Avoid bug in accelerate==1.1.0

## Testing ##
* Verified that accelerate==1.1.1 is installed by default
* Verified test script runs without issue on new version

```python3
from transformers import AutoModelForCausalLM
from accelerate import cpu_offload
from accelerate.utils.modeling import get_state_dict_offloaded_model

model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B-Instruct")
cpu_offload(model)

state_dict = get_state_dict_offloaded_model(model)
```