### PR TITLE
re-add vllm e2e test now that bug is fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -800,5 +800,6 @@ integrations/pytorch/pytorch_vision*
 nm_temp_test_logs/*
 sparse_logs/*
 wandb/
+timings/
 output_finetune/
 env_log.json

--- a/tests/e2e/vLLM/configs/sparse2of4_fp8_dynamic_qwen.yaml
+++ b/tests/e2e/vLLM/configs/sparse2of4_fp8_dynamic_qwen.yaml
@@ -1,0 +1,7 @@
+cadence: "nightly"
+test_type: "regression"
+model: Qwen/Qwen2.5-0.5B
+recipe: tests/e2e/vLLM/recipes/Sparse_2of4/recipe_sparse_2of4_fp8_dynamic.yaml
+scheme: sparse2of4_fp8_dynamic
+dataset_id: garage-bAInd/Open-Platypus
+dataset_split: train


### PR DESCRIPTION
SUMMARY:
An e2e test was removed from #1131 as it was failing out at vllm for a reason that has since been resolved by https://github.com/vllm-project/vllm/pull/13198. This re-adds the test shown [here](https://github.com/vllm-project/llm-compressor/pull/1131#issuecomment-2651712214).

I confirmed this runs with [the nightly vllm wheel built by the testing CI/CD](https://github.com/neuralmagic/llm-compressor-testing/actions/runs/13360960551). 

This adds <2 minutes to the nightly test time.

TEST PLAN:
No new src code to test.
