### PR TITLE
Fix `test_model_reload` test

### DIFF
--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -11,7 +11,7 @@ from compressed_tensors import (
     ModelCompressor,
     SparsityCompressionConfig,
     is_module_offloaded,
-    update_parameter_data,
+    update_offload_parameter,
 )
 from loguru import logger
 from safetensors.torch import storage_ptr
@@ -238,14 +238,15 @@ def patch_tied_tensors_bug(model: torch.nn.Module):
 
         if storage_ptr(input_embed.weight) == storage_ptr(output_embed.weight):
             for module in (input_embed, output_embed):
-                offloaded = is_module_offloaded(module)
-                if offloaded:
-                    module._hf_hook.pre_forward(module)
-
-                update_parameter_data(module, module.weight.data.clone(), "weight")
-
-                if offloaded:
-                    module._hf_hook.post_forward(module, None)
+                if not is_module_offloaded(module):
+                    # create new storage ptr for onloaded weight
+                    untied_data = module.weight.data.clone()
+                    module.weight.data = untied_data
+                else:
+                    # create new storage ptr for offloaded weight
+                    # note `update_offload_parameter` does not create a new storage ptr
+                    untied_data = module._hf_hook.weights_map["weight"].clone()
+                    update_offload_parameter(module, "weight", untied_data)
 
 
 def get_model_compressor(


### PR DESCRIPTION
## Purpose ##
* Fix failing `test_model_reload` resulting from slightly different behavior of `update_offload_parameter`

## Changes ##
* With the newest changes to `update_offload_parameter`, the new parameter data is copied into the existing tensor rather than replacing it. This breaks its use case for `patch_tied_tensors_bug`, which uses the function to create new tensors which are untied.

## Testing ##
* Previously failing tests in `tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py` now pass