### PR TITLE
BLOOM Default Smoothquant Mappings

### DIFF
--- a/src/llmcompressor/modifiers/smoothquant/utils.py
+++ b/src/llmcompressor/modifiers/smoothquant/utils.py
@@ -33,6 +33,16 @@ MIXTRAL_MAPPINGS: List[LayerMap] = [
         balance_layers=["re:.*gate"], smooth_layers="re:.*post_attention_layernorm"
     ),
 ]
+BLOOM_SMOOTHQUANT_MAPPINGS: List[LayerMap] = [
+    LayerMap(
+        balance_layers=["re:.*query_key_value"],
+        smooth_layers="re:.*input_layernorm",
+    ),
+    LayerMap(
+        balance_layers=["re:.*dense_h_to_4h"],
+        smooth_layers="re:.*post_attention_layernorm",
+    ),
+]
 
 
 # Registry of layer mappings for different architectures
@@ -42,6 +52,7 @@ MAPPINGS_REGISTRY: Dict[str, List[LayerMap]] = {
     "MixtralForCausalLM": MIXTRAL_MAPPINGS,
     "MistralForCausalLM": DEFAULT_SMOOTHQUANT_MAPPINGS,
     "Qwen2ForCausalLM": DEFAULT_SMOOTHQUANT_MAPPINGS,
+    "BloomForCausalLM": BLOOM_SMOOTHQUANT_MAPPINGS,
 }
 
 


### PR DESCRIPTION
## Purpose ##
* Provide default smoothquant mappings for the `transformers.BloomForCausalLM` architecture
* Fixes #905

## Architecture ##
```
BloomForCausalLM(
  (transformer): BloomModel(
    (word_embeddings): Embedding(250880, 1024)
    (word_embeddings_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
    (h): ModuleList(
      (0-23): 24 x BloomBlock(
        (input_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
        (self_attention): BloomAttention(
          (query_key_value): Linear(in_features=1024, out_features=3072, bias=True)
          (dense): Linear(in_features=1024, out_features=1024, bias=True)
          (attention_dropout): Dropout(p=0.0, inplace=False)
        )
        (post_attention_layernorm): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
        (mlp): BloomMLP(
          (dense_h_to_4h): Linear(in_features=1024, out_features=4096, bias=True)
          (gelu_impl): BloomGelu()
          (dense_4h_to_h): Linear(in_features=4096, out_features=1024, bias=True)
        )
      )
    )
    (ln_f): LayerNorm((1024,), eps=1e-05, elementwise_affine=True)
  )
  (lm_head): Linear(in_features=1024, out_features=250880, bias=False)
)
```

## Testing ##
```python3
from llmcompressor.transformers import oneshot

recipe = """
quant_stage:
    quant_modifiers:
        SmoothQuantModifier:
            smoothing_strength: 0.5
            ignore: ["model.decoder.final_layer_norm"]
        GPTQModifier:
            dampening_frac: 0.1
            scheme: "W8A8"
            targets: ["Linear"]
            ignore: ["lm_head"]
"""

oneshot(
    model="bigscience/bloom-560m",
    dataset="open_platypus",
    recipe=recipe,
    output_dir="outdir",
    max_seq_length=64,
    num_calibration_samples=64,
)
```