### PR TITLE
Also run on pushes to `main`

### DIFF
--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches: main
     types: [ labeled, synchronize ]
+  push:
+    branches: main
 
 env:
   CADENCE: "commit"
@@ -15,7 +17,7 @@ env:
 jobs:
   transformers-tests:
     runs-on: gcp-k8s-vllm-l4-solo
-    if: contains(github.event.pull_request.labels.*.name, 'ready')
+    if: contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push'
     steps:
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
SUMMARY:
In #1079, the transformers tests were put behind a 'ready' label on pull requests only. This PR updates that workflow to also run that test job on pushes to `main` (e.g. after a PR is merged).


TEST PLAN:
Changes tested externally.
