### PR TITLE
[Tests] Update transformers tests to run kv_cache tests

### DIFF
--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -88,3 +88,7 @@ jobs:
         if: (success() || failure()) && steps.install.outcome == 'success'
         run: |
           pytest -v tests/llmcompressor/transformers/obcq
+      - name: Running KV Cache Tests
+        if: (success() || failure()) && steps.install.outcome == 'success'
+        run: |
+          pytest -v tests/llmcompressor/transformers/kv_cache


### PR DESCRIPTION
SUMMARY:
- Update such that kv_cache tests run as part of the per-commit CI/CD testing
