### PR TITLE
Addback: ConstantPruningModifier for finetuning cases

### DIFF
--- a/examples/quantization_2of4_sparse_w4a16/2of4_w4a16_group-128_recipe.yaml
+++ b/examples/quantization_2of4_sparse_w4a16/2of4_w4a16_group-128_recipe.yaml
@@ -6,6 +6,20 @@ sparsity_stage:
       mask_structure: "2:4"
       targets: ["Linear"]
       ignore: ["re:.*lm_head"]
+finetuning_stage:
+  run_type: train
+  finetuning_modifiers:
+    ConstantPruningModifier:
+      targets: [
+        're:.*q_proj.weight',
+        're:.*k_proj.weight', 
+        're:.*v_proj.weight',
+        're:.*o_proj.weight',
+        're:.*gate_proj.weight',
+        're:.*up_proj.weight',
+        're:.*down_proj.weight',
+      ]
+      start: 0
 quantization_stage:
   run_type: oneshot
   quantization_modifiers:

--- a/examples/quantization_2of4_sparse_w4a16/2of4_w4a16_recipe.yaml
+++ b/examples/quantization_2of4_sparse_w4a16/2of4_w4a16_recipe.yaml
@@ -6,6 +6,20 @@ sparsity_stage:
       mask_structure: "2:4"
       targets: ["Linear"]
       ignore: ["re:.*lm_head"]
+finetuning_stage:
+  run_type: train
+  finetuning_modifiers:
+    ConstantPruningModifier:
+      targets: [
+        're:.*q_proj.weight',
+        're:.*k_proj.weight', 
+        're:.*v_proj.weight',
+        're:.*o_proj.weight',
+        're:.*gate_proj.weight',
+        're:.*up_proj.weight',
+        're:.*down_proj.weight',
+      ]
+      start: 0
 quantization_stage:
   run_type: oneshot
   quantization_modifiers:


### PR DESCRIPTION
We mistakenly also removed `ConstantPruningModifier` from finetuning examples as a part of #1267

This PR adds it back for fine-tuning examples.