### PR TITLE
Fix versioning for source installs

### DIFF
--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -65,8 +65,10 @@ jobs:
       - name: "⚙️ Install compressed-tensors dependencies"
         id: install
         run: |
-          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
-          pip3 install ./compressed-tensors/
+          pip3 uninstall -y compressed-tensors
+          export GIT_CEILING_DIRECTORIES="$(pwd)"
+          cd compressed-tensors
+          BUILD_TYPE=nightly pip3 install .
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
       - name: "🔬 Running transformers tests"

--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -51,12 +51,17 @@ jobs:
         with:
           python-version: '3.9'
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: "⚙️ Install dependencies"
         run: pip3 install -U pip setuptools && pip3 install .[dev]
       - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
+          fetch-depth: 0
+          fetch-tags: true
       - name: "⚙️ Install compressed-tensors dependencies"
         id: install
         run: |

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -4,7 +4,7 @@ on:
 
 env:
   CADENCE: "commit"
-  
+
 jobs:
 
   base-tests:
@@ -14,12 +14,17 @@ jobs:
         with:
           python-version: '3.12'
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: "⚙️ Install dependencies"
         run: pip3 install -U pip setuptools && pip3 install .[dev]
       - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
+          fetch-depth: 0
+          fetch-tags: true
       - name: "⚙️ Install compressed-tensors dependencies"
         run: |
           pip3 uninstall -y compressed-tensors compressed-tensors-nightly
@@ -36,12 +41,17 @@ jobs:
         with:
           python-version: '3.11'
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: "⚙️ Install dependencies"
         run: pip3 install -U pip setuptools && pip3 install .[dev]
       - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
+          fetch-depth: 0
+          fetch-tags: true
       - name: "⚙️ Install compressed-tensors dependencies"
         run: |
           pip3 uninstall -y compressed-tensors compressed-tensors-nightly
@@ -59,12 +69,17 @@ jobs:
         with:
           python-version: '3.10'
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: "⚙️ Install dependencies"
         run: pip3 install -U pip setuptools && pip3 install .[dev]
       - uses: actions/checkout@v4
         with:
           repository: "neuralmagic/compressed-tensors"
           path: "compressed-tensors"
+          fetch-depth: 0
+          fetch-tags: true
       - name: "⚙️ Install compressed-tensors dependencies"
         run: |
           pip3 uninstall -y compressed-tensors compressed-tensors-nightly

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -27,8 +27,10 @@ jobs:
           fetch-tags: true
       - name: "⚙️ Install compressed-tensors dependencies"
         run: |
-          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
-          pip3 install ./compressed-tensors/
+          pip3 uninstall -y compressed-tensors
+          export GIT_CEILING_DIRECTORIES="$(pwd)"
+          cd compressed-tensors
+          BUILD_TYPE=nightly pip3 install .
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
       - name: "🔬 Running base tests"
@@ -54,8 +56,10 @@ jobs:
           fetch-tags: true
       - name: "⚙️ Install compressed-tensors dependencies"
         run: |
-          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
-          pip3 install ./compressed-tensors/
+          pip3 uninstall -y compressed-tensors
+          export GIT_CEILING_DIRECTORIES="$(pwd)"
+          cd compressed-tensors
+          BUILD_TYPE=nightly pip3 install .
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
       - name: "🔬 Running pytorch tests"
@@ -82,8 +86,10 @@ jobs:
           fetch-tags: true
       - name: "⚙️ Install compressed-tensors dependencies"
         run: |
-          pip3 uninstall -y compressed-tensors compressed-tensors-nightly
-          pip3 install ./compressed-tensors/
+          pip3 uninstall -y compressed-tensors
+          export GIT_CEILING_DIRECTORIES="$(pwd)"
+          cd compressed-tensors
+          BUILD_TYPE=nightly pip3 install .
       - name: "Clean compressed-tensors directory"
         run: rm -r compressed-tensors/
       - name: "🔬 Running pytorch tests"


### PR DESCRIPTION
SUMMARY:
Update the various source installs in testing workflows to properly fetch git tags and set the `BUILD_TYPE` to nightly. This notably results in installing a nightly-style version of `compressed-tensors` for the source install to allow it to satisfy the version requirements from `llm-compressor`.

TEST PLAN:
Prior to these changes, you would find a broken `llm-compressor` version in the local install, as well as a warning about the source install version of `compressed-tensors` being incompatible:

```
Successfully installed […] llmcompressor-0.1.dev1+g67614d5 […]
...
Installing collected packages: compressed-tensors
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
llmcompressor 0.1.dev1+g8ca8fd3 requires compressed-tensors>=0.9.4a2, but you have compressed-tensors 0.1.dev1+g16e6435 which is incompatible.
Successfully installed compressed-tensors-0.1.dev1+g16e6435
```

With the changes, both packages have proper versioning and no compatibility complaints:

```
Successfully installed […] llmcompressor-0.5.1.dev28+g3b1aac94 […]
...
Installing collected packages: compressed-tensors
Successfully installed compressed-tensors-0.9.4a20250421
```