### PR TITLE
[WIP] Oneshot Callbacks

### DIFF
--- a/src/llmcompressor/core/events/event.py
+++ b/src/llmcompressor/core/events/event.py
@@ -44,7 +44,7 @@ class EventType(Enum):
     BATCH_START = "batch_start"
     LOSS_CALCULATED = "loss_calculated"
     BATCH_END = "batch_end"
-    SEQUENTIAL_BATCH_END = "sequential_batch_end"
+    SEQUENTIAL_LAYER_END = "sequential_layer_end"
 
     # step lifecycle
     OPTIM_PRE_STEP = "optim_pre_step"

--- a/src/llmcompressor/core/events/event.py
+++ b/src/llmcompressor/core/events/event.py
@@ -44,6 +44,7 @@ class EventType(Enum):
     BATCH_START = "batch_start"
     LOSS_CALCULATED = "loss_calculated"
     BATCH_END = "batch_end"
+    SEQUENTIAL_BATCH_END = "sequential_batch_end"
 
     # step lifecycle
     OPTIM_PRE_STEP = "optim_pre_step"

--- a/src/llmcompressor/core/events/event.py
+++ b/src/llmcompressor/core/events/event.py
@@ -44,7 +44,7 @@ class EventType(Enum):
     BATCH_START = "batch_start"
     LOSS_CALCULATED = "loss_calculated"
     BATCH_END = "batch_end"
-    SEQUENTIAL_LAYER_END = "sequential_layer_end"
+    SEQUENTIAL_EPOCH_END = "sequential_epoch_end"
 
     # step lifecycle
     OPTIM_PRE_STEP = "optim_pre_step"

--- a/src/llmcompressor/core/session_functions.py
+++ b/src/llmcompressor/core/session_functions.py
@@ -213,14 +213,15 @@ class LifecycleCallbacks:
         return cls.event(EventType.BATCH_END, **kwargs)
 
     @classmethod
-    def sequential_layer_end(cls, **kwargs) -> ModifiedState:
+    def sequential_epoch_end(cls, **kwargs) -> ModifiedState:
         """
-        Invoke a sequential batch end event for the active session
+        Invoke a sequential epoch end event for the active session. This event should be
+        called after one sequential layer has been calibrated/trained for one epoch
 
         This is called after a sequential layer has been calibrated with one batch, see
         `src/llmcompressor/pipelines/sequential/pipeline.py` for usage example
         """
-        return cls.event(EventType.SEQUENTIAL_LAYER_END, **kwargs)
+        return cls.event(EventType.SEQUENTIAL_EPOCH_END, **kwargs)
 
 
 callbacks = LifecycleCallbacks

--- a/src/llmcompressor/core/session_functions.py
+++ b/src/llmcompressor/core/session_functions.py
@@ -211,16 +211,16 @@ class LifecycleCallbacks:
         """
         active_session()._log_model_info()
         return cls.event(EventType.BATCH_END, **kwargs)
-    
+
     @classmethod
-    def sequential_batch_end(cls, **kwargs) -> ModifiedState:
+    def sequential_layer_end(cls, **kwargs) -> ModifiedState:
         """
         Invoke a sequential batch end event for the active session
-        
+
         This is called after a sequential layer has been calibrated with one batch, see
         `src/llmcompressor/pipelines/sequential/pipeline.py` for usage example
         """
-        return cls.event(EventType.SEQUENTIAL_BATCH_END, **kwargs)
+        return cls.event(EventType.SEQUENTIAL_LAYER_END, **kwargs)
 
 
 callbacks = LifecycleCallbacks

--- a/src/llmcompressor/core/session_functions.py
+++ b/src/llmcompressor/core/session_functions.py
@@ -211,6 +211,16 @@ class LifecycleCallbacks:
         """
         active_session()._log_model_info()
         return cls.event(EventType.BATCH_END, **kwargs)
+    
+    @classmethod
+    def sequential_batch_end(cls, **kwargs) -> ModifiedState:
+        """
+        Invoke a sequential batch end event for the active session
+        
+        This is called after a sequential layer has been calibrated with one batch, see
+        `src/llmcompressor/pipelines/sequential/pipeline.py` for usage example
+        """
+        return cls.event(EventType.SEQUENTIAL_BATCH_END, **kwargs)
 
 
 callbacks = LifecycleCallbacks

