### PR TITLE
[Docs] Point to smoothquant guide after failure to match

### DIFF
--- a/src/llmcompressor/utils/pytorch/module.py
+++ b/src/llmcompressor/utils/pytorch/module.py
@@ -157,7 +157,7 @@ def match_layers_params(
 
     missed = [target for found, target in zip(targets_found, targets) if not found]
     if len(missed) > 0:
-        raise ValueError(f"Could not find targets {missed} in module {module}")
+        raise ValueError(f"Could not find targets {missed} in module {type(module)}")
 
     return resolved
 


### PR DESCRIPTION
## Purpose ##
* Encourage open source community engagement by pointing to resources for users to add their own smoothquant mappings

## Related issues ##
* #909

## Changes ##
* Catch errors that result from failure to match mappings to modules. Have that error point users towards the smoothquant guide
* Reduce error verbosity when `match_layers_params` fails
  * While there's some sense in printing the whole module, the module `repr` is almost always not unique and is not any more helpful than just printing the name of the module

## Testing ##
* TODO: Test and show resulting UI