### PR TITLE
Update e2e/lm-eval test infrastructure

### DIFF
--- a/tests/e2e/vLLM/run_tests.sh
+++ b/tests/e2e/vLLM/run_tests.sh
@@ -4,7 +4,7 @@ SUCCESS=0
 
 while getopts "c:t:" OPT; do
   case ${OPT} in
-    c ) 
+    c )
         CONFIG="$OPTARG"
         ;;
     t )
@@ -25,9 +25,7 @@ do
 
     export TEST_DATA_FILE="$MODEL_CONFIG"
     pytest \
-        -r a \
         --capture=tee-sys \
-        --junitxml="test-results/e2e-$(date +%s).xml" \
         "$TEST" || LOCAL_SUCCESS=$?
 
     if [[ $LOCAL_SUCCESS == 0 ]]; then

--- a/tests/lmeval/test_lmeval.py
+++ b/tests/lmeval/test_lmeval.py
@@ -39,6 +39,9 @@ TEST_DATA_FILE = os.environ.get("TEST_DATA_FILE", None)
 # Will run each test case in its own process through run_tests.sh
 # emulating vLLM CI testing
 @requires_gpu_count(1)
+@pytest.mark.parametrize(
+    "test_data_file", [pytest.param(TEST_DATA_FILE, id=TEST_DATA_FILE)]
+)
 @pytest.mark.skipif(
     not lm_eval_installed, reason="lm eval is not installed, skipping test"
 )
@@ -58,8 +61,8 @@ class TestLMEval:
     be used for quantization. Otherwise, the recipe will always be used if given.
     """  # noqa: E501
 
-    def set_up(self):
-        eval_config = yaml.safe_load(Path(TEST_DATA_FILE).read_text(encoding="utf-8"))
+    def set_up(self, test_data_file: str):
+        eval_config = yaml.safe_load(Path(test_data_file).read_text(encoding="utf-8"))
 
         if os.environ.get("CADENCE", "commit") != eval_config.get("cadence"):
             pytest.skip("Skipping test; cadence mismatch")
@@ -88,9 +91,9 @@ class TestLMEval:
         self.num_calibration_samples = 512
         self.max_seq_length = 2048
 
-    def test_lm_eval(self):
+    def test_lm_eval(self, test_data_file: str):
         # Run vLLM with saved model
-        self.set_up()
+        self.set_up(test_data_file)
         if not self.save_dir:
             self.save_dir = self.model.split("/")[1] + f"-{self.scheme}"
         oneshot_model, processor = run_oneshot_for_e2e_testing(


### PR DESCRIPTION
SUMMARY:
Remove some no longer necessary flags from the `run_tests.sh` script and update e2e/lm-eval test infra to use pytest’s parametrization.

**Unused flags**

A couple of the flags in the test script were added to support reporting efforts in our CI/CD, but they are no longer necessary as they are handled outside the test script.

**e2e/lm-eval test parametrization**

This change is primarily to improve the reporting for these sets of tests, particularly about the test name that is generated. There are some challenges that the current, non-pytest parametrization approach introduce:

1. The parametrization index is included in the generated name. This is problematic because any change to the order of the parametrization then results in breaking references (e.g., historic views of the test results) between past and future runs.
2. Parametrizing a class results in a 'proper' class name, which normalizes certain values. Specifically, the parameters here are file paths which include slashes which are in turn normalized, replacing the slashes with different characters.
    * Alternatively, `pytest` puts all parametrization in the test name itself and doesn't do any of this normalization, preserving the original data.

For point 2, an example of the before/after naming:

```
Before
classname: tests/e2e/vLLM/test_vllm.py::TestvLLM_0_tests_e2e_vLLM_configs_kv_cache_tinyllama_yaml
test name: test_vllm
full name: tests/e2e/vLLM/test_vllm.py::TestvLLM_0_tests_e2e_vLLM_configs_kv_cache_tinyllama_yaml::test_vllm

After
classname: tests/e2e/vLLM/test_vllm.py::TestvLLM
test name: test_vllm[tests/e2e/vLLM/configs/kv_cache_tinyllama.yaml]
full name: tests/e2e/vLLM/test_vllm.py::TestvLLM::test_vllm[tests/e2e/vLLM/configs/kv_cache_tinyllama.yaml]
```

TEST PLAN:
There are two (internal) test runs, one e2e and one lm-eval, showing the new changes working without issue to be communicated internally.
