### PR TITLE
patch awq tests/readme after QuantizationMixin refactor

### DIFF
--- a/examples/awq/README.md
+++ b/examples/awq/README.md
@@ -10,22 +10,7 @@ The AWQ recipe has been inferfaced as follows, where the `AWQModifier` adjusts m
 
 ```python
 recipe = [
-    AWQModifier(
-        ignore=["lm_head"],
-        config_groups={
-            "group_0": QuantizationScheme(
-                targets=["Linear"],
-                weights=QuantizationArgs(
-                    num_bits=4,
-                    type=QuantizationType.INT,
-                    dynamic=False,
-                    symmetric=False,
-                    strategy=QuantizationStrategy.GROUP,
-                    group_size=128,
-                ),
-            )
-        },
-    ),
+    AWQModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
 ]
 ```
 

--- a/examples/awq/README.md
+++ b/examples/awq/README.md
@@ -10,8 +10,7 @@ The AWQ recipe has been inferfaced as follows, where the `AWQModifier` adjusts m
 
 ```python
 recipe = [
-    AWQModifier(bits=4, symmetric=False),
-    QuantizationModifier(
+    AWQModifier(
         ignore=["lm_head"],
         config_groups={
             "group_0": QuantizationScheme(

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -167,8 +167,7 @@ class Oneshot:
             recipe=self.recipe,
             recipe_stage=recipe_stage,
             recipe_args=self.recipe_args.recipe_args,
-            calib_data=calibration_dataloader,  # only used by AWQModifier, remove once
-            # AWQModifier supports calibration pipelines
+            calib_data=calibration_dataloader,
         )
 
         user_pipeline = self.dataset_args.pipeline

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -167,6 +167,8 @@ class Oneshot:
             recipe=self.recipe,
             recipe_stage=recipe_stage,
             recipe_args=self.recipe_args.recipe_args,
+            calib_data=calibration_dataloader,  # only used by AWQModifier, remove once
+            # AWQModifier supports calibration pipelines
         )
 
         user_pipeline = self.dataset_args.pipeline

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -167,8 +167,6 @@ class Oneshot:
             recipe=self.recipe,
             recipe_stage=recipe_stage,
             recipe_args=self.recipe_args.recipe_args,
-            calib_data=calibration_dataloader,  # only used by AWQModifier, remove once
-            # AWQModifier supports calibration pipelines
         )
 
         user_pipeline = self.dataset_args.pipeline

--- a/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_group_quant_asym_awq.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_group_quant_asym_awq.yaml
@@ -1,7 +1,6 @@
 quant_stage:
   quant_modifiers:
     AWQModifier:
-      symmetric: false
       ignore: [lm_head]
       config_groups:
         group_0:

--- a/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_group_quant_asym_awq.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_group_quant_asym_awq.yaml
@@ -1,9 +1,7 @@
 quant_stage:
   quant_modifiers:
     AWQModifier:
-      bits: 4
       symmetric: false
-    QuantizationModifier:
       ignore: [lm_head]
       config_groups:
         group_0:


### PR DESCRIPTION
SUMMARY:
Resolves e2e test failures:
```
FAILED tests/e2e/vLLM/test_vllm.py::TestvLLM::test_vllm[tests/e2e/vLLM/configs/w4a16_grouped_quant_asym_awq.yaml] - pydantic_core._pydantic_core.ValidationError: 1 validation error for AWQModifier
  Assertion failed, In AWQ, all config groups must use the same configuration for num_bits [type=assertion_error, input_value={'bits': 4, 'symmetric': False}, input_type=dict]
FAILED MODEL: tests/e2e/vLLM/configs/w4a16_grouped_quant_asym_awq.yaml
```

Also updated the README

TEST PLAN:
No new src code, just fixing failing tests
