### PR TITLE
Unpin `pynvml` to fix e2e test failures with vLLM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "transformers>4.0,<5.0",
         "datasets",
         "accelerate>=0.20.3,!=1.1.0",
-        "pynvml==11.5.3",
+        "pynvml",
         "compressed-tensors"
         if version_info.build_type == "release"
         else "compressed-tensors-nightly",


### PR DESCRIPTION
SUMMARY:
- vLLM throws a runtime error if pynvml < 12.0 is installed 
- Unpin pynvml version to prevent error and allow e2e tests to run

TEST PLAN:
- e2e tests now run
