### PR TITLE
Update ReadMe and test for cpu_offloading

### DIFF
--- a/examples/big_models_with_accelerate/README.md
+++ b/examples/big_models_with_accelerate/README.md
@@ -54,7 +54,7 @@ When working with `accelerate`, it is important to keep in mind that CPU offload
 
 We will show working examples for each use case:
 - **CPU Offloading**: Quantize `Llama-70B` to `FP8` using `PTQ` with a single GPU
-- **Multi-GPU**: Quantize `Llama-70B` to `INT8` using `GPTQ` and `SmoothQuant` with 8 GPUs
+- **Multi-GPU**: Quantize `Llama-70B` to `INT8` using `GPTQ` and `SmoothQuant` with 2 GPUs
 
 ### Installation
 
@@ -83,7 +83,7 @@ For quantization methods that require calibration data (e.g. `GPTQ`), CPU offloa
 
 Note that running non-sequential `GPTQ` requires significant additional memory beyond the model size. As a rough rule of thumb, running `GPTQModifier` non-sequentially will take up 3x the model size for a 16-bit model and 2x the model size for a 32-bit model (these estimates include the memory required to store the model itself in GPU).
 
-- `multi_gpu_int8.py` demonstrates quantizing the weights and activations of `Llama-70B` to `int8` on 8 A100s:
+- `multi_gpu_int8.py` demonstrates quantizing the weights and activations of `Llama-70B` to `int8` on 2 A100s:
 
 ```python
 export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

--- a/examples/big_models_with_accelerate/README.md
+++ b/examples/big_models_with_accelerate/README.md
@@ -81,12 +81,10 @@ The resulting model `./Meta-Llama-3-70B-Instruct-FP8-Dynamic` is ready to run wi
 
 For quantization methods that require calibration data (e.g. `GPTQ`), CPU offloading is too slow. For these methods, `llmcompressor` can use `accelerate` multi-GPU to quantize models that are larger than a single GPU. For example, when quantizing a model to `int8`, we typically use `GPTQ` to statically quantize the weights, which requires calibration data.
 
-Note that running non-sequential `GPTQ` requires significant additional memory beyond the model size. As a rough rule of thumb, running `GPTQModifier` non-sequentially will take up 3x the model size for a 16-bit model and 2x the model size for a 32-bit model (these estimates include the memory required to store the model itself in GPU).
-
 - `multi_gpu_int8.py` demonstrates quantizing the weights and activations of `Llama-70B` to `int8` on 2 A100s:
 
 ```python
-export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+export CUDA_VISIBLE_DEVICES=0,1
 python multi_gpu_int8.py
 ```
 

--- a/tests/examples/test_big_models_with_accelerate.py
+++ b/tests/examples/test_big_models_with_accelerate.py
@@ -43,7 +43,6 @@ class TestBigModelsWithAccelerate:
                 "",
                 id="multi_gpu_int8",
                 marks=[
-                    requires_gpu_mem(630),
                     requires_gpu_count(2),
                     pytest.mark.multi_gpu,
                 ],

--- a/tests/examples/test_big_models_with_accelerate.py
+++ b/tests/examples/test_big_models_with_accelerate.py
@@ -7,7 +7,6 @@ from tests.examples.utils import (
     copy_and_run_script,
     gen_cmd_fail_message,
     requires_gpu_count,
-    requires_gpu_mem,
 )
 
 


### PR DESCRIPTION
Summary
- ReadMe incorrectly states the requirement of 8 gpus, it should be 2. This has resulted in users being confused.
- The test case has a memory limit, which is not needed