### PR TITLE
Remove requires_torch

### DIFF
--- a/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
+++ b/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
@@ -13,11 +13,9 @@ from tests.llmcompressor.modifiers.conf import (
     setup_modifier_factory,
 )
 from tests.llmcompressor.pytorch.helpers import LinearNet
-from tests.testing_utils import requires_torch
 
 
 @pytest.mark.unit
-@requires_torch
 class TestInvalidLayerwiseRecipesRaiseExceptions(unittest.TestCase):
     def setUp(self):
         setup_modifier_factory()
@@ -45,7 +43,6 @@ class TestInvalidLayerwiseRecipesRaiseExceptions(unittest.TestCase):
 
 
 @pytest.mark.unit
-@requires_torch
 class TestSuccessfulLayerwiseRecipe(unittest.TestCase):
     def setUp(self):
         setup_modifier_factory()
@@ -66,7 +63,6 @@ class TestSuccessfulLayerwiseRecipe(unittest.TestCase):
 
 
 @pytest.mark.unit
-@requires_torch
 class TestCreateDefaultQuantModifier(unittest.TestCase):
     def setUp(self):
         setup_modifier_factory()
@@ -91,7 +87,6 @@ class TestCreateDefaultQuantModifier(unittest.TestCase):
 
 
 @pytest.mark.unit
-@requires_torch
 class TestSetQuantIfModifierAlreadyExists(unittest.TestCase):
     def setUp(self):
         setup_modifier_factory()

--- a/tests/llmcompressor/pytorch/modifiers/pruning/wanda/test_pytorch.py
+++ b/tests/llmcompressor/pytorch/modifiers/pruning/wanda/test_pytorch.py
@@ -4,11 +4,9 @@ import pytest
 
 from llmcompressor.modifiers.factory import ModifierFactory
 from tests.llmcompressor.modifiers.conf import setup_modifier_factory
-from tests.testing_utils import requires_torch
 
 
 @pytest.mark.unit
-@requires_torch
 class TestWandaPytorchIsRegistered(unittest.TestCase):
     def setUp(self):
         self.kwargs = dict(

--- a/tests/llmcompressor/pytorch/modifiers/smoothquant/test_pytorch.py
+++ b/tests/llmcompressor/pytorch/modifiers/smoothquant/test_pytorch.py
@@ -6,11 +6,9 @@ from torch.nn import Linear
 from llmcompressor.core import State
 from llmcompressor.modifiers.smoothquant import SmoothQuantModifier
 from tests.llmcompressor.pytorch.helpers import LinearNet
-from tests.testing_utils import requires_torch
 
 
 @pytest.mark.unit
-@requires_torch
 class TestSmoothQuantMapping(unittest.TestCase):
     def setUp(self):
         self.model = LinearNet()

--- a/tests/llmcompressor/transformers/compression/test_quantization.py
+++ b/tests/llmcompressor/transformers/compression/test_quantization.py
@@ -14,12 +14,11 @@ from llmcompressor.pytorch.utils import tensors_to_device
 from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.finetune.data import TextGenerationDataset
 from llmcompressor.transformers.finetune.data.data_args import DataTrainingArguments
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/compression/configs"
 
 
-@requires_torch
 @requires_gpu
 @pytest.mark.integration
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))

--- a/tests/llmcompressor/transformers/compression/test_run_compressed.py
+++ b/tests/llmcompressor/transformers/compression/test_run_compressed.py
@@ -9,12 +9,11 @@ from compressed_tensors.quantization import QuantizationStatus
 from parameterized import parameterized_class
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIG_DIR = "tests/llmcompressor/transformers/compression/run_compressed_configs"
 
 
-@requires_torch
 @requires_gpu
 @parameterized_class(parse_params(CONFIG_DIR))
 class TestQuantizationMatches(unittest.TestCase):

--- a/tests/llmcompressor/transformers/finetune/data/test_dataset_loading.py
+++ b/tests/llmcompressor/transformers/finetune/data/test_dataset_loading.py
@@ -8,7 +8,6 @@ from llmcompressor.transformers.finetune.data import TextGenerationDataset
 from llmcompressor.transformers.finetune.data.data_args import DataTrainingArguments
 from llmcompressor.transformers.finetune.runner import StageRunner
 from llmcompressor.transformers.finetune.training_args import TrainingArguments
-from tests.testing_utils import requires_torch
 
 
 @pytest.mark.unit
@@ -283,7 +282,6 @@ class TestSplitLoading(unittest.TestCase):
         self.assertIsInstance(train_dataset[0], dict)
 
 
-@requires_torch
 @pytest.mark.unit
 class TestTokenizationDataset(unittest.TestCase):
     @pytest.fixture(autouse=True)

--- a/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/finetune/finetune_custom"
 GPU_CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/finetune/finetune_custom/gpu"
@@ -112,7 +112,6 @@ class TestFinetuneNoRecipeCustomDataset(unittest.TestCase):
         self.monkeypatch.undo()
 
 
