### PR TITLE
AWQ: Clean up forward passes with kwargs using inspect.bind

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -620,8 +620,7 @@ def _sanitize_kwargs(inputs_kwargs, module):
         sanitized_kwargs = {}
         
     # Handle special case for use_cache if needed
-    if 'use_cache' in sanitized_kwargs:
-        del sanitized_kwargs['use_cache']
+    sanitized_kwargs.pop("use_cache", None)
         
     return sanitized_kwargs
 


### PR DESCRIPTION
Changes Made
- Simplified the `_sanitize_kwargs` function in `src/llmcompressor/modifiers/awq/base.py`
- Replaced manual parameter filtering with `inspect.Signature.bind_partial`

 used `bind_partial()` instead of `bind()` 
- In the AWQ context only handling keyword arguments, not all positional arguments
- The tensor input is handled separately and passed as a positional argument in `tensor_forward_with_input_args`
- `bind_partial()` allows for partial binding of arguments similar to `functools.partial` which is exactly what we need here since we're only providing some of the parameters : ) 


Fix #1385