### PR TITLE
Remove Michael

### DIFF
--- a/examples/multimodal_vision/pixtral_example.py
+++ b/examples/multimodal_vision/pixtral_example.py
@@ -8,7 +8,7 @@ from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.tracing import TraceableLlavaForConditionalGeneration
 
 # Load model.
-model_id = "mgoin/pixtral-12b"
+model_id = "mistral-community/pixtral-12b"
 model = TraceableLlavaForConditionalGeneration.from_pretrained(
     model_id, device_map="auto", torch_dtype="auto"
 )


### PR DESCRIPTION
## Purpose ##
* Michael has outstayed his welcome
* Because there is now a mistral-community version of the pixtral-12b model, he is no longer needed

## Changes ##
* Replace `mgoin/pixtral-12b` with `mistral-community/pixtral-12b/pixtral-12b`