### PR TITLE
[GPTQ] Change actorder default to "static"

### DIFF
--- a/src/llmcompressor/modifiers/quantization/gptq/base.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/base.py
@@ -75,8 +75,9 @@ class GPTQModifier(Modifier, QuantizationMixin):
     :param block_size: Used to determine number of columns to compress in one pass
     :param dampening_frac: Amount of dampening to apply to H, as a fraction of the
         diagonal norm
-    :param actorder: order in which weight columns are quantized. For more information,
-        on actorder options, see https://github.com/vllm-project/vllm/pull/8135
+    :param actorder: order in which weight columns are quantized. Defaults to "static"
+        activation ordering, which achieves best accuracy recovery with no runtime cost.
+        For more information, see https://github.com/vllm-project/vllm/pull/8135
     :param offload_hessians: Set to True for decreased memory usage but increased
         runtime.
 
@@ -109,7 +110,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
     sequential_targets: Union[str, List[str], None] = None
     block_size: int = 128
     dampening_frac: Optional[float] = 0.01
-    actorder: Optional[ActivationOrdering] = None
+    actorder: Optional[ActivationOrdering] = ActivationOrdering.STATIC
     offload_hessians: bool = False
 
     # private variables


### PR DESCRIPTION
## Purpose ##
* Use best defaults for GPTQ quantization

## Prerequisites ##
* https://github.com/vllm-project/llm-compressor/pull/1424

## Changes ##
* Set gptq actorder default to "static"

## Testing ##
* Ran llama w4a16 example to completion