### PR TITLE
Update w4a16_actorder_weight.yaml lmeval config

### DIFF
--- a/tests/lmeval/configs/w4a16_actorder_weight.yaml
+++ b/tests/lmeval/configs/w4a16_actorder_weight.yaml
@@ -1,6 +1,6 @@
 cadence: "weekly"
 model: meta-llama/Meta-Llama-3-8B-Instruct
-scheme: W4A16_actorder_group
+scheme: W4A16_actorder_weight
 recipe: tests/e2e/vLLM/recipes/actorder/recipe_w4a16_actorder_weight.yaml
 dataset_id: HuggingFaceH4/ultrachat_200k
 dataset_split: train_sft


### PR DESCRIPTION
SUMMARY:
Update the `w4a16_actorder_weight.yaml` lmeval config to have the appropriate `scheme` value. This resolves an issue where the timing CSV files had a filename clash resulting in the later test overwriting the first.

TEST PLAN:
Affected tests have been executed in our internal CI to verify.
