### PR TITLE
[Callbacks] Remove double initialization, replace with update_state

### DIFF
--- a/src/llmcompressor/core/__init__.py
+++ b/src/llmcompressor/core/__init__.py
@@ -17,6 +17,7 @@ from llmcompressor.core.session_functions import (
     finalize,
     initialize,
     reset_session,
+    update_state,
 )
 from llmcompressor.core.state import Data, Hardware, ModifiedState, State
 
@@ -37,6 +38,7 @@ __all__ = [
     "active_session",
     "reset_session",
     "initialize",
+    "update_state",
     "finalize",
     "apply",
     "callbacks",

--- a/src/llmcompressor/core/lifecycle.py
+++ b/src/llmcompressor/core/lifecycle.py
@@ -108,6 +108,13 @@ class CompressionLifecycle:
 
         return mod_data
 
+    def update_state(self, **kwargs):
+        """
+        TODO
+        """
+        logger.info(f"Updated state with {kwargs}")
+        self.state.update(**kwargs)
+
     def finalize(self, **kwargs) -> List[Any]:
         """
         Finalize the compression lifecycle.

--- a/src/llmcompressor/core/session.py
+++ b/src/llmcompressor/core/session.py
@@ -143,6 +143,21 @@ class CompressionSession:
             modifier_data=mod_data,
         )
 
+    def update_state(self, **kwargs) -> ModifiedState:
+        """
+        TODO
+        """
+
+        self._lifecycle.update_state(
+            **kwargs,
+        )
+
+        return ModifiedState(
+            model=self.state.model,
+            optimizer=self.state.optimizer,
+            loss=self.state.loss,
+        )
+
     def finalize(self, **kwargs) -> ModifiedState:
         """
         Finalize the session for compression. This will run the finalize method

--- a/src/llmcompressor/core/session_functions.py
+++ b/src/llmcompressor/core/session_functions.py
@@ -12,6 +12,7 @@ __all__ = [
     "active_session",
     "reset_session",
     "initialize",
+    "update_state",
     "finalize",
     "apply",
     "callbacks",
@@ -120,6 +121,13 @@ def initialize(
         batches_per_step=batches_per_step,
         **kwargs,
     )
+
+
+def update_state(**kwargs) -> ModifiedState:
+    """
+    TODO
+    """
+    return active_session().update_state(**kwargs)
 
 
 def finalize(**kwargs) -> ModifiedState:

--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -18,6 +18,7 @@ from llmcompressor.core import (
     create_session,
     finalize,
     initialize,
+    update_state,
 )
 from llmcompressor.metrics import LoggerManager
 from llmcompressor.modifiers.distillation.utils.pytorch.model_wrapper import (
@@ -224,7 +225,9 @@ class SessionManagerMixIn:
                 len(self.train_dataset) / total_batch_size
             )
 
-        initialize(optimizer=self.optimizer, steps_per_epoch=self.total_steps_per_epoch)
+        update_state(
+            optimizer=self.optimizer, steps_per_epoch=self.total_steps_per_epoch
+        )
 
         return self.optimizer
 


### PR DESCRIPTION
## Purpose ##
* Calling `initialize` twice is a confusing and misleading api. However, in some training pipelines (in this example HF trainer, but potentially others), it may be more convenient to `initialize` once and then update the state with lazily variables later

## Changes ##
* Implement `update_state` which 
* Replace the second `initialize` call in session_mixin with an `update_state` call