### PR TITLE
Update text_generation.py

### DIFF
--- a/src/llmcompressor/transformers/finetune/text_generation.py
+++ b/src/llmcompressor/transformers/finetune/text_generation.py
@@ -346,7 +346,7 @@ def main(
         data_args=data_args,
         train_dataset=train_dataset or calib_dataset,
         eval_dataset=eval_dataset,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,
         data_collator=data_collator,
     )
 


### PR DESCRIPTION
i avoid this warning.
packages/llmcompressor/transformers/finetune/session_mixin.py:95: FutureWarning: `tokenizer` is deprecated and will be removed in version 5.0.0 for `Trainer.__init__`. Use `processing_class` instead.

SUMMARY:
"replace tokenizer by processing_class in trainer"



