### PR TITLE
Support pack_quantized format for nonuniform mixed-precision

### DIFF
--- a/src/llmcompressor/transformers/compression/quantization_format.py
+++ b/src/llmcompressor/transformers/compression/quantization_format.py
@@ -42,10 +42,10 @@ def infer_quantization_format(
         is_weight_only = len(input_args) == 0 and len(weight_args) > 0
 
         if is_weight_only:  # w4a16 and w8a16
-            is_valid_pack = (
-                len(weight_args) == 1
-                and weight_args[0].num_bits in [4, 8]
-                and weight_args[0].type == QuantizationType.INT.value
+            is_valid_pack = all(
+                weight_arg.num_bits in [4, 8]
+                and weight_arg.type == QuantizationType.INT.value
+                for weight_arg in weight_args
             )
             if not is_valid_pack:  # packing only valid for int4 and int 8
                 return CompressionFormat.naive_quantized


### PR DESCRIPTION
Creating a non-uniformly quantized model with W4A16 and W8A16 layers would result in naive_quantization to be used as the storage format, which isn't valid in vLLM. At least this PR will unblock nonuniform INT weight-only quantization strategies.

Example model with "mlp" for 4bit and "self_attn" for 8bit: https://huggingface.co/nm-testing/Llama-3.2-1B-Instruct-GPTQ-nonuniform