### PR TITLE
fix lm eval test reproducbility issues

### DIFF
--- a/tests/lmeval/configs/vl_fp8_dynamic_per_token.yaml
+++ b/tests/lmeval/configs/vl_fp8_dynamic_per_token.yaml
@@ -1,8 +1,7 @@
 cadence: weekly
-model: Qwen/Qwen2-VL-2B-Instruct
-model_class: TraceableQwen2VLForConditionalGeneration
+model: Qwen/Qwen2.5-VL-7B-Instruct
+model_class: TraceableQwen2_5_VLForConditionalGeneration
 scheme: FP8_DYNAMIC
-seed: 42  # compressed model is sensitive to random seed
 lmeval:
   model: "hf-multimodal"
   model_args:

--- a/tests/lmeval/configs/vl_int8_w8a8_dynamic_per_token.yaml
+++ b/tests/lmeval/configs/vl_int8_w8a8_dynamic_per_token.yaml
@@ -5,7 +5,6 @@ scheme: INT8_dyn_per_token
 recipe: tests/e2e/vLLM/recipes/INT8/recipe_int8_channel_weight_dynamic_per_token.yaml
 dataset_id: lmms-lab/flickr30k
 dataset_split: "test[:512]"
-seed: 42 #compressed model is sensitive to random seed
 lmeval:
   model: "hf-multimodal"
   model_args:

--- a/tests/lmeval/configs/vl_w4a16_actorder_weight.yaml
+++ b/tests/lmeval/configs/vl_w4a16_actorder_weight.yaml
@@ -1,11 +1,10 @@
 cadence: "weekly"
-model: Qwen/Qwen2-VL-2B-Instruct
-model_class: TraceableQwen2VLForConditionalGeneration
+model: llava-hf/llava-1.5-7b-hf
+model_class: TraceableLlavaForConditionalGeneration
 recipe: tests/e2e/vLLM/recipes/actorder/recipe_w4a16_actorder_weight.yaml
 dataset_id: lmms-lab/flickr30k
 dataset_split: "test[:512]"
 scheme: W4A16_actorder_group
-seed: 42 #compressed model is sensitive to random seed
 lmeval:
   model: "hf-multimodal"
   model_args:
@@ -15,5 +14,5 @@ lmeval:
   task: mmmu_val_economics
   num_fewshot: 0
   metrics:
-    acc,none: 0.366
+    acc,none: 0.233
   batch_size: 4


### PR DESCRIPTION
SUMMARY:
lm-eval multimodal tests were failing to reproduce across different versions of compressed tensors. After upgrading the models from 2B to 7B, the tests appear to be reproducing across compressed tensors 0.9.1, 0.9.2 and nightly. I ran extensively for the fp8 config across different versions of CT, and it always returned the same result. 

I also removed the random seed from the configs. after running several of each of the 3 configs, i did not see any change in result. this may cause errors during ci/cd testing but I'd like to see if it does, i feel that is a better e2e test anyway.

The Qwen2.5 7B model was erroring out during GPTQ, there was some error during the Hessian calculation. I confirmed the visual part of the model is excluded, but it was occurring in the `model.layers[_].mlp.down_proj` matrix which is a `Linear(in_features=18944, out_features=3584, bias=False)` layer. Maybe the strange shape was causing an issue? The llava model runs fine. @kylesayrs is this cause for concern and deeper analysis?


TEST PLAN:
no new src code, just fixing tests
