### PR TITLE
Pin transformers to <4.52.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,8 @@ setup(
         "requests>=2.0.0",
         "tqdm>=4.0.0",
         "torch>=1.7.0",
-        "transformers>4.0,<5.0",
+        # TODO (#1457) revert to "transformers>4.0,<5.0" after tests pass
+        "transformers>4.0,<4.52.0",
         "datasets",
         "accelerate>=0.20.3,!=1.1.0",
         "pynvml",


### PR DESCRIPTION
SUMMARY:
See #1457 for error report. This will pin transformers version in setup.py until issue is resolved


TEST PLAN:
no new src code, tests should pass now with pin
