### PR TITLE
Bump: Min python version to 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
             "llmcompressor.trace=llmcompressor.transformers.tracing.debug:main",
         ]
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR updates the minimum Python version requirement from 3.8 to 3.9 in `setup.py`. Python 3.8 reached its end-of-life (EOL) on October 14, 2024, and is no longer receiving security updates or bug fixes. Aligning with the broader ecosystem, the [vLLM project](https://github.com/vllm-project/vllm/blob/27df5199d99627e1eb101071c2155f888181bd64/pyproject.toml#L22) also requires Python 3.9+,