### PR TITLE
Revert "Fix Multi-Context Manager Syntax for Python 3.9 Compatibility…

### DIFF
--- a/src/llmcompressor/modifiers/obcq/base.py
+++ b/src/llmcompressor/modifiers/obcq/base.py
@@ -119,9 +119,11 @@ class SparseGPTModifier(SparsityModifierMixin, Modifier):
             num_samples = self._num_samples[module]
 
             logger.info(f"Sparsifying {name} using {num_samples} samples")
-            with torch.no_grad(), align_module_device(module), CompressionLogger(
-                module
-            ) as comp_logger:
+            with (
+                torch.no_grad(),
+                align_module_device(module),
+                CompressionLogger(module) as comp_logger,
+            ):
                 loss, sparsified_weight = sparsify_weight(
                     module=module,
                     hessians_dict=self._hessians,

--- a/src/llmcompressor/modifiers/pruning/wanda/base.py
+++ b/src/llmcompressor/modifiers/pruning/wanda/base.py
@@ -103,8 +103,10 @@ class WandaPruningModifier(SparsityModifierMixin, Modifier):
             num_samples = self._num_samples[module]
 
             logger.info(f"Sparsifying {name} using {num_samples} samples")
-            with torch.no_grad(), align_module_device(module), CompressionLogger(
-                module
+            with (
+                torch.no_grad(),
+                align_module_device(module),
+                CompressionLogger(module),
             ):
                 sparsified_weight = sparsify_weight(
                     module=module,

--- a/src/llmcompressor/modifiers/quantization/gptq/base.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/base.py
@@ -337,11 +337,12 @@ class GPTQModifier(Modifier, HooksMixin):
             quant_args = getattr_chain(module, "quantization_scheme.weights")
 
             logger.info(f"Quantizing {name} using {num_samples} samples")
-            with torch.no_grad(), align_module_device(
-                module
-            ), self._maybe_onload_hessian(module), CompressionLogger(
-                module
-            ) as comp_logger:
+            with (
+                torch.no_grad(),
+                align_module_device(module),
+                self._maybe_onload_hessian(module),
+                CompressionLogger(module) as comp_logger,
+            ):
                 loss, quantized_weight, scale, zero_point, g_idx = quantize_weight(
                     module=module,
                     quant_args=quant_args,

--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -71,7 +71,10 @@ def trace_subgraphs(
     concrete_args = populate_concrete_args(model, sample_input)
 
     # trace
-    with calibration_forward_context(model), HooksMixin.disable_hooks():
+    with (
+        calibration_forward_context(model),
+        HooksMixin.disable_hooks(),
+    ):
         graph = GraphModule(
             model,
             tracer.trace(

--- a/tests/llmcompressor/modifiers/utils/test_hooks.py
+++ b/tests/llmcompressor/modifiers/utils/test_hooks.py
@@ -139,8 +139,9 @@ def test_disable_hooks_composable():
     handle_b = mod_b.register_hook(model.linear2, mod_b.hook, "forward_pre")
 
     # composing two keeps
-    with HooksMixin.disable_hooks(keep=set([handle_b])), HooksMixin.disable_hooks(
-        keep=set([handle_a])
+    with (
+        HooksMixin.disable_hooks(keep=set([handle_b])),
+        HooksMixin.disable_hooks(keep=set([handle_a])),
     ):
         model(model.dummy_inputs)
     assert mod_a.hook_called and mod_b.hook_called


### PR DESCRIPTION
- This was merged without applying any transformer testing
