### PR TITLE
Fix project URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "sparsity, optimization, model optimization, model compression, "
     ),
     license="Apache",
-    url="https://github.com/neuralmagic/llm-compressor",
+    url="https://github.com/vllm-project/llm-compressor",
     include_package_data=True,
     package_dir={"": "src"},
     packages=find_packages(


### PR DESCRIPTION
SUMMARY:
Fix project URL in setup.py. The project has been moved to vllm-project. The old link https://github.com/neuralmagic/llm-compressor is a 404 now.


TEST PLAN:
The homepage link on https://pypi.org/project/vllm/ points to a non-existing project.
