### PR TITLE
[Lifecycle] Initialize only once, trigger on_start for each pipeline

### DIFF
--- a/src/llmcompressor/core/events/event.py
+++ b/src/llmcompressor/core/events/event.py
@@ -45,7 +45,7 @@ class EventType(Enum):
     LOSS_CALCULATED = "loss_calculated"
     BATCH_END = "batch_end"
 
-    # calibration lifecycle (TODO: support batched lifecyled)
+    # calibration lifecycle (TODO: support batched lifecyle)
     CALIBRATION_EPOCH_START = "calibration_epoch_start"
     SEQUENTIAL_EPOCH_END = "sequential_epoch_end"
     CALIBRATION_EPOCH_END = "calibration_epoch_end"

--- a/src/llmcompressor/core/events/event.py
+++ b/src/llmcompressor/core/events/event.py
@@ -44,6 +44,9 @@ class EventType(Enum):
     BATCH_START = "batch_start"
     LOSS_CALCULATED = "loss_calculated"
     BATCH_END = "batch_end"
+
+    # calibration lifecycle (TODO: support batched lifecyled)
+    CALIBRATION_EPOCH_START = "calibration_epoch_start"
     SEQUENTIAL_EPOCH_END = "sequential_epoch_end"
     CALIBRATION_EPOCH_END = "calibration_epoch_end"
 

--- a/src/llmcompressor/core/lifecycle.py
+++ b/src/llmcompressor/core/lifecycle.py
@@ -77,15 +77,6 @@ class CompressionLifecycle:
         self.__init__()
         logger.info("Compression lifecycle reset")
 
