### PR TITLE
use smaller portion of dataset

### DIFF
--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
@@ -19,9 +19,9 @@ class TestOneshotAndFinetune(unittest.TestCase):
     def _test_oneshot_and_finetune(self):
         from llmcompressor.transformers import apply
 
-        splits = {"train": "train[:50%]", "calibration": "train[50%:60%]"}
+        splits = {"train": "train[:30%]", "calibration": "train[30%:40%]"}
         if self.dataset == "ultrachat-200k":
-            splits = {"train": "train_gen[:50%]", "calibration": "train_gen[50%:60%]"}
+            splits = {"train": "train_gen[:30%]", "calibration": "train_gen[30%:40%]"}
 
         apply(
             model=self.model,


### PR DESCRIPTION
SUMMARY:
- Don't get OOM locally but we seem to get it occasionally in our CI runners
- Use a smaller dataset fraction to prevent this from happening
