### PR TITLE
[OneshotRefactor] Update oneshot to post_train

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Quantization is applied by selecting an algorithm and calling the `oneshot` API.
 ```python
 from llmcompressor.modifiers.quantization import GPTQModifier
 from llmcompressor.modifiers.smoothquant import SmoothQuantModifier
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 from transformers import AutoModelForCausalLM
 
 # Select quantization algorithm. In this case, we:
@@ -72,7 +72,7 @@ recipe = [
 
 # Apply quantization using the built in open_platypus dataset.
 #   * See examples for demos showing how to pass a custom calibration set
-oneshot(
+post_train(
     model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
     dataset="open_platypus",
     recipe=recipe,

--- a/examples/big_models_with_accelerate/cpu_offloading_fp8.py
+++ b/examples/big_models_with_accelerate/cpu_offloading_fp8.py
@@ -1,7 +1,7 @@
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 MODEL_ID = "meta-llama/Meta-Llama-3-70B-Instruct"
 OUTPUT_DIR = MODEL_ID.split("/")[1] + "-FP8-Dynamic"
@@ -18,7 +18,7 @@ recipe = QuantizationModifier(
 )
 
 # Apply quantization and save in `compressed-tensors` format.
-oneshot(
+post_train(
     model=model,
     recipe=recipe,
     tokenizer=AutoTokenizer.from_pretrained(MODEL_ID),

--- a/examples/big_models_with_accelerate/mult_gpus_int8_device_map.py
+++ b/examples/big_models_with_accelerate/mult_gpus_int8_device_map.py
@@ -2,9 +2,9 @@ import torch
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
 from llmcompressor.modifiers.smoothquant import SmoothQuantModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.compression.helpers import calculate_offload_device_map
 
 MODEL_ID = "meta-llama/Meta-Llama-3-70B-Instruct"
@@ -70,7 +70,7 @@ recipe = [
 
 SAVE_DIR = MODEL_ID.split("/")[1] + "-INT8"
 
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/big_models_with_accelerate/multi_gpu_int8.py
+++ b/examples/big_models_with_accelerate/multi_gpu_int8.py
@@ -1,8 +1,8 @@
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 
 MODEL_ID = "meta-llama/Meta-Llama-3-70B-Instruct"
 SAVE_DIR = MODEL_ID.split("/")[1] + "-W8A8-Dynamic"
@@ -67,7 +67,7 @@ recipe = [
 # 4) Apply algorithms and save in `compressed-tensors` format.
 # if you encounter GPU out-of-memory issues, consider using an explicit
 # device map (see multi_gpus_int8_device_map.py)
-oneshot(
+post_train(
     model=model,
     tokenizer=tokenizer,
     dataset=ds,

--- a/examples/finetuning/example_alternating_recipe.yaml
+++ b/examples/finetuning/example_alternating_recipe.yaml
@@ -1,5 +1,5 @@
 initial_sparsity_stage:
-  run_type: oneshot
+  run_type: post_train
   obcq_modifiers:
     SparseGPTModifier:
       sparsity: 0.5
@@ -17,7 +17,7 @@ initial_training_stage:
       targets: '__ALL__'
       start: 0
 next_sparsity_stage:
-  run_type: oneshot
+  run_type: post_train
   obcq_modifiers:
     SparseGPTModifier:
       sparsity: 0.7

--- a/examples/multimodal_audio/whisper_example.py
+++ b/examples/multimodal_audio/whisper_example.py
@@ -2,8 +2,8 @@ import torch
 from datasets import load_dataset
 from transformers import WhisperProcessor
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.tracing import TraceableWhisperForConditionalGeneration
 
 # Select model and load it.
@@ -70,7 +70,7 @@ def process(sample):
 ds = ds.map(process, remove_columns=ds.column_names)
 
 
-# Define a oneshot data collator for multimodal inputs.
+# Define a post_train data collator for multimodal inputs.
 def data_collator(batch):
     assert len(batch) == 1
     return {key: torch.tensor(value) for key, value in batch[0].items()}
@@ -80,7 +80,7 @@ def data_collator(batch):
 recipe = GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"])
 
 # Apply algorithms.
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/multimodal_vision/idefics3_example.py
+++ b/examples/multimodal_vision/idefics3_example.py
@@ -4,8 +4,8 @@ from datasets import load_dataset
 from PIL import Image
 from transformers import AutoProcessor
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.tracing import TraceableIdefics3ForConditionalGeneration
 
 # Load model.
@@ -22,7 +22,7 @@ NUM_CALIBRATION_SAMPLES = 512
 MAX_SEQUENCE_LENGTH = 4096  # Seems to be required here
 
 
-# Define a oneshot data collator for multimodal inputs.
+# Define a post_train data collator for multimodal inputs.
 def data_collator(batch):
     assert len(batch) == 1
     return {key: torch.tensor(value) for key, value in batch[0].items()}
@@ -80,8 +80,8 @@ def tokenize(sample):
 # avoid errors with writer_batch_size
 ds = ds.map(tokenize, writer_batch_size=1, remove_columns=ds.column_names)
 
-# Perform oneshot
-oneshot(
+# Perform post_train
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/multimodal_vision/llava_example.py
+++ b/examples/multimodal_vision/llava_example.py
@@ -3,8 +3,8 @@ import torch
 from PIL import Image
 from transformers import AutoProcessor
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.tracing import TraceableLlavaForConditionalGeneration
 
 # Load model.
@@ -21,7 +21,7 @@ NUM_CALIBRATION_SAMPLES = 512
 MAX_SEQUENCE_LENGTH = 2048
 
 
-# Define a oneshot data collator for multimodal inputs.
+# Define a post_train data collator for multimodal inputs.
 def data_collator(batch):
     assert len(batch) == 1
     return {key: torch.tensor(value) for key, value in batch[0].items()}
@@ -37,8 +37,8 @@ recipe = [
     ),
 ]
 
-# Perform oneshot
-oneshot(
+# Perform post_train
+post_train(
     model=model,
     tokenizer=model_id,
     dataset=DATASET_ID,

--- a/examples/multimodal_vision/mllama_example.py
+++ b/examples/multimodal_vision/mllama_example.py
@@ -3,8 +3,8 @@ import torch
 from PIL import Image
 from transformers import AutoProcessor
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.tracing import TraceableMllamaForConditionalGeneration
 
 # Load model.
@@ -21,7 +21,7 @@ NUM_CALIBRATION_SAMPLES = 512
 MAX_SEQUENCE_LENGTH = 2048
 
 
-# Define a oneshot data collator for multimodal inputs.
+# Define a post_train data collator for multimodal inputs.
 def data_collator(batch):
     assert len(batch) == 1
     return {key: torch.tensor(value) for key, value in batch[0].items()}
@@ -36,8 +36,8 @@ recipe = [
     ),
 ]
 
-# Perform oneshot
-oneshot(
+# Perform post_train
+post_train(
     model=model,
     tokenizer=model_id,
     dataset=DATASET_ID,

--- a/examples/multimodal_vision/phi3_vision_example.py
+++ b/examples/multimodal_vision/phi3_vision_example.py
@@ -2,8 +2,8 @@ import torch
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoProcessor
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 
 # Load model.
 model_id = "microsoft/Phi-3-vision-128k-instruct"
@@ -59,7 +59,7 @@ def tokenize(sample):
 ds = ds.map(tokenize, writer_batch_size=1, remove_columns=ds.column_names)
 
 
-# Define a oneshot data collator for multimodal inputs.
+# Define a post_train data collator for multimodal inputs.
 def data_collator(batch):
     assert len(batch) == 1
     return {key: torch.tensor(value) for key, value in batch[0].items()}
@@ -73,8 +73,8 @@ recipe = GPTQModifier(
     ignore=["lm_head", "re:model.vision_embed_tokens.*"],
 )
 
-# Perform oneshot
-oneshot(
+# Perform post_train
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/multimodal_vision/pixtral_example.py
+++ b/examples/multimodal_vision/pixtral_example.py
@@ -3,8 +3,8 @@ import torch
 from PIL import Image
 from transformers import AutoProcessor
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.tracing import TraceableLlavaForConditionalGeneration
 
 # Load model.
@@ -21,7 +21,7 @@ DATASET_SPLIT = {"calibration": f"test[:{NUM_CALIBRATION_SAMPLES}]"}
 MAX_SEQUENCE_LENGTH = 2048
 
 
-# Define a oneshot data collator for multimodal inputs.
+# Define a post_train data collator for multimodal inputs.
 # NOTE: for transformers<4.48.0, please squeeze the first dimension of `pixel_values`
 # by appending `[0]` to the end of line 32
 def data_collator(batch):
@@ -43,8 +43,8 @@ recipe = [
     ),
 ]
 
-# Perform oneshot
-oneshot(
+# Perform post_train
+post_train(
     model=model,
     tokenizer=model_id,
     dataset=DATASET_ID,

--- a/examples/multimodal_vision/qwen2_vl_example.py
+++ b/examples/multimodal_vision/qwen2_vl_example.py
@@ -6,8 +6,8 @@ from datasets import load_dataset
 from qwen_vl_utils import process_vision_info
 from transformers import AutoProcessor
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.tracing import TraceableQwen2VLForConditionalGeneration
 
 # Load model.
@@ -66,7 +66,7 @@ def preprocess_and_tokenize(example):
 ds = ds.map(preprocess_and_tokenize, remove_columns=ds["calibration"].column_names)
 
 
-# Define a oneshot data collator for multimodal inputs.
+# Define a post_train data collator for multimodal inputs.
 def data_collator(batch):
     assert len(batch) == 1
     return {key: torch.tensor(value) for key, value in batch[0].items()}
@@ -82,8 +82,8 @@ recipe = [
     ),
 ]
 
-# Perform oneshot
-oneshot(
+# Perform post_train
+post_train(
     model=model,
     tokenizer=model_id,
     dataset=ds,

--- a/examples/quantization_2of4_sparse_w4a16/2of4_w4a16_group-128_recipe.yaml
+++ b/examples/quantization_2of4_sparse_w4a16/2of4_w4a16_group-128_recipe.yaml
@@ -1,5 +1,5 @@
 sparsity_stage:
-  run_type: oneshot
+  run_type: post_train
   sparsity_modifiers:
     SparseGPTModifier:
       sparsity: 0.5
@@ -20,7 +20,7 @@ finetuning_stage:
       ]
       start: 0
 quantization_stage:
-  run_type: oneshot
+  run_type: post_train
   quantization_modifiers:
     GPTQModifier:
       ignore: ["lm_head"]

--- a/examples/quantization_2of4_sparse_w4a16/2of4_w4a16_recipe.yaml
+++ b/examples/quantization_2of4_sparse_w4a16/2of4_w4a16_recipe.yaml
@@ -1,5 +1,5 @@
 sparsity_stage:
-  run_type: oneshot
+  run_type: post_train
   sparsity_modifiers:
     SparseGPTModifier:
       sparsity: 0.5
@@ -20,7 +20,7 @@ finetuning_stage:
       ]
       start: 0
 quantization_stage:
-  run_type: oneshot
+  run_type: post_train
   quantization_modifiers:
     GPTQModifier:
       ignore: ["lm_head"]

--- a/examples/quantization_2of4_sparse_w4a16/llama7b_sparse_w4a16.py
+++ b/examples/quantization_2of4_sparse_w4a16/llama7b_sparse_w4a16.py
@@ -35,7 +35,7 @@ lr_scheduler_type = "cosine"
 warmup_ratio = 0.1
 
 # this will run the recipe stage by stage:
-# oneshot sparsification -> finetuning -> oneshot quantization
+# post_train sparsification -> finetuning -> post_train quantization
 apply(
     model=model,
     dataset=dataset,

--- a/examples/quantization_kv_cache/README.md
+++ b/examples/quantization_kv_cache/README.md
@@ -75,7 +75,7 @@ Configure and apply the FP8 quantization for weights, activations, and KV cache.
 Notice the new `kv_cache_scheme` section:
 
 ```python
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 
 recipe = """
 quant_stage:
@@ -105,7 +105,7 @@ quant_stage:
                 symmetric: true
 """
 
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantization_kv_cache/gemma2_fp8_kv_example.py
+++ b/examples/quantization_kv_cache/gemma2_fp8_kv_example.py
@@ -1,7 +1,7 @@
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 
 # Select model and load it.
 MODEL_ID = "google/gemma-2-9b-it"
