### PR TITLE
Fix missing logs when calling oneshot

### DIFF
--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -1,5 +1,8 @@
+import os
+from datetime import datetime
 from typing import Optional
 
+from loguru import logger
 from torch.utils.data import DataLoader
 from transformers import PreTrainedModel
 
@@ -100,6 +103,15 @@ class Oneshot:
         :param output_dir: Path to save the output model after carrying out oneshot
 
         """
+        base_log_path = "sparse_logs"  # TODO: maybe make this an input argument?
+        if base_log_path:
+            os.makedirs(base_log_path, exist_ok=True)
+            date_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            logger.add(
+                f"{base_log_path}/oneshot_{date_str}.log",
+                level="DEBUG",
+            )
+
         model_args, dataset_args, recipe_args, _, output_dir = parse_args(**kwargs)
 
         self.model_args = model_args

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -85,6 +85,7 @@ class Oneshot:
 
     def __init__(
         self,
+        log_dir: Optional[str] = "sparse_logs",
         **kwargs,
     ):
         """
@@ -103,12 +104,12 @@ class Oneshot:
         :param output_dir: Path to save the output model after carrying out oneshot
 
         """
-        base_log_path = "sparse_logs"  # TODO: maybe make this an input argument?
-        if base_log_path:
-            os.makedirs(base_log_path, exist_ok=True)
+        # Set up logging
+        if log_dir:
+            os.makedirs(log_dir, exist_ok=True)
             date_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             logger.add(
-                f"{base_log_path}/oneshot_{date_str}.log",
+                f"{log_dir}/oneshot_{date_str}.log",
                 level="DEBUG",
             )
 

--- a/src/llmcompressor/modifiers/stage.py
+++ b/src/llmcompressor/modifiers/stage.py
@@ -67,7 +67,6 @@ class StageModifiers(ModifierInterface, BaseModel):
                 modifier.initialize(state, **kwargs)
             if accelerator:
                 accelerator.wait_for_everyone()
-        state.loggers.system.info(tag="stage", string="Modifiers initialized")
 
     def finalize(self, state: "State", **kwargs):
         """
@@ -88,7 +87,6 @@ class StageModifiers(ModifierInterface, BaseModel):
                 accelerator.wait_for_everyone()
 
         self.applied = True
-        state.loggers.system.info(tag="stage", string="Modifiers finalized")
 
     def update_event(self, state: "State", event: "Event", **kwargs):
         """


### PR DESCRIPTION
Fix missing logs when calling oneshot #1441 

Summary:

When calling oneshot (e.g., in gemma2_example.py), a sparse_logs folder is created, but the log file inside is nearly empty. This is because the logging setup in lifecycle.py and state.py uses loguru, but oneshot itself didn’t configure loguru to write logs to a file. As a result, logs were not being saved properly.

This PR fixes the issue by adding a log file configuration directly in the oneshot init. This ensures loguru writes to the appropriate file by default.

To clean up the nearly empty log file, I removed the two lines from stage.py that were generating it. These messages appear to be redundant, as similar info is already captured by loguru.

Currently, I set the log path defaults to sparse_logs. Maybe we can consider making the log file path an optional input, allowing users to disable file logging by passing None. Let me know what you guys think.

Test Plan:

Ran gemma2_example.py after the changes:
A proper log file was generated in sparse_logs
The original nearly empty log file was no longer created

Also ran make test and got the same results as the current main.
