### PR TITLE
Replace tj-actions with custom action

### DIFF
--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -23,22 +23,13 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: neuralmagic/nm-actions/actions/changed-files@main
         with:
-          files: |
-            **
-            !examples/**
-            !tests/e2e/**
-            !tests/lmeval/**
-            !tests/examples/**
-            !**/*.md
-            !.github/**
-            .github/workflows/test-check-transformers.yaml
-
+          include-patterns: '**,.github/workflows/test-check-transformers.yaml'
+          exclude-patterns: 'examples/**,tests/e2e/**,tests/lmeval/**,tests/examples/**,**/*.md,.github/**'
       - name: Log relevant output
         run: |
-          echo "changes-present: ${{ steps.changed-files.outputs.any_modified }}"
-          echo "all modified files: ${{ steps.changed-files.outputs.all_modified_files }}"
+          echo "all modified files: ${{ steps.changed-files.outputs.all_changed_files }}"
         shell: bash
 
   transformers-tests:

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -12,10 +12,6 @@ env:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
-
-    outputs:
-      changes-present: ${{ steps.changed-files.outputs.any_modified }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Log relevant output
         run: |
-          echo "changes-present: ${{ steps.changed-files.outputs.any_modified }}
+          echo "changes-present: ${{ steps.changed-files.outputs.all_changed_files }}
         shell: bash
 
   transformers-tests:

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -36,8 +36,9 @@ jobs:
         shell: bash
 
   transformers-tests:
+    needs: [detect-changes]
     runs-on: gcp-k8s-vllm-l4-solo
-    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push')
+    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push') && needs.detect-changes.outputs.changes-present == 'true'
     steps:
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -12,6 +12,8 @@ env:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    outputs:
+      changes-present: ${{ steps.changed-files.outputs.all_changed_files}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,15 +32,16 @@ jobs:
             tests/lmeval/**
             tests/examples/**
             **/*.md
+
       - name: Log relevant output
         run: |
-          echo "all modified files: ${{ steps.changed-files.outputs.all_changed_files }}"
+          echo "changes-present: ${{ steps.changed-files.outputs.any_modified }}
         shell: bash
 
   transformers-tests:
     needs: [detect-changes]
     runs-on: gcp-k8s-vllm-l4-solo
-    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push') && needs.detect-changes.outputs.changes-present == 'true'
+    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push') && needs.detect-changes.outputs.changes-present != ''
     steps:
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -21,8 +21,16 @@ jobs:
         id: changed-files
         uses: neuralmagic/nm-actions/actions/changed-files@main
         with:
-          include-patterns: '**,.github/workflows/test-check-transformers.yaml'
-          exclude-patterns: 'examples/**,tests/e2e/**,tests/lmeval/**,tests/examples/**,**/*.md,.github/**'
+          include-patterns: |
+            **
+            .github/workflows/test-check-transformers.yaml
+          exclude-patterns: |
+            examples/**
+            tests/e2e/**
+            tests/lmeval/**
+            tests/examples/**
+            **/*.md
+            .github/**
       - name: Log relevant output
         run: |
           echo "all modified files: ${{ steps.changed-files.outputs.all_changed_files }}"

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -30,16 +30,14 @@ jobs:
             tests/lmeval/**
             tests/examples/**
             **/*.md
-            .github/**
       - name: Log relevant output
         run: |
           echo "all modified files: ${{ steps.changed-files.outputs.all_changed_files }}"
         shell: bash
 
   transformers-tests:
-    needs: [detect-changes]
     runs-on: gcp-k8s-vllm-l4-solo
-    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push') && needs.detect-changes.outputs.changes-present == 'true'
+    if: (contains(github.event.pull_request.labels.*.name, 'ready') || github.event_name == 'push')
     steps:
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
SUMMARY:
Due to recent security issue. Modify the workflow to use custom action

wait for this pr to be merged : https://github.com/neuralmagic/nm-actions/pull/46/
