### PR TITLE
[Fix Test Failure]: Propagate name change to test

### DIFF
--- a/src/llmcompressor/transformers/compression/sparsity_config.py
+++ b/src/llmcompressor/transformers/compression/sparsity_config.py
@@ -27,7 +27,7 @@ class SparsityConfigMetadata:
     metadata from the model
     """
 
-    SPARSITY_THRESHOLD: float = 0.5
+    SPARSITY_THRESHOLD: float = 0.49
 
     @staticmethod
     def infer_global_sparsity(

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -522,7 +522,7 @@ def test_sparse_24_compressor_is_lossless(model_stub, recipe, sparse_format, tmp
     shutil.rmtree(tmp_path)
 
 
-def test_no_sparse_compression_flag(tmp_path):
+def test_disable_sparse_compression_flag(tmp_path):
     two_four_sparse_model_id = "nm-testing/llama2.c-stories42M-pruned2.4"
     two_four_sparse_model = AutoModelForCausalLM.from_pretrained(
         two_four_sparse_model_id, torch_dtype="auto"
@@ -530,7 +530,7 @@ def test_no_sparse_compression_flag(tmp_path):
     modify_save_pretrained(two_four_sparse_model)
 
     save_path = tmp_path / "no_sparse_compression_model"
-    two_four_sparse_model.save_pretrained(save_path, no_sparse_compression=True)
+    two_four_sparse_model.save_pretrained(save_path, disable_sparse_compression=True)
 
     config = AutoConfig.from_pretrained(save_path)
     quantization_config = getattr(config, QUANTIZATION_CONFIG_NAME, None)


### PR DESCRIPTION
This PR addresses two key updates:  

1. **Test Update**:  
   In [PR #948](https://github.com/vllm-project/llm-compressor/pull/948), a flag name was updated during the review process. However, this update wasn't reflected in the relevant test. This PR propagates the updated flag name to the associated test.  

2. **Sparsity Threshold Adjustment**:  
   As requested in [PR #948](https://github.com/vllm-project/llm-compressor/pull/948), the sparsity threshold has been reduced to `0.49`.  
