### PR TITLE
Raise warning for 24 compressed sparse-only models

### DIFF
--- a/src/llmcompressor/transformers/compression/sparsity_config.py
+++ b/src/llmcompressor/transformers/compression/sparsity_config.py
@@ -183,7 +183,8 @@ class SparsityConfigMetadata:
         if not is_model_quantized(model):
             logger.warning(
                 "Compressed Sparse-only 2:4 models are not supported in vLLM<=0.7.0, "
-                "consider saving with disable_sparse_compression=True"
+                "consider saving with `disable_sparse_compression` set, "
+                "`model.save_pretrained(..., disable_sparse_compression=True)`"
             )
             return True
 

--- a/src/llmcompressor/transformers/compression/sparsity_config.py
+++ b/src/llmcompressor/transformers/compression/sparsity_config.py
@@ -181,7 +181,10 @@ class SparsityConfigMetadata:
             return False
 
         if not is_model_quantized(model):
-            # non-quantized 2:4 sparse models are supported
+            logger.warning(
+                "Compressed Sparse-only 2:4 models are not supported in vLLM<=0.7.0, "
+                "consider saving with disable_sparse_compression=True"
+            )
             return True
 
         # when model is quantized, and has 2:4 sparsity


### PR DESCRIPTION
In a recent update, we disabled Cutlass kernels for sparse-only models https://github.com/vllm-project/vllm/pull/12417. As a result, sparse-24-only compressed-models are no longer runnable in vLLM.

This PR introduces a warning message to inform users when compression is enabled in scenarios where sparse-only models are unsupported. This ensures clarity and avoids unexpected behavior when using sparse-24 configurations with vLLM.

Changes:

- Added a warning to notify users when attempting to enable compression with sparse-only models in unsupported configurations.
