### PR TITLE
[Bugfix][Tracing] Fix qwen2_5_vl

### DIFF
--- a/src/llmcompressor/transformers/tracing/qwen2_5_vl.py
+++ b/src/llmcompressor/transformers/tracing/qwen2_5_vl.py
@@ -413,8 +413,6 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLForConditionalGeneration):
                     second_per_grid_ts,
                     attention_mask,
                 )
-                # TRACING: the position_ids shape is known
-                position_ids = maybe_install_metadata_position_ids(position_ids, input_ids)
                 self.rope_deltas = rope_deltas
             # then use the prev pre-calculated rope-deltas to get the correct position ids
             else:
@@ -430,6 +428,9 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLForConditionalGeneration):
                     delta = delta.repeat_interleave(batch_size // delta.shape[0], dim=0)
                 position_ids = position_ids.add(delta)
                 position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+
+        # TRACING: the position_ids shape is known
+        position_ids = maybe_install_metadata_position_ids(position_ids, input_ids)
 
         outputs = self.model(
             input_ids=None,


### PR DESCRIPTION
## Purpose ##
* Fix failing qwen_2_5_vl e2e test

## Changes ##
* For recipes that run smoothquant before gptq, these recipes would populate `self.rope_deltas`. The existence of `self.rope_deltas` meant that subsequent tracing calls would not trigger [the condition to inject tracing metadata](https://github.com/vllm-project/llm-compressor/blob/main/src/llmcompressor/transformers/tracing/qwen2_5_vl.py#L406), leading to a tracing failure

## Testing ##
* `CADENCE=weekly TEST_DATA_FILE=tests/lmeval/configs/vl_int8_w8a8_dynamic_per_token.yaml python3 -m pytest tests/lmeval/test_lmeval.py -sx`