@@ -73,7 +73,7 @@ quant_stage:
 """
 
 # Apply algorithms.
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantization_kv_cache/llama3_fp8_kv_example.py
+++ b/examples/quantization_kv_cache/llama3_fp8_kv_example.py
@@ -2,7 +2,7 @@ from datasets import load_dataset
 from loguru import logger
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -74,7 +74,7 @@ quant_stage:
 """
 
 # Apply algorithms.
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantization_kv_cache/phi3.5_fp8_kv_example.py
+++ b/examples/quantization_kv_cache/phi3.5_fp8_kv_example.py
@@ -1,7 +1,7 @@
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 
 # Select model and load it.
 # Phi-3.5 is a special case for KV cache quantization because it has
@@ -75,7 +75,7 @@ quant_stage:
 """
 
 # Apply algorithms.
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantization_w4a16/README.md
+++ b/examples/quantization_w4a16/README.md
@@ -86,14 +86,14 @@ In our case, we will apply the default GPTQ recipe for `int4` (which uses static
 > See the `Recipes` documentation for more information on making complex recipes
 
 ```python
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
 
 # Configure the quantization algorithm to run.
 recipe = GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"])
 
 # Apply quantization.
-oneshot(
+post_train(
     model=model, dataset=ds,
     recipe=recipe,
     max_seq_length=MAX_SEQUENCE_LENGTH,

--- a/examples/quantization_w4a16/llama3_example.py
+++ b/examples/quantization_w4a16/llama3_example.py
@@ -2,7 +2,7 @@ from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -58,7 +58,7 @@ ds = ds.map(tokenize, remove_columns=ds.column_names)
 recipe = GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"])
 
 # Apply algorithms.
-oneshot(
+post_train
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantization_w4a16/llama3_example.py
+++ b/examples/quantization_w4a16/llama3_example.py
@@ -1,8 +1,8 @@
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from llmcompressor.modifiers.quantization import GPTQModifier
 from llmcompressor import post_train
+from llmcompressor.modifiers.quantization import GPTQModifier
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -58,7 +58,7 @@ ds = ds.map(tokenize, remove_columns=ds.column_names)
 recipe = GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"])
 
 # Apply algorithms.
-post_train
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantization_w8a8_fp8/README.md
+++ b/examples/quantization_w8a8_fp8/README.md
@@ -54,7 +54,7 @@ We recommend targeting all `Linear` layers using the `FP8_DYNAMIC` scheme, which
 Since simple PTQ does not require data for weight quantization and the activations are quantized dynamically, we do not need any calibration data for this quantization flow.
 
 ```python
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
 
 # Configure the simple PTQ quantization
@@ -62,7 +62,7 @@ recipe = QuantizationModifier(
   targets="Linear", scheme="FP8_DYNAMIC", ignore=["lm_head"])
 
 # Apply the quantization algorithm.
-oneshot(model=model, recipe=recipe)
+post_train(model=model, recipe=recipe)
 
 # Save the model.
 SAVE_DIR = MODEL_ID.split("/")[1] + "-FP8-Dynamic"

--- a/examples/quantization_w8a8_fp8/gemma2_example.py
+++ b/examples/quantization_w8a8_fp8/gemma2_example.py
@@ -1,7 +1,7 @@
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 MODEL_ID = "google/gemma-2-27b-it"
 
@@ -21,7 +21,7 @@ recipe = QuantizationModifier(
 
 # 3) Apply quantization and save in compressed-tensors format.
 OUTPUT_DIR = MODEL_ID.split("/")[1] + "-FP8-Dynamic"
-oneshot(
+post_train(
     model=model,
     recipe=recipe,
     tokenizer=tokenizer,

--- a/examples/quantization_w8a8_fp8/llama3.2_vision_example.py
+++ b/examples/quantization_w8a8_fp8/llama3.2_vision_example.py
@@ -1,7 +1,7 @@
 from transformers import AutoProcessor, MllamaForConditionalGeneration
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 MODEL_ID = "meta-llama/Llama-3.2-11B-Vision-Instruct"
 
@@ -23,7 +23,7 @@ recipe = QuantizationModifier(
 
 # Apply quantization and save to disk in compressed-tensors format.
 SAVE_DIR = MODEL_ID.split("/")[1] + "-FP8-Dynamic"
-oneshot(
+post_train(
     model=model,
     recipe=recipe,
     output_dir=SAVE_DIR,

--- a/examples/quantization_w8a8_fp8/llama3_example.py
+++ b/examples/quantization_w8a8_fp8/llama3_example.py
@@ -1,7 +1,7 @@
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
 
@@ -20,7 +20,7 @@ recipe = QuantizationModifier(
 )
 
 # Apply quantization.
-oneshot(model=model, recipe=recipe)
+post_train(model=model, recipe=recipe)
 
 # Confirm generations of the quantized model look sane.
 print("========== SAMPLE GENERATION ==============")

--- a/examples/quantization_w8a8_fp8/llava1.5_example.py
+++ b/examples/quantization_w8a8_fp8/llava1.5_example.py
@@ -1,7 +1,7 @@
 from transformers import AutoProcessor, LlavaForConditionalGeneration
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 MODEL_ID = "llava-hf/llava-1.5-7b-hf"
 
@@ -23,7 +23,7 @@ recipe = QuantizationModifier(
 
 # Apply quantization and save to disk in compressed-tensors format.
 SAVE_DIR = MODEL_ID.split("/")[1] + "-FP8-Dynamic"
-oneshot(model=model, recipe=recipe, output_dir=SAVE_DIR)
+post_train(model=model, recipe=recipe, output_dir=SAVE_DIR)
 processor.save_pretrained(SAVE_DIR)
 
 # Confirm generations of the quantized model look sane.

--- a/examples/quantization_w8a8_fp8/qwen2vl_example.py
+++ b/examples/quantization_w8a8_fp8/qwen2vl_example.py
@@ -1,7 +1,7 @@
 from transformers import AutoProcessor, Qwen2VLForConditionalGeneration
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 MODEL_ID = "Qwen/Qwen2-VL-7B-Instruct"
 
@@ -23,7 +23,7 @@ recipe = QuantizationModifier(
 
 # Apply quantization and save to disk in compressed-tensors format.
 SAVE_DIR = MODEL_ID.split("/")[1] + "-FP8-Dynamic"
-oneshot(model=model, recipe=recipe, output_dir=SAVE_DIR)
+post_train(model=model, recipe=recipe, output_dir=SAVE_DIR)
 processor.save_pretrained(SAVE_DIR)
 
 # Confirm generations of the quantized model look sane.

--- a/examples/quantization_w8a8_fp8/whisper_example.py
+++ b/examples/quantization_w8a8_fp8/whisper_example.py
@@ -1,8 +1,8 @@
 from datasets import load_dataset
 from transformers import AutoProcessor, WhisperForConditionalGeneration
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 MODEL_ID = "openai/whisper-large-v2"
 
@@ -23,7 +23,7 @@ recipe = QuantizationModifier(
 )
 
 # Apply quantization.
-oneshot(model=model, recipe=recipe)
+post_train(model=model, recipe=recipe)
 
 # Confirm generations of the quantized model look sane.
 print("========== SAMPLE GENERATION ==============")

--- a/examples/quantization_w8a8_int8/README.md
+++ b/examples/quantization_w8a8_int8/README.md
@@ -86,7 +86,7 @@ We first select the quantization algorithm. For W8A8, we want to:
 > See the `Recipes` documentation for more information on recipes
 
 ```python
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
 from llmcompressor.modifiers.smoothquant import SmoothQuantModifier
 
@@ -97,7 +97,7 @@ recipe = [
 ]
 
 # Apply quantization.
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantization_w8a8_int8/gemma2_example.py
+++ b/examples/quantization_w8a8_int8/gemma2_example.py
@@ -1,8 +1,8 @@
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 
 # 1) Select model and load it.
 MODEL_ID = "google/gemma-2-2b-it"
@@ -58,7 +58,7 @@ ds = ds.map(tokenize, remove_columns=ds.column_names)
 recipe = GPTQModifier(targets="Linear", scheme="W8A8", ignore=["lm_head"])
 
 # 4) Apply quantization and save to disk compressed.
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantization_w8a8_int8/llama3_example.py
+++ b/examples/quantization_w8a8_int8/llama3_example.py
@@ -1,9 +1,9 @@
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
 from llmcompressor.modifiers.smoothquant import SmoothQuantModifier
-from llmcompressor.transformers import oneshot
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -63,7 +63,7 @@ recipe = [
 ]
 
 # Apply algorithms and save to output_dir
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantizing_moe/README.md
+++ b/examples/quantizing_moe/README.md
@@ -51,11 +51,11 @@ NOTE: `.*block_sparse_moe.gate` layers do not quantize well, hence they are igno
 The `oneshot` method applies the selected recipe to your model and dataset without requiring any fine-tuning. The model will be sparsified and saved to `Mixtral-8x7B-Instruct-v0.1-FP8`.
 
 ```python
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 
 output_dir = "Mixtral-8x7B-Instruct-v0.1-FP8"
 
-oneshot(
+post_train(
     model=model,
     dataset=dataset,
     recipe=recipe,

--- a/examples/quantizing_moe/README.md
+++ b/examples/quantizing_moe/README.md
@@ -61,7 +61,6 @@ post_train(
     recipe=recipe,
     save_compressed=True,
     output_dir=output_dir,
-    overwrite_output_dir=True,
     max_seq_length=2048,
     num_calibration_samples=512,
 )

--- a/examples/quantizing_moe/deepseek_moe_w4a16.py
+++ b/examples/quantizing_moe/deepseek_moe_w4a16.py
@@ -2,7 +2,7 @@ import torch
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 from llmcompressor.transformers.compression.helpers import calculate_offload_device_map
 
 # NOTE: transformers 4.48.0 has an import error with DeepSeek.
@@ -72,7 +72,7 @@ recipe = "deepseek_recipe_w4a16.yaml"
 SAVE_DIR = MODEL_ID.split("/")[1] + "-W4A16"
 
 
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantizing_moe/deepseek_moe_w8a8_fp8.py
+++ b/examples/quantizing_moe/deepseek_moe_w8a8_fp8.py
@@ -1,8 +1,8 @@
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 # NOTE: transformers 4.48.0 has an import error with DeepSeek.
 # Please consider either downgrading your transformers version to a
@@ -67,7 +67,7 @@ recipe = [
 
 SAVE_DIR = MODEL_ID.split("/")[1] + "-FP8"
 
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantizing_moe/deepseek_moe_w8a8_int8.py
+++ b/examples/quantizing_moe/deepseek_moe_w8a8_int8.py
@@ -2,8 +2,8 @@ import torch
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.compression.helpers import calculate_offload_device_map
 
 # NOTE: transformers 4.48.0 has an import error with DeepSeek.
@@ -79,7 +79,7 @@ recipe = [
 
 SAVE_DIR = MODEL_ID.split("/")[1] + "-W8A8"
 
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/quantizing_moe/mixtral_moe_w8a8_fp8.py
+++ b/examples/quantizing_moe/mixtral_moe_w8a8_fp8.py
@@ -2,8 +2,8 @@ from typing import List
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.compression.helpers import calculate_offload_device_map
 
 MODEL_ID = "mistralai/Mixtral-8x7B-Instruct-v0.1"
@@ -37,7 +37,7 @@ layers_to_ignore: List[str] = [
 recipe = QuantizationModifier(scheme="FP8", targets="Linear", ignore=layers_to_ignore)
 
 
-oneshot(
+post_train(
     model=model,
     tokenizer=tokenizer,
     dataset=DATASET_ID,

--- a/examples/quantizing_moe/mixtral_moe_w8a8_fp8.py
+++ b/examples/quantizing_moe/mixtral_moe_w8a8_fp8.py
@@ -45,7 +45,6 @@ post_train(
     max_seq_length=MAX_SEQ_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     save_compressed=SAVE_COMPRESSED,
-    overwrite_output_dir=True,
     output_dir=SAVE_DIR,
 )
 

--- a/examples/sparse_2of4_quantization_fp8/README.md
+++ b/examples/sparse_2of4_quantization_fp8/README.md
@@ -84,7 +84,7 @@ if fp8_enabled:
 The script applies compression using the oneshot function:
 
 ```python
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/examples/sparse_2of4_quantization_fp8/llama3_8b_2of4.py
+++ b/examples/sparse_2of4_quantization_fp8/llama3_8b_2of4.py
@@ -3,10 +3,10 @@ import argparse
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.obcq import SparseGPTModifier
 from llmcompressor.modifiers.pruning import ConstantPruningModifier
 from llmcompressor.modifiers.quantization import QuantizationModifier
-from llmcompressor.transformers import oneshot
 
 # Configuration
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -100,7 +100,7 @@ ds = ds.map(tokenize, remove_columns=ds.column_names)
 recipe, save_dir = get_recipe(args.fp8)
 
 # Apply compression
-oneshot(
+post_train(
     model=model,
     dataset=ds,
     recipe=recipe,

--- a/src/llmcompressor/__init__.py
+++ b/src/llmcompressor/__init__.py
@@ -44,3 +44,5 @@ from llmcompressor.core.session_functions import (
     pre_initialize_structure,
     reset_session,
 )
+
+from .entrypoints import post_train

--- a/src/llmcompressor/args/README.md
+++ b/src/llmcompressor/args/README.md
@@ -5,18 +5,18 @@ Parsers in `llm-compressor` define the input arguments required for various entr
 Each entry point (e.g., oneshot) carries out its logic based on the provided input arguments, `model`, `recipe`, and `dataset`.
 
 ```python
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 
 model = ...
 recipe = ...
 dataset = ...
-oneshot(model=model, recipe=recipe, dataset=dataset)
+post_train(model=model, recipe=recipe, dataset=dataset)
 ```
 
 In addition, users can futher control execution by providing additional arguments. For example, to save the optimized model after completion, the `output_dir` parameter can be specified:
 
 ```python
-oneshot(
+post_train(
     ..., 
     output_dir=...,
 )

--- a/src/llmcompressor/args/model_arguments.py
+++ b/src/llmcompressor/args/model_arguments.py
@@ -5,8 +5,9 @@ from typing import Optional
 @dataclass
 class ModelArguments:
     """
