### PR TITLE
[Tracing] Trace with eager attention

### DIFF
--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -89,7 +89,9 @@ def trace_subgraphs(
     concrete_args = populate_concrete_args(model, sample_input)
 
     # trace
-    with calibration_forward_context(model), HooksMixin.disable_hooks():
+    with calibration_forward_context(model), HooksMixin.disable_hooks(), patch_attr(
+        model.config, "_attn_implementation", "eager"
+    ):
         graph = GraphModule(
             model,
             tracer.trace(


### PR DESCRIPTION
## Purpose ##
* Enable higher-granularity tracing for llama-style models
* Tracing at the linear level requires tracing into the attention mechanism, which can be complex for non-eager implementations

## Changes ##
* Use eager attention implementation when tracing

## Testing ##
* After #1308 lands, you can now perform sequential calibration of llama3 models with `Linear` granularity