### PR TITLE
[Bugfix] Pass `trust_remote_code_model=True` for deepseek examples

### DIFF
--- a/examples/quantizing_moe/deepseek_moe_w4a16.py
+++ b/examples/quantizing_moe/deepseek_moe_w4a16.py
@@ -75,6 +75,7 @@ oneshot(
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     save_compressed=True,
+    trust_remote_code_model=True,
     output_dir=SAVE_DIR,
 )
 

--- a/examples/quantizing_moe/deepseek_moe_w8a8_fp8.py
+++ b/examples/quantizing_moe/deepseek_moe_w8a8_fp8.py
@@ -69,6 +69,7 @@ oneshot(
     recipe=recipe,
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    trust_remote_code_model=True,
     save_compressed=True,
     output_dir=SAVE_DIR,
 )

--- a/examples/quantizing_moe/deepseek_moe_w8a8_int8.py
+++ b/examples/quantizing_moe/deepseek_moe_w8a8_int8.py
@@ -81,6 +81,7 @@ oneshot(
     recipe=recipe,
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    trust_remote_code_model=True,
     save_compressed=True,
     output_dir=SAVE_DIR,
 )


### PR DESCRIPTION
SUMMARY:
- Pass `trust_remote_code_model=True` for deepseek models
- Needed due to the slight differences in how tokenizer and processor pull down their relevant configs