### PR TITLE
Consolidate build config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm>8"]
+requires = ["setuptools", "wheel", "setuptools_scm==8.2.0"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-version_file = "src/llmcompressor/version.py"
 
 [tool.black]
 line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
     use_scm_version={
         "version_scheme": version_func,
         "local_scheme": localversion_func,
+        "version_file": "src/llmcompressor/version.py",
     },
     author="Neuralmagic, Inc.",
     author_email="support@neuralmagic.com",


### PR DESCRIPTION
SUMMARY:
Consolidate all build configuration into `setup.py`. The current split between `pyproject.toml` and `setup.py` seems to cause some kind of race condition/unpredictable behavior with the tooling regarding whether it will honor the version functions defined in `setup.py`.

TEST PLAN:
Relevant changes are identical to those in https://github.com/neuralmagic/compressed-tensors/pull/304; and a build is produced internally here: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/14732959015