### PR TITLE
Deprecate `oneshot_device` arg in favor of `device_map`

### DIFF
--- a/src/llmcompressor/args/model_arguments.py
+++ b/src/llmcompressor/args/model_arguments.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Dict, Optional, Union
+
+import torch
 
 
 @dataclass
@@ -80,8 +82,11 @@ class ModelArguments:
         metadata={"help": "Whether to compress sparse models during save"},
     )
     oneshot_device: Optional[str] = field(
-        default="cuda:0",
-        metadata={"help": "Device to run oneshot calibration on"},
+        default=None,
+        metadata={
+            "help": "This field is deprecated, please use `device_map` instead. "
+            "Device to run oneshot calibration on"
+        },
     )
     model_revision: str = field(
         default="main",
@@ -89,4 +94,7 @@ class ModelArguments:
             "help": "The specific model version to use "
             "(can be a branch name, tag name or commit id)"
         },
+    )
+    device_map: Dict[str, Union[int, str, torch.device]] = field(
+        default="auto", metadata={}
     )

--- a/src/llmcompressor/pytorch/model_load/helpers.py
+++ b/src/llmcompressor/pytorch/model_load/helpers.py
@@ -16,7 +16,6 @@ __all__ = [
     "initialize_recipe",
     "save_model_and_recipe",
     "copy_python_files_from_model_cache",
-    "fallback_to_cpu",
     "parse_dtype",
     "get_session_model",
     "get_completed_stages",
@@ -85,22 +84,6 @@ def save_model_and_recipe(
 
     # copy python files from cache dir to save_path if any
     copy_python_files_from_model_cache(model, save_path)
-
-
-def fallback_to_cpu(device: str) -> str:
-    """
-    Takes in a device string and forces it to cpu if cuda is not available
-
-    :param device: device id to check
-    :return: device modified for CUDA status
-    """
-    if "cuda" in device and not torch.cuda.is_available():
-        logger.warning(
-            f"Requested {device} but CUDA is not available, falling back to CPU"
-        )
-        return "cpu"
-
-    return device
 
 
 def parse_dtype(dtype_arg: Union[str, torch.dtype]) -> torch.dtype:

--- a/src/llmcompressor/transformers/finetune/text_generation.py
+++ b/src/llmcompressor/transformers/finetune/text_generation.py
@@ -155,7 +155,8 @@ def parse_args(**kwargs):
         )
     if model_args.oneshot_device is not None:
         warnings.warn(
-            "`oneshot_device` argument is deprecated. Please use `device_map` instead",
+            "`oneshot_device` argument is deprecated and will no longer fall back to "
+            "CPU. Please use `device_map` instead",
             DeprecationWarning,
         )
         device_map_default = ModelArguments.__dataclass_fields__["device_map"].default


### PR DESCRIPTION
## Purpose ##
* Generalize and clarify arg name

## Follow Ups ##
* Add deprecation information to metadata, and use the metadata to generalize deprecation warnings