### PR TITLE
Sparse 2:4 + FP8 Quantization e2e vLLM tests

### DIFF
--- a/tests/e2e/vLLM/configs/sparse2of4_fp8_dynamic.yaml
+++ b/tests/e2e/vLLM/configs/sparse2of4_fp8_dynamic.yaml
@@ -1,0 +1,7 @@
+cadence: "nightly"
+test_type: "regression"
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+recipe: tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4_fp8_dynamic.yaml
+scheme: sparse2of4_fp8_dynamic
+dataset_id: HuggingFaceH4/ultrachat_200k
+dataset_split: train_sft

--- a/tests/e2e/vLLM/configs/sparse_24.yaml
+++ b/tests/e2e/vLLM/configs/sparse_24.yaml
@@ -1,0 +1,8 @@
+cadence: "nightly"
+test_type: "regression"
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+recipe: tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4.yaml
+scheme: sparse2of4_only
+dataset_id: HuggingFaceH4/ultrachat_200k
+dataset_split: train_sft
+save_compressed: False

--- a/tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4.yaml
+++ b/tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4.yaml
@@ -1,0 +1,6 @@
+sparsity_stage:
+  sparsity_modifiers:
+    SparseGPTModifier:
+      sparsity: 0.5
+      mask_structure: "2:4"
+      sequential_update: false

--- a/tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4_fp8_dynamic.yaml
+++ b/tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4_fp8_dynamic.yaml
@@ -1,0 +1,25 @@
+sparsity_stage:
+  run_type: oneshot
+  sparsity_modifiers:
+    SparseGPTModifier:
+      sparsity: 0.5
+      mask_structure: "2:4"
+      sequential_update: false
+quantization_stage:
+  run_type: oneshot
+  quantization_modifiers:
+    ConstantPruningModifier:
+      targets: [
+        're:.*q_proj.weight',
+        're:.*k_proj.weight', 
+        're:.*v_proj.weight',
+        're:.*o_proj.weight',
+        're:.*gate_proj.weight',
+        're:.*up_proj.weight',
+        're:.*down_proj.weight',
+      ]
+      start: 0
+    QuantizationModifier:
+      targets: ["Linear"]
+      ignore: ["lm_head"]
+      scheme: "FP8_DYNAMIC"

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -13,7 +13,6 @@ from llmcompressor.core import active_session
 from tests.e2e.e2e_utils import run_oneshot_for_e2e_testing
 from tests.examples.utils import requires_gpu_count
 
-"""
 try:
     from vllm import LLM, SamplingParams
 
@@ -21,7 +20,7 @@ try:
 except ImportError:
     vllm_installed = False
     logger.warning("vllm is not installed. This test will be skipped")
-"""
+
 
 HF_MODEL_HUB_NAME = "nm-testing"
 
@@ -44,7 +43,7 @@ def record_config_file(record_testsuite_property: Callable[[str, object], None])
 # Will run each test case in its own process through run_tests.sh
 # emulating vLLM CI testing
 @requires_gpu_count(1)
-# @pytest.mark.skipif(not vllm_installed, reason="vLLM is not installed, skipping test")
+@pytest.mark.skipif(not vllm_installed, reason="vLLM is not installed, skipping test")
 class TestvLLM:
     """
     The following test quantizes a model using a preset scheme or recipe,
@@ -149,7 +148,6 @@ class TestvLLM:
             folder_path=self.save_dir,
         )
 
-        """
         logger.info("================= RUNNING vLLM =========================")
 
         sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
@@ -172,7 +170,6 @@ class TestvLLM:
             logger.info(generated_text)
 
         self.tear_down()
-        """
 
     def tear_down(self):
         if self.save_dir is not None:

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -13,6 +13,7 @@ from llmcompressor.core import active_session
 from tests.e2e.e2e_utils import run_oneshot_for_e2e_testing
 from tests.examples.utils import requires_gpu_count
 
+"""
 try:
     from vllm import LLM, SamplingParams
 
@@ -20,6 +21,7 @@ try:
 except ImportError:
     vllm_installed = False
     logger.warning("vllm is not installed. This test will be skipped")
+"""
 
 HF_MODEL_HUB_NAME = "nm-testing"
 
@@ -42,7 +44,7 @@ def record_config_file(record_testsuite_property: Callable[[str, object], None])
 # Will run each test case in its own process through run_tests.sh
 # emulating vLLM CI testing
 @requires_gpu_count(1)
-@pytest.mark.skipif(not vllm_installed, reason="vLLM is not installed, skipping test")
+# @pytest.mark.skipif(not vllm_installed, reason="vLLM is not installed, skipping test")
 class TestvLLM:
     """
     The following test quantizes a model using a preset scheme or recipe,
@@ -74,6 +76,7 @@ class TestvLLM:
         self.recipe = eval_config.get("recipe")
         self.quant_type = eval_config.get("quant_type")
         self.save_dir = eval_config.get("save_dir")
+        self.save_compressed = eval_config.get("save_compressed", True)
 
         logger.info("========== RUNNING ==============")
         logger.info(self.scheme)
@@ -113,7 +116,9 @@ class TestvLLM:
         self._check_session_contains_recipe()
 
         logger.info("================= SAVING TO DISK ======================")
-        oneshot_model.save_pretrained(self.save_dir)
+        oneshot_model.save_pretrained(
+            self.save_dir, save_compressed=self.save_compressed
+        )
         tokenizer.save_pretrained(self.save_dir)
         recipe_path = os.path.join(self.save_dir, "recipe.yaml")
 
@@ -144,6 +149,7 @@ class TestvLLM:
             folder_path=self.save_dir,
         )
 
+        """
         logger.info("================= RUNNING vLLM =========================")
 
         sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
@@ -166,6 +172,7 @@ class TestvLLM:
             logger.info(generated_text)
 
         self.tear_down()
+        """
 
     def tear_down(self):
         if self.save_dir is not None:


### PR DESCRIPTION
SUMMARY:
- Add 2:4 Sparsity + FP8 Quantization e2e tests


TEST PLAN:
- Models produced by the tests:
nm-testing/TinyLlama-1.1B-Chat-v1.0-sparse2of4_fp8_dynamic-e2e
nm-testing/TinyLlama-1.1B-Chat-v1.0-sparse2of4_only-e2e
- Verified to run e2e with vLLM
