### PR TITLE
Update pytest command to capture results to file

### DIFF
--- a/tests/e2e/vLLM/run_tests.sh
+++ b/tests/e2e/vLLM/run_tests.sh
@@ -8,24 +8,23 @@ MODEL_CONFIGS="$PWD/tests/e2e/vLLM/configs"
 for MODEL_CONFIG in "$MODEL_CONFIGS"/*
 do
     LOCAL_SUCCESS=0
-    
+
     echo "=== RUNNING MODEL: $MODEL_CONFIG ==="
 
-    export TEST_DATA_FILE=${MODEL_CONFIG}
-    pytest -s $PWD/tests/e2e/vLLM/test_vllm.py || LOCAL_SUCCESS=$?
+    export TEST_DATA_FILE="$MODEL_CONFIG"
+    pytest \
+        --capture=tee-sys \
+        --junitxml="test-results/e2e-$(date +%s).xml" \
+        "$PWD/tests/e2e/vLLM/test_vllm.py" || LOCAL_SUCCESS=$?
 
     if [[ $LOCAL_SUCCESS == 0 ]]; then
-        echo "=== PASSED MODEL: ${MODEL_CONFIG} ==="
+        echo "=== PASSED MODEL: $MODEL_CONFIG ==="
     else
-        echo "=== FAILED MODEL: ${MODEL_CONFIG} ==="
+        echo "=== FAILED MODEL: $MODEL_CONFIG ==="
     fi
 
     SUCCESS=$((SUCCESS + LOCAL_SUCCESS))
 
 done
 
-if [ "${SUCCESS}" -eq "0" ]; then
-    exit 0
-else
-    exit 1
-fi
+exit "$SUCCESS"


### PR DESCRIPTION
This PR updates the recently added `run_tests.sh` script to include flags in the `pytest` command so test results will be captured. It also fixes the improper use of `-s` as well as makes variable usage consistently safer by wrapping in quotes to prevent unexpected globbing/etc. (now fully passes `shellcheck`).