### PR TITLE
Revert transformers version pin 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "requests>=2.0.0",
         "tqdm>=4.0.0",
         "torch>=1.7.0",
-        "transformers>4.0,<4.50",
+        "transformers>4.0,<5.0",
         "datasets",
         "accelerate>=0.20.3,!=1.1.0",
         "pynvml",


### PR DESCRIPTION
SUMMARY:
"This reverts the "temporary pin" of the transformers version introduced by https://github.com/vllm-project/llm-compressor/pull/1202/commits/73de4e253411fec8eeda65f575fc74651f14a77c enabling use of for example mistral-small3.1"


TEST PLAN:
"Excuted the test suite on my local machine"
