### PR TITLE
Transformers - tensor parallel bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "requests>=2.0.0",
         "tqdm>=4.0.0",
         "torch>=1.7.0",
-        "transformers>4.0,<5.0",
+        "transformers>4.0,<=4.49.0",
         "datasets",
         "accelerate>=0.20.3,!=1.1.0",
         "pynvml",


### PR DESCRIPTION
SUMMARY:

Fix for the bug in using multiple GPUs
```
self = <tests.llmcompressor.transformers.finetune.test_finetune_no_recipe_custom_dataset.TestOneshotCustomDatasetSmall_0_commit testMethod=test_oneshot_then_finetune_small>

    def test_oneshot_then_finetune_small(self):
>       self._test_finetune_wout_recipe_custom_dataset()

tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py:133: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py:38: in _test_finetune_wout_recipe_custom_dataset
    train(
src/llmcompressor/entrypoints/train.py:88: in train
    train_result = trainer.train(
src/llmcompressor/transformers/finetune/session_mixin.py:345: in train
    output = super().train(*args, **kwargs)
venv/lib/python3.10/site-packages/transformers/trainer.py:2245: in train
    return inner_training_loop(
venv/lib/python3.10/site-packages/transformers/trainer.py:2556: in _inner_training_loop
    tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
src/llmcompressor/transformers/finetune/session_mixin.py:262: in training_step
    model_outputs = super().training_step(
venv/lib/python3.10/site-packages/transformers/trainer.py:3718: in training_step
    loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
src/llmcompressor/transformers/finetune/session_mixin.py:289: in compute_loss
    loss = super().compute_loss(
venv/lib/python3.10/site-packages/transformers/trainer.py:3783: in compute_loss
    outputs = model(**inputs)
venv/lib/python3.10/site-packages/torch/nn/modules/module.py:1736: in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
venv/lib/python3.10/site-packages/torch/nn/modules/module.py:1747: in _call_impl
    return forward_call(*args, **kwargs)
venv/lib/python3.10/site-packages/torch/nn/parallel/data_parallel.py:183: in forward
    inputs, module_kwargs = self.scatter(inputs, kwargs, self.device_ids)
venv/lib/python3.10/site-packages/torch/nn/parallel/data_parallel.py:207: in scatter
    return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
venv/lib/python3.10/site-packages/torch/nn/parallel/scatter_gather.py:89: in scatter_kwargs
    scattered_kwargs = scatter(kwargs, target_gpus, dim) if kwargs else []
venv/lib/python3.10/site-packages/torch/nn/parallel/scatter_gather.py:75: in scatter
    res = scatter_map(inputs)
venv/lib/python3.10/site-packages/torch/nn/parallel/scatter_gather.py:66: in scatter_map
    return [type(obj)(i) for i in zip(*map(scatter_map, obj.items()))]
venv/lib/python3.10/site-packages/torch/nn/parallel/scatter_gather.py:62: in scatter_map
    return list(zip(*map(scatter_map, obj)))
venv/lib/python3.10/site-packages/torch/nn/parallel/scatter_gather.py:58: in scatter_map
    return Scatter.apply(target_gpus, None, dim, obj)
venv/lib/python3.10/site-packages/torch/autograd/function.py:575: in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
venv/lib/python3.10/site-packages/torch/nn/parallel/_functions.py:104: in forward
    outputs = comm.scatter(input, target_gpus, chunk_sizes, ctx.dim, streams)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

tensor = tensor(18, device='cuda:0'), devices = [0, 1]
chunk_sizes = None, dim = 0, streams = None

    def scatter(tensor, devices=None, chunk_sizes=None, dim=0, streams=None, *, out=None):
        """Scatters tensor across multiple GPUs.
    
        Args:
            tensor (Tensor): tensor to scatter. Can be on CPU or GPU.
            devices (Iterable[torch.device, str or int], optional): an iterable of
              GPU devices, among which to scatter.
            chunk_sizes (Iterable[int], optional): sizes of chunks to be placed on
              each device. It should match :attr:`devices` in length and sums to
              ``tensor.size(dim)``. If not specified, :attr:`tensor` will be divided
              into equal chunks.
            dim (int, optional): A dimension along which to chunk :attr:`tensor`.
              Default: ``0``.
            streams (Iterable[torch.cuda.Stream], optional): an iterable of Streams, among
              which to execute the scatter. If not specified, the default stream will
              be utilized.
            out (Sequence[Tensor], optional, keyword-only): the GPU tensors to
              store output results. Sizes of these tensors must match that of
              :attr:`tensor`, except for :attr:`dim`, where the total size must
              sum to ``tensor.size(dim)``.
    
        .. note::
            Exactly one of :attr:`devices` and :attr:`out` must be specified. When
            :attr:`out` is specified, :attr:`chunk_sizes` must not be specified and
            will be inferred from sizes of :attr:`out`.
    
        Returns:
            - If :attr:`devices` is specified,
                a tuple containing chunks of :attr:`tensor`, placed on
                :attr:`devices`.
            - If :attr:`out` is specified,
                a tuple containing :attr:`out` tensors, each containing a chunk of
                :attr:`tensor`.
        """
        tensor = _handle_complex(tensor)
        if out is None:
            devices = [_get_device_index(d) for d in devices]
>           return tuple(torch._C._scatter(tensor, devices, chunk_sizes, dim, streams))
E           RuntimeError: chunk expects at least a 1-dimensional tensor

venv/lib/python3.10/site-packages/torch/nn/parallel/comm.py:205: RuntimeError
```


TEST PLAN:
"please outline how the changes were tested"
