### PR TITLE
Add torch device to list of offloadable types

### DIFF
--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -164,7 +164,9 @@ class IntermediatesCache:
                 value=tuple(self._offload_value(v) for v in value), device=None
             )
 
-        if not isinstance(value, (int, str, float, bool, torch.dtype, type(None))):
+        if not isinstance(
+            value, (int, str, float, bool, torch.dtype, torch.device, type(None))
+        ):
             warnings.warn(f"Offloading not implemented for type {type(value)}.")
 
         return IntermediateValue(value=value, device=None)


### PR DESCRIPTION
## Purpose ##
* Squelch warning about torch device not being offloadable
```
llm-compressor/src/llmcompressor/pipelines/cache.py:168: UserWarning: Offloading not implemented for type <class 'torch.device'>.
  warnings.warn(f"Offloading not implemented for type {type(value)}.")
```
