### PR TITLE
[Tests] Remove clear_ml test from GHA

### DIFF
--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -83,7 +83,6 @@ jobs:
         if: (success() || failure()) && steps.install.outcome == 'success'
         run: |
           pytest tests/llmcompressor/transformers/sparsification -v
-          pytest tests/llmcompressor/transformers/test_clear_ml.py -v
       - name: Running OBCQ Tests
         if: (success() || failure()) && steps.install.outcome == 'success'
         run: |


### PR DESCRIPTION
## Purpose ##
* Complete the removal of clear_ml #1261 by deleting the clear_ml test from the transformers gha

```
============================= test session starts ==============================
platform linux -- Python 3.9.21, pytest-8.3.5, pluggy-1.5.0 -- /home/runner/_work/_tool/Python/3.9.21/x64/bin/python
cachedir: .pytest_cache
rootdir: /home/runner/_work/llm-compressor/llm-compressor
configfile: pyproject.toml
plugins: mock-3.14.0, rerunfailures-15.0
ERROR: file or directory not found: tests/llmcompressor/transformers/test_clear_ml.py
collecting ... collected 0 items
```