### PR TITLE
Add helpful info to the marlin-24 example 

### DIFF
--- a/examples/quantization_2of4_sparse_w4a16/llama7b_sparse_w4a16.py
+++ b/examples/quantization_2of4_sparse_w4a16/llama7b_sparse_w4a16.py
@@ -1,4 +1,5 @@
 import torch
+from loguru import logger
 from transformers import AutoModelForCausalLM
 
 from llmcompressor.transformers import apply
@@ -51,4 +52,8 @@ apply(
     learning_rate=learning_rate,
     lr_scheduler_type=lr_scheduler_type,
     warmup_ratio=warmup_ratio,
+)
+logger.info(
+    "Note: vLLM requires the dtype=torch.float16 when running the ",
+    "compressed marlin-24 model",
 )


### PR DESCRIPTION
SUMMARY:
- There has been an increase in the number of users that are running the marlin24 example and a common question/issue seems to be running it on vLLM without setting the dtype correctly for the kernel
- Update the example to make it more obvious