### PR TITLE
[Tracing] Fix Traceable Imports

### DIFF
--- a/src/llmcompressor/transformers/tracing/gemma3.py
+++ b/src/llmcompressor/transformers/tracing/gemma3.py
@@ -32,14 +32,12 @@ import torch.nn as nn
 from transformers.cache_utils import Cache, StaticCache, HybridCache
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.utils import (
-    add_start_docstrings,
     logging,
     is_torch_flex_attn_available,
 )
 from transformers.processing_utils import Unpack
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.models.gemma3.modeling_gemma3 import (
-    GEMMA3_START_DOCSTRING,
     Gemma3ForConditionalGeneration,
     Gemma3CausalLMOutputWithPast,
     CausalLMOutputWithPast,
@@ -276,10 +274,7 @@ def bidirectional_mask(token_type_ids: torch.Tensor,
         )
     return causal_mask
 
-@add_start_docstrings(
-    """The GEMMA3 model which consists of a vision backbone and a language model.""",
-    GEMMA3_START_DOCSTRING,
-)
+
 class Gemma3ForConditionalGeneration(Gemma3ForConditionalGeneration):
     def __init__(self, config):
         super().__init__(config)

--- a/src/llmcompressor/transformers/tracing/mllama.py
+++ b/src/llmcompressor/transformers/tracing/mllama.py
@@ -19,17 +19,14 @@
 from typing import List, Optional, Tuple, Union
 
 import torch
-import torch.utils.checkpoint
 
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.utils import (
-    add_start_docstrings,
     logging,
 )
 
 # TRACING: imports
 from transformers.models.mllama.modeling_mllama import (
-    MLLAMA_START_DOCSTRING,
     MllamaForConditionalGeneration,
 )
 
@@ -69,10 +66,6 @@ def _prepare_cross_attention_mask(
 
 
 # TRACING: needs to use updated _prepare_cross_attention_mask
-@add_start_docstrings(
-    """The Mllama model which consists of a vision encoder and a language model.""",
-    MLLAMA_START_DOCSTRING,
-)
 class MllamaForConditionalGeneration(MllamaForConditionalGeneration):
     def forward(
         self,


### PR DESCRIPTION
## Purpose ##
* Fix traceable definitions, for which transformers no longer supports the `START_DOCSTRING`

## Changes ##
* Remove `START_DOCSTRING` imports from Gemma and Mllama

## Testing ##
```python3
from llmcompressor.transformers import tracing
```