### PR TITLE
awq -- hotfix to missing kwargs

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -623,6 +623,7 @@ def _sanitize_kwargs(inputs_kwargs, module):
             k not in sanitized_kwargs
             and k != "use_cache"
             and v.default is inspect.Parameter.empty
+            and str(v.annotation).startswith("typing.Optional")
         ):
             sanitized_kwargs[k] = None
 


### PR DESCRIPTION
SUMMARY:
This PR resolves the issues surrounding an Optional parameter passed into a torch module's .forward method during AWQ. Previous attempts to resolve in #1384 also added kwargs for parameters passed in positionally later on. This will make the addition to kwargs more strict, only if the annotation indicates if it is an optional field.

This hotfix will fail if optional fields are passed in positionally, if typing annotation is `a: int | None` instead of `a: typing.Optional[int]`, or if there is no typehint at all and the field is not provided. It will be addressed with a more general solution soon, see #1385 


TEST PLAN:
New test was run with python 3.9 and passed -- https://github.com/neuralmagic/llm-compressor-testing/actions/runs/14713323963/job/41291028422
