### PR TITLE
AWQ sanitize_kwargs minor cleanup

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -11,7 +11,6 @@ from tqdm import tqdm
 from llmcompressor.core import State
 from llmcompressor.modifiers import Modifier
 from llmcompressor.modifiers.utils.pytorch_helpers import run_calibration_forward
-from llmcompressor.pytorch.utils import tensor_forward_with_input_args
 from llmcompressor.utils.fsdp.helpers import get_fsdp_parent
 from llmcompressor.utils.helpers import calibration_forward_context
 from llmcompressor.utils.pytorch.module import (
@@ -590,11 +589,10 @@ class AWQModifier(Modifier):
         """
         kwargs = input_kwargs or self._module_kwargs
         kwargs = _sanitize_kwargs(kwargs, module)
-        return tensor_forward_with_input_args(
-            module=module,
-            inputs=inputs,
-            input_kwargs=kwargs,
-        )[0]
+
+        inputs = inputs.to(next(module.parameters()).device)
+
+        return module(inputs, **kwargs)[0]
 
 
 def _sanitize_kwargs(input_kwargs: Dict[str, Any], module: Module) -> Dict[str, Any]:

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -2,7 +2,11 @@ import inspect
 from typing import Any, Dict, List, Optional, Union
 
 import torch
-from compressed_tensors.utils import align_module_device, update_offload_parameter
+from compressed_tensors.utils import (
+    align_module_device,
+    get_execution_device,
+    update_offload_parameter,
+)
 from loguru import logger
 from pydantic import ConfigDict
 from torch.nn import Module
@@ -590,7 +594,7 @@ class AWQModifier(Modifier):
         kwargs = input_kwargs or self._module_kwargs
         kwargs = _sanitize_kwargs(kwargs, module)
 
-        inputs = inputs.to(next(module.parameters()).device)
+        inputs = inputs.to(get_execution_device(module))
 
         return module(inputs, **kwargs)[0]
 

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -599,9 +599,8 @@ class AWQModifier(Modifier):
 
 def _sanitize_kwargs(inputs_kwargs, module):
     """
-    Remove the arguments that are not supported in the module's
-    forward pass to avoid breaking behaviour between different versions
-    of transformers.
+    Sanitize input keyword arguments to match the module's forward method signature
+    using inspect.bind_partial.
 
     Args:
         inputs_kwargs (`dict`):

--- a/src/llmcompressor/pytorch/utils/helpers.py
+++ b/src/llmcompressor/pytorch/utils/helpers.py
@@ -26,8 +26,6 @@ __all__ = [
     "tensors_to_precision",
     "tensors_module_forward",
     "tensor_sparsity",
-    "tensor_forward_with_input_args",
-    "sanitize_kwargs_for_module",
     "get_linear_layers",
     "get_quantized_layers",
     "set_deterministic_seeds",
@@ -202,43 +200,6 @@ def tensor_sparsity(
         zeros = zeros.permute(*permute).contiguous()
 
     return zeros.float() / float(total)
-
-
-def sanitize_kwargs_for_module(
-    kwargs: Dict[str, Any], module: Module
-) -> Dict[str, Any]:
-    """
-    Sanitize the kwargs for a Module by removing any keys that are not
-    in the signature of the forward method.
-    :param kwargs: the kwargs to sanitize
-    :param module: the Module to sanitize the kwargs for
-    :return: the sanitized kwargs for the callable object
-    """
-    if not isinstance(kwargs, dict):
-        raise TypeError(f"Expected a dictionary as kwargs, but got {kwargs}")
-
-    allowed_params = inspect.signature(module.forward).parameters
-    return {key: value for key, value in kwargs.items() if key in allowed_params}
-
-
-def tensor_forward_with_input_args(
-    module: Module, inputs: Tensor, input_kwargs: Dict[str, Any]
-) -> Tensor:
-    """
-    Forward the given inputs through the given module with the given input_kwargs.
-    This function is a wrapper around tensors_module_forward that ensures that the
-    input_kwargs are sanitized and passed to the module as keyword arguments during
-    the forward pass.
-    :param module: the module to forward the inputs through
-    :param inputs: the inputs to forward through the module
-    :param input_kwargs: the keyword arguments to pass to the
-        module during the forward pass
-    :return: the output of the module after forwarding the inputs through it
-    """
-    inputs = inputs.to(next(module.parameters()).device)
-    input_kwargs = sanitize_kwargs_for_module(input_kwargs, module)
-
-    return tensors_module_forward(inputs, functools.partial(module, **input_kwargs))
 
 
 ##############################

--- a/src/llmcompressor/pytorch/utils/helpers.py
+++ b/src/llmcompressor/pytorch/utils/helpers.py
@@ -2,8 +2,6 @@
 Utility / helper functions
 """
 
-import functools
-import inspect
 import random
 from typing import Any, Dict, Iterable, List, Mapping, OrderedDict, Tuple, Union
 

--- a/tests/llmcompressor/pytorch/utils/test_helpers.py
+++ b/tests/llmcompressor/pytorch/utils/test_helpers.py
@@ -7,7 +7,6 @@ from torch import Tensor
 from torch.nn import Linear, Module, ReLU, Sequential
 
 from llmcompressor.pytorch.utils import (
-    sanitize_kwargs_for_module,
     tensor_sparsity,
     tensors_module_forward,
     tensors_to_device,

--- a/tests/llmcompressor/pytorch/utils/test_helpers.py
+++ b/tests/llmcompressor/pytorch/utils/test_helpers.py
@@ -8,7 +8,6 @@ from torch.nn import Linear, Module, ReLU, Sequential
 
 from llmcompressor.pytorch.utils import (
     sanitize_kwargs_for_module,
-    tensor_forward_with_input_args,
     tensor_sparsity,
     tensors_module_forward,
     tensors_to_device,
@@ -497,43 +496,3 @@ def test_tensor_sparsity_cuda(tensor, dim, expected_sparsity):
     sparsity = tensor_sparsity(tensor, dim)
     assert expected_sparsity.shape == sparsity.shape
     assert torch.sum((sparsity.detach().cpu() - expected_sparsity).abs()) < 0.001
-
-
-class TestSanitizeKwargsForModule:
-    @pytest.fixture
-    def module(self):
-        return Linear(10, 20)
-
-    def test_sanitize_kwargs_for_module_not_dict(self, module):
-        # Test with kwargs that are not a dictionary
-        with pytest.raises(TypeError):
-            sanitize_kwargs_for_module("not a dictionary", module)
-
-    def test_sanitize_kwargs_for_module_not_in_signature(self, module):
-        # Test with kwargs that are not in the signature of the forward method
-        kwargs = {"not_in_signature": 123}
-        sanitized_kwargs = sanitize_kwargs_for_module(kwargs, module)
-        assert sanitized_kwargs == {}
-
-    def test_sanitize_kwargs_for_module_in_signature(self, module):
-        # Test with kwargs that are in the signature of the forward method
-        kwargs = {"input": torch.randn(1, 10)}
-        sanitized_kwargs = sanitize_kwargs_for_module(kwargs, module)
-        assert sanitized_kwargs == kwargs
-
-
-class TestTensorForwardWithInputArgs:
-    @pytest.fixture
-    def module(self):
-        return Linear(10, 20)
-
-    def test_tensor_forward_with_input_args(self, module):
-        # Test with valid inputs and input_kwargs
-        inputs = torch.randn(1, 10)
-        input_kwargs = {}
-        output = tensor_forward_with_input_args(module, inputs, input_kwargs)
-        assert output.shape == (1, 20)
-
-        # Test with input_kwargs that are not in the signature of the forward method
-        input_kwargs = {"not_in_signature": 123}
-        tensor_forward_with_input_args(module, inputs, input_kwargs)


### PR DESCRIPTION
SUMMARY:
Using `inspect.bind_partial` inside the AWQ `_sanitize_kwargs` helper does provide the robust support we were hoping. We still need to explicitly add None for the edge case, and `bind_partial` will fail if the input kwargs have fields that are not in the `module.forward` signature. 

So we have to stick with what we have. This PR just has some minor touch-ups and typehints, and removes the helpers that were only used by AWQ and not needed

Resolves https://github.com/vllm-project/llm-compressor/issues/1385
Replaces https://github.com/vllm-project/llm-compressor/pull/1386 

TEST PLAN:
No net new src code, just minor cleanup and redundant code removal
