### PR TITLE
AWQ Qwen and Phi mappings

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -16,9 +16,13 @@ from tqdm import tqdm
 
 from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers import Modifier
+<<<<<<< HEAD
 from llmcompressor.modifiers.quantization.calibration import update_weight_zp_scale
 from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.modifiers.utils.hooks import HooksMixin
+=======
+from llmcompressor.modifiers.utils.pytorch_helpers import run_calibration_forward
+>>>>>>> 6b873714 (squashed/rebased)
 from llmcompressor.utils.fsdp.helpers import get_fsdp_parent
 from llmcompressor.utils.helpers import calibration_forward_context
 from llmcompressor.utils.pytorch.module import (

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -294,9 +294,7 @@ class AWQModifier(Modifier, QuantizationMixin):
         """
         resolved_mappings: list[ResolvedMapping] = []
         num_skipped_mappings = 0
-        pbar = tqdm(self.mappings, desc="Resolving Mappings")
-        for mapping in pbar:
-            pbar.set_description(f"Resolving Mappings ({num_skipped_mappings} skipped)")
+        for mapping in self.mappings:
             to_smooth_layers = get_layers(mapping.smooth_layer, model)
             for layer_name, smooth_layer in to_smooth_layers.items():
                 # always exclude `.weight_observer`, only want `.weight`

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -16,13 +16,9 @@ from tqdm import tqdm
 
 from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers import Modifier
-<<<<<<< HEAD
 from llmcompressor.modifiers.quantization.calibration import update_weight_zp_scale
 from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.modifiers.utils.hooks import HooksMixin
-=======
-from llmcompressor.modifiers.utils.pytorch_helpers import run_calibration_forward
->>>>>>> 6b873714 (squashed/rebased)
 from llmcompressor.utils.fsdp.helpers import get_fsdp_parent
 from llmcompressor.utils.helpers import calibration_forward_context
 from llmcompressor.utils.pytorch.module import (

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -27,7 +27,7 @@ from llmcompressor.utils.pytorch.module import (
     get_parent_by_name,
 )
 
-from .mappings import get_layer_mappings_from_architecture, AWQMapping, ResolvedMapping
+from .mappings import AWQMapping, ResolvedMapping, get_layer_mappings_from_architecture
 
 __all__ = ["AWQModifier"]
 

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -506,13 +506,9 @@ class AWQModifier(Modifier, QuantizationMixin):
                             # in this case, default to scaling the last output features
                             # because the desired smooth layer is v_proj
                             # https://github.com/casper-hansen/AutoAWQ/blob/main/awq/quantize/scale.py#L123
-                            update_offload_parameter(
-                                module,
-                                "weight",
-                                module.weight[-scales.size(0) :].div_(
-                                    scales.view(-1, 1)
-                                ),
-                            )
+                            weight = module.weight
+                            weight[-scales.size(0) :].div_(scales.view(-1, 1))
+                            update_offload_parameter(module, "weight", weight)
                         if hasattr(module, "bias") and module.bias is not None:
                             update_offload_parameter(
                                 module,

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -313,9 +313,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                         # exclude v_proj->o_proj mappings whose shapes are incompatible
                         # https://github.com/mit-han-lab/llm-awq/pull/67#issuecomment-1681632777
                         if (
-                            ".v_proj" in layer_name
-                            and ".o_proj" in balance_name
-                            and isinstance(smooth_layer, torch.nn.Linear)
+                            isinstance(smooth_layer, torch.nn.Linear)
                             and isinstance(balance_layer, torch.nn.Linear)
                             and ".o_proj" in balance_name
                             and (

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -293,7 +293,7 @@ class AWQModifier(Modifier, QuantizationMixin):
         repeat for model.layer.1 and so on
         """
         resolved_mappings: list[ResolvedMapping] = []
-        num_skipped_mappings = 0
+        num_skipped_oproj_mappings = 0
         for mapping in self.mappings:
             to_smooth_layers = get_layers(mapping.smooth_layer, model)
             for layer_name, smooth_layer in to_smooth_layers.items():
@@ -331,7 +331,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                                 )
                             )
                         ):
-                            num_skipped_mappings += 1
+                            num_skipped_oproj_mappings += 1
                             continue
 
                         balance_layers.append(balance_layer)
@@ -361,9 +361,9 @@ class AWQModifier(Modifier, QuantizationMixin):
                             parent_name=parent_name,
                         )
                     )
-        if num_skipped_mappings > 0:
+        if num_skipped_oproj_mappings > 0:
             logger.info(
-                f"Excluded {num_skipped_mappings} from resolved "
+                f"Excluded {num_skipped_oproj_mappings} from resolved "
                 "mappings due to shape mismatch"
             )
         self._resolved_mappings = resolved_mappings

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -16,6 +16,11 @@ from tqdm import tqdm
 
 from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers import Modifier
+from llmcompressor.modifiers.awq.mappings import (
+    AWQMapping,
+    ResolvedMapping,
+    get_layer_mappings_from_architecture,
+)
 from llmcompressor.modifiers.quantization.calibration import update_weight_zp_scale
 from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.modifiers.utils.hooks import HooksMixin
@@ -26,8 +31,6 @@ from llmcompressor.utils.pytorch.module import (
     get_matching_layer,
     get_parent_by_name,
 )
