### PR TITLE
Require 'ready' label for transformers tests

### DIFF
--- a/.github/workflows/set-comment.yaml
+++ b/.github/workflows/set-comment.yaml
@@ -17,7 +17,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '👋 Hi! Thank you for contributing to llm-compressor. Please add the ready label when the PR is ready for review.'
+              body: '👋 Hi! Thank you for contributing to llm-compressor. Please add the ready label when the PR is ready for review.\n\n**Note:** This is required to trigger the transformers tests.'
             })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/set-comment.yaml
+++ b/.github/workflows/set-comment.yaml
@@ -17,7 +17,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '👋 Hi! Thank you for contributing to llm-compressor. Please add the ready label when the PR is ready for review.\n\n**Note:** This is required to trigger the transformers tests.'
+              body: '👋 Hi! Thank you for contributing to llm-compressor. Please add the ready label when the PR is ready for review.\n\n**Note:** This is required to complete the testing suite, please only add the label once the PR is code complete and local testing has been performed.'
             })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -1,0 +1,61 @@
+name: Test Checks (Transformers)
+on:
+  pull_request:
+    branches: main
+    types: [ labeled, synchronize ]
+
+env:
+  CADENCE: "commit"
+  CLEARML_WEB_HOST: ${{ secrets.CLEARML_WEB_HOST }}
+  CLEARML_API_HOST: ${{ secrets.CLEARML_API_HOST }}
+  CLEARML_API_ACCESS_KEY: ${{ secrets.CLEARML_API_ACCESS_KEY }}
+  CLEARML_FILES_HOST: ${{ secrets.CLEARML_FILES_HOST }}
+  CLEARML_API_SECRET_KEY: ${{ secrets.CLEARML_API_SECRET_KEY }}
+
+jobs:
+  transformers-tests:
+    runs-on: gcp-k8s-vllm-l4-solo
+    if: contains(github.event.pull_request.labels.*.name, 'ready')
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - uses: actions/checkout@v4
+      - name: "⚙️ Install dependencies"
+        run: pip3 install -U pip setuptools && pip3 install .[dev]
+      - uses: actions/checkout@v4
+        with:
+          repository: "neuralmagic/compressed-tensors"
+          path: "compressed-tensors"
+      - name: "⚙️ Install compressed-tensors dependencies"
+        id: install
+        run: |
+          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
+          pip3 install ./compressed-tensors/
+      - name: "Clean compressed-tensors directory"
+        run: rm -r compressed-tensors/
+      - name: "🔬 Running transformers tests"
+        if: (success() || failure()) && steps.install.outcome == 'success'
+        run: |
+          pytest -v tests/llmcompressor/transformers/compression
+      - name: Run Finetune Tests
+        if: (success() || failure()) && steps.install.outcome == 'success'
+        run: |
+          pytest -v tests/llmcompressor/transformers/finetune
+      - name: Running GPTQ Tests
+        if: (success() || failure()) && steps.install.outcome == 'success'
+        run: |
+          pytest -v tests/llmcompressor/transformers/gptq
+      - name: Running ONESHOT Tests
+        if: (success() || failure()) && steps.install.outcome == 'success'
+        run: |
+          pytest -v tests/llmcompressor/transformers/oneshot
+      - name: Running Sparsification Tests
+        if: (success() || failure()) && steps.install.outcome == 'success'
+        run: |
+          pytest tests/llmcompressor/transformers/sparsification -v
+          pytest tests/llmcompressor/transformers/test_clear_ml.py -v
+      - name: Running OBCQ Tests
+        if: (success() || failure()) && steps.install.outcome == 'success'
+        run: |
+          pytest -v tests/llmcompressor/transformers/obcq

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -1,4 +1,4 @@
-name: Test Checks
+name: Test Checks (Base/PyTorch)
 on:
   push:
 
@@ -79,49 +79,3 @@ jobs:
       - name: "🔬 Running pytorch tests"
         run: |
           pytest -v tests/llmcompressor/pytorch
-
-  transformers-tests:
-    runs-on: gcp-k8s-vllm-l4-solo
-    steps:
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.9'
-      - uses: actions/checkout@v4
-      - name: "⚙️ Install dependencies"
-        run: pip3 install -U pip setuptools && pip3 install .[dev]
-      - uses: actions/checkout@v4
-        with:
-          repository: "neuralmagic/compressed-tensors"
-          path: "compressed-tensors"
-      - name: "⚙️ Install compressed-tensors dependencies"
-        id: install
-        run: |
-          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
-          pip3 install ./compressed-tensors/
-      - name: "Clean compressed-tensors directory"
-        run: rm -r compressed-tensors/
-      - name: "🔬 Running transformers tests"
-        if: (success() || failure()) && steps.install.outcome == 'success'
-        run: |
-          pytest -v tests/llmcompressor/transformers/compression
-      - name: Run Finetune Tests
-        if: (success() || failure()) && steps.install.outcome == 'success'
-        run: |
-          pytest -v tests/llmcompressor/transformers/finetune
-      - name: Running GPTQ Tests
-        if: (success() || failure()) && steps.install.outcome == 'success'
-        run: |
-          pytest -v tests/llmcompressor/transformers/gptq
-      - name: Running ONESHOT Tests
-        if: (success() || failure()) && steps.install.outcome == 'success'
-        run: |
-          pytest -v tests/llmcompressor/transformers/oneshot
-      - name: Running Sparsification Tests
-        if: (success() || failure()) && steps.install.outcome == 'success'
-        run: |
-          pytest tests/llmcompressor/transformers/sparsification -v
-          pytest tests/llmcompressor/transformers/test_clear_ml.py -v
-      - name: Running OBCQ Tests
-        if: (success() || failure()) && steps.install.outcome == 'success'
-        run: |
-          pytest -v tests/llmcompressor/transformers/obcq


### PR DESCRIPTION
SUMMARY:
This PR moves the `transformers-tests` job to its own workflow which only runs on a PR that has the 'ready' label. With this implementation, if the PR already has the 'ready' label when a new commit is pushed, the new commit will re-run the job. I also updated the PR comment workflow to note that the 'ready' label must be added to run this job.

There are some visual warts/caveats that come with these triggers because the filtering cannot be done by the triggers, only the jobs:

Whenever a label is added or a commit is pushed, the workflow will still be triggered. However, if the PR does not have the 'ready' label, the `transformers-tests` job will be skipped. While the job being skipped means the runner/resources will not actually be used, it also means that the workflow/job will still show up in various places in the GitHub UI (Actions tab, PR checks). It will show as skipped, but it will still allow the green check mark because that appears as long as there are no failures.

Basically, this means that reviews/people able to merge will need to pay closer attention to the jobs run on the PR to make sure that the `transformers-tests` job was run/not skipped.

TEST PLAN:
Should affect this PR.