-    Model variables used for post_train (post-training quantization, and sparsification),
-    finetuning and stage runners (sequential run of post_train and finetune).
+    Model variables used for post_train (post-training quantization, and
+    sparsification), finetuning and stage runners (sequential run of
+    post_train and finetune).
 
     """
 

--- a/src/llmcompressor/args/model_arguments.py
+++ b/src/llmcompressor/args/model_arguments.py
@@ -5,8 +5,8 @@ from typing import Optional
 @dataclass
 class ModelArguments:
     """
-    Model variables used for oneshot calibration, finetuning and
-    stage runners (sequential run of oneshot and finetune).
+    Model variables used for post_train (post-training quantization, and sparsification),
+    finetuning and stage runners (sequential run of oneshot and finetune).
 
     """
 
@@ -79,9 +79,9 @@ class ModelArguments:
         default=True,
         metadata={"help": "Whether to compress sparse models during save"},
     )
-    oneshot_device: Optional[str] = field(
+    post_train_device: Optional[str] = field(
         default="cuda:0",
-        metadata={"help": "Device to run oneshot calibration on"},
+        metadata={"help": "Device to run post_train calibration on"},
     )
     model_revision: str = field(
         default="main",

--- a/src/llmcompressor/args/model_arguments.py
+++ b/src/llmcompressor/args/model_arguments.py
@@ -6,7 +6,7 @@ from typing import Optional
 class ModelArguments:
     """
     Model variables used for post_train (post-training quantization, and sparsification),
-    finetuning and stage runners (sequential run of oneshot and finetune).
+    finetuning and stage runners (sequential run of post_train and finetune).
 
     """
 

--- a/src/llmcompressor/args/training_arguments.py
+++ b/src/llmcompressor/args/training_arguments.py
@@ -16,7 +16,7 @@ class TrainingArguments(HFTrainingArgs):
 
     """
 
