### PR TITLE
[Callbacks] Remove `on_update`

### DIFF
--- a/src/llmcompressor/modifiers/distillation/output/base.py
+++ b/src/llmcompressor/modifiers/distillation/output/base.py
@@ -123,7 +123,7 @@ class OutputDistillationModifier(Modifier):
             teacher_wrapper.kd_enabled = True
         self.wrapped_kd_model_.kd_enabled = True
 
-    def on_update(self, state: State, event: Event, **kwargs):
+    def on_event(self, state: State, event: Event, **kwargs):
         if event.type_ == EventType.LOSS_CALCULATED and event.should_update(
             self.start, self.end, self.update
         ):

--- a/src/llmcompressor/modifiers/modifier.py
+++ b/src/llmcompressor/modifiers/modifier.py
@@ -156,7 +156,7 @@ class Modifier(ModifierInterface, HooksMixin):
     def update_event(self, state: State, event: Event, **kwargs):
         """
         Update modifier based on the given event. In turn calls
-        on_start, on_update, and on_end based on the event and
+        on_start, on_event, and on_end based on the event and
         modifier settings. Returns immediately if the modifier is
         not initialized
 
@@ -166,12 +166,10 @@ class Modifier(ModifierInterface, HooksMixin):
         :param kwargs: Additional arguments for updating the modifier
         """
         if not self.initialized_:
-            return
+            raise RuntimeError("Please call `initialize()` before triggering events")
 
         if self.finalized_:
-            raise RuntimeError("cannot update a finalized modifier")
-
-        self.on_event(state, event, **kwargs)
+            raise RuntimeError("Cannot trigger events after `finalize()`")
 
         # handle starting the modifier if needed
         if (
@@ -181,9 +179,8 @@ class Modifier(ModifierInterface, HooksMixin):
         ):
             self.on_start(state, event, **kwargs)
             self.started_ = True
-            self.on_update(state, event, **kwargs)
 
-            return
+        self.on_event(state, event, **kwargs)
 
         # handle ending the modifier if needed
         if (
@@ -193,12 +190,6 @@ class Modifier(ModifierInterface, HooksMixin):
         ):
             self.on_end(state, event, **kwargs)
             self.ended_ = True
-            self.on_update(state, event, **kwargs)
-
-            return
-
-        if self.started_ and not self.ended_:
-            self.on_update(state, event, **kwargs)
 
     def should_start(self, event: Event) -> bool:
         """
@@ -267,18 +258,6 @@ class Modifier(ModifierInterface, HooksMixin):
         :param state: The current state of the model
         :param event: The event that triggered the start
         :param kwargs: Additional arguments for starting the modifier
-        """
-        pass
-
-    def on_update(self, state: State, event: Event, **kwargs):
-        """
-        on_update is called when the model in question must be
-        updated based on passed in event. Must be implemented by the
-        inheriting modifier.
-
-        :param state: The current state of the model
-        :param event: The event that triggered the update
-        :param kwargs: Additional arguments for updating the model
         """
         pass
 

--- a/src/llmcompressor/modifiers/pruning/constant/base.py
+++ b/src/llmcompressor/modifiers/pruning/constant/base.py
@@ -56,7 +56,7 @@ class ConstantPruningModifier(Modifier, LayerParamMasking):
         self.enable_masks()
 
     @torch.no_grad()
-    def on_update(self, state: State, event: Event, **kwargs):
+    def on_event(self, state: State, event: Event, **kwargs):
         if self._use_hooks:
             # hooks are used to update, so nothing to do here
             return

--- a/src/llmcompressor/modifiers/pruning/magnitude/base.py
+++ b/src/llmcompressor/modifiers/pruning/magnitude/base.py
@@ -107,7 +107,7 @@ class MagnitudePruningModifier(Modifier, LayerParamMasking):
 
         self.enable_masks()
 
-    def on_update(self, state: State, event: Event, **kwargs):
+    def on_event(self, state: State, event: Event, **kwargs):
         if event.type_ == EventType.BATCH_START:
             sparsity = self.scheduler_function_(event, state)
             if sparsity != self.current_sparsity_:

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -121,7 +121,7 @@ class QuantizationModifier(Modifier):
         module = state.model
         module.apply(update_weight_zp_scale)
 
-    def on_update(self, state: State, event: Event, **kwargs):
+    def on_event(self, state: State, event: Event, **kwargs):
         if event.type_ == EventType.BATCH_START:
             if self.check_should_disable_observer(event):
                 module = state.model


### PR DESCRIPTION
## Purpose ##
* Simplify modifier lifecycle

## Prerequisites ##
* #1198

## Changes ##
* Change the silent nullop when a modifier receives an event but hasn't been initialized
* Trigger on_event between starting and stopping
* Rename `on_update` to `on_event` to remove the concept of "updating" a modifier