### PR TITLE
CompressionLogger add time units

### DIFF
--- a/src/llmcompressor/utils/metric_logging.py
+++ b/src/llmcompressor/utils/metric_logging.py
@@ -124,7 +124,7 @@ class CompressionLogger:
 
         if self.start_tick is not None:
             duration = stop_tick - self.start_tick
-            patch.log("METRIC", f"time {duration:.2f}")
+            patch.log("METRIC", f"time {duration:.2f}s")
         if self.loss is not None:
             patch.log("METRIC", f"error {self.loss:.2f}")
 


### PR DESCRIPTION
## Purpose ##
* Clarify the units associated with compression logging

```
2025-01-02T17:13:07.957698+0000 | compress_module | INFO - Quantizing model.layers.7.mlp.up_proj using 512 samples
2025-01-02T17:13:10.417796+0000 | compress | METRIC - time 2.46s
2025-01-02T17:13:10.420249+0000 | compress | METRIC - error 512.74
2025-01-02T17:13:10.569306+0000 | compress | METRIC - GPU 0 | usage: 0.55% | total memory: 85 GB
2025-01-02T17:13:10.569378+0000 | compress | METRIC - GPU 1 | usage: 99.80% | total memory: 85 GB
2025-01-02T17:13:10.569404+0000 | compress | METRIC - GPU 2 | usage: 0.55% | total memory: 85 GB
2025-01-02T17:13:10.569423+0000 | compress | METRIC - GPU 3 | usage: 0.55% | total memory: 85 GB
2025-01-02T17:13:10.569441+0000 | compress | METRIC - GPU 4 | usage: 1.79% | total memory: 85 GB
2025-01-02T17:13:10.569457+0000 | compress | METRIC - GPU 5 | usage: 82.69% | total memory: 85 GB
2025-01-02T17:13:10.569472+0000 | compress | METRIC - GPU 6 | usage: 0.55% | total memory: 85 GB
2025-01-02T17:13:10.569486+0000 | compress | METRIC - GPU 7 | usage: 0.55% | total memory: 85 GB
2025-01-02T17:13:10.569539+0000 | compress | METRIC - Compressed module size: 475.267072 MB
```

## Changes ##
* Add `s` to end of time metric log