### PR TITLE
[Bug Fix] Fix test that requre GPU

### DIFF
--- a/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
+++ b/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
@@ -8,6 +8,7 @@ from parameterized import parameterized_class
 from transformers import AutoModelForCausalLM
 from transformers.utils.quantization_config import CompressedTensorsConfig
 
+from llmcompressor.transformers.utils import is_model_ct_quantized
 from llmcompressor.transformers.utils.helpers import infer_recipe_from_model_path
 from tests.testing_utils import parse_params, requires_gpu
 
@@ -137,10 +138,17 @@ class TestConsecutiveRunsGPU(TestConsecutiveRuns):
     def setUp(self):
         from transformers import AutoModelForCausalLM
 
+        kwargs = {}
+        # if optimized model is passed, then must be using Linear Modules
+        if is_model_ct_quantized(self.model):
+            kwargs["quantization_config"] = CompressedTensorsConfig(
+                run_compressed=False
+            )
+
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model,
             device_map=self.device,
-            quantization_config=self.quantization_config,
+            **kwargs,
         )
 
         self.output = "./oneshot_output"

--- a/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
+++ b/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
@@ -8,7 +8,7 @@ from parameterized import parameterized_class
 from transformers import AutoModelForCausalLM
 from transformers.utils.quantization_config import CompressedTensorsConfig
 
-from llmcompressor.transformers.utils import is_model_ct_quantized
+from llmcompressor.transformers.utils import is_model_ct_quantized_from_path
 from llmcompressor.transformers.utils.helpers import infer_recipe_from_model_path
 from tests.testing_utils import parse_params, requires_gpu
 
@@ -139,11 +139,9 @@ class TestConsecutiveRunsGPU(TestConsecutiveRuns):
         from transformers import AutoModelForCausalLM
 
         kwargs = {}
-        # if optimized model is passed, then must be using Linear Modules
-        if is_model_ct_quantized(self.model):
-            kwargs["quantization_config"] = CompressedTensorsConfig(
-                run_compressed=False
-            )
+        # if optimized self.model is passed, then must be using Linear Modules
+        if is_model_ct_quantized_from_path(self.model):
+            kwargs["quantization_config"] = self.quantization_config
 
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model,

--- a/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
+++ b/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
@@ -103,24 +103,24 @@ class TestConsecutiveRuns(unittest.TestCase):
         shutil.rmtree(self.output)
 
 
-@pytest.mark.integration
-@parameterized_class(parse_params(CONFIGS_DIRECTORY))
-class TestConsecutiveRunsSmall(TestConsecutiveRuns):
-    model = None
-    first_recipe = None
-    second_recipe = None
-    dataset = None
+# @pytest.mark.integration
+# @parameterized_class(parse_params(CONFIGS_DIRECTORY))
+# class TestConsecutiveRunsSmall(TestConsecutiveRuns):
+#     model = None
+#     first_recipe = None
+#     second_recipe = None
+#     dataset = None
 
-    def setUp(self):
-        import torch
+#     def setUp(self):
+#         import torch
 
-        self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        self.output = "./oneshot_output"
-        self.output_first = Path(self.output) / "test_1"
-        self.output_second = Path(self.output) / "test_2"
+#         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+#         self.output = "./oneshot_output"
+#         self.output_first = Path(self.output) / "test_1"
+#         self.output_second = Path(self.output) / "test_2"
 
-    def test_consecutive_runs_small(self):
-        self._test_consecutive_runs(tolerance=1e-3)
+#     def test_consecutive_runs_small(self):
+#         self._test_consecutive_runs(tolerance=1e-3)
 
 
 # TODO: @Satrat and @dsikka, revisit if we want these nightly or weekly
@@ -138,16 +138,17 @@ class TestConsecutiveRunsGPU(TestConsecutiveRuns):
     def setUp(self):
         from transformers import AutoModelForCausalLM
 
-        kwargs = {}
-        # if optimized self.model is passed, then must be using Linear Modules
-        if is_model_ct_quantized_from_path(self.model):
-            kwargs["quantization_config"] = self.quantization_config
+        self.assertFalse(
+            is_model_ct_quantized_from_path(self.model),
+            "The provided model is quantized. Please use a dense model.",
+        )
 
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model,
             device_map=self.device,
-            **kwargs,
         )
+
+        breakpoint()
 
         self.output = "./oneshot_output"
         self.output_first = Path(self.output) / "test_1"

--- a/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
+++ b/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
@@ -103,24 +103,24 @@ class TestConsecutiveRuns(unittest.TestCase):
         shutil.rmtree(self.output)
 
 
-# @pytest.mark.integration
-# @parameterized_class(parse_params(CONFIGS_DIRECTORY))
-# class TestConsecutiveRunsSmall(TestConsecutiveRuns):
-#     model = None
-#     first_recipe = None
-#     second_recipe = None
-#     dataset = None
+@pytest.mark.integration
+@parameterized_class(parse_params(CONFIGS_DIRECTORY))
+class TestConsecutiveRunsSmall(TestConsecutiveRuns):
+    model = None
+    first_recipe = None
+    second_recipe = None
+    dataset = None
 
-#     def setUp(self):
-#         import torch
+    def setUp(self):
+        import torch
 
-#         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-#         self.output = "./oneshot_output"
-#         self.output_first = Path(self.output) / "test_1"
-#         self.output_second = Path(self.output) / "test_2"
+        self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        self.output = "./oneshot_output"
+        self.output_first = Path(self.output) / "test_1"
+        self.output_second = Path(self.output) / "test_2"
 
-#     def test_consecutive_runs_small(self):
-#         self._test_consecutive_runs(tolerance=1e-3)
+    def test_consecutive_runs_small(self):
+        self._test_consecutive_runs(tolerance=1e-3)
 
 
 # TODO: @Satrat and @dsikka, revisit if we want these nightly or weekly
@@ -147,8 +147,6 @@ class TestConsecutiveRunsGPU(TestConsecutiveRuns):
             self.model,
             device_map=self.device,
         )
-
-        breakpoint()
 
         self.output = "./oneshot_output"
         self.output_first = Path(self.output) / "test_1"


### PR DESCRIPTION
SUMMARY:
Nightly tests uses gpus, ci tests dont. 
In the set up of `tests/llmcompressor/transformers/obcq/test_consecutive_runs.py`, a bug was found where `quantization_config` was always passed. This will result in an error if the model from the config file is not optimized. 
We are passing in dense model, so it fails.


TEST PLAN:
Run the failing test, make sure it passes!
