### PR TITLE
Make `transformers-tests` job conditional on files changed

### DIFF
--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -15,9 +15,33 @@ env:
   CLEARML_API_SECRET_KEY: ${{ secrets.CLEARML_API_SECRET_KEY }}
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+
+    outputs:
+      changes-present: ${{ steps.changed-files.outputs.any_modified }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files_ignore: |
+            examples/**
+            tests/e2e/**
+            tests/lmeval/**
+            tests/examples/**
+            **/*.md
+            .github/workflows/*
+
   transformers-tests:
+    needs: [detect-changes]
     runs-on: gcp-k8s-vllm-l4-solo
-    if: contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push'
+    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push') && needs.detect-changes.outputs.changes-present
     steps:
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -30,13 +30,15 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v45
         with:
-          files_ignore: |
-            examples/**
-            tests/e2e/**
-            tests/lmeval/**
-            tests/examples/**
-            **/*.md
-            .github/workflows/*
+          files: |
+            **
+            !examples/**
+            !tests/e2e/**
+            !tests/lmeval/**
+            !tests/examples/**
+            !**/*.md
+            !.github/**
+            .github/workflows/test-check-transformers.yaml
 
       - name: Log relevant output
         run: |

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -38,10 +38,16 @@ jobs:
             **/*.md
             .github/workflows/*
 
+      - name: Log relevant output
+        run: |
+          echo "changes-present: ${{ steps.changed-files.outputs.any_modified }}"
+          echo "all modified files: ${{ steps.changed-files.outputs.all_modified_files }}"
+        shell: bash
+
   transformers-tests:
     needs: [detect-changes]
     runs-on: gcp-k8s-vllm-l4-solo
-    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push') && needs.detect-changes.outputs.changes-present
+    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push') && needs.detect-changes.outputs.changes-present == 'true'
     steps:
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
SUMMARY:
Make `transformers-tests` job conditional on files changed by way of using the `tj-actions/changed-files@v45` action to check which files changed (ignoring files/folders based on a separate trial: #1194).


TEST PLAN:
Verify this PR:
1. Correctly results in skipping the `transformers-tests` job
2. Allows merging with the skipped job
