### PR TITLE
Add `pull_request` trigger to base tests workflow

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -1,5 +1,8 @@
 name: Test Checks (Base/PyTorch)
 on:
+  pull_request:
+    branches:
+      - main
   push:
 
 env:


### PR DESCRIPTION
SUMMARY:
Add the `pull_request` trigger to the `test-check.yaml` workflow to enable it to run on PRs from forked repos.

TEST PLAN:
Workflow running on this PR indicates that it is not (syntactically) broken, and by using the same triggers as others do that work on PRs from forks (e.g. `linkcheck.yml`, `quality-check.yaml`) suggests it will become enabled for those PRs as well as those runs indicate that the trigger was `on: pull_request`.
