### PR TITLE
bugfix kv cache quantization with ignored layers

### DIFF
--- a/src/llmcompressor/modifiers/quantization/cache.py
+++ b/src/llmcompressor/modifiers/quantization/cache.py
@@ -155,12 +155,8 @@ class QuantizedKVParameterCache(DynamicCache):
             zps = self.v_zps
 
         scale, zp = observer(tensor)
-        if len(scales) <= layer_idx:
-            _pad_and_append_at_idx_(scales, layer_idx, scale)
-            _pad_and_append_at_idx_(zps, layer_idx, zp)
-        else:
-            scales[layer_idx] = scale
-            zps[layer_idx] = scale
+        _pad_and_append_at_idx_(scales, layer_idx, scale)
+        _pad_and_append_at_idx_(zps, layer_idx, zp)
 
         q_tensor = quantize(
             x=tensor,


### PR DESCRIPTION
SUMMARY:
Users may ignore some layers in configuration, meaning list indices may not correspond to a given layer index when values are being appended to a list for each layer. We must account for that case by padding list so that index of lists always corresponds to layer_idx

Resolves #1295 . I can confirm i see the error original poster is reporting, using their recipe with `meta-llama/Meta-Llama-3-8B-Instruct`, and that this PR resolves it. I am able to run `lm_eval` on the quantized model. I will move this to ready for review to get feedback.


TEST PLAN:
Add doctests to unit test new helper function, not sure if these get tested though.