-    do_oneshot: Optional[bool] = field(
+    do_post_train: Optional[bool] = field(
         default=False,
         metadata={"help": "Whether to run one-shot calibration in stages"},
     )

--- a/src/llmcompressor/entrypoints/__init__.py
+++ b/src/llmcompressor/entrypoints/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .post_train import post_train

--- a/src/llmcompressor/entrypoints/post_train.py
+++ b/src/llmcompressor/entrypoints/post_train.py
@@ -63,7 +63,7 @@ def _post_process(model_args, output_dir):
             model_args.tokenizer.save_pretrained(output_dir)
 
 
-def _parse_oneshot_args(**kwargs):
+def _parse_post_train_args(**kwargs):
     """
     Parses kwargs by grouping into model, data or training arg groups:
         * model_args in
@@ -142,7 +142,7 @@ def run_post_train(
             recipe=recipe,
             recipe_args=recipe_args,
             calib_data=dataloader,
-            start=-1,  # oneshot-specific argument
+            start=-1,  # post_train-specific argument
             copy_data=False,
             min_tokens_per_module=min_tokens_per_module,
         )
@@ -151,7 +151,7 @@ def run_post_train(
 def post_train(
     **kwargs,
 ):
-    model_args, data_args, recipe_args, output_dir = _parse_oneshot_args(**kwargs)
+    model_args, data_args, recipe_args, output_dir = _parse_post_train_args(**kwargs)
 
     # update model and processor
     _preprocess(model_args)

--- a/src/llmcompressor/entrypoints/post_train.py
+++ b/src/llmcompressor/entrypoints/post_train.py
@@ -1,0 +1,169 @@
+from typing import Optional
+
+from loguru import logger
+from transformers import HfArgumentParser
+
+from llmcompressor.args import DatasetArguments, ModelArguments, RecipeArguments
+from llmcompressor.core.session_functions import active_session
+from llmcompressor.transformers.finetune.data.data_helpers import (
+    get_calibration_dataloader,
+)
+from llmcompressor.transformers.finetune.text_generation import (
+    initialize_model_from_path,
+    initialize_processor_from_path,
+)
+from llmcompressor.transformers.sparsification.compressed_tensors_utils import (
+    modify_save_pretrained,
+    patch_tied_tensors_bug,
+)
+
+
+def _warn_tied_embeddings(model_args):
+    if model_args.tie_word_embeddings:
+        logger.debug(
+            "The tie_word_embeddings flag is by default set to False. "
+            "This guarantees that the one-shot algorithm saves the final "
+            "weights without errors. Detected tie_word_embeddings=True. "
+            "This may cause issues with the one-shot algorithm on save."
+        )
+
+
+def _preprocess(model_args) -> None:
+    """
+    Update model and processor on model_args
+    """
+    _warn_tied_embeddings(model_args)
+
+    # Initialize model
+    if isinstance(model_args.model, str):
+        # update once intialize_model_from_path PR is merged
+        # model_args.model, _ = initialize_model_from_path(model_args)
+
+        _, _, model_args.model = initialize_model_from_path(model_args)
+
+    patch_tied_tensors_bug(model_args.model)
+    modify_save_pretrained(model_args.model)
+
+    # Initialize processor
+    if isinstance(model_args.processor, (str, type(None))):
+        model_args.processor = initialize_processor_from_path(
+            model_args, model_args.model
+        )
+
+    return model_args.model, model_args.processor
+
+
+def _post_process(model_args, output_dir):
+    if output_dir is not None:
+        model_args.model.save_pretrained(
+            output_dir,
+            save_compressed=model_args.save_compressed,
+        )
+        if model_args.tokenizer:
+            model_args.tokenizer.save_pretrained(output_dir)
+
+
+def _parse_oneshot_args(**kwargs):
+    """
+    Parses kwargs by grouping into model, data or training arg groups:
+        * model_args in
+            src/llmcompressor/transformers/utils/arg_parser/model_args.py
+        * data_args in
+            src/llmcompressor/transformers/utils/arg_parser/data_args.py
+        * recipe_args in
+            src/llmcompressor/transformers/utils/arg_parser/recipe_args.py
+        * training_args in
+            src/llmcompressor/transformers/utils/arg_parser/training_args.py
+
+    """
+    output_dir = kwargs.pop("output_dir", None)
+
+    parser = HfArgumentParser((ModelArguments, DatasetArguments, RecipeArguments))
+
+    if not kwargs:
+
+        def _get_output_dir_from_argv() -> Optional[str]:
+            import sys
+
+            output_dir = None
+            if "--output_dir" in sys.argv:
+                index = sys.argv.index("--output_dir")
+                sys.argv.pop(index)
+                if index < len(sys.argv):  # Check if value exists afer the flag
+                    output_dir = sys.argv.pop(index)
+
+            return output_dir
+
+        output_dir = _get_output_dir_from_argv() or output_dir
+        parsed_args = parser.parse_args_into_dataclasses()
+    else:
+        parsed_args = parser.parse_dict(kwargs)
+
+    model_args, data_args, recipe_args = parsed_args
+
+    if recipe_args.recipe_args is not None:
+        if not isinstance(recipe_args.recipe_args, dict):
+            arg_dict = {}
+            for recipe_arg in recipe_args.recipe_args:
+                key, value = recipe_arg.split("=")
+                arg_dict[key] = value
+            recipe_args.recipe_args = arg_dict
+
+    # raise depreciation warnings
+    if data_args.remove_columns is not None:
+        logger.waning(
+            "`remove_columns` argument is depreciated. When tokenizing datasets, all "
+            "columns which are invalid inputs the tokenizer will be removed",
+            DeprecationWarning,
+        )
+
+    # silently assign tokenizer to processor
+    if model_args.tokenizer:
+        if model_args.processor:
+            raise ValueError("Cannot use both a tokenizer and processor")
+        model_args.processor = model_args.tokenizer
+    model_args.tokenizer = None
+
+    return model_args, data_args, recipe_args, output_dir
+
+
+def run_post_train(
+    model,
+    recipe,
+    recipe_args,
+    dataloader,
+    min_tokens_per_module: Optional[str] = None,
+):
+    session = active_session()
+    for action in ("initialize", "finalize"):
+        session_action = getattr(session, action)
+        session_action(
+            model=model,
+            recipe=recipe,
+            recipe_args=recipe_args,
+            calib_data=dataloader,
+            start=-1,  # oneshot-specific argument
+            copy_data=False,
+            min_tokens_per_module=min_tokens_per_module,
+        )
+
+
+def post_train(
+    **kwargs,
+):
+    model_args, data_args, recipe_args, output_dir = _parse_oneshot_args(**kwargs)
+
+    # update model and processor
+    _preprocess(model_args)
+
+    calibration_dataloader = get_calibration_dataloader(data_args, model_args.processor)
+
+    run_post_train(
+        model=model_args.model,
+        recipe=recipe_args.recipe,
+        recipe_args=recipe_args.recipe_args,
+        dataloader=calibration_dataloader,
+        min_tokens_per_module=data_args.min_tokens_per_module,
+    )
+
+    _post_process(output_dir)

--- a/src/llmcompressor/recipe/recipe.py
+++ b/src/llmcompressor/recipe/recipe.py
@@ -39,7 +39,7 @@ class Recipe(RecipeBase):
 
         (Note: all modifiers are wrapped into a single stage
         with the modifier_group_name as the stage name. If modifier_group_name is None,
-        the default run type is `oneshot`)
+        the default run type is `post_train`)
 
         Lfecycle:
         | - Validate Modifiers
@@ -48,7 +48,7 @@ class Recipe(RecipeBase):
 
         :param modifiers: The list of RecipeModifier instances
         :param modifier_group_name: The stage_name of the recipe,
-            if `oneshot` or `train` the run_type of the recipe will be
+            if `post_train` or `train` the run_type of the recipe will be
             inferred from the modifier_group_name, if None, a dummy default
             group_name will be assigned.
         :return: The Recipe instance created from the modifiers
@@ -97,7 +97,7 @@ class Recipe(RecipeBase):
             accept a RecipeModifier instance, or a list of
             RecipeModifiers
         :param modifier_group_name: The stage_name of the recipe,
-            if `oneshot` or `train` the run_type of the recipe will be
+            if `post_train` or `train` the run_type of the recipe will be
             inferred from the modifier_group_name, if None, a dummy default
             group_name will be assigned. This argument is only used
             when creating a recipe from a Modifier/list of Modifier(s)
@@ -651,14 +651,14 @@ def create_recipe_string_from_modifiers(
 
     :param modifiers: The list of Modifier instances
     :param modifier_group_name: The stage_name of the recipe,
-        if `oneshot` or `train` the run_type of the recipe will be
+        if `post_train` or `train` the run_type of the recipe will be
         inferred from the modifier_group_name, if None, a dummy default
         group_name will be assigned.
     :return: A string in yaml format from which the recipe can be created
     """
 
     # Recipe(s) are yaml/json strings of the following format:
-    # run_type_stage: # should contain oneshot/train
+    # run_type_stage: # should contain post_train/train
     #    modifiers:
     #        ModifierTypeOne:
     #            start: 0.0

--- a/src/llmcompressor/recipe/stage.py
+++ b/src/llmcompressor/recipe/stage.py
@@ -13,7 +13,7 @@ __all__ = ["RecipeStage", "StageRunType"]
 
 class StageRunType(Enum):
     TRAIN = "train"
-    ONESHOT = "oneshot"
+    POST_TRAIN = "post_train"
 
 
 class RecipeStage(RecipeBase):
@@ -21,7 +21,7 @@ class RecipeStage(RecipeBase):
     Represents a stage in a recipe.
 
     :param group: Name of the current stage
-    :param run_type: Whether this is a oneshot or training stage
+    :param run_type: Whether this is a post_train or training stage
     :param args: Optional RecipeArgs to use for this stage
     :param enabled: True to enable the stage, False otherwise
     :param modifiers: list of RecipeModifiers that are a part of this stage
@@ -44,15 +44,18 @@ class RecipeStage(RecipeBase):
         """
         Infers the stage type from the type attribute or stage name, falls back to None
 
-        :return: string representing stage type, either train or oneshot, or None if
+        :return: string representing stage type, either train or post_train, or None if
         stage cannot be inferred
         """
-        if self.run_type == StageRunType.TRAIN or self.run_type == StageRunType.ONESHOT:
+        if (
+            self.run_type == StageRunType.TRAIN
+            or self.run_type == StageRunType.POST_TRAIN
+        ):
             return self.run_type
         if StageRunType.TRAIN.value in self.group:
             return StageRunType.TRAIN
-        if StageRunType.ONESHOT.value in self.group:
-            return StageRunType.ONESHOT
+        if StageRunType.POST_TRAIN.value in self.group:
+            return StageRunType.POST_TRAIN
         return None
 
     def calculate_start(self) -> int:

--- a/src/llmcompressor/transformers/finetune/README.md
+++ b/src/llmcompressor/transformers/finetune/README.md
@@ -100,7 +100,7 @@ accelerate launch
 
 ## Running One-shot from Python (without FSDP)
 ```python
-from llmcompressor.transformers import oneshot
+from llmcompressor import post_train
 
 model ="Xenova/llama2.c-stories15M"
 dataset_name = "open_platypus"
@@ -113,7 +113,7 @@ splits = {
     "calibration": "train[:20%]"
 }
 
-oneshot(
+post_train(
     model=model,
     dataset=dataset_name,
     concatenate_data=concatenate_data,

--- a/src/llmcompressor/transformers/finetune/README.md
+++ b/src/llmcompressor/transformers/finetune/README.md
@@ -108,7 +108,6 @@ concatenate_data = False
 pad_to_max_length = False
 output_dir = "./output_oneshot"
 recipe = "test_oneshot_recipe.yaml"
-overwrite_output_dir = True
 splits = {
     "calibration": "train[:20%]"
 }
@@ -119,7 +118,6 @@ post_train(
     concatenate_data=concatenate_data,
     output_dir=output_dir,
     recipe=recipe,
-    overwrite_output_dir=overwrite_output_dir,
     pad_to_max_length = pad_to_max_length,
     splits = splits
 )

--- a/src/llmcompressor/transformers/finetune/__init__.py
+++ b/src/llmcompressor/transformers/finetune/__init__.py
@@ -2,4 +2,4 @@
 
 from .data import TextGenerationDataset
 from .session_mixin import SessionManagerMixIn
-from .text_generation import apply, compress, eval, oneshot, train
+from .text_generation import apply, compress, eval, train

--- a/src/llmcompressor/transformers/finetune/data/data_helpers.py
+++ b/src/llmcompressor/transformers/finetune/data/data_helpers.py
@@ -98,7 +98,7 @@ def make_dataset_splits(
     do_train: bool = False,
     do_eval: bool = False,
     do_predict: bool = False,
-    do_oneshot: bool = False,
+    do_post_train: bool = False,
 ) -> Dict[str, Dataset]:
     """
     Restructures the datasets dictionary based on what tasks will be run
@@ -108,7 +108,7 @@ def make_dataset_splits(
     :param do_train: Whether to store the train dataset
     :param do_eval: Whether to store the validation dataset
     :param do_predict: Whether to store the test dataset
-    :param do_oneshot: Whether to store the calibration dataset
+    :param do_post_train: Whether to store the calibration dataset
     :return: Datasets to be used by the requested tasks
     """
 
@@ -132,11 +132,11 @@ def make_dataset_splits(
         if "test" not in tokenized_datasets:
             raise ValueError("--do_predict requires a test dataset")
         predict_split = tokenized_datasets["test"]
-    if do_oneshot:
+    if do_post_train:
         calib_split = tokenized_datasets.get("calibration")
         if calib_split is None:
             if "train" not in tokenized_datasets:
-                raise ValueError("--do_oneshot requires a calibration dataset")
+                raise ValueError("--do_post_train requires a calibration dataset")
             calib_split = tokenized_datasets["train"]
 
     split_datasets = {
@@ -305,7 +305,7 @@ def get_calibration_dataloader(
 
     datasets = make_dataset_splits(
         tokenized_datasets,
-        do_oneshot=True,
+        do_post_train=True,
     )
 
     calibration_dataset = datasets.get("calibration")

--- a/src/llmcompressor/transformers/finetune/data/data_helpers.py
+++ b/src/llmcompressor/transformers/finetune/data/data_helpers.py
@@ -250,17 +250,16 @@ def transform_dataset_keys(data_files: Dict[str, Any]):
 def get_calibration_dataloader(
     data_args,
     processor,
-    add_labels: bool = False,  # for oneshot
 ):
     """
     Obtain the dataloader for post_train (ptq, sparsification)
 
+    :param data_args: DatasetArgument dataclass
     :param processor: processor or tokenizer to use for dataset tokenization
-    :param add_labels: if True, add labels column to dataset splits
     """
     if data_args.dataset is None:
         logger.info(
-            "Running oneshot without calibration data. This is expected for "
+            "Running post_train without calibration data. This is expected for "
             "weight-only and dynamic quantization"
         )
         return
@@ -301,7 +300,7 @@ def get_calibration_dataloader(
                 split=split_str,
                 processor=processor,
             )
-            tokenized_datasets[split_name] = dataset_manager(add_labels=add_labels)
+            tokenized_datasets[split_name] = dataset_manager(add_labels=False)
 
     datasets = make_dataset_splits(
         tokenized_datasets,

--- a/src/llmcompressor/transformers/finetune/data/data_helpers.py
+++ b/src/llmcompressor/transformers/finetune/data/data_helpers.py
@@ -1,9 +1,11 @@
 import logging
 import os
+import re
 from typing import Any, Callable, Dict, List, Optional
 
 import torch
 from datasets import Dataset, load_dataset
+from loguru import logger
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from transformers.data import default_data_collator
 
@@ -243,3 +245,74 @@ def transform_dataset_keys(data_files: Dict[str, Any]):
             transform_dataset_key(dataset_key)
 
     return data_files
+
+
+def get_calibration_dataloader(
+    data_args,
+    processor,
+    add_labels: bool = False,  # for oneshot
+):
+    """
+    Obtain the dataloader for post_train (ptq, sparsification)
+
+    :param processor: processor or tokenizer to use for dataset tokenization
+    :param add_labels: if True, add labels column to dataset splits
+    """
+    if data_args.dataset is None:
+        logger.info(
+            "Running oneshot without calibration data. This is expected for "
+            "weight-only and dynamic quantization"
+        )
+        return
+
+    splits = data_args.splits
+    tokenized_datasets = {}
+
+    def _get_split_name(inp_str):
+        # strip out split name, for ex train[60%:] -> train
+        match = re.match(r"(\w*)\[.*\]", inp_str)
+        if match is not None:
+            return match.group(1)
+        return inp_str
+
+    if splits is None:
+        splits = {"all": None}
+    elif isinstance(splits, str):
+        splits = {_get_split_name(splits): splits}
+    elif isinstance(splits, List):
+        splits = {_get_split_name(s): s for s in splits}
+
+    # default to custom dataset if dataset provided isn't a string
+    registry_id = data_args.dataset if isinstance(data_args.dataset, str) else "custom"
+    for split_name, split_str in splits.items():
+        dataset = data_args.dataset
+        if hasattr(dataset, "column_names") and "input_ids" in dataset.column_names:
+            # dataset is already tokenized
+            tokenized_datasets[split_name] = dataset
+        else:
+            # dataset needs to be tokenized
+            from llmcompressor.transformers.finetune.data.base import (
+                TextGenerationDataset,
+            )
+
+            dataset_manager = TextGenerationDataset.load_from_registry(
+                registry_id,
+                data_args=data_args,
+                split=split_str,
+                processor=processor,
+            )
+            tokenized_datasets[split_name] = dataset_manager(add_labels=add_labels)
+
+    datasets = make_dataset_splits(
+        tokenized_datasets,
+        do_oneshot=True,
+    )
+
+    calibration_dataset = datasets.get("calibration")
+
+    return format_calibration_data(
+        tokenized_dataset=calibration_dataset,
+        num_calibration_samples=data_args.num_calibration_samples,
+        do_shuffle=data_args.shuffle_calibration_samples,
+        collate_fn=data_args.data_collator,
+    )

--- a/src/llmcompressor/transformers/finetune/runner.py
+++ b/src/llmcompressor/transformers/finetune/runner.py
@@ -124,7 +124,7 @@ class StageRunner:
             do_train=self._training_args.do_train,
             do_eval=self._training_args.do_eval,
             do_predict=self._training_args.do_predict,
-            do_oneshot=self._training_args.do_oneshot,
+            do_post_train=self._training_args.do_post_train,
         )
 
     def get_dataset_split(self, split_name: str) -> Dataset:

--- a/src/llmcompressor/transformers/finetune/runner.py
+++ b/src/llmcompressor/transformers/finetune/runner.py
@@ -76,7 +76,7 @@ class StageRunner:
         if self._data_args.dataset is None:
             self.processor = self._model_args.processor
             logger.info(
-                "Running oneshot without calibration data. This is expected for "
+                "Running post_train without calibration data. This is expected for "
                 "weight-only and dynamic quantization"
             )
             return
@@ -136,9 +136,10 @@ class StageRunner:
         """
         return self.datasets.get(split_name, None)
 
+    # TODO: delete or update for stages runner
     def one_shot(self, stage: Optional[str] = None):
         """
-        Run oneshot calibration on the active model
+        Run post_train calibration on the active model
 
         :param stage: which stage of the recipe to run, or None to run whole recipe
         """
@@ -255,7 +256,7 @@ class StageRunner:
             self._training_args.output_dir = self._output_dir
 
             # run stage
-            if run_type is StageRunType.ONESHOT:
+            if run_type is StageRunType.POST_TRAIN:
                 self.one_shot(stage=stage_name)
             elif run_type is StageRunType.TRAIN:
                 self.train(checkpoint=checkpoint, stage=stage_name)

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -429,11 +429,12 @@ class SessionManagerMixIn:
 
         return output
 
+    # TODO: delete
     def one_shot(
         self, calibration_data: Optional[DataLoader] = None, stage: Optional[str] = None
     ):
         """
-        Run oneshot calibration on the active model
+        Run post_train calibration on the active model
         :param stage: which stage of the recipe to run, or None to run whole recipe
         :param calib_data: dataloader of calibration data
         """
@@ -453,7 +454,11 @@ class SessionManagerMixIn:
         # self.maybe_log_model_sparsification()
         self.accelerator.wait_for_everyone()
 
-    def save_model(self, output_dir: str, _internal_call=False, _is_oneshot=False):
+    def save_model(
+        self,
+        output_dir: str,
+        _internal_call=False,
+    ):
         """
         Override of the save_model function and expects it to exist in the parent.
         Calls into super() to save the model and additionally saves any recipes

--- a/src/llmcompressor/transformers/finetune/text_generation.py
+++ b/src/llmcompressor/transformers/finetune/text_generation.py
@@ -83,7 +83,7 @@ def eval(**kwargs):
     main(model_args, data_args, recipe_args, training_args)
 
 
-def oneshot(**kwargs):
+def post_train(**kwargs):
     """
     CLI entrypoint for running oneshot calibration
     """
@@ -95,6 +95,13 @@ def oneshot(**kwargs):
 
 
 # alias
+def post_train**kwargs):
+    logger.warning(
+        ("oneshot is now deprecated. Please use " "`post_train` method instead.")
+    )
+    return post_train
+
+
 one_shot = oneshot
 
 
@@ -313,7 +320,7 @@ def main(
         - Trainer()
             - SessionMixIn()
             - HFTransformersTrainer()
-        - StageRunner.train() and/or evaluate() and/or predict() and/or oneshot()
+        - StageRunner.train() and/or evaluate() and/or predict() and/or post_train()
 
     :param model_args: Arguments pertaining to which model/config/tokenizer we are
     going to fine-tune from

--- a/src/llmcompressor/transformers/finetune/text_generation.py
+++ b/src/llmcompressor/transformers/finetune/text_generation.py
@@ -210,14 +210,14 @@ def initialize_model_from_path(
     set_seed(training_args.seed)
 
     # Fallback to CPU if GPU requested and not available
-    training_args.oneshot_device = fallback_to_cpu(model_args.oneshot_device)
+    training_args.post_train_device = fallback_to_cpu(model_args.post_train_device)
 
     # Trainer handles device assignment for FSDP and training, don't do mapping here
     # if running oneshot outside of FSDP, apply user device settings
     device_map = None
     fsdp_enabled = os.environ.get("ACCELERATE_USE_FSDP", "false") == "true"
     if not fsdp_enabled and training_args.do_oneshot:
-        device_map = training_args.oneshot_device
+        device_map = training_args.post_train_device
         logger.warning(f"Moving {model_path} to device {device_map} for One-Shot")
     elif not fsdp_enabled:
         device_map = "auto"

--- a/src/llmcompressor/transformers/finetune/text_generation.py
+++ b/src/llmcompressor/transformers/finetune/text_generation.py
@@ -89,13 +89,13 @@ def post_train(**kwargs):
     """
     # TODO: Get rid of training args when Oneshot refactor comes in
     model_args, data_args, recipe_args, training_args = parse_args(**kwargs)
-    training_args.do_oneshot = True
+    training_args.do_post_train = True
 
     main(model_args, data_args, recipe_args, training_args)
 
 
 # alias
-def post_train**kwargs):
+def oneshot(**kwargs):
     logger.warning(
         ("oneshot is now deprecated. Please use " "`post_train` method instead.")
     )
@@ -216,7 +216,7 @@ def initialize_model_from_path(
     # if running oneshot outside of FSDP, apply user device settings
     device_map = None
     fsdp_enabled = os.environ.get("ACCELERATE_USE_FSDP", "false") == "true"
-    if not fsdp_enabled and training_args.do_oneshot:
+    if not fsdp_enabled and training_args.do_post_train:
         device_map = training_args.post_train_device
         logger.warning(f"Moving {model_path} to device {device_map} for One-Shot")
     elif not fsdp_enabled:
@@ -344,7 +344,7 @@ def main(
         for stage in recipe_obj.stages:
             run_type = stage.infer_run_type()
             if run_type is StageRunType.ONESHOT:
-                training_args.do_oneshot = True
+                training_args.do_post_train = True
             elif run_type is StageRunType.TRAIN:
                 training_args.do_train = True
 
@@ -438,7 +438,7 @@ def main(
         stage_runner.train(checkpoint)
 
     # One Shot
-    if training_args.do_oneshot:
+    if training_args.do_post_train:
         stage_runner.one_shot()
 
     # Evaluation

--- a/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py
@@ -73,7 +73,7 @@ def modify_fsdp_model_save_pretrained(trainer, processor: Processor):
             :param kwargs: additional kwargs to pass on to model.save_pretrained
             """
             try:
-                trainer.save_model(output_dir=save_directory, _is_oneshot=True)
+                trainer.save_model(output_dir=save_directory)
             except AssertionError:
                 # fallback to this in the case of quantization
                 unwrap_and_export_model(

--- a/tests/e2e/e2e_utils.py
+++ b/tests/e2e/e2e_utils.py
@@ -53,6 +53,6 @@ def run_oneshot_for_e2e_testing(
     logger.info("ONESHOT KWARGS", oneshot_kwargs)
     oneshot(
         **oneshot_kwargs,
-        oneshot_device=device,
+        post_train_device=device,
     )
     return oneshot_kwargs["model"], tokenizer

--- a/tests/e2e/e2e_utils.py
+++ b/tests/e2e/e2e_utils.py
@@ -2,12 +2,12 @@ from datasets import load_dataset
 from loguru import logger
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import post_train
 from llmcompressor.modifiers.quantization import GPTQModifier, QuantizationModifier
-from llmcompressor.transformers import oneshot
 from tests.testing_utils import preprocess_tokenize_dataset
 
 
-def run_oneshot_for_e2e_testing(
+def run_post_train_for_e2e_testing(
     model: str,
     device: str,
     num_calibration_samples: int,
@@ -20,7 +20,7 @@ def run_oneshot_for_e2e_testing(
     quant_type: str,
 ):
     # Load model.
-    oneshot_kwargs = {}
+    post_train_kwargs = {}
     loaded_model = AutoModelForCausalLM.from_pretrained(
         model, device_map=device, torch_dtype="auto"
     )
@@ -30,29 +30,29 @@ def run_oneshot_for_e2e_testing(
         ds = load_dataset(dataset_id, name=dataset_config, split=dataset_split)
         ds = ds.shuffle(seed=42).select(range(num_calibration_samples))
         ds = preprocess_tokenize_dataset(ds, tokenizer, max_seq_length)
-        oneshot_kwargs["dataset"] = ds
-        oneshot_kwargs["max_seq_length"] = max_seq_length
-        oneshot_kwargs["num_calibration_samples"] = num_calibration_samples
+        post_train_kwargs["dataset"] = ds
+        post_train_kwargs["max_seq_length"] = max_seq_length
+        post_train_kwargs["num_calibration_samples"] = num_calibration_samples
 
-    oneshot_kwargs["model"] = loaded_model
+    post_train_kwargs["model"] = loaded_model
     if recipe:
-        oneshot_kwargs["recipe"] = recipe
+        post_train_kwargs["recipe"] = recipe
     else:
         # Test assumes that if a recipe was not provided, using
         # a compatible preset sceme
         if quant_type == "GPTQ":
-            oneshot_kwargs["recipe"] = GPTQModifier(
+            post_train_kwargs["recipe"] = GPTQModifier(
                 targets="Linear", scheme=scheme, ignore=["lm_head"]
             )
         else:
-            oneshot_kwargs["recipe"] = QuantizationModifier(
+            post_train_kwargs["recipe"] = QuantizationModifier(
                 targets="Linear", scheme=scheme, ignore=["lm_head"]
             )
 
     # Apply quantization.
-    logger.info("ONESHOT KWARGS", oneshot_kwargs)
-    oneshot(
-        **oneshot_kwargs,
+    logger.info("ONESHOT KWARGS", post_train_kwargs)
+    post_train(
+        **post_train_kwargs,
         post_train_device=device,
     )
-    return oneshot_kwargs["model"], tokenizer
+    return post_train_kwargs["model"], tokenizer

--- a/tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4_fp8_dynamic.yaml
+++ b/tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4_fp8_dynamic.yaml
@@ -1,12 +1,12 @@
 sparsity_stage:
-  run_type: oneshot
+  run_type: post_train
   sparsity_modifiers:
     SparseGPTModifier:
       sparsity: 0.5
       mask_structure: "2:4"
       sequential_update: false
 quantization_stage:
-  run_type: oneshot
+  run_type: post_train
   quantization_modifiers:
     ConstantPruningModifier:
       targets: [

--- a/tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_group-128_recipe.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_group-128_recipe.yaml
@@ -1,12 +1,12 @@
 sparsity_stage:
-  run_type: oneshot
+  run_type: post_train
   sparsity_modifiers:
     SparseGPTModifier:
       sparsity: 0.5
       mask_structure: "2:4"
       sequential_update: false
 quantization_stage:
-  run_type: oneshot
+  run_type: post_train
   quantization_modifiers:
     GPTQModifier:
       ignore: ["lm_head"]

--- a/tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_recipe.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_recipe.yaml
@@ -1,12 +1,12 @@
 sparsity_stage:
-  run_type: oneshot
+  run_type: post_train
   sparsity_modifiers:
     SparseGPTModifier:
       sparsity: 0.5
       mask_structure: "2:4"
       sequential_update: false
 quantization_stage:
-  run_type: oneshot
+  run_type: post_train
   quantization_modifiers:
     GPTQModifier:
       ignore: ["lm_head"]

--- a/tests/e2e/vLLM/test_lmeval.py
+++ b/tests/e2e/vLLM/test_lmeval.py
@@ -8,7 +8,7 @@ import yaml
 from loguru import logger
 
 from llmcompressor.core import active_session
-from tests.e2e.e2e_utils import run_oneshot_for_e2e_testing
+from tests.e2e.e2e_utils import run_post_train_for_e2e_testing
 from tests.examples.utils import requires_gpu_count
 
 try:
@@ -76,7 +76,7 @@ class TestLMEval:
         self.set_up()
         if not self.save_dir:
             self.save_dir = self.model.split("/")[1] + f"-{self.scheme}"
-        oneshot_model, tokenizer = run_oneshot_for_e2e_testing(
+        post_train_model, tokenizer = run_post_train_for_e2e_testing(
             model=self.model,
             device=self.device,
             num_calibration_samples=self.num_calibration_samples,
@@ -90,7 +90,7 @@ class TestLMEval:
         )
 
         logger.info("================= SAVING TO DISK ======================")
-        oneshot_model.save_pretrained(self.save_dir)
+        post_train_model.save_pretrained(self.save_dir)
         tokenizer.save_pretrained(self.save_dir)
         recipe_path = os.path.join(self.save_dir, "recipe.yaml")
 

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -10,7 +10,7 @@ from loguru import logger
 from parameterized import parameterized_class
 
 from llmcompressor.core import active_session
-from tests.e2e.e2e_utils import run_oneshot_for_e2e_testing
+from tests.e2e.e2e_utils import run_post_train_for_e2e_testing
 from tests.examples.utils import requires_gpu_count
 
 try:
@@ -94,7 +94,7 @@ class TestvLLM:
         self.set_up()
         if not self.save_dir:
             self.save_dir = self.model.split("/")[1] + f"-{self.scheme}"
-        oneshot_model, tokenizer = run_oneshot_for_e2e_testing(
+        post_train_model, tokenizer = run_post_train_for_e2e_testing(
             model=self.model,
             device=self.device,
             num_calibration_samples=self.num_calibration_samples,
@@ -111,7 +111,7 @@ class TestvLLM:
         self._check_session_contains_recipe()
 
         logger.info("================= SAVING TO DISK ======================")
-        oneshot_model.save_pretrained(
+        post_train_model.save_pretrained(
             self.save_dir, save_compressed=self.save_compressed
         )
         tokenizer.save_pretrained(self.save_dir)

--- a/tests/llmcompressor/recipe/test_stage.py
+++ b/tests/llmcompressor/recipe/test_stage.py
@@ -4,7 +4,7 @@ from llmcompressor.recipe import Recipe, StageRunType
 def test_run_type_as_param():
     recipe_str = """
     first_stage:
-        run_type: oneshot
+        run_type: post_train
         some_modifiers:
             QuantizationModifier:
                 ignore: ["lm_head"]
@@ -21,13 +21,13 @@ def test_run_type_as_param():
     """
 
     recipe = Recipe.create_instance(recipe_str)
-    assert recipe.stages[0].infer_run_type() == StageRunType.ONESHOT
+    assert recipe.stages[0].infer_run_type() == StageRunType.POST_TRAIN
     assert recipe.stages[1].infer_run_type() == StageRunType.TRAIN
 
 
 def test_run_type_as_name():
     recipe_str = """
-    first_oneshot_stage:
+    first_post_train_stage:
         some_modifiers:
             QuantizationModifier:
                 ignore: ["lm_head"]
@@ -43,7 +43,7 @@ def test_run_type_as_name():
     """
 
     recipe = Recipe.create_instance(recipe_str)
-    assert recipe.stages[0].infer_run_type() == StageRunType.ONESHOT
+    assert recipe.stages[0].infer_run_type() == StageRunType.POST_TRAIN
     assert recipe.stages[1].infer_run_type() == StageRunType.TRAIN
 
 

--- a/tests/llmcompressor/transformers/compression/test_quantization.py
+++ b/tests/llmcompressor/transformers/compression/test_quantization.py
@@ -10,9 +10,9 @@ from parameterized import parameterized_class
 from torch.utils.data import DataLoader
 from transformers import AutoModelForCausalLM, AutoTokenizer, DefaultDataCollator
 
+from llmcompressor import post_train
 from llmcompressor.args import DatasetArguments
 from llmcompressor.pytorch.utils import tensors_to_device
-from llmcompressor.transformers import oneshot
 from llmcompressor.transformers.finetune.data import TextGenerationDataset
 from tests.testing_utils import parse_params, requires_gpu
 
@@ -39,7 +39,7 @@ class TestQuantizationMatches(unittest.TestCase):
         cls.model = AutoModelForCausalLM.from_pretrained(
             cls.model_stub, torch_dtype=cls.weight_dtype, device_map="cuda:0"
         )
-        model = cls._run_oneshot(
+        model = cls._run_post_train(
             cls.model,
             cls.new_recipe,
             cls.dataset,
@@ -54,12 +54,12 @@ class TestQuantizationMatches(unittest.TestCase):
         torch.cuda.empty_cache()
 
     @staticmethod
-    def _run_oneshot(model, recipe, dataset, output_dir):
+    def _run_post_train(model, recipe, dataset, output_dir):
         num_calibration_samples = 512
         max_seq_length = 512
         pad_to_max_length = False
 
-        oneshot(
+        post_train(
             model=model,
             dataset=dataset,
             overwrite_output_dir=True,

--- a/tests/llmcompressor/transformers/compression/test_quantization.py
+++ b/tests/llmcompressor/transformers/compression/test_quantization.py
@@ -62,7 +62,6 @@ class TestQuantizationMatches(unittest.TestCase):
         post_train(
             model=model,
             dataset=dataset,
-            overwrite_output_dir=True,
             output_dir=output_dir,
             max_seq_length=max_seq_length,
             num_calibration_samples=num_calibration_samples,

--- a/tests/llmcompressor/transformers/finetune/data/test_dataset_loading.py
+++ b/tests/llmcompressor/transformers/finetune/data/test_dataset_loading.py
@@ -324,7 +324,7 @@ class TestTokenizationDataset(unittest.TestCase):
             data_args=DatasetArguments(
                 dataset=tokenized_dataset, shuffle_calibration_samples=False
             ),
-            training_args=TrainingArguments(do_oneshot=True),
+            training_args=TrainingArguments(do_post_train=True),
             recipe_args=RecipeArguments(),
         )
         stage_runner.populate_datasets(processor=None)

--- a/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
@@ -41,7 +41,7 @@ class TestFinetuneNoRecipeCustomDataset(unittest.TestCase):
             recipe=None,
             num_train_epochs=self.num_train_epochs,
             concatenate_data=concatenate_data,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             text_column="text",
             dataset_path=dataset_path,
             preprocessing_func=preprocessing_func,

--- a/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
@@ -37,7 +37,6 @@ class TestFinetuneNoRecipeCustomDataset(unittest.TestCase):
             model=self.model,
             dataset=self.file_extension,
             output_dir=self.output,
-            overwrite_output_dir=True,
             recipe=None,
             num_train_epochs=self.num_train_epochs,
             concatenate_data=concatenate_data,

--- a/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
@@ -130,9 +130,9 @@ class TestOneshotCustomDatasetSmall(TestFinetuneNoRecipeCustomDataset):
         else:
             self.device = "cpu"
 
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
 
-    def test_oneshot_then_finetune_small(self):
+    def test_post_train_then_finetune_small(self):
         self._test_finetune_wout_recipe_custom_dataset()
 
 
@@ -150,7 +150,7 @@ class TestOneshotCustomDatasetGPU(TestFinetuneNoRecipeCustomDataset):
 
         self.monkeypatch = pytest.MonkeyPatch()
         self.device = "cuda:0"
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
         self.monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
 
         self.model = AutoModelForCausalLM.from_pretrained(
@@ -158,5 +158,5 @@ class TestOneshotCustomDatasetGPU(TestFinetuneNoRecipeCustomDataset):
         )
         self.monkeypatch = pytest.MonkeyPatch()
 
-    def test_oneshot_then_finetune_gpu(self):
+    def test_post_train_then_finetune_gpu(self):
         self._test_finetune_wout_recipe_custom_dataset()

--- a/tests/llmcompressor/transformers/finetune/test_finetune_oneshot_with_modifier.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_oneshot_with_modifier.py
@@ -20,9 +20,9 @@ class TestOneshotWithModifierObject(unittest.TestCase):
     def setUp(self):
         self.output = Path("./finetune_output")
 
-    def test_oneshot_with_modifier_object(self):
+    def test_post_train_with_modifier_object(self):
+        from llmcompressor import post_train
         from llmcompressor.modifiers.obcq.base import SparseGPTModifier
-        from llmcompressor.transformers import oneshot
 
         recipe_str = [
             SparseGPTModifier(sparsity=0.5, targets=[r"re:model.layers.\d+$"])
@@ -31,10 +31,10 @@ class TestOneshotWithModifierObject(unittest.TestCase):
         device = "cuda:0"
         concatenate_data = False
         num_calibration_samples = 64
-        output_dir = self.output / "oneshot_out"
+        output_dir = self.output / "post_train_out"
         splits = {"calibration": "train[:10%]"}
 
-        oneshot(
+        post_train(
             model=self.model,
             dataset=self.dataset,
             output_dir=output_dir,

--- a/tests/llmcompressor/transformers/finetune/test_finetune_oneshot_with_modifier.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_oneshot_with_modifier.py
@@ -42,7 +42,7 @@ class TestOneshotWithModifierObject(unittest.TestCase):
             recipe=recipe_str,
             concatenate_data=concatenate_data,
             splits=splits,
-            oneshot_device=device,
+            post_train_device=device,
         )
 
     def tearDown(self):

--- a/tests/llmcompressor/transformers/finetune/test_finetune_without_recipe.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_without_recipe.py
@@ -37,7 +37,7 @@ class TestFinetuneWithoutRecipe(unittest.TestCase):
             max_steps=max_steps,
             concatenate_data=concatenate_data,
             splits=splits,
-            oneshot_device=device,
+            post_train_device=device,
         )
 
     def tearDown(self):

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
@@ -16,7 +16,7 @@ GPU_CONFIGS_DIRECTORY = (
 
 
 class TestOneshotAndFinetune(unittest.TestCase):
-    def _test_oneshot_and_finetune(self):
+    def _test_post_train_and_finetune(self):
         from llmcompressor.transformers import apply
 
         splits = {"train": "train[:30%]", "calibration": "train[30%:40%]"}
@@ -40,12 +40,12 @@ class TestOneshotAndFinetune(unittest.TestCase):
 
         config_os = ModelCompressor.parse_sparsity_config(
             AutoConfig.from_pretrained(
-                os.path.join(self.output, "stage_test_oneshot")
+                os.path.join(self.output, "stage_test_post_train")
             ).quantization_config
         )
         config_ft = ModelCompressor.parse_sparsity_config(
             AutoConfig.from_pretrained(
-                os.path.join(self.output, "stage_test_oneshot")
+                os.path.join(self.output, "stage_test_post_train")
             ).quantization_config
         )
         assert config_ft["global_sparsity"] >= config_os["global_sparsity"]
@@ -72,8 +72,8 @@ class TestOneshotAndFinetuneSmall(TestOneshotAndFinetune):
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
         self.output = "./finetune_output"
 
-    def test_oneshot_then_finetune_small(self):
-        self._test_oneshot_and_finetune()
+    def test_post_train_then_finetune_small(self):
+        self._test_post_train_and_finetune()
 
 
 @requires_gpu
@@ -98,5 +98,5 @@ class TestOneshotAndFinetuneGPU(TestOneshotAndFinetune):
             self.model, device_map=self.device, torch_dtype=torch.bfloat16
         )
 
-    def test_oneshot_then_finetune_gpu(self):
-        self._test_oneshot_and_finetune()
+    def test_post_train_then_finetune_gpu(self):
+        self._test_post_train_and_finetune()

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
@@ -32,7 +32,7 @@ class TestOneshotAndFinetune(unittest.TestCase):
             num_train_epochs=self.num_train_epochs,
             concatenate_data=self.concat_txt,
             splits=splits,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             precision="bfloat16",
             bf16=True,
             dataset_config_name=self.dataset_config_name,

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py
@@ -23,7 +23,7 @@ class TestOneshotAndFinetuneWithTokenizer(unittest.TestCase):
         # use just one atm
         self.monkeypatch = pytest.MonkeyPatch()
 
-    def test_oneshot_and_finetune_with_tokenizer(self):
+    def test_post_train_and_finetune_with_tokenizer(self):
         from datasets import load_dataset
         from transformers import AutoModelForCausalLM, AutoTokenizer
 

--- a/tests/llmcompressor/transformers/finetune/test_safetensors.py
+++ b/tests/llmcompressor/transformers/finetune/test_safetensors.py
@@ -35,7 +35,7 @@ class TestSafetensors(unittest.TestCase):
             output_dir=output_dir,
             max_steps=max_steps,
             splits=splits,
-            oneshot_device=device,
+            post_train_device=device,
         )
 
         assert os.path.exists(output_dir / "model.safetensors")
@@ -49,7 +49,7 @@ class TestSafetensors(unittest.TestCase):
             output_dir=new_output_dir,
             max_steps=max_steps,
             splits=splits,
-            oneshot_device=device,
+            post_train_device=device,
         )
 
     def tearDown(self):

--- a/tests/llmcompressor/transformers/gptq/test_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_oneshot.py
@@ -74,7 +74,6 @@ class TestGPTQOneShotWithFullScheme(unittest.TestCase):
         post_train(
             model=self.model,
             dataset=self.dataset,
-            overwrite_output_dir=True,
             output_dir=self.output,
             recipe=self.recipe,
             post_train_device=self.device,

--- a/tests/llmcompressor/transformers/gptq/test_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_oneshot.py
@@ -77,7 +77,7 @@ class TestGPTQOneShotWithFullScheme(unittest.TestCase):
             overwrite_output_dir=True,
             output_dir=self.output,
             recipe=self.recipe,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             num_calibration_samples=9,
         )
         model_loaded = AutoModelForCausalLM.from_pretrained(

--- a/tests/llmcompressor/transformers/gptq/test_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_oneshot.py
@@ -63,15 +63,15 @@ class TestGPTQOneShotWithFullScheme(unittest.TestCase):
     def setUp(self):
         import torch
 
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
         self.model = "roneneldan/TinyStories-1M"
         self.dataset = "open_platypus"
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
-    def test_oneshot_application(self):
-        from llmcompressor.transformers import oneshot
+    def test_post_train_application(self):
+        from llmcompressor import post_train
 
-        oneshot(
+        post_train(
             model=self.model,
             dataset=self.dataset,
             overwrite_output_dir=True,

--- a/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
+++ b/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
@@ -26,14 +26,14 @@ class TestConsecutiveRuns(unittest.TestCase):
     ):
         import math
 
+        from llmcompressor import post_train
         from llmcompressor.core import active_session
         from llmcompressor.pytorch.model_load.helpers import initialize_recipe
         from llmcompressor.pytorch.utils.helpers import tensor_sparsity
-        from llmcompressor.transformers import oneshot
         from llmcompressor.utils.pytorch import qat_active
 
         # test recipe with 50% sparsity, quantization and smoothquant
-        oneshot(
+        post_train(
             model=self.model,
             dataset=self.dataset,
             num_calibration_samples=num_calibration_samples,
@@ -66,7 +66,7 @@ class TestConsecutiveRuns(unittest.TestCase):
             initialize_recipe(model=first_model, recipe_path=recipe)
 
         # reload saved model and up sparsity to 0.7
-        oneshot(
+        post_train(
             model=self.output_first,
             dataset=self.dataset,
             num_calibration_samples=num_calibration_samples,
@@ -115,7 +115,7 @@ class TestConsecutiveRunsSmall(TestConsecutiveRuns):
         import torch
 
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
         self.output_first = Path(self.output) / "test_1"
         self.output_second = Path(self.output) / "test_2"
 
@@ -148,7 +148,7 @@ class TestConsecutiveRunsGPU(TestConsecutiveRuns):
             device_map=self.device,
         )
 
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
         self.output_first = Path(self.output) / "test_1"
         self.output_second = Path(self.output) / "test_2"
 

--- a/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
+++ b/tests/llmcompressor/transformers/obcq/test_consecutive_runs.py
@@ -39,7 +39,7 @@ class TestConsecutiveRuns(unittest.TestCase):
             num_calibration_samples=num_calibration_samples,
             recipe=self.first_recipe,
             output_dir=self.output_first,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             clear_sparse_session=False,
         )
 
@@ -72,7 +72,7 @@ class TestConsecutiveRuns(unittest.TestCase):
             num_calibration_samples=num_calibration_samples,
             recipe=self.second_recipe,
             output_dir=self.output_second,
-            oneshot_device=self.device,
+            post_train_device=self.device,
         )
 
         second_model = AutoModelForCausalLM.from_pretrained(

--- a/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
+++ b/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
@@ -17,7 +17,7 @@ MASK_STRUCTURE_CONFIGS_DIRECTORY = (
 @parameterized_class(parse_params(MASK_STRUCTURE_CONFIGS_DIRECTORY))
 class TestMaskStructurePreserved(unittest.TestCase):
     """
-    Tests that the mask structure is preserved across multiple runs of oneshot
+    Tests that the mask structure is preserved across multiple runs of post_train
     initial model is pruned using a mask_structure, and then the pruned model
     is further pruned and quantized.
     """
@@ -34,28 +34,28 @@ class TestMaskStructurePreserved(unittest.TestCase):
         import torch
 
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
         self.output_first = Path(self.output) / "test_1"
         self.output_second = Path(self.output) / "test_2"
 
     def test_mask_structure_preserved(self):
         """
-        Checks that the mask structure is preserved across runs of oneshot
+        Checks that the mask structure is preserved across runs of post_train
         between the initial pruning and the subsequent pruning + quantization
         """
         import math
 
         import torch
 
+        from llmcompressor import post_train
         from llmcompressor.pytorch.model_load.helpers import get_session_model
         from llmcompressor.pytorch.utils.helpers import tensor_sparsity
-        from llmcompressor.transformers import oneshot
         from llmcompressor.utils.pytorch import qat_active
 
         tolerance = 1e-3
         num_calibration_samples = 16
 
-        oneshot(
+        post_train(
             model=self.model,
             dataset=self.dataset,
             num_calibration_samples=num_calibration_samples,
@@ -79,7 +79,7 @@ class TestMaskStructurePreserved(unittest.TestCase):
 
         reset_session()
 
-        oneshot(
+        post_train(
             model=self.output_first,
             dataset=self.dataset,
             num_calibration_samples=num_calibration_samples,

--- a/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
+++ b/tests/llmcompressor/transformers/obcq/test_mask_structure_preservation.py
@@ -61,7 +61,7 @@ class TestMaskStructurePreserved(unittest.TestCase):
             num_calibration_samples=num_calibration_samples,
             recipe=self.initial_pruning_only_recipe,
             output_dir=self.output_first,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             clear_sparse_session=False,
             save_compressed=False,
         )
@@ -85,7 +85,7 @@ class TestMaskStructurePreserved(unittest.TestCase):
             num_calibration_samples=num_calibration_samples,
             recipe=self.subsequent_prune_and_quant_recipe,
             output_dir=self.output_second,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             clear_sparse_session=False,
             save_compressed=False,
         )

--- a/tests/llmcompressor/transformers/obcq/test_obcq_completion.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_completion.py
@@ -54,7 +54,7 @@ class TestOBCQCompletion(unittest.TestCase):
         oneshot(
             model=self.model,
             dataset=self.dataset,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             recipe=self.recipe,
             max_seq_length=512,
             num_calibration_samples=self.num_samples,

--- a/tests/llmcompressor/transformers/obcq/test_obcq_completion.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_completion.py
@@ -14,8 +14,8 @@ GPU_CONFIGS_DIRECTORY = (
 
 class TestOBCQCompletion(unittest.TestCase):
     """
-    Test for oneshot for quantization and quantization + sparsity. Sparsity-only tests
-    can be found under `test_obcq_sparsity.py`
+    Test for post_train for quantization and quantization + sparsity.
+    Sparsity-only tests can be found under `test_obcq_sparsity.py`
     """
 
     def labeled_dataloader(self, dataset_name, model_name):
@@ -44,14 +44,14 @@ class TestOBCQCompletion(unittest.TestCase):
 
         return data_loader
 
-    def _test_oneshot_completion(self, model_name: str = None):
+    def _test_post_train_completion(self, model_name: str = None):
         import torch
 
+        from llmcompressor import post_train
         from llmcompressor.pytorch.model_load.helpers import get_session_model
         from llmcompressor.pytorch.utils import tensors_to_device
-        from llmcompressor.transformers import oneshot
 
-        oneshot(
+        post_train(
             model=self.model,
             dataset=self.dataset,
             post_train_device=self.device,
@@ -110,10 +110,10 @@ class TestOBCQCompletionSmall(TestOBCQCompletion):
         import torch
 
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
 
     def test_obcq_completion_small(self):
-        self._test_oneshot_completion()
+        self._test_post_train_completion()
 
 
 @requires_gpu
@@ -133,12 +133,12 @@ class TestOBCQCompletionGPU(TestOBCQCompletion):
         from transformers import AutoModelForCausalLM
 
         self.model_name = None
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
 
         self.model_name = self.model
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model, device_map=self.device, torch_dtype=torch.bfloat16
         )
 
-    def test_oneshot_completion_gpu(self):
-        self._test_oneshot_completion(model_name=self.model_name)
+    def test_post_train_completion_gpu(self):
+        self._test_post_train_completion(model_name=self.model_name)

--- a/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
@@ -33,7 +33,7 @@ class TestSparsities(unittest.TestCase):
         post_train(
             model=self.model,
             dataset=self.dataset,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             recipe=self.recipe,
             max_seq_length=128,
             num_calibration_samples=64,
@@ -85,7 +85,7 @@ class TestSparsitiesGPU(unittest.TestCase):
         post_train(
             model=self.model,
             dataset=self.dataset,
-            oneshot_device=self.device,
+            post_train_device=self.device,
             recipe=self.recipe,
             max_seq_length=128,
             num_calibration_samples=64,

--- a/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
@@ -23,7 +23,7 @@ class TestSparsities(unittest.TestCase):
         import torch
 
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
 
     def test_sparsities(self):
         from llmcompressor import post_train
@@ -71,7 +71,7 @@ class TestSparsitiesGPU(unittest.TestCase):
         import torch
         from transformers import AutoModelForCausalLM
 
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
 
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model, device_map=self.device, torch_dtype=torch.bfloat16

--- a/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
@@ -26,11 +26,11 @@ class TestSparsities(unittest.TestCase):
         self.output = "./oneshot_output"
 
     def test_sparsities(self):
+        from llmcompressor import post_train
         from llmcompressor.pytorch.model_load.helpers import get_session_model
         from llmcompressor.pytorch.utils.helpers import tensor_sparsity
-        from llmcompressor.transformers import oneshot
 
-        oneshot(
+        post_train(
             model=self.model,
             dataset=self.dataset,
             oneshot_device=self.device,
@@ -78,11 +78,11 @@ class TestSparsitiesGPU(unittest.TestCase):
         )
 
     def test_sparsities_gpu(self):
+        from llmcompressor import post_train
         from llmcompressor.pytorch.model_load.helpers import get_session_model
         from llmcompressor.pytorch.utils.helpers import tensor_sparsity
-        from llmcompressor.transformers import oneshot
 
-        oneshot(
+        post_train(
             model=self.model,
             dataset=self.dataset,
             oneshot_device=self.device,

--- a/tests/llmcompressor/transformers/oneshot/dataset_processing.py
+++ b/tests/llmcompressor/transformers/oneshot/dataset_processing.py
@@ -52,7 +52,7 @@ def get_data_utils(dataset_name: str) -> Dict:
     """
     Given the name of a dataset, fetch the appropriate set of data processing utils.
     Returns a dictionary of data processing utils required to process the data when
-    providing tokenized data to oneshot.
+    providing tokenized data to post_train.
     Includes:
         1. dataload: function to load the dataset
         2. preprocess: preprocessing function to apply to the dataset

--- a/tests/llmcompressor/transformers/oneshot/test_api_inputs.py
+++ b/tests/llmcompressor/transformers/oneshot/test_api_inputs.py
@@ -28,7 +28,7 @@ class TestOneShotInputs(unittest.TestCase):
 
         self.tokenizer = AutoTokenizer.from_pretrained(self.model)
         self.model = AutoModelForCausalLM.from_pretrained(self.model)
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
         self.kwargs = {"dataset_config_name": self.dataset_config_name}
 
         data_utils = get_data_utils(self.dataset)
@@ -48,9 +48,9 @@ class TestOneShotInputs(unittest.TestCase):
             self.tokenizer = None
 
     def test_one_shot_inputs(self):
-        from llmcompressor.transformers import oneshot
+        from llmcompressor import post_train
 
-        oneshot(
+        post_train(
             model=self.model,
             tokenizer=self.tokenizer,
             dataset=self.dataset,

--- a/tests/llmcompressor/transformers/oneshot/test_cli.py
+++ b/tests/llmcompressor/transformers/oneshot/test_cli.py
@@ -21,9 +21,9 @@ class TestOneShotCli(unittest.TestCase):
 
     def setUp(self):
         if self.tokenize:
-            pytest.skip("Tokenized data input not supported for oneshot cli")
+            pytest.skip("Tokenized data input not supported for post_train cli")
 
-        self.output = "./oneshot_output"
+        self.output = "./post_train_output"
         self.additional_args = []
         if self.dataset_config_name:
             self.additional_args.append("--dataset_config_name")

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -65,7 +65,7 @@ def test_sparse_model_reload(compressed, config, dtype, tmp_path):
         recipe=recipe_str,
         concatenate_data=concatenate_data,
         splits=splits,
-        oneshot_device=device,
+        post_train_device=device,
         precision=dtype,
         clear_sparse_session=False,
     )
@@ -189,7 +189,7 @@ def test_quant_model_reload(format, dtype, tmp_path):
         recipe=recipe_str,
         concatenate_data=concatenate_data,
         splits=splits,
-        oneshot_device=device,
+        post_train_device=device,
         clear_sparse_session=False,
         precision=dtype,
     )
@@ -394,7 +394,7 @@ def test_compressor_stacking(model_stub, recipe, sparse_format, quant_format, tm
         recipe=recipe,
         concatenate_data=concatenate_data,
         splits=splits,
-        oneshot_device=device,
+        post_train_device=device,
         clear_sparse_session=False,
     )
 
@@ -479,7 +479,7 @@ def test_sparse_24_compressor_is_lossless(model_stub, recipe, sparse_format, tmp
         recipe=recipe,
         concatenate_data=concatenate_data,
         splits=splits,
-        oneshot_device=device,
+        post_train_device=device,
         clear_sparse_session=False,
     )
 

--- a/tests/llmcompressor/transformers/test_clear_ml.py
+++ b/tests/llmcompressor/transformers/test_clear_ml.py
@@ -26,7 +26,7 @@ def test_finetune_wout_recipe(tmp_path: Path):
     max_steps = 50
     splits = "train"
 
-    Task.init(project_name="test", task_name="test_oneshot_and_finetune")
+    Task.init(project_name="test", task_name="test_post_train_and_finetune")
 
     train(
         model=model,

--- a/tests/llmcompressor/transformers/test_clear_ml.py
+++ b/tests/llmcompressor/transformers/test_clear_ml.py
@@ -36,5 +36,5 @@ def test_finetune_wout_recipe(tmp_path: Path):
         max_steps=max_steps,
         concatenate_data=concatenate_data,
         splits=splits,
-        oneshot_device=device,
+        post_train_device=device,
     )


### PR DESCRIPTION
SUMMARY:
* Update `oneshot` to post_train
* Make `post_train` have its own pipeline, decoupled form `main`
* Make `post_train`'s input arguments only dependent on `ModelArguments`, `DatasetArguments`, and `RecipeArguments`. Any `TrainingArguments`-related input arg will raise an error. Ex. `overwrite_output_dir`.
* Update any `oneshot` usage in the function name (`run_oneshot_and_finetune`)`, Enum attributes (`RecipeStages`), variable name (`oneshot_model`) to `post_train`. 

TODO
* Update folder names from oneshot to post_train (ex. `"tests/llmcompressor/transformers/oneshot/oneshot_configs"`)

TEST PLAN:
* Pass existing tests
* search `oneshot` using `grep`. 

FOLLOWUPS:
* Remove oneshot dependent code (ex. `SessionMixin.apply`)
* Remove stage-runner
