### PR TITLE
[BugFix] Multi-gpu temp bug fix

### DIFF
--- a/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
@@ -108,6 +108,7 @@ class TestFinetuneNoRecipeCustomDataset(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output)
+        self.monkeypatch.undo()
 
 
 @pytest.mark.integration
@@ -120,8 +121,11 @@ class TestOneshotCustomDatasetSmall(TestFinetuneNoRecipeCustomDataset):
     def setUp(self):
         import torch
 
+        self.monkeypatch = pytest.MonkeyPatch()
+
         if torch.cuda.is_available():
             self.device = "cuda:0"
+            self.monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
         else:
             self.device = "cpu"
 
@@ -143,8 +147,10 @@ class TestOneshotCustomDatasetGPU(TestFinetuneNoRecipeCustomDataset):
         import torch
         from transformers import AutoModelForCausalLM
 
+        self.monkeypatch = pytest.MonkeyPatch()
         self.device = "cuda:0"
         self.output = "./oneshot_output"
+        self.monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
 
         self.model = AutoModelForCausalLM.from_pretrained(
             self.model, device_map=self.device, torch_dtype=torch.bfloat16

--- a/tests/llmcompressor/transformers/finetune/test_finetune_without_recipe.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_without_recipe.py
@@ -18,12 +18,14 @@ class TestFinetuneWithoutRecipe(unittest.TestCase):
 
     def setUp(self):
         self.output = "./finetune_output"
+        self.monkeypatch = pytest.MonkeyPatch()
 
     def test_finetune_without_recipe(self):
         from llmcompressor import train
 
         recipe_str = None
         device = "cuda:0"
+        self.monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
 
         concatenate_data = False
         max_steps = 50
@@ -42,3 +44,4 @@ class TestFinetuneWithoutRecipe(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.output)
+        self.monkeypatch.undo()

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
@@ -55,6 +55,7 @@ class TestOneshotAndFinetune(unittest.TestCase):
         # TODO: we get really nice stats from finetune that we should log
         # stored in results.json
         shutil.rmtree(self.output)
+        self.monkeypatch.undo()
 
 
 @pytest.mark.integration
@@ -66,11 +67,14 @@ class TestOneshotAndFinetuneSmall(TestOneshotAndFinetune):
     dataset_config_name = None
     num_train_epochs = None
     concat_txt = None
+    monkeypatch = pytest.MonkeyPatch()
 
     def setUp(self):
         import torch
 
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        if self.device == "cuda:0":
+            self.monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
         self.output = "./finetune_output"
 
     def test_oneshot_then_finetune_small(self):


### PR DESCRIPTION
Signed-off-by: George Ohashi <george@neuralmagic.com>

SUMMARY:
Bug caused by transformers >4.50.0, where in multi-gpu cases, a bug in data-parallel forward pass.
```
...
src/llmcompressor/transformers/finetune/session_mixin.py:289: in compute_loss
    loss = super().compute_loss(
venv/lib/python3.10/site-packages/transformers/trainer.py:3783: in compute_loss
    outputs = model(**inputs)
venv/lib/python3.10/site-packages/torch/nn/modules/module.py:1736: in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
venv/lib/python3.10/site-packages/torch/nn/modules/module.py:1747: in _call_impl
    return forward_call(*args, **kwargs)
venv/lib/python3.10/site-packages/torch/nn/parallel/data_parallel.py:183: in forward
    inputs, module_kwargs = self.scatter(inputs, kwargs, self.device_ids)
venv/lib/python3.10/site-packages/torch/nn/parallel/data_parallel.py:207: in scatter
    return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
...
```

Fix by monkey patching the test to use one GPU. 
The other way is to use a lower transformers version.

Failures are seen here:
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/14014229250/job/39237843197


TEST PLAN:
Pass nightly tests
