### PR TITLE
[Tracing] Raise `_is_compiling_flag` while tracing

### DIFF
--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -3,6 +3,7 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
+import torch
 from compressed_tensors import has_offloaded_params
 from compressed_tensors.quantization import find_name_or_class_matches
 from torch.fx import Graph, GraphModule, Node
@@ -89,7 +90,9 @@ def trace_subgraphs(
     concrete_args = populate_concrete_args(model, sample_input)
 
     # trace
-    with calibration_forward_context(model), HooksMixin.disable_hooks():
+    with calibration_forward_context(model), HooksMixin.disable_hooks(), patch_attr(
+        torch.compiler, "_is_compiling_flag", True
+    ):
         graph = GraphModule(
             model,
             tracer.trace(


### PR DESCRIPTION
## Purpose ##
* Avoid skip untraceable code which has been marked by implementers using `is_torchdynamo_compiling` and other checks

[transformers/models/llava/modeling_llava.py](is_torchdynamo_compiling)
```python3
if not is_torchdynamo_compiling() and inputs_embeds[special_image_mask].numel() != image_features.numel():
                n_image_tokens = (input_ids == self.config.image_token_id).sum()
                n_image_features = image_features.shape[0] * image_features.shape[1]
                raise ValueError(
                    f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
                )


[torch/compiler/__init__.py](https://github.com/pytorch/pytorch/blob/cbcf6772231a2c216be707627b6613e8c79a86ed/torch/compiler/__init__.py#L381-L383)
```python3
def is_compiling() -> bool:
    """
    Indicates whether a graph is executed/traced as part of torch.compile() or torch.export().
```