### PR TITLE
AWQ resolved mappings -- ensure shapes align

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -166,9 +166,23 @@ class AWQModifier(Modifier):
                         balance_name, balance_layer = get_matching_layer(
                             balance_suffix, layer_name, model
                         )
-                        if balance_layer:
-                            balance_layers.append(balance_layer)
-                            balance_names.append(balance_name)
+                        if not (balance_layer):
+                            continue
+
+                        # exclude balance layers whose shapes are incompatible
+                        if (
+                            isinstance(smooth_layer, torch.nn.Linear)
+                            and isinstance(balance_layer, torch.nn.Linear)
+                            and smooth_layer.out_features != balance_layer.in_features
+                        ):
+                            logger.info(
+                                f"Excluding {layer_name} -> {balance_name} "
+                                + "due to shape mismatch"
+                            )
+                            continue
+
+                        balance_layers.append(balance_layer)
+                        balance_names.append(balance_name)
 
                     # each mapping can contain multiple layers to balance, but only
                     # one layer to smooth

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -186,8 +186,9 @@ class AWQModifier(Modifier):
 
                     # each mapping can contain multiple layers to balance, but only
                     # one layer to smooth
-
-                    if len(balance_layers) == 1:
+                    if len(balance_layers) == 0:
+                        continue
+                    elif len(balance_layers) == 1:
                         # for single balance layer, parent is the balance layer
                         parent_name, parent = balance_name, balance_layer
                     else:

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -180,7 +180,7 @@ class AWQModifier(Modifier):
                         ):
                             logger.info(
                                 f"Excluding {layer_name} -> {balance_name} "
-                                + "due to shape mismatch"
+                                "due to shape mismatch"
                             )
                             continue
 

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -28,8 +28,6 @@ AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
             "re:.*input_layernorm",
             ["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"],
         ),
-        # TODO (Brian INFERENG-530) when resolving, only add
-        # if v_proj/o_proj shapes match up
         AWQMapping("re:.*v_proj", ["re:.*o_proj"]),
         AWQMapping(
             "re:.*post_attention_layernorm",

--- a/tests/llmcompressor/modifiers/awq/test_base.py
+++ b/tests/llmcompressor/modifiers/awq/test_base.py
@@ -1,6 +1,7 @@
 import pytest
+import torch
 
-from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.awq import AWQModifier, AWQMapping
 from llmcompressor.modifiers.factory import ModifierFactory
 from tests.llmcompressor.modifiers.conf import setup_modifier_factory
 
@@ -18,3 +19,83 @@ class test_awq_is_registered:
     )
 
     assert isinstance(modifier, AWQModifier), "AWQModifier not registered"
+
+
+@pytest.mark.unit
+def test_set_resolved_mappings():
+    awq = AWQModifier(
+        mappings=[
+            AWQMapping(
+                "re:.*input_layernorm",
+                ["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"],
+            ),
+            AWQMapping("re:.*v_proj", ["re:.*o_proj"]),
+            AWQMapping(
+                "re:.*up_proj",
+                ["re:.*down_proj"],
+            ),
+        ]
+    )
+    self_attn = torch.nn.ModuleDict(
+        {
+            "q_proj": torch.nn.Linear(4, 4),
+            "k_proj": torch.nn.Linear(4, 4),
+            "v_proj": torch.nn.Linear(4, 4),
+            "o_proj": torch.nn.Linear(4, 4),
+        }
+    )
+    mlp = torch.nn.ModuleDict(
+        {
+            "up_proj": torch.nn.Linear(4, 10),
+            "down_proj": torch.nn.Linear(10, 4),
+        }
+    )
+    model = torch.nn.ModuleDict(
+        {
+            "self_attn": self_attn,
+            "input_layernorm": torch.nn.LayerNorm(4),
+            "mlp": mlp,
+        }
+    )
+    awq._set_resolved_mappings(model)
+    for mapping in awq._resolved_mappings:
+        if "input_layernorm" in mapping.smooth_name:
+            assert set(mapping.balance_names) == {
+                "self_attn.q_proj",
+                "self_attn.k_proj",
+                "self_attn.v_proj",
+            }
+            assert set(mapping.balance_layers) == {
+                self_attn.q_proj,
+                self_attn.k_proj,
+                self_attn.v_proj,
+            }
+            assert mapping.parent_name == "self_attn"
+            assert mapping.parent == self_attn
+        if "self_attn.v_proj" in mapping.smooth_name:
+            assert set(mapping.balance_names) == {"self_attn.o_proj"}
+            assert mapping.parent_name == "self_attn.o_proj"
+        if "mlp.up_proj" in mapping.smooth_name:
+            assert set(mapping.balance_names) == {"mlp.down_proj"}
+            assert mapping.parent_name == "mlp.down_proj"
+
+    # make sure we exclude case where o_proj/v_proj shapes are mismatched
+    awq = AWQModifier(
+        mappings=[
+            AWQMapping("re:.*v_proj", ["re:.*o_proj"]),
+        ]
+    )
+    model = torch.nn.ModuleDict(
+        {
+            "self_attn": torch.nn.ModuleDict(
+                {
+                    "q_proj": torch.nn.Linear(4, 2),
+                    "k_proj": torch.nn.Linear(4, 2),
+                    "v_proj": torch.nn.Linear(4, 2),
+                    "o_proj": torch.nn.Linear(4, 4),
+                }
+            )
+        }
+    )
+    awq._set_resolved_mappings(model)
+    assert len(awq._resolved_mappings) == 0

--- a/tests/llmcompressor/modifiers/awq/test_base.py
+++ b/tests/llmcompressor/modifiers/awq/test_base.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from llmcompressor.modifiers.awq import AWQModifier, AWQMapping
+from llmcompressor.modifiers.awq import AWQMapping, AWQModifier
 from llmcompressor.modifiers.factory import ModifierFactory
 from tests.llmcompressor.modifiers.conf import setup_modifier_factory
 


### PR DESCRIPTION
SUMMARY:
Add a robustness check to AWQ to exclude mappings where the layer shapes don't align. This is a known issue, just wanted to do it in a different PR because it occurs in a different location in AutoAWQ, and I wanted to keep the initial AWQ PR to be as close to the AutoAWQ implementation so the git history reflects our changes well.


TEST PLAN:
Added unit test to check default case and edge cases