--- a/src/llmcompressor/modifiers/obcq/base.py
+++ b/src/llmcompressor/modifiers/obcq/base.py
@@ -117,7 +117,7 @@ class SparseGPTModifier(SparsityModifierMixin, Modifier):
             )
 
     def on_event(self, state: State, event: Event, **kwargs):
-        if event.type_ == EventType.SEQUENTIAL_LAYER_END:
+        if event.type_ == EventType.SEQUENTIAL_EPOCH_END:
             self.compress_modules()
 
     def compress_modules(self):

--- a/src/llmcompressor/modifiers/obcq/sgpt_mixin.py
+++ b/src/llmcompressor/modifiers/obcq/sgpt_mixin.py
@@ -170,7 +170,6 @@ class SparsityModifierMixin(HooksMixin):
                 state.data.calib,
                 self.sequential_targets,
                 self.ignore,
-                self,
             )
             return True
 
@@ -186,7 +185,6 @@ class SparsityModifierMixin(HooksMixin):
                     state.model,
                     state.data.calib,
                     self.sequential_targets,
-                    self,
                 )
                 return True
 

--- a/src/llmcompressor/modifiers/pruning/wanda/base.py
+++ b/src/llmcompressor/modifiers/pruning/wanda/base.py
@@ -74,6 +74,14 @@ class WandaPruningModifier(SparsityModifierMixin, Modifier):
         args: Tuple[torch.Tensor, ...],
         _output: torch.Tensor,
     ):
+        """
+        Calibration hook used to accumulate the row scalars of the input to the module
+
+        :param module: module being calibrated
+        :param args: inputs to the module, the first element of which is the
+            cannonical input
+        :param _output: uncompressed module output, unused
+        """
         # Assume that the first argument is the input
         inp = args[0]
 
@@ -96,6 +104,9 @@ class WandaPruningModifier(SparsityModifierMixin, Modifier):
             self.compress_modules()
 
     def compress_modules(self):
+        """
+        Sparsify modules which have been calibrated
+        """
         for module in list(self._num_samples.keys()):
             name = self._module_names[module]
             sparsity = self._module_sparsities[module]

--- a/src/llmcompressor/modifiers/pruning/wanda/base.py
+++ b/src/llmcompressor/modifiers/pruning/wanda/base.py
@@ -100,7 +100,7 @@ class WandaPruningModifier(SparsityModifierMixin, Modifier):
         )
 
     def on_event(self, state: State, event: Event, **kwargs):
-        if event.type_ == EventType.SEQUENTIAL_LAYER_END:
+        if event.type_ == EventType.SEQUENTIAL_EPOCH_END:
             self.compress_modules()
 
     def compress_modules(self):

--- a/src/llmcompressor/modifiers/pruning/wanda/base.py
+++ b/src/llmcompressor/modifiers/pruning/wanda/base.py
@@ -9,7 +9,7 @@ from compressed_tensors.utils import (
 from loguru import logger
 from pydantic import PrivateAttr
 
-from llmcompressor.core import State
+from llmcompressor.core import State, Event, EventType
 from llmcompressor.modifiers import Modifier
 from llmcompressor.modifiers.obcq.sgpt_mixin import SparsityModifierMixin
 from llmcompressor.modifiers.pruning.wanda.wanda_sparsify import (
@@ -91,11 +91,12 @@ class WandaPruningModifier(SparsityModifierMixin, Modifier):
             self._num_samples[module],
         )
 
-    def on_sequential_batch_end(self):
+    def on_event(self, state: State, event: Event, **kwargs):
         """
-        Sparsify modules
-        TODO: implement with event callback
+        Sparsify modules which have been calibrated with samples
         """
+        if event.type_ != EventType.SEQUENTIAL_BATCH_END:
+            return
 
         for module in list(self._num_samples.keys()):
             name = self._module_names[module]

--- a/src/llmcompressor/modifiers/quantization/gptq/base.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/base.py
@@ -326,7 +326,7 @@ class GPTQModifier(Modifier, HooksMixin):
             )
 
     def on_event(self, state: State, event: Event, **kwargs):