-@requires_torch
 @pytest.mark.integration
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestOneshotCustomDatasetSmall(TestFinetuneNoRecipeCustomDataset):
@@ -137,7 +136,6 @@ class TestOneshotCustomDatasetSmall(TestFinetuneNoRecipeCustomDataset):
         self._test_finetune_wout_recipe_custom_dataset()
 
 
-@requires_torch
 @requires_gpu
 @pytest.mark.integration
 @parameterized_class(parse_params(GPU_CONFIGS_DIRECTORY))

--- a/tests/llmcompressor/transformers/finetune/test_finetune_oneshot_with_modifier.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_oneshot_with_modifier.py
@@ -5,13 +5,12 @@ from pathlib import Path
 import pytest
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/finetune/finetune_generic"
 
 
 @pytest.mark.integration
-@requires_torch
 @requires_gpu
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestOneshotWithModifierObject(unittest.TestCase):

--- a/tests/llmcompressor/transformers/finetune/test_finetune_without_recipe.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_without_recipe.py
@@ -4,13 +4,12 @@ import unittest
 import pytest
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/finetune/finetune_generic"
 
 
 @pytest.mark.integration
-@requires_torch
 @requires_gpu
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestFinetuneWithoutRecipe(unittest.TestCase):

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
@@ -7,7 +7,7 @@ from compressed_tensors.compressors import ModelCompressor
 from parameterized import parameterized_class
 from transformers import AutoConfig
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/finetune/finetune_oneshot_configs"
 GPU_CONFIGS_DIRECTORY = (
@@ -56,7 +56,6 @@ class TestOneshotAndFinetune(unittest.TestCase):
         shutil.rmtree(self.output)
 
 
-@requires_torch
 @pytest.mark.integration
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestOneshotAndFinetuneSmall(TestOneshotAndFinetune):
@@ -77,7 +76,6 @@ class TestOneshotAndFinetuneSmall(TestOneshotAndFinetune):
         self._test_oneshot_and_finetune()
 
 
-@requires_torch
 @requires_gpu
 @pytest.mark.integration
 @parameterized_class(parse_params(GPU_CONFIGS_DIRECTORY))

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py
@@ -4,13 +4,12 @@ import unittest
 import pytest
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/finetune/finetune_tokenizer"
 
 
 @pytest.mark.integration
-@requires_torch
 @requires_gpu
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestOneshotAndFinetuneWithTokenizer(unittest.TestCase):

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_then_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_then_finetune.py
@@ -5,11 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from tests.testing_utils import requires_torch
-
 
 @pytest.mark.unit
-@requires_torch
 @pytest.mark.skipif(
     "CADENCE" in os.environ
     and (os.environ["CADENCE"] == "weekly" or os.environ["CADENCE"] == "nightly"),

--- a/tests/llmcompressor/transformers/finetune/test_safetensors.py
+++ b/tests/llmcompressor/transformers/finetune/test_safetensors.py
@@ -6,13 +6,12 @@ from pathlib import Path
 import pytest
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/finetune/finetune_generic"
 
 
 @pytest.mark.integration
-@requires_torch
 @requires_gpu
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestSafetensors(unittest.TestCase):

--- a/tests/llmcompressor/transformers/gptq/test_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_oneshot.py
@@ -6,7 +6,6 @@ from parameterized import parameterized_class
 from transformers import AutoModelForCausalLM
 
 from llmcompressor.modifiers.quantization.gptq import GPTQModifier
-from tests.testing_utils import requires_torch
 
 recipe_str = """
 quant_stage:
@@ -51,7 +50,6 @@ recipe_modifier_shorthand_b = GPTQModifier(
 )
 
 
-@requires_torch
 @parameterized_class(
     [
         {"recipe": recipe_str},

--- a/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
+++ b/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/obcq/obcq_configs/consec_runs"
 GPU_CONFIGS_DIRECTORY = (
@@ -83,7 +83,6 @@ class TestConsecutiveRuns(unittest.TestCase):
         shutil.rmtree(self.output)
 
 
-@requires_torch
 @pytest.mark.integration
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestConsecutiveRunsSmall(TestConsecutiveRuns):
@@ -106,7 +105,6 @@ class TestConsecutiveRunsSmall(TestConsecutiveRuns):
 
 # TODO: @Satrat and @dsikka, revisit if we want these nightly or weekly
 @requires_gpu
-@requires_torch
 @pytest.mark.integration
 @parameterized_class(parse_params(GPU_CONFIGS_DIRECTORY))
 class TestConsecutiveRunsGPU(TestConsecutiveRuns):

--- a/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
+++ b/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
@@ -6,14 +6,13 @@ from compressed_tensors.utils import tensor_follows_mask_structure
 from parameterized import parameterized_class
 
 from llmcompressor.core import reset_session
-from tests.testing_utils import parse_params, requires_torch
+from tests.testing_utils import parse_params
 
 MASK_STRUCTURE_CONFIGS_DIRECTORY = (
     "tests/llmcompressor/transformers/obcq/obcq_configs/consec_runs/mask_structure"
 )
 
 
-@requires_torch
 @pytest.mark.integration
 @parameterized_class(parse_params(MASK_STRUCTURE_CONFIGS_DIRECTORY))
 class TestMaskStructurePreserved(unittest.TestCase):

--- a/tests/llmcompressor/transformers/obcq/test_obcq_completion.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_completion.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/obcq/obcq_configs/completion"
 GPU_CONFIGS_DIRECTORY = (
@@ -99,7 +99,6 @@ class TestOBCQCompletion(unittest.TestCase):
         shutil.rmtree(self.output)
 
 
-@requires_torch
 @requires_gpu
 @pytest.mark.integration
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
@@ -121,7 +120,6 @@ class TestOBCQCompletionSmall(TestOBCQCompletion):
         self._test_oneshot_completion()
 
 
-@requires_torch
 @requires_gpu
 @pytest.mark.integration
 @parameterized_class(parse_params(GPU_CONFIGS_DIRECTORY))

--- a/tests/llmcompressor/transformers/obcq/test_obcq_infer_targets.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_infer_targets.py
@@ -3,11 +3,9 @@ import unittest
 import pytest
 
 from llmcompressor.utils.pytorch.module import get_no_split_params
-from tests.testing_utils import requires_torch
 
 
 @pytest.mark.integration
-@requires_torch
 class TestInferTargets(unittest.TestCase):
     def setUp(self):
         from transformers import AutoModelForCausalLM

--- a/tests/llmcompressor/transformers/obcq/test_obcq_lm_head.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_lm_head.py
@@ -2,11 +2,8 @@ import unittest
 
 import pytest
 
-from tests.testing_utils import requires_torch
-
 
 @pytest.mark.integration
-@requires_torch
 class TestLMHead(unittest.TestCase):
     def setUp(self):
         import torch

--- a/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
@@ -5,13 +5,12 @@ import unittest
 import pytest
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_gpu, requires_torch
+from tests.testing_utils import parse_params, requires_gpu
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/obcq/obcq_configs/sparse"
 GPU_CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/obcq/obcq_configs/sparse/gpu"
 
 
-@requires_torch
 @pytest.mark.integration
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestSparsities(unittest.TestCase):
@@ -59,7 +58,6 @@ class TestSparsities(unittest.TestCase):
 
 # TODO: @Satrat and @dsikka, revisit if we want these nightly or weekly
 @requires_gpu
-@requires_torch
 @pytest.mark.integration
 @parameterized_class(parse_params(GPU_CONFIGS_DIRECTORY))
 class TestSparsitiesGPU(unittest.TestCase):

--- a/tests/llmcompressor/transformers/obcq/test_sgpt_defaults.py
+++ b/tests/llmcompressor/transformers/obcq/test_sgpt_defaults.py
@@ -2,11 +2,8 @@ import unittest
 
 import pytest
 
-from tests.testing_utils import requires_torch
-
 
 @pytest.mark.integration
-@requires_torch
 class TestSGPTDefaults(unittest.TestCase):
     def test_sgpt_defaults(self):
         from llmcompressor.core.state import State

--- a/tests/llmcompressor/transformers/oneshot/test_api_inputs.py
+++ b/tests/llmcompressor/transformers/oneshot/test_api_inputs.py
@@ -5,7 +5,7 @@ import pytest
 from parameterized import parameterized_class
 
 from tests.llmcompressor.transformers.oneshot.dataset_processing import get_data_utils
-from tests.testing_utils import parse_params, requires_torch
+from tests.testing_utils import parse_params
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/oneshot/oneshot_configs"
 
@@ -15,7 +15,6 @@ CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/oneshot/oneshot_configs"
 
 @pytest.mark.smoke
 @pytest.mark.integration
-@requires_torch
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestOneShotInputs(unittest.TestCase):
     model = None

--- a/tests/llmcompressor/transformers/oneshot/test_cli.py
+++ b/tests/llmcompressor/transformers/oneshot/test_cli.py
@@ -4,14 +4,13 @@ import unittest
 import pytest
 from parameterized import parameterized_class
 
-from tests.testing_utils import parse_params, requires_torch, run_cli_command
+from tests.testing_utils import parse_params, run_cli_command
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/oneshot/oneshot_configs"
 
 
 @pytest.mark.smoke
 @pytest.mark.integration
-@requires_torch
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestOneShotCli(unittest.TestCase):
     model = None

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -37,10 +37,6 @@ def is_gpu_available():
         return False
 
 
-def requires_torch(test_case):
-    return unittest.skipUnless(is_torch_available(), "test requires PyTorch")(test_case)
-
-
 def requires_gpu(test_case):
     return unittest.skipUnless(is_gpu_available(), "test requires GPU")(test_case)
 


### PR DESCRIPTION
## Purpose ##
* Remove unnecessary code, since torch is a base dependency of llm-compressor, rather than being an extra

## Changes ##
* Remove all uses and definitions of `requires_torch`

## Testing ##
* CI tests
* `grep -r 'requires_torch' src tests examples/`