### PR TITLE
Remove MonkeyPatch for GPUs

### DIFF
--- a/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
@@ -108,7 +108,6 @@ class TestFinetuneNoRecipeCustomDataset(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output)
-        self.monkeypatch.undo()
 
 
 @pytest.mark.integration
@@ -121,11 +120,8 @@ class TestOneshotCustomDatasetSmall(TestFinetuneNoRecipeCustomDataset):
     def setUp(self):
         import torch
 
-        self.monkeypatch = pytest.MonkeyPatch()
-
         if torch.cuda.is_available():
             self.device = "cuda:0"
-            self.monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
         else:
             self.device = "cpu"
 
@@ -147,15 +143,12 @@ class TestOneshotCustomDatasetGPU(TestFinetuneNoRecipeCustomDataset):
         import torch
         from transformers import AutoModelForCausalLM
 
-        self.monkeypatch = pytest.MonkeyPatch()
         self.device = "cuda:0"
         self.output = "./oneshot_output"
-        self.monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
 
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model, device_map=self.device, torch_dtype=torch.bfloat16
         )
-        self.monkeypatch = pytest.MonkeyPatch()
 
     def test_oneshot_then_finetune_gpu(self):
         self._test_finetune_wout_recipe_custom_dataset()

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py
@@ -21,15 +21,12 @@ class TestOneshotAndFinetuneWithTokenizer(unittest.TestCase):
         self.output = "./finetune_output"
         # finetune workflows in general seem to have trouble with multi-gpus
         # use just one atm
-        self.monkeypatch = pytest.MonkeyPatch()
 
     def test_oneshot_and_finetune_with_tokenizer(self):
         from datasets import load_dataset
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
         from llmcompressor.transformers import compress
-
-        self.monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
 
         recipe_str = (
             "tests/llmcompressor/transformers/finetune/test_alternate_recipe.yaml"
@@ -71,4 +68,3 @@ class TestOneshotAndFinetuneWithTokenizer(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output)
-        self.monkeypatch.undo()


### PR DESCRIPTION
SUMMARY:
- This was added previously due to an error we were seeing with multiple GPUs (i.e having more than one gpu visible would cause an error)
- Can verify this no longer happens