### PR TITLE
patch_tied_tensors_bug: support malformed model definitions

### DIFF
--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -236,6 +236,10 @@ def patch_tied_tensors_bug(model: torch.nn.Module):
         input_embed = model.get_input_embeddings()
         output_embed = model.get_output_embeddings()
 
+        if input_embed is None or output_embed is None:
+            # some models fail to properly override the abstract methods
+            return
+
         if storage_ptr(input_embed.weight) == storage_ptr(output_embed.weight):
             for module in (input_embed, output_embed):
                 if not is_module_offloaded(module):


### PR DESCRIPTION
## Purpose ##
* Support malformed model definitions which do not override the abstract methods `get_input_embeddings` and `get_output_embeddings`

```
Traceback (most recent call last):
  File "/home/kylesayrs/llm-compressor/tmp.py", line 11, in <module>
    patch_tied_tensors_bug(model)
  File "/home/kylesayrs/llm-compressor/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py", line 243, in patch_tied_tensors_bug
    if storage_ptr(input_embed.weight) == storage_ptr(output_embed.weight):
AttributeError: 'NoneType' object has no attribute 'weight'
```

## Changes ##
* Add `None` check in `patch_tied_tensors_bug`

## Testing ##
```python3
from transformers import AutoModelForCausalLM
from llmcompressor.transformers.sparsification.compressed_tensors_utils import patch_tied_tensors_bug

MODEL_ID = "THUDM/glm-4v-9b"
model = AutoModelForCausalLM.from_pretrained("THUDM/glm-4v-9b", trust_remote_code=True)
patch_tied_tensors_bug(model)
```