-
-from .mappings import AWQMapping, ResolvedMapping, get_layer_mappings_from_architecture
 
 __all__ = ["AWQModifier"]
 

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -313,7 +313,9 @@ class AWQModifier(Modifier, QuantizationMixin):
                         # exclude v_proj->o_proj mappings whose shapes are incompatible
                         # https://github.com/mit-han-lab/llm-awq/pull/67#issuecomment-1681632777
                         if (
-                            isinstance(smooth_layer, torch.nn.Linear)
+                            ".v_proj" in layer_name
+                            and ".o_proj" in balance_name
+                            and isinstance(smooth_layer, torch.nn.Linear)
                             and isinstance(balance_layer, torch.nn.Linear)
                             and ".o_proj" in balance_name
                             and (

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from torch.nn import Module
 from loguru import logger
+from torch.nn import Module
 
 __all__ = ["AWQMapping", "AWQ_MAPPING_REGISTRY", "get_layer_mappings_from_architecture"]
 

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -22,24 +22,25 @@ class AWQMapping:
     balance_layers: list[str]
 
 
+_default_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm",
+        ["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"],
+    ),
+    AWQMapping("re:.*v_proj", ["re:.*o_proj"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm",
+        ["re:.*gate_proj", "re:.*up_proj"],
+    ),
+    AWQMapping(
+        "re:.*up_proj",
+        ["re:.*down_proj"],
+    ),
+]
+
 AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
-    "Llama": [
-        AWQMapping(
-            "re:.*input_layernorm",
-            ["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"],
-        ),
-        AWQMapping("re:.*v_proj", ["re:.*o_proj"]),
-        AWQMapping(
-            "re:.*post_attention_layernorm",
-            ["re:.*gate_proj", "re:.*up_proj"],
-        ),
-        AWQMapping(
-            "re:.*up_proj",
-            ["re:.*down_proj"],
-        ),
-    ],
-    # TODO (Brian INFERENG-529) Add Qwen mappings
-    # "Qwen": [ ],
+    "Llama": _default_mappings,
+    "Qwen": _default_mappings,
 }
 
 

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -38,9 +38,28 @@ _default_mappings = [
     ),
 ]
 
+# Phi merges q, k, and v proj layers into a single qkv_proj layer
+# and merged gate and up proj layers into a single gate_up_proj layer
+_phi_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm",
+        ["re:.*qkv_proj"],
+    ),
+    AWQMapping("re:.*qkv_proj", ["re:.*o_proj"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm",
+        ["re:.*gate_up_proj"],
+    ),
+    AWQMapping(
+        "re:.*gate_up_proj",
+        ["re:.*down_proj"],
+    ),
+]
+
 AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "Llama": _default_mappings,
     "Qwen": _default_mappings,
+    "Phi": _phi_mappings,
 }
 
 

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -38,8 +38,9 @@ _default_mappings = [
     ),
 ]
 
-# Phi merges q, k, and v proj layers into a single qkv_proj layer
-# and merged gate and up proj layers into a single gate_up_proj layer
+# Phi merges
+#  q, k, and v proj layers into a single qkv_proj layer
+#  gate and up proj layers into a single gate_up_proj layer
 _phi_mappings = [
     AWQMapping(
         "re:.*input_layernorm",

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -2,8 +2,9 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from torch.nn import Module
+from loguru import logger
 
-__all__ = ["AWQMapping", "AWQ_MAPPING_REGISTRY"]
+__all__ = ["AWQMapping", "AWQ_MAPPING_REGISTRY", "get_layer_mappings_from_architecture"]
 
 
 @dataclass
@@ -58,9 +59,12 @@ _phi_mappings = [
 ]
 
 AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
-    "Llama": _default_mappings,
-    "Qwen": _default_mappings,
-    "Phi": _phi_mappings,
+    "LlamaForCausalLM": _default_mappings,
+    "Qwen2ForCausalLM": _default_mappings,
+    "Qwen3ForCausalLM": _default_mappings,
+    "MistralForCausalLM": _default_mappings,
+    "Phi3ForCausalLM": _phi_mappings,
+    "Phi3VForCausalLM": _phi_mappings,
 }
 
 
@@ -85,3 +89,18 @@ class ResolvedMapping:
     balance_names: Optional[List[str]] = None
     parent: Optional[Module] = None
     parent_name: Optional[str] = None
+
+
+def get_layer_mappings_from_architecture(architecture: str) -> List[AWQMapping]:
+    """
+    :param architecture: str: The architecture of the model
+    :return: list: The layer mappings for the given architecture
+    """
+
+    if architecture not in AWQ_MAPPING_REGISTRY:
+        logger.info(
+            f"Architecture {architecture} not found in mappings. "
+            f"Using default mappings: {_default_mappings}"
+        )
+
+    return AWQ_MAPPING_REGISTRY.get(architecture, _default_mappings)


### PR DESCRIPTION
SUMMARY:
I wanted to create a PR showing users how they can add more mappings to AWQ to account for more models. Turns out qwen has the exact same as Llama, so I added one for Phi as well. I also updated the naming and used the infer pattern employed in SmoothQuant, rather than requiring user to set it

TEST PLAN:
`examples/awq/llama_example.py` works on this branch for 

```python
MODEL_ID = "microsoft/Phi-4-mini-reasoning"
```


TODOs:
- [x] Merge in after #1451 lands