-    def initialize_recipe(
-        self,
-        recipe: Optional[RecipeInput] = None,
-        recipe_stage: Optional[RecipeStageInput] = None,
-        recipe_args: Optional[RecipeArgsInput] = None,
-    ):
-        self.recipe_container.append(recipe, recipe_stage, recipe_args)
-        self.modifiers = self.recipe_container.get_modifiers()
-
     def initialize(
         self,
         recipe: Optional[RecipeInput] = None,
@@ -104,7 +95,8 @@ class CompressionLifecycle:
 
         logger.debug("Initializing compression lifecycle")
         if not (recipe is recipe_stage is recipe_args is None):
-            self.initialize_recipe(recipe, recipe_stage, recipe_args)
+            self.recipe_container.append(recipe, recipe_stage, recipe_args)
+            self.modifiers = self.recipe_container.get_modifiers()
         self._set_model_layer_prefix()
 
         mod_data = []

--- a/src/llmcompressor/core/lifecycle.py
+++ b/src/llmcompressor/core/lifecycle.py
@@ -92,6 +92,8 @@ class CompressionLifecycle:
         :rtype: List[Any]
         """
         self.state.update(**kwargs)
+        if self.initialized_:  # TODO: do not initialize twice
+            return
 
         logger.debug("Initializing compression lifecycle")
         if not (recipe is recipe_stage is recipe_args is None):

--- a/src/llmcompressor/core/session_functions.py
+++ b/src/llmcompressor/core/session_functions.py
@@ -137,6 +137,16 @@ class LifecycleCallbacks:
         return cls.event(EventType.BATCH_END, **kwargs)
 
     @classmethod
+    def calibration_epoch_start(cls, **kwargs) -> ModifiedState:
+        """
+        Invoke a epoch start event for the active session during calibration. This event
+        should be called before calibration starts for one epoch
+
+        see `src/llmcompressor/pipelines/basic/pipeline.py` for usage example
+        """
+        return cls.event(EventType.CALIBRATION_EPOCH_START, **kwargs)
+
+    @classmethod
     def sequential_epoch_end(cls, **kwargs) -> ModifiedState:
         """
         Invoke a sequential epoch end event for the active session. This event should be

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -160,8 +160,9 @@ class Oneshot:
         session = active_session()
         session.reset()
 
-        session.lifecycle.state.update(model=self.model, start=-1)
-        session.lifecycle.initialize_recipe(
+        session.initialize(
+            model=self.model,
+            start=-1,
             recipe=self.recipe,
             recipe_stage=recipe_stage,
             recipe_args=self.recipe_args.recipe_args,

--- a/src/llmcompressor/modifiers/quantization/gptq/base.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/base.py
@@ -138,6 +138,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         # prepare module names
         self._module_names = {m: name for name, m in state.model.named_modules()}
 
+    def on_start(self, state: State, event: Event, **kwargs):
         # register hooks
         added_hook = False
         for module in state.model.modules():
@@ -161,6 +162,10 @@ class GPTQModifier(Modifier, QuantizationMixin):
         return True
 
     def on_event(self, state: State, event: Event, **kwargs):
+        if event.type_ == EventType.CALIBRATION_EPOCH_START:
+            # TODO: modify lifecycle to start on calibration epoch start
+            self.on_start(state, None)
+
         if event.type_ == EventType.SEQUENTIAL_EPOCH_END:
             self.compress_modules()
 

--- a/src/llmcompressor/pipelines/basic/pipeline.py
+++ b/src/llmcompressor/pipelines/basic/pipeline.py
@@ -5,7 +5,7 @@ import tqdm
 from compressed_tensors.utils import get_execution_device
 from torch.utils.data.dataloader import DataLoader
 
-from llmcompressor.core import LifecycleCallbacks, active_session
+from llmcompressor.core import LifecycleCallbacks
 from llmcompressor.modifiers.utils.pytorch_helpers import apply_pad_mask_to_batch
 from llmcompressor.pytorch.utils.helpers import tensors_to_device
 from llmcompressor.utils.helpers import calibration_forward_context
@@ -33,10 +33,9 @@ def run_pipeline(
     :param dataloader: loads data for calibration
     :param modifiers: list of modifiers, only included to match PipelineFn signature
     """
-    session = active_session()
     model_device = get_execution_device(model)
 
-    session.initialize()
+    LifecycleCallbacks.calibration_epoch_start()
 
     with calibration_forward_context(model):
         for batch in tqdm.tqdm(dataloader, desc="Calibrating"):

--- a/src/llmcompressor/pipelines/data_free/pipeline.py
+++ b/src/llmcompressor/pipelines/data_free/pipeline.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import torch
 from torch.utils.data.dataloader import DataLoader
 
-from llmcompressor.core.session_functions import LifecycleCallbacks, active_session
+from llmcompressor.core.session_functions import LifecycleCallbacks
 
 if TYPE_CHECKING:
     from llmcompressor.args.dataset_arguments import DatasetArguments
@@ -19,6 +19,5 @@ def run_pipeline(
     """
     A pipeline for data-free calibration
     """
-    session = active_session()
-    session.initialize()
+    LifecycleCallbacks.calibration_epoch_start()
     LifecycleCallbacks.calibration_epoch_end()

--- a/src/llmcompressor/pipelines/layer_sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/layer_sequential/pipeline.py
@@ -55,7 +55,8 @@ def run_pipeline(
     sequential_targets, _ = get_targets_from_modifiers(modifiers, model)
     layers = match_modules(model, sequential_targets)
 
-    session.initialize()
+    LifecycleCallbacks.calibration_epoch_start()
+
     with calibration_forward_context(model), DisableQuantization(model):
         # prepare intermediates cache
         intermediates: IntermediatesCache = capture_first_layer_intermediates(

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -56,7 +56,8 @@ def run_pipeline(
     sample_input = next(iter(dataloader))
     subgraphs = trace_subgraphs(model, sample_input, sequential_targets, ignore)
 
-    session.initialize()
+    LifecycleCallbacks.calibration_epoch_start()
+
     with calibration_forward_context(model), DisableQuantization(model):
         # prepare intermediates cache
         model_device = get_execution_device(model)

--- a/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
+++ b/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
@@ -51,7 +51,8 @@ class TestSuccessfulLayerwiseRecipe(unittest.TestCase):
             sparsity=sparsities, block_size=128, targets=targets
         )
         testing_harness = LifecyleTestingHarness(model=LinearNet(), start=-1)
-        modifier.initialize(testing_harness.get_state())  # falls back to basic pipeline
+        modifier.initialize(testing_harness.get_state())
+        modifier.on_start(testing_harness.get_state(), None)
 
         model = testing_harness.state.model
         num_hooks = len(modifier._hooks)
@@ -69,6 +70,7 @@ class TestApplyQuantization(unittest.TestCase):
 
         testing_harness = LifecyleTestingHarness(model=LinearNet(), start=-1)
         modifier.initialize(testing_harness.get_state())
+        modifier.on_start(testing_harness.get_state(), None)
 
         model = testing_harness.state.model
         for module in model.modules():


### PR DESCRIPTION
## Purpose ##
* Clarify modifier lifecycle by only initializing once per oneshot, and triggering start at the start of each pipeline
* Prepare for batch-wise calibration

## Change ##
* Add `calibration_epoch_start` to trigger start at the start of each calibration pipeline
* Remove `initialize_recipe`, since `initialize` is only called once now
* Modify modifiers to start on `calibration_epoch_start`