-        if event.type_ == EventType.SEQUENTIAL_LAYER_END:
+        if event.type_ == EventType.SEQUENTIAL_EPOCH_END:
             self.compress_modules()
 
     def compress_modules(self):

--- a/src/llmcompressor/modifiers/quantization/gptq/base.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/base.py
@@ -236,7 +236,6 @@ class GPTQModifier(Modifier, HooksMixin):
                 state.data.calib,
                 self.sequential_targets,
                 self.ignore,
-                self,
             )
             return True
 
@@ -257,7 +256,6 @@ class GPTQModifier(Modifier, HooksMixin):
                     state.model,
                     state.data.calib,
                     self.sequential_targets,
-                    self,
                 )
                 return True
 

--- a/src/llmcompressor/modifiers/quantization/gptq/base.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/base.py
@@ -13,7 +13,7 @@ from compressed_tensors.utils import (
 from loguru import logger
 from pydantic import Field, PrivateAttr, field_validator
 
-from llmcompressor.core import State
+from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers import Modifier, ModifierFactory
 from llmcompressor.modifiers.quantization.calibration import freeze_module_quantization
 from llmcompressor.modifiers.quantization.gptq.gptq_quantize import (
@@ -279,6 +279,8 @@ class GPTQModifier(Modifier, HooksMixin):
 
         :param state: session state storing input model and calibration data
         """
+        self.compress_modules()  # compress any remaining modules
+
         if self._quantization_modifier:
             self._quantization_modifier.finalize(state, **kwargs)
 
@@ -324,11 +326,15 @@ class GPTQModifier(Modifier, HooksMixin):
                 self._num_samples[module],
             )
 
-    def on_sequential_batch_end(self):
+    def on_event(self, state: State, event: Event, **kwargs):
         """
         Quantize modules.
         TODO: implement with event callback
         """
+        if event.type_ == EventType.SEQUENTIAL_LAYER_END:
+            self.compress_modules()
+
+    def compress_modules(self):
         for module in list(self._num_samples.keys()):
             name = self._module_names[module]
             num_samples = self._num_samples[module]

--- a/src/llmcompressor/modifiers/smoothquant/base.py
+++ b/src/llmcompressor/modifiers/smoothquant/base.py
@@ -13,7 +13,9 @@ from llmcompressor.modifiers.smoothquant.utils import (
     get_layer_mappings_from_architecture,
     handle_mapping_resolution_errors,
 )
+from llmcompressor.modifiers.utils.pytorch_helpers import run_calibration_forward
 from llmcompressor.utils.fsdp.helpers import get_fsdp_parent
+from llmcompressor.utils.helpers import calibration_forward_context
 from llmcompressor.utils.pytorch.module import (
     get_layers,
     get_matching_layer,
@@ -130,7 +132,11 @@ class SmoothQuantModifier(Modifier):
         self.resolved_mappings_ = self._resolve_mappings(state.model)
         self.scales_ = {}
 
+        calibration_dataloader = state.data.calib
+
         self._setup_scale_hooks()
+        self._calibrate(state.model, calibration_dataloader)
+        self._apply_smoothing(state.model)
 
         return True
 
@@ -238,6 +244,31 @@ class SmoothQuantModifier(Modifier):
             name = mapping.smooth_name
             layer = mapping.smooth_layer
             self.register_hook(layer, create_hook_fn(name), "forward")
+
+    @torch.no_grad()
+    def _calibrate(self, model: Module, calibration_dataloader: List):
+        """
+        Catch the output dynamic ranges of each layer that will be smoothed by running
+        forward passes with calibration_dataloader
+        """
+        class_name = self.__class__.__name__.replace("PyTorch", "")
+        logger.info(
+            f"Running {class_name} calibration with "
+            f"{len(calibration_dataloader)} samples..."
+        )
+        if not calibration_dataloader:
+            raise ValueError(
+                "Calibration data loader not set, must populate the calib_data field of"
+                " CompressionSession to run the SmoothQuant modifier"
+            )
+
+        with calibration_forward_context(model):
+            run_calibration_forward(
+                model,
+                calibration_dataloader,
+                self.num_calibration_steps,
+                self.calibration_function,
+            )
 
     @torch.no_grad()
     def _apply_smoothing(self, model: Module):

--- a/src/llmcompressor/modifiers/smoothquant/base.py
+++ b/src/llmcompressor/modifiers/smoothquant/base.py
@@ -138,7 +138,7 @@ class SmoothQuantModifier(Modifier):
         """
         Sparsify modules which have been calibrated with samples
         """
-        if event.type_ == EventType.SEQUENTIAL_LAYER_END:
+        if event.type_ == EventType.SEQUENTIAL_EPOCH_END:
             self._apply_smoothing(state.model)
 
     def on_finalize(self, state: State, **kwargs) -> bool:

--- a/src/llmcompressor/modifiers/smoothquant/base.py
+++ b/src/llmcompressor/modifiers/smoothquant/base.py
@@ -2,19 +2,18 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
-from compressed_tensors.utils.offload import is_module_offloaded
+from compressed_tensors.utils.offload import align_module_device
 from loguru import logger
+from pydantic import ConfigDict
 from torch.nn import Module
 
-from llmcompressor.core import State
+from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers import Modifier
 from llmcompressor.modifiers.smoothquant.utils import (
     get_layer_mappings_from_architecture,
     handle_mapping_resolution_errors,
 )
-from llmcompressor.modifiers.utils.pytorch_helpers import run_calibration_forward
 from llmcompressor.utils.fsdp.helpers import get_fsdp_parent
-from llmcompressor.utils.helpers import calibration_forward_context
 from llmcompressor.utils.pytorch.module import (
     get_layers,
     get_matching_layer,
@@ -105,7 +104,7 @@ class SmoothQuantModifier(Modifier):
     num_calibration_steps: Optional[int] = None
     calibration_function: Optional[Callable] = None
 
-    resolved_mappings_: Optional[List] = None
+    resolved_mappings_: Optional[List[SmoothQuantMapping]] = None
     scales_: Optional[Dict] = None
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -131,13 +130,16 @@ class SmoothQuantModifier(Modifier):
         self.resolved_mappings_ = self._resolve_mappings(state.model)
         self.scales_ = {}
 
-        calibration_dataloader = state.data.calib
-
         self._setup_scale_hooks()
-        self._calibrate(state.model, calibration_dataloader)
-        self._apply_smoothing(state.model)
 
         return True
+
+    def on_event(self, state: State, event: Event, **kwargs):
+        """
+        Sparsify modules which have been calibrated with samples
+        """
+        if event.type_ == EventType.SEQUENTIAL_LAYER_END:
+            self._apply_smoothing(state.model)
 
     def on_finalize(self, state: State, **kwargs) -> bool:
         """
@@ -146,6 +148,9 @@ class SmoothQuantModifier(Modifier):
         :param state: unused
         :return: True
         """
+        self.remove_hooks()
+        self._apply_smoothing(state.model)
+
         if self.scales_ is not None:
             self.scales_.clear()
         if self.resolved_mappings_ is not None:
@@ -166,7 +171,7 @@ class SmoothQuantModifier(Modifier):
         )
 
     @handle_mapping_resolution_errors
-    def _resolve_mappings(self, model: Module) -> List:
+    def _resolve_mappings(self, model: Module) -> List[SmoothQuantMapping]:
         """
         Transforms the list of activations to smooth and their corresponding weights
         into SmoothQuantMapping objects, resolving regular expressions.
@@ -235,34 +240,6 @@ class SmoothQuantModifier(Modifier):
             self.register_hook(layer, create_hook_fn(name), "forward")
 
     @torch.no_grad()
-    def _calibrate(self, model: Module, calibration_dataloader: List):
-        """
-        Catch the output dynamic ranges of each layer that will be smoothed by running
-        forward passes with calibration_dataloader
-        """
-        class_name = self.__class__.__name__.replace("PyTorch", "")
-        logger.info(
-            f"Running {class_name} calibration with "
-            f"{len(calibration_dataloader)} samples..."
-        )
-        if not calibration_dataloader:
-            raise ValueError(
-                "Calibration data loader not set, must populate the calib_data field of"
-                " CompressionSession to run the SmoothQuant modifier"
-            )
-
-        with calibration_forward_context(model):
-            run_calibration_forward(
-                model,
-                calibration_dataloader,
-                self.num_calibration_steps,
-                self.calibration_function,
-            )
-
-        # remove the hooks now that we are done calibrating
-        self.remove_hooks()
-
-    @torch.no_grad()
     def _apply_smoothing(self, model: Module):
         """
         After calibration, apply smoothing to the activations and push the transform
@@ -273,8 +250,11 @@ class SmoothQuantModifier(Modifier):
 
         This modifies the weights of the model in-place.
         """
-        logger.info("Smoothing activation scales...")
         for mapping in self.resolved_mappings_:
+            if mapping.smooth_name not in self.scales_:
+                continue
+            logger.info(f"Smoothing with {mapping.smooth_name}")
+
             activation_scales = (  # get dynamic range for each activation channel
                 self.scales_[mapping.smooth_name].max_channel_vals
                 - self.scales_[mapping.smooth_name].min_channel_vals
@@ -289,22 +269,16 @@ class SmoothQuantModifier(Modifier):
 
             @torch.no_grad()
             def smooth(module):
-                offloaded = is_module_offloaded(module)
-                if offloaded:
-                    module._hf_hook.pre_forward(module)
-
-                if module in balance_layers:
-                    module.weight.mul_(scales.view(1, -1))
-                elif module == smooth_layer:
-                    if module.weight.ndim == 1:
-                        module.weight.div_(scales)
-                    else:
-                        module.weight.div_(scales.view(-1, 1))
-                    if hasattr(module, "bias") and module.bias is not None:
-                        module.bias.div_(scales)
-
-                if offloaded:
-                    module._hf_hook.post_forward(module, None)
+                with align_module_device(module):
+                    if module in balance_layers:
+                        module.weight.mul_(scales.view(1, -1))
+                    elif module == smooth_layer:
+                        if module.weight.ndim == 1:
+                            module.weight.div_(scales)
+                        else:
+                            module.weight.div_(scales.view(-1, 1))
+                        if hasattr(module, "bias") and module.bias is not None:
+                            module.bias.div_(scales)
 
             parent = get_fsdp_parent(mapping.smooth_name, model)
             if parent is not None:
@@ -314,6 +288,9 @@ class SmoothQuantModifier(Modifier):
                 for layer in balance_layers:
                     smooth(layer)
                 smooth(smooth_layer)
+
+            # clear calibration data
+            del self.scales_[mapping.smooth_name]
 
     def _calculate_smoothing_scales(
         self, balance_layers: List[Module], activation_scales: torch.Tensor
@@ -329,15 +306,9 @@ class SmoothQuantModifier(Modifier):
         # get the channel-wise dynamic range for each layer to be balanced
         weight_scales = []
         for layer in balance_layers:
-            offloaded = is_module_offloaded(layer)
-            if offloaded:
-                layer._hf_hook.pre_forward(layer)
-
-            scale = layer.weight.abs().max(dim=0, keepdim=True)[0]
-            weight_scales.append(scale)
-
-            if offloaded:
-                layer._hf_hook.post_forward(layer, None)
+            with align_module_device(layer):
+                scale = layer.weight.abs().max(dim=0, keepdim=True)[0]
+                weight_scales.append(scale)
 
         weight_scales = 2.0 * torch.cat(weight_scales, dim=0).max(dim=0)[0]
 
@@ -350,3 +321,5 @@ class SmoothQuantModifier(Modifier):
         scales = torch.where(weight_scales > 0.0, scales, activation_scales)
 
         return scales
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/src/llmcompressor/pipelines/basic/pipeline.py
+++ b/src/llmcompressor/pipelines/basic/pipeline.py
@@ -5,7 +5,6 @@ import torch.utils.data.dataloader
 import tqdm
 from compressed_tensors.utils import get_execution_device
 
-from llmcompressor.core import LifecycleCallbacks
 from llmcompressor.modifiers.utils.pytorch_helpers import apply_pad_mask_to_batch
 from llmcompressor.pytorch.utils.helpers import tensors_to_device
 from llmcompressor.utils.helpers import calibration_forward_context
@@ -40,5 +39,3 @@ def run_pipeline(
             batch = apply_pad_mask_to_batch(batch)
             batch = tensors_to_device(batch, model_device)
             model(**batch)
-
-        LifecycleCallbacks.sequential_layer_end()

--- a/src/llmcompressor/pipelines/basic/pipeline.py
+++ b/src/llmcompressor/pipelines/basic/pipeline.py
@@ -5,6 +5,7 @@ import torch.utils.data.dataloader
 import tqdm
 from compressed_tensors.utils import get_execution_device
 
+from llmcompressor.core import LifecycleCallbacks
 from llmcompressor.modifiers.utils.pytorch_helpers import apply_pad_mask_to_batch
 from llmcompressor.pytorch.utils.helpers import tensors_to_device
 from llmcompressor.utils.helpers import calibration_forward_context
@@ -40,6 +41,4 @@ def run_pipeline(
             batch = tensors_to_device(batch, model_device)
             model(**batch)
 
-        # TODO: replace with a lifecycle event
-        if callback_modifier:
-            callback_modifier.on_sequential_batch_end()
+        LifecycleCallbacks.sequential_layer_end()

--- a/src/llmcompressor/pipelines/layer_sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/layer_sequential/pipeline.py
@@ -66,7 +66,7 @@ def run_pipeline(
                 layer(**inputs)
 
             # trigger compression
-            LifecycleCallbacks.sequential_batch_end()
+            LifecycleCallbacks.sequential_layer_end()
 
             # this pass does not trigger modifier hooks
             # and is only used for capturing outputs from the newly compressed modules

--- a/src/llmcompressor/pipelines/layer_sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/layer_sequential/pipeline.py
@@ -66,7 +66,7 @@ def run_pipeline(
                 layer(**inputs)
 
             # trigger compression
-            LifecycleCallbacks.sequential_layer_end()
+            LifecycleCallbacks.sequential_epoch_end()
 
             # this pass does not trigger modifier hooks
             # and is only used for capturing outputs from the newly compressed modules

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -67,7 +67,7 @@ def run_pipeline(
                 forward_function(model, **inputs)
 
             # trigger compression
-            LifecycleCallbacks.sequential_layer_end()
+            LifecycleCallbacks.sequential_epoch_end()
 
             # this pass does not trigger modifier hooks
             # and is only used for capturing outputs from the newly compressed modules

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -67,7 +67,7 @@ def run_pipeline(
                 forward_function(model, **inputs)
 
             # trigger compression
-            LifecycleCallbacks.sequential_batch_end()
+            LifecycleCallbacks.sequential_layer_end()
 
             # this pass does not trigger modifier hooks
             # and is only used for capturing outputs from the newly compressed modules


### PR DESCRIPTION
## Purpose ##
* Standardize oneshot callbacks and prepare for oneshot pipeline extraction

## Changes ##
* Implement the `sequential_epoch_end` callback event which should be called after one sequential layer has been calibrated with one epoch
  * Add callback event to sequential and layer_sequential pipelines
* Trigger module compression both on the `SEQUENTIAL_EPOCH_END` event as well as on finalize
* Prepare smoothquant for pipeline extraction
  * Replace uses of `_hf_hook. pre_forward` with `align_module_device` for clarity
  * Specify `resolved_mappings_` type hint for clarity
  * Trigger `_apply_smoothing` on the `SEQUENTIAL_EPOCH_END` as well as on finalize
  * Add a [guard](https://github.com/vllm-project/llm-compressor/pull/1244/files#diff-90bb5efcbf5f23ba1db62664a91f6b2d6492a909c387cd82c1589f45d5e8615cR285) which allows the `_apply_smoothing` function to be called multiple times per session (as is required by sequential pipeline)

## Testing ##
* Cannot test since cannot call events before initialization