### PR TITLE
[Bugfix] Disable generation of deepseek models with transformers>=4.48

### DIFF
--- a/examples/quantizing_moe/deepseek_moe_w4a16.py
+++ b/examples/quantizing_moe/deepseek_moe_w4a16.py
@@ -1,6 +1,7 @@
 import torch
 from datasets import load_dataset
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from packaging.version import Version
+from transformers import AutoModelForCausalLM, AutoTokenizer, __version__
 
 from llmcompressor import oneshot
 from llmcompressor.transformers.compression.helpers import calculate_offload_device_map
@@ -84,11 +85,18 @@ oneshot(
 )
 
 # Confirm generations of the quantized model look sane.
-print("========== SAMPLE GENERATION ==============")
-input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
-output = model.generate(input_ids, max_new_tokens=20)
-print(tokenizer.decode(output[0]))
-print("==========================================")
+# Generation is broken for deepseek models when using the latest transformers package
+if Version(__version__) < Version("4.48"):
+    print("========== SAMPLE GENERATION ==============")
+    input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
+    output = model.generate(input_ids, max_new_tokens=20)
+    print(tokenizer.decode(output[0]))
+    print("==========================================")
+else:
+    print(
+        "WARNING: cannot perform sample generation of "
+        "deepseek models with transformers >= 4.48"
+    )
 
 
 # Run the model on vLLM

--- a/examples/quantizing_moe/deepseek_moe_w8a8_fp8.py
+++ b/examples/quantizing_moe/deepseek_moe_w8a8_fp8.py
@@ -1,5 +1,6 @@
 from datasets import load_dataset
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from packaging.version import Version
+from transformers import AutoModelForCausalLM, AutoTokenizer, __version__
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.quantization import QuantizationModifier
@@ -78,10 +79,18 @@ oneshot(
     output_dir=SAVE_DIR,
 )
 
-print("========== SAMPLE GENERATION ==============")
-SAMPLE_INPUT = ["I love quantization because"]
-tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
-inputs = tokenizer(SAMPLE_INPUT, return_tensors="pt", padding=True).to(model.device)
-output = model.generate(**inputs, max_length=50)
-text_output = tokenizer.batch_decode(output)
-print(text_output)
+# Confirm generations of the quantized model look sane.
+# Generation is broken for deepseek models when using the latest transformers package
+if Version(__version__) < Version("4.48"):
+    print("========== SAMPLE GENERATION ==============")
+    SAMPLE_INPUT = ["I love quantization because"]
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+    inputs = tokenizer(SAMPLE_INPUT, return_tensors="pt", padding=True).to(model.device)
+    output = model.generate(**inputs, max_length=50)
+    text_output = tokenizer.batch_decode(output)
+    print(text_output)
+else:
+    print(
+        "WARNING: cannot perform sample generation of "
+        "deepseek models with transformers >= 4.48"
+    )

--- a/examples/quantizing_moe/mixtral_moe_w8a8_fp8.py
+++ b/examples/quantizing_moe/mixtral_moe_w8a8_fp8.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from packaging.version import Version
+from transformers import AutoModelForCausalLM, AutoTokenizer, __version__
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.quantization import QuantizationModifier
@@ -49,8 +50,15 @@ oneshot(
 )
 
 # Confirm generations of the quantized model look sane.
-print("========== SAMPLE GENERATION ==============")
-input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
-output = model.generate(input_ids, max_new_tokens=20)
-print(tokenizer.decode(output[0]))
-print("==========================================")
+# Generation is broken for deepseek models when using the latest transformers package
+if Version(__version__) < Version("4.48"):
+    print("========== SAMPLE GENERATION ==============")
+    input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
+    output = model.generate(input_ids, max_new_tokens=20)
+    print(tokenizer.decode(output[0]))
+    print("==========================================")
+else:
+    print(
+        "WARNING: cannot perform sample generation of "
+        "deepseek models with transformers >= 4.48"
+    )


### PR DESCRIPTION
## Purpose ##
* Generation is broken on deepseek models due to a deprecation by transformers. This PR skips generation in that case

## Related Issues ##
* https://github.com/huggingface/transformers/issues/36071
* https://huggingface.co/deepseek-ai/DeepSeek-V3/discussions/88