### PR TITLE
Load Compressed Tensors Models with run_compressed=False

### DIFF
--- a/src/llmcompressor/transformers/utils/helpers.py
+++ b/src/llmcompressor/transformers/utils/helpers.py
@@ -510,7 +510,7 @@ def load_quantized_model_decompressed(pretrained_model_name_or_path: str, **kwar
     quant_method = config.quantization_config.get("quant_method", None)
 
     # Only add run_compressed for compressed-tensors models
-    if quant_method is not None and quant_method == "compressed-tensors":
+    if quant_method == "compressed-tensors":
         config.quantization_config["run_compressed"] = False
 
     return AutoModelForCausalLM.from_pretrained(

--- a/tests/llmcompressor/transformers/test_helpers.py
+++ b/tests/llmcompressor/transformers/test_helpers.py
@@ -1,0 +1,40 @@
+from compressed_tensors.linear.compressed_linear import CompressedLinear
+from compressed_tensors.quantization.utils import iter_named_leaf_modules
+from transformers import AutoModelForCausalLM
+
+from llmcompressor.transformers.utils.helpers import load_quantized_model_decompressed
+
+
+def test_load_quantized_model_decompressed():
+    """run_compressed set to False module should be a Linear module"""
+
+    MODEL_ID = "nm-testing/tinyllama-w8a8-compressed-hf-quantizer"
+
+    model = load_quantized_model_decompressed(MODEL_ID)
+    compressed_linear_counts = 0
+
+    for _, submodule in iter_named_leaf_modules(
+        model,
+    ):
+        if isinstance(submodule, CompressedLinear):
+            compressed_linear_counts += 1
+
+    assert compressed_linear_counts == 0
+
+
+def test_load_quantized_model_compressed():
+    """run_compressed set to True module should be a CompressedLinear module"""
+
+    MODEL_ID = "nm-testing/tinyllama-w8a8-compressed-hf-quantizer"
+
+    model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+    compressed_linear_counts = 0
+
+    # Some layers may be linear but not quantized. Ex. lm_head
+    for _, submodule in iter_named_leaf_modules(
+        model,
+    ):
+        if isinstance(submodule, CompressedLinear):
+            compressed_linear_counts += 1
+
+    assert compressed_linear_counts > 0


### PR DESCRIPTION
SUMMARY:
Load Compressed Tensors Models with run_compressed=False


TEST PLAN:
Made tests to check that run_compressed=False (new pathway) do not have any Compressed Linear
Made tests to check that run_compressed=True (AutoModelForCausalLM pathway) has Compressed Linear. 

