### PR TITLE
[TRL_SFT_Trainer] Fix and Update Examples code

### DIFF
--- a/examples/trl_mixin/ex_trl_constant.py
+++ b/examples/trl_mixin/ex_trl_constant.py
@@ -3,7 +3,7 @@ from sft_trainer import SFTTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from trl import DataCollatorForCompletionOnlyLM
 
-from llmcompressor.args import TrainingArguments
+from llmcompressor.args import ModelArguments
 
 model_path = "neuralmagic/Llama-2-7b-pruned50-retrained"
 output_dir = "./output_trl_sft_test_7b_gsm8k_sft_data"
@@ -39,21 +39,23 @@ def formatting_prompts_func(example):
 response_template = "Answer:"
 collator = DataCollatorForCompletionOnlyLM(response_template, tokenizer=tokenizer)
 
-training_args = TrainingArguments(
+training_args = dict(
     output_dir=output_dir,
-    num_train_epochs=0.6,
+    num_train_epochs=0.1,
     logging_steps=50,
     gradient_checkpointing=True,
+    max_seq_length=512,
 )
+model_args = ModelArguments(model=model)
 
 trainer = SFTTrainer(
     model=model,
-    tokenizer=tokenizer,
+    processing_class=tokenizer,
     recipe=recipe,
     train_dataset=dataset,
     formatting_func=formatting_prompts_func,
     data_collator=collator,
     args=training_args,
-    max_seq_length=512,
+    model_args=model_args,
 )
 trainer.train()

--- a/examples/trl_mixin/ex_trl_constant.py
+++ b/examples/trl_mixin/ex_trl_constant.py
@@ -39,9 +39,9 @@ def formatting_prompts_func(example):
 response_template = "Answer:"
 collator = DataCollatorForCompletionOnlyLM(response_template, tokenizer=tokenizer)
 
-training_args = dict(
+trl_sft_config_args = dict(
     output_dir=output_dir,
-    num_train_epochs=0.1,
+    num_train_epochs=0.6,
     logging_steps=50,
     gradient_checkpointing=True,
     max_seq_length=512,
@@ -55,7 +55,7 @@ trainer = SFTTrainer(
     train_dataset=dataset,
     formatting_func=formatting_prompts_func,
     data_collator=collator,
-    args=training_args,
+    trl_sft_config_args=trl_sft_config_args,
     model_args=model_args,
 )
 trainer.train()

--- a/examples/trl_mixin/sft_trainer.py
+++ b/examples/trl_mixin/sft_trainer.py
@@ -1,7 +1,6 @@
 from trl import SFTConfig as TRLSFTConfig
 from trl import SFTTrainer as TRLSFTTrainer
 
-from llmcompressor.args import TrainingArguments
 from llmcompressor.transformers.finetune.session_mixin import SessionManagerMixIn
 
 __all__ = ["SFTTrainer"]
@@ -10,11 +9,9 @@ __all__ = ["SFTTrainer"]
 class SFTTrainer(SessionManagerMixIn, TRLSFTTrainer):
     def __init__(self, *args, **kwargs):
         sft_config_args = kwargs.get("args")
-        if (
-            sft_config_args is not None
-            and sft_config_args.__class__.__name__ == "TrainingArguments"
-        ):
-            kwargs["args"] = SFTConfig(**sft_config_args.to_dict())
+        if sft_config_args is not None:
+            kwargs["args"] = TRLSFTConfig(**sft_config_args)
+
         super().__init__(*args, **kwargs)
 
     def _prepare_dataset(self, dataset, *args, **kwargs):
@@ -23,14 +20,3 @@ class SFTTrainer(SessionManagerMixIn, TRLSFTTrainer):
             return dataset
 
         return super()._prepare_dataset(dataset, *args, **kwargs)
-
-
-class SFTConfig(TrainingArguments, TRLSFTConfig):
-    """
-    This class is needed to wrap the llmcompressor.transformers.TrainingArguments
-    and TRLSFTConfig classes. This allows for the use of arguments and
-    configurations from both classes when training a model.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)

--- a/examples/trl_mixin/sft_trainer.py
+++ b/examples/trl_mixin/sft_trainer.py
@@ -1,3 +1,5 @@
+from typing import Dict, Optional
+
 from trl import SFTConfig as TRLSFTConfig
 from trl import SFTTrainer as TRLSFTTrainer
 
@@ -7,11 +9,9 @@ __all__ = ["SFTTrainer"]
 
 
 class SFTTrainer(SessionManagerMixIn, TRLSFTTrainer):
-    def __init__(self, *args, **kwargs):
-        sft_config_args = kwargs.get("args")
-        if sft_config_args is not None:
-            kwargs["args"] = TRLSFTConfig(**sft_config_args)
-
+    def __init__(self, trl_sft_config_args: Optional[Dict] = None, *args, **kwargs):
+        if trl_sft_config_args is not None:
+            kwargs["args"] = TRLSFTConfig(**trl_sft_config_args)
         super().__init__(*args, **kwargs)
 
     def _prepare_dataset(self, dataset, *args, **kwargs):

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -66,8 +66,8 @@ class SessionManagerMixIn:
     def __init__(
         self,
         recipe: str,
-        data_args: "DatasetArguments",
         model_args: "ModelArguments",
+        data_args: Optional["DatasetArguments"] = None,
         teacher: Optional[Union[Module, str]] = None,
         recipe_args: Optional[Union[Dict[str, Any], str]] = None,
         **kwargs,


### PR DESCRIPTION
SUMMARY:
* Fix examples script failure https://github.com/neuralmagic/llm-compressor-testing/actions/runs/13350457472/job/37286313648

PROBLEM
1. 
```bash
 cpy 2 '/home/gohashi/llm-compressor/examples/trl_mixin/ex_trl_constant.py'
...
TypeError: SessionManagerMixIn.__init__() missing 2 required positional arguments: 'data_args' and 'model_args'

```

2.
```bash
(.venv) gohashi@janice:~/llm-compressor$ cpy 2 '/home/gohashi/llm-compressor/examples/trl_mixin/ex_trl_constant.py'
...
TypeError: SFTTrainer.__init__() got an unexpected keyword argument 'max_seq_length'
```

3.
```bash
(.venv) gohashi@janice:~/llm-compressor$ cpy 2 '/home/gohashi/llm-compressor/examples/trl_mixin/ex_trl_constant.py'
...
AttributeError: 'NoneType' object has no attribute 'save_compressed'
```

4.
```
(.venv) gohashi@janice:~/llm-compressor$ cpy 2 '/home/gohashi/llm-compressor/examples/trl_mixin/ex_trl_constant.py'
...
/home/gohashi/llm-compressor/src/llmcompressor/transformers/finetune/session_mixin.py:97: FutureWarning: `tokenizer` is deprecated and removed starting from version 0.16.0 for `SFTTrainer.__init__`. Use `processing_class` instead.
...
```


SOLUTION:
1. Caused by https://github.com/vllm-project/llm-compressor/pull/1103/files#diff-059b8cf7e48691cd2d5ddda1d0ba5f584657a70c5804797d38c902b433777335R69-R70, where `model_args` and `data_args` is required. Add it to the code and make `model_args` and `data_args` optional
2. `max_seq_length` is not a part of `TrainingArgs`, which gets called by super first. We see that it is used in `SFTConfig` that inherits `TRLSFTConfig` where `max_seq_length` is used.  `TRLSFTConfig` inherits `TrainingArguments` to modify the code.
3. Make `model_args` required
4. Bug warning. Update `tokenizer` to `processing_class`

TEST PLAN:
* Pass`[examples/trl_mixin/ex_trl_constant.py](https://github.com/vllm-project/llm-compressor/compare/sessionmixin-revert-signature?expand=1#diff-f14ef5a7e5c54f35e347fd75ed37e39b8f6db081199bd6233cf14d2c1b4bdef9)`
* Pass existing tests
