### PR TITLE
AWQModifier fast resolve mappings, better logging, MoE support

### DIFF
--- a/examples/awq/qwen3_moe_example.py
+++ b/examples/awq/qwen3_moe_example.py
@@ -1,0 +1,82 @@
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.awq import AWQModifier
+
+# Select model and load it.
+MODEL_ID = "Qwen/Qwen3-30B-A3B"
+
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_ID, device_map="auto", torch_dtype="auto"
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
+
+# Select calibration dataset.
+DATASET_ID = "mit-han-lab/pile-val-backup"
+DATASET_SPLIT = "validation"
+
+# Select number of samples. 256 samples is a good place to start.
+# Increasing the number of samples can improve accuracy.
+NUM_CALIBRATION_SAMPLES = 256
+MAX_SEQUENCE_LENGTH = 512
+
+# Load dataset and preprocess.
+ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {
+        "text": tokenizer.apply_chat_template(
+            [{"role": "user", "content": example["text"]}],
+            tokenize=False,
+        )
+    }
+
+
+ds = ds.map(preprocess)
+
+
+# Tokenize inputs.
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+# Configure the quantization algorithm to run.
+# NOTE: vllm currently does not support asym MoE, using symmetric here
+recipe = [
+    AWQModifier(
+        ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
+        scheme="W4A16",
+        targets=["Linear"],
+    ),
+]
+
+# Apply algorithms.
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+# Confirm generations of the quantized model look sane.
+print("\n\n")
+print("========== SAMPLE GENERATION ==============")
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
+output = model.generate(input_ids, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================\n\n")
+
+# Save to disk compressed.
+SAVE_DIR = MODEL_ID.split("/")[-1] + "-awq-sym"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -767,7 +767,9 @@ def get_lowest_common_parent(names: List[str], module: Module) -> Tuple[str, Mod
             parent_name = s1[:i].rstrip(".")
             break
 
-    while parent_name != "":
+    while True:
+        if parent_name == "":
+            return "", module
         parent = get_layer_by_name(parent_name, module)
         if not isinstance(parent, torch.nn.ModuleList):
             return parent_name, parent

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -338,9 +338,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                         # exclude v_proj->o_proj mappings whose shapes are incompatible
                         # https://github.com/mit-han-lab/llm-awq/pull/67#issuecomment-1681632777
                         if (
-                            ".v_proj" in smooth_name
-                            and ".o_proj" in balance_name
-                            and isinstance(smooth_layer, torch.nn.Linear)
+                            isinstance(smooth_layer, torch.nn.Linear)
                             and isinstance(balance_layer, torch.nn.Linear)
                             and ".o_proj" in balance_name
                             and (
@@ -406,6 +404,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                 _output: torch.Tensor,
             ):
                 self._smooth_activation_means[smooth_name] = _accumulate_mean(
+                    # Assume that first argument is the input
                     args[0].cpu().detach().squeeze(),
                     self._smooth_activation_means.get(smooth_name, None),
                 )

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -749,17 +749,19 @@ def _accumulate_mean(
     return (prev_sum + sum_added) / new_count, new_count
 
 
-def get_lowest_common_parent(names: List[str], module: Module) -> str:
+def get_lowest_common_parent(names: List[str], module: Module) -> Tuple[str, Module]:
     """
     Given a list of names, returns the lowest-scope common parent,
     excluding parents of type ModuleList, which don't seem to play
     nicely with hooks.
-    Slight alteration from os.path.commonprefix
+    Returns name of parent and pointer to parent module
+
+    Implementation is a small alteration of os.path.commonprefix
     https://docs.python.org/3/library/os.path.html#os.path.commonprefix
     """
     s1 = min(names)
     s2 = max(names)
-    parent_name = s1
+    parent_name = ""
     for i, c in enumerate(s1):
         if c != s2[i]:
             parent_name = s1[:i].rstrip(".")

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -27,9 +27,9 @@ from llmcompressor.pipelines.cache import IntermediatesCache
 from llmcompressor.utils.fsdp.helpers import get_fsdp_parent
 from llmcompressor.utils.helpers import calibration_forward_context
 from llmcompressor.utils.pytorch.module import (
+    get_layer_by_name,
     get_layers,
     get_matching_layer,
-    get_layer_by_name,
 )
 
 __all__ = ["AWQModifier"]

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -62,6 +62,7 @@ AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "LlamaForCausalLM": _default_mappings,
     "Qwen2ForCausalLM": _default_mappings,
     "Qwen3ForCausalLM": _default_mappings,
+    "Qwen3MoeForCausalLM": _default_mappings,
     "MistralForCausalLM": _default_mappings,
     "Phi3ForCausalLM": _phi_mappings,
     "Phi3VForCausalLM": _phi_mappings,

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -39,6 +39,22 @@ _default_mappings = [
     ),
 ]
 
+_moe_default_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm$",
+        ["re:.*q_proj$", "re:.*k_proj$", "re:.*v_proj$"],
+    ),
+    AWQMapping("re:.*v_proj$", ["re:.*o_proj$"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm$",
+        ["re:.*mlp.experts.*.gate_proj$", "re:.*mlp.experts.*.up_proj$"],
+    ),
+    AWQMapping(
+        "re:.*up_proj$",
+        ["re:.*down_proj$"],
+    ),
+]
+
 # Phi merges
 #  q, k, and v proj layers into a single qkv_proj layer
 #  gate and up proj layers into a single gate_up_proj layer
@@ -62,7 +78,7 @@ AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "LlamaForCausalLM": _default_mappings,
     "Qwen2ForCausalLM": _default_mappings,
     "Qwen3ForCausalLM": _default_mappings,
-    "Qwen3MoeForCausalLM": _default_mappings,
+    "Qwen3MoeForCausalLM": _moe_default_mappings,
     "MistralForCausalLM": _default_mappings,
     "Phi3ForCausalLM": _phi_mappings,
     "Phi3VForCausalLM": _phi_mappings,

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -76,12 +76,13 @@ _phi_mappings = [
 
 AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "LlamaForCausalLM": _default_mappings,
-    "Qwen2ForCausalLM": _default_mappings,
-    "Qwen3ForCausalLM": _default_mappings,
-    "Qwen3MoeForCausalLM": _moe_default_mappings,
     "MistralForCausalLM": _default_mappings,
     "Phi3ForCausalLM": _phi_mappings,
     "Phi3VForCausalLM": _phi_mappings,
+    "Qwen2ForCausalLM": _default_mappings,
+    "Qwen2MoeForCausalLM": _moe_default_mappings,
+    "Qwen3ForCausalLM": _default_mappings,
+    "Qwen3MoeForCausalLM": _moe_default_mappings,
 }
 
 

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -25,17 +25,17 @@ class AWQMapping:
 
 _default_mappings = [
     AWQMapping(
-        "re:.*input_layernorm",
-        ["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"],
+        "re:.*input_layernorm$",
+        ["re:.*q_proj$", "re:.*k_proj$", "re:.*v_proj$"],
     ),
-    AWQMapping("re:.*v_proj", ["re:.*o_proj"]),
+    AWQMapping("re:.*v_proj$", ["re:.*o_proj$"]),
     AWQMapping(
-        "re:.*post_attention_layernorm",
-        ["re:.*gate_proj", "re:.*up_proj"],
+        "re:.*post_attention_layernorm$",
+        ["re:.*gate_proj$", "re:.*up_proj$"],
     ),
     AWQMapping(
-        "re:.*up_proj",
-        ["re:.*down_proj"],
+        "re:.*up_proj$",
+        ["re:.*down_proj$"],
     ),
 ]
 
@@ -44,17 +44,17 @@ _default_mappings = [
 #  gate and up proj layers into a single gate_up_proj layer
 _phi_mappings = [
     AWQMapping(
-        "re:.*input_layernorm",
-        ["re:.*qkv_proj"],
+        "re:.*input_layernorm$",
+        ["re:.*qkv_proj$"],
     ),
-    AWQMapping("re:.*qkv_proj", ["re:.*o_proj"]),
+    AWQMapping("re:.*qkv_proj$", ["re:.*o_proj$"]),
     AWQMapping(
-        "re:.*post_attention_layernorm",
-        ["re:.*gate_up_proj"],
+        "re:.*post_attention_layernorm$",
+        ["re:.*gate_up_proj$"],
     ),
     AWQMapping(
-        "re:.*gate_up_proj",
-        ["re:.*down_proj"],
+        "re:.*gate_up_proj$",
+        ["re:.*down_proj$"],
     ),
 ]
 

--- a/src/llmcompressor/utils/pytorch/module.py
+++ b/src/llmcompressor/utils/pytorch/module.py
@@ -4,7 +4,7 @@ Utility / helper functions
 
 import difflib
 import re
-from functools import reduce
+from operator import attrgetter
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
@@ -343,5 +343,4 @@ def get_layer_by_name(layer_name: str, module: Module) -> Module:
     :param module: Module in which to search for layer_name
     :return: Module, the layer with name layer_name
     """
-    names = layer_name.split(sep=".")
-    return reduce(getattr, names, module)
+    return attrgetter(layer_name)(module)

--- a/src/llmcompressor/utils/pytorch/module.py
+++ b/src/llmcompressor/utils/pytorch/module.py
@@ -4,6 +4,7 @@ Utility / helper functions
 
 import difflib
 import re
+from functools import reduce
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
@@ -53,7 +54,6 @@ __all__ = [
     "set_layer",
     "get_params",
     "get_param",
-    "set_param",
     "get_terminal_layers",
     "get_prunable_layers",
     "get_quantizable_layers",
@@ -61,7 +61,7 @@ __all__ = [
     "get_layers_params",
     "get_matching_layer",
     "get_no_split_params",
-    "get_parent_by_name",
+    "get_layer_by_name",
 ]
 
 
@@ -208,15 +208,6 @@ def get_param(target: str, module: Module) -> Tuple[str, Parameter]:
     return name, param
 
 
-def set_param(target: str, param: Parameter, module: Module) -> Parameter:
-    layer_name, param_name = target.rsplit(".", 1)
-    layer = get_layer(layer_name, module)[1]
-    old_param = getattr(layer, param_name)
-    setattr(layer, param_name, param)
-
-    return old_param
-
-
 def get_terminal_layers(module: Module) -> Dict[str, Module]:
     terminal = {}
 
@@ -344,20 +335,13 @@ def get_no_split_params(model: PreTrainedModel) -> Union[str, List[str]]:
     return no_split_modules
 
 
-def get_parent_by_name(layer_name: str, model: Module) -> Tuple[str, Module]:
+# https://discuss.pytorch.org/t/how-to-access-to-a-layer-by-module-name/83797/8
+def get_layer_by_name(layer_name: str, module: Module) -> Module:
     """
-    Get the parent layer of a layer by name.
-    :param layer_name: Name of the layer to find the parent of.
-    :param model: Model to search for the parent layer.
-    :return: Tuple containing the name of the parent layer
-        and the parent layer itself.
+    Get the layer of a module by name.
+    :param layer_name: Name of the layer to find.
+    :param module: Module in which to search for layer_name
+    :return: Module, the layer with name layer_name
     """
-    if not any(layer_name == name for name, _ in model.named_modules()):
-        raise ValueError(f"Layer '{layer_name}' not found in model")
-
-    parent_name_parts = layer_name.split(".")[:-1]
-    if not parent_name_parts:
-        return "", model
-
-    parent_name = ".".join(parent_name_parts)
-    return get_layer(parent_name, model)
+    names = layer_name.split(sep=".")
+    return reduce(getattr, names, module)

--- a/tests/llmcompressor/modifiers/awq/test_base.py
+++ b/tests/llmcompressor/modifiers/awq/test_base.py
@@ -202,12 +202,13 @@ def test_get_lowest_common_parent():
     )
     model = torch.nn.ModuleDict(
         {
+            "embed_tokens": torch.nn.Linear(4, 2),
             "decoder": torch.nn.ModuleDict(
                 {
                     "self_attn": self_attn,
                     "mlp": mlp,
                 }
-            )
+            ),
         }
     )
 
@@ -225,3 +226,8 @@ def test_get_lowest_common_parent():
         ["decoder.mlp.experts.1.gate_proj", "decoder.self_attn.v_proj"], model
     )
     assert parent_name == "decoder" and parent == model["decoder"]
+
+    parent_name, parent = get_lowest_common_parent(
+        ["embed_tokens", "decoder.self_attn.v_proj"], model
+    )
+    assert parent_name == "" and parent == model

--- a/tests/llmcompressor/utils/pytorch/test_module.py
+++ b/tests/llmcompressor/utils/pytorch/test_module.py
@@ -1,7 +1,7 @@
 import pytest
 import torch.nn as nn
 
-from llmcompressor.utils.pytorch import get_parent_by_name
+from llmcompressor.utils.pytorch import get_layer_by_name
 
 
 @pytest.fixture
@@ -15,28 +15,20 @@ def example_nested_module() -> str:
 
 
 @pytest.mark.unit
-def test_get_parent_by_name(example_nested_module):
-    # Test getting the parent of the first layer
-    name, parent = get_parent_by_name("0", example_nested_module)
-    assert parent == example_nested_module
-
+def test_get_layer_by_name(example_nested_module):
     # Test getting the parent of a nested layer
-    name, parent = get_parent_by_name("1.0", example_nested_module)
-    assert parent == example_nested_module[1]
-    assert name == "1"
+    layer = get_layer_by_name("0", example_nested_module)
+    assert layer == example_nested_module[0]
 
-    name, parent = get_parent_by_name("1.1", example_nested_module)
-    assert parent == example_nested_module[1]
-    assert name == "1"
+    layer = get_layer_by_name("1.1", example_nested_module)
+    assert layer == example_nested_module[1][1]
 
-    name, parent = get_parent_by_name("2.0", example_nested_module)
-    assert parent == example_nested_module[2]
-    assert name == "2"
+    layer = get_layer_by_name("2.0", example_nested_module)
+    assert layer == example_nested_module[2][0]
 
-    name, parent = get_parent_by_name("2.1", example_nested_module)
-    assert parent == example_nested_module[2]
-    assert name == "2"
+    layer = get_layer_by_name("2.1", example_nested_module)
+    assert layer == example_nested_module[2][1]
 
     # Test getting the parent of a non-existent layer
-    with pytest.raises(ValueError):
-        get_parent_by_name("non_existent_layer", example_nested_module)
+    with pytest.raises(AttributeError):
+        get_layer_by_name("non_existent_layer", example_nested_module)


### PR DESCRIPTION
SUMMARY:
In AWQ, resolving mappings can take a while because it is traversing the entire model tree, rather than just the parent, to find the balance layers. This scopes the search to just the parent module. For MoE models, the previous implementation only found a single layer for each regex string provided in mappings. This updates that to find as many as it can, which is necessary for mappings like 

```python
AWQMapping(
    "re:.*post_attention_layernorm$",
    ["re:.*mlp.experts.*.gate_proj$", "re:.*mlp.experts.*.up_proj$"],
)
```

which have multiple gate_proj and up_proj layers, one for each expert.

gsm8k results with `Qwen/Qwen3-30B-A3B` MoE model after AWQ W4A16 Symmetric:

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3813|±  |0.0134|
|     |       |strict-match    |     5|exact_match|↑  |0.8810|±  |0.0089|

TEST PLAN:
- [x] working with `Qwen/Qwen3-30B-A3B` with [same set of mappings used in AutoAWQ](https://github.com/casper-hansen/AutoAWQ/blob/main/awq/models/qwen3_moe.py#L24). Example included in this PR in `examples/awq/qwen3_moe_example.py`. Ran successfully in ~2 hours on a single H100 with ~70GB of 80GB used (additional memory needed during saving)
- [x] Same wikitext PPL (14.0814) as on `main` for `meta-llama/Llama-3.2-3B-Instruct`
