### PR TITLE
update minimal python to 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
             "llmcompressor.trace=llmcompressor.transformers.tracing.debug:main",
         ]
     },
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Resolves #1250 

SUMMARY:
Chained context managers were introduced by python3.10


TEST PLAN:
N/A
