### PR TITLE
[Audio] Support Whisper V3

### DIFF
--- a/examples/multimodal_audio/whisper_example.py
+++ b/examples/multimodal_audio/whisper_example.py
@@ -12,7 +12,7 @@ MODEL_ID = "openai/whisper-large-v2"
 model = TraceableWhisperForConditionalGeneration.from_pretrained(
     MODEL_ID,
     device_map="auto",
-    torch_dtype="auto",
+    torch_dtype=torch.float32,  # whisper v3 uses float16 weights
 )
 model.config.forced_decoder_ids = None
 processor = WhisperProcessor.from_pretrained(MODEL_ID)


### PR DESCRIPTION
## Purpose ##
* Support Whisper V3 model

## Changes ##
* Change default whisper model to v3
* Modify preprocessing function to be simpler
* Add dtype conversion to preprocessing function
  * Note that this is only required for feature extractor processors, as they return values which are float types (not just token ids, which work regardless of model dtype)

## Follow-ups ##
* Dtype conversion should theoretically be injected into prebaked dataset pathways as well, although I consider this low priority since we push users towards writing their own data processing functions

## Testing ##
* Quantized Whisper v3 model
* Note that you may have to add `ds.cleanup_cache_files()` to line 40 in order to overwrite any existing mapping caches