### PR TITLE
Remove unccessary step in 2of4 Example

### DIFF
--- a/examples/quantization_2of4_sparse_w4a16/README.md
+++ b/examples/quantization_2of4_sparse_w4a16/README.md
@@ -89,21 +89,6 @@ apply(
 
 ```
 
-
-### Step 3: Compression
-
-The resulting model will be uncompressed. To save a final compressed copy of the model 
-run the following:
-
-```python
-import torch
-from transformers import AutoModelForCausalLM
-
-compressed_output_dir = "output_llama7b_2of4_w4a16_channel_compressed"
-model = AutoModelForCausalLM.from_pretrained(output_dir, torch_dtype=torch.bfloat16)
-model.save_pretrained(compressed_output_dir, save_compressed=True)
-```
-
 ### Custom Quantization
 The current repo supports multiple quantization techniques configured using a recipe. Supported strategies are `tensor`, `group` and `channel`. 
 The above recipe (`2of4_w4a16_recipe.yaml`) uses channel-wise quantization specified by `strategy: "channel"` in its config group. 


### PR DESCRIPTION
SUMMARY:
- We now compress when saving by default, remove confusing additional step in 2of4 ReadMe
