### PR TITLE
[VLM] Fix mllama targets

### DIFF
--- a/examples/multimodal_vision/mllama_example.py
+++ b/examples/multimodal_vision/mllama_example.py
@@ -32,6 +32,7 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
+        sequential_targets=["MllamaSelfAttentionDecoderLayer"],
         ignore=["re:.*lm_head", "re:multi_modal_projector.*", "re:vision_model.*"],
     ),
 ]


### PR DESCRIPTION
## Purpose ##
* When #1389 landed, modules being skipped by ignore were no longer being skipped. However, this requires that the sequential targets list be correct. Mllama defaults to targeting vision layers, and hence the vision tower was being traced, leading to errors.

```python3
_no_split_modules = [
    "MllamaVisionEncoderLayer",
    "MllamaCrossAttentionDecoderLayer",
    "MllamaSelfAttentionDecoderLayer",
]
```

## Changes ##
* Only target text decoder layers, not vision decoder layers

## Testing ##
* #1335 passes