### PR TITLE
Fix cut off log in entrypoints/utils.py `post_process()`

### DIFF
--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -99,9 +99,9 @@ def post_process(
 
     else:
         logger.warning(
-            "Optimized model is not saved. To save, please provide",
-            "`output_dir` as input arg.",
-            "Ex. `oneshot(..., output_dir=...)`",
+            "Optimized model is not saved. To save, please provide"
+            "`output_dir` as input arg."
+            "Ex. `oneshot(..., output_dir=...)`"
         )
 
     # Reset the one-time-use session upon completion
@@ -242,7 +242,7 @@ def initialize_processor_from_path(
             use_fast=True,
             revision=model_args.model_revision,
             use_auth_token=True if model_args.use_auth_token else None,
-            trust_remote_code=model_args.trust_remote_code_model,
+            trust_remote_code=True,
         )
 
     except ValueError as exception:

--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -242,7 +242,7 @@ def initialize_processor_from_path(
             use_fast=True,
             revision=model_args.model_revision,
             use_auth_token=True if model_args.use_auth_token else None,
-            trust_remote_code=True,
+            trust_remote_code=model_args.trust_remote_code_model,
         )
 
     except ValueError as exception:


### PR DESCRIPTION
Without this change, you would only the first line of the log in your output
```
2025-04-08T21:29:25.849507+0000 | post_process | WARNING - Optimized model is not saved. To save, please provide
```
