### PR TITLE
Adding amdsmi for AMD gpus

### DIFF
--- a/src/llmcompressor/utils/metric_logging.py
+++ b/src/llmcompressor/utils/metric_logging.py
@@ -8,13 +8,14 @@ from torch.nn import Module
 __all__ = ["get_GPU_memory_usage", "get_layer_size_mb", "CompressionLogger"]
 
 
-def get_GPU_memory_usage() -> List[Tuple]:
+def get_GPU_memory_usage() -> List[Tuple[float, float]]:
     if torch.version.hip:
         return get_GPU_usage_amd()
     else:
         return get_GPU_usage_nv()
 
-def get_GPU_usage_nv() -> List [Tuple]:
+
+def get_GPU_usage_nv() -> List[Tuple[float, float]]:
     try:
         import pynvml
         from pynvml import NVMLError
@@ -44,10 +45,12 @@ def get_GPU_usage_nv() -> List [Tuple]:
         logger.warning("Failed to obtain GPU usage from pynvml")
         return []
 
-def get_GPU_usage_amd() -> List[Tuple]:
+
+def get_GPU_usage_amd() -> List[Tuple[float, float]]:
     usage = []
     try:
         import amdsmi
+
         try:
             amdsmi.amdsmi_init()
             devices = amdsmi.amdsmi_get_processor_handles()
@@ -65,12 +68,13 @@ def get_GPU_usage_amd() -> List[Tuple]:
                     (memory_percentage, vram_memory_total / (1e9)),
                 )
             amdsmi.amdsmi_shut_down()
-        except amdsmi.AmdSmiException as _err:
-            logger.warning(f"amdsmi library error:\n {_err}")
+        except amdsmi.AmdSmiException as error:
+            logger.warning(f"amdsmi library error:\n {error}")
     except ImportError:
         logger.warning("Failed to obtain GPU usage from amdsmi")
 
     return usage
+
 
 def get_layer_size_mb(module: Module) -> float:
     param_size = 0

--- a/src/llmcompressor/utils/metric_logging.py
+++ b/src/llmcompressor/utils/metric_logging.py
@@ -16,6 +16,9 @@ def get_GPU_memory_usage() -> List[Tuple[float, float]]:
 
 
 def get_GPU_usage_nv() -> List[Tuple[float, float]]:
+    """
+    get gpu usage for Nvidia GPUs using nvml lib
+    """
     try:
         import pynvml
         from pynvml import NVMLError
@@ -47,6 +50,9 @@ def get_GPU_usage_nv() -> List[Tuple[float, float]]:
 
 
 def get_GPU_usage_amd() -> List[Tuple[float, float]]:
+    """
+    get gpu usage for AMD GPUs using amdsmi lib
+    """
     usage = []
     try:
         import amdsmi


### PR DESCRIPTION
SUMMARY:
NVML dont work with AMD GPUs, Hence adding amdsmi 


TEST PLAN:
Found the issue while testing changes for [glm4v INT8 Quantization.](https://github.com/vllm-project/llm-compressor/issues/1003#issuecomment-2563300961) Hence Tested the changes with same.

```
2024-12-28T12:30:41.069669+0000 | compress_module | INFO - Quantizing transformer.encoder.layers.0.self_attention.dense using 512 samples
2024-12-28T12:30:42.261763+0000 | compress | METRIC - time 1.19
2024-12-28T12:30:42.261899+0000 | compress | METRIC - error 0.00
2024-12-28T12:30:42.266418+0000 | compress | METRIC - GPU 0 | usage: 87.67% | total memory: 48 GB
2024-12-28T12:30:42.266538+0000 | compress | METRIC - Compressed module size: 33.56672 MB
```
