### PR TITLE
[Tests] Fix oneshot + finetune test by passing splits to oneshot

### DIFF
--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
@@ -25,6 +25,7 @@ class TestOneshotAndFinetune(unittest.TestCase):
 
         oneshot_args = dict(
             dataset=self.dataset,
+            splits=splits,
             output_dir=self.output,
             recipe=self.recipe,
             num_calibration_samples=64,
@@ -36,7 +37,6 @@ class TestOneshotAndFinetune(unittest.TestCase):
 
         train_args = dict(
             num_train_epochs=self.num_train_epochs,
-            splits=splits,
             precision="bfloat16",
             bf16=True,
         )
@@ -75,24 +75,24 @@ class TestOneshotAndFinetune(unittest.TestCase):
         shutil.rmtree(self.output)
 
 
-@pytest.mark.integration
-@parameterized_class(parse_params(CONFIGS_DIRECTORY))
-class TestOneshotAndFinetuneSmall(TestOneshotAndFinetune):
-    model = None
-    dataset = None
-    recipe = None
-    dataset_config_name = None
-    num_train_epochs = None
-    concat_txt = None
+# @pytest.mark.integration
+# @parameterized_class(parse_params(CONFIGS_DIRECTORY))
+# class TestOneshotAndFinetuneSmall(TestOneshotAndFinetune):
+#     model = None
+#     dataset = None
+#     recipe = None
+#     dataset_config_name = None
+#     num_train_epochs = None
+#     concat_txt = None
 
-    def setUp(self):
-        import torch
+#     def setUp(self):
+#         import torch
 
-        self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        self.output = "./finetune_output"
+#         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+#         self.output = "./finetune_output"
 
-    def test_oneshot_then_finetune_small(self):
-        self._test_oneshot_and_finetune()
+#     def test_oneshot_then_finetune_small(self):
+#         self._test_oneshot_and_finetune()
 
 
 @requires_gpu

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py
@@ -75,24 +75,24 @@ class TestOneshotAndFinetune(unittest.TestCase):
         shutil.rmtree(self.output)
 
 
-# @pytest.mark.integration
-# @parameterized_class(parse_params(CONFIGS_DIRECTORY))
-# class TestOneshotAndFinetuneSmall(TestOneshotAndFinetune):
-#     model = None
-#     dataset = None
-#     recipe = None
-#     dataset_config_name = None
-#     num_train_epochs = None
-#     concat_txt = None
+@pytest.mark.integration
+@parameterized_class(parse_params(CONFIGS_DIRECTORY))
+class TestOneshotAndFinetuneSmall(TestOneshotAndFinetune):
+    model = None
+    dataset = None
+    recipe = None
+    dataset_config_name = None
+    num_train_epochs = None
+    concat_txt = None
 
-#     def setUp(self):
-#         import torch
+    def setUp(self):
+        import torch
 
-#         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-#         self.output = "./finetune_output"
+        self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        self.output = "./finetune_output"
 
-#     def test_oneshot_then_finetune_small(self):
-#         self._test_oneshot_and_finetune()
+    def test_oneshot_then_finetune_small(self):
+        self._test_oneshot_and_finetune()
 
 
 @requires_gpu


### PR DESCRIPTION
## Purpose ##
* Fix test which was failing because the calibration split was not explicitly passed to the oneshot call. While normally this would not be a problem, as `make_dataset_splits` will auto-infer which split is the calibration split, the `make_dataset_splits` function does its inference using the split name `train`, whereas ultrachat uses the spilt name `train_sft`.

## Changes ##
* Pass `splits` argument to oneshot and train calls. This also reduces the runtime of the test significantly.