### PR TITLE
[Tests] Fix activation recipe for w8a8 asym

### DIFF
--- a/tests/e2e/vLLM/recipes/INT8/recipe_w8a8_static_asym.yaml
+++ b/tests/e2e/vLLM/recipes/INT8/recipe_w8a8_static_asym.yaml
@@ -7,5 +7,5 @@ quant_stage:
       config_groups:
         group_0:
           weights: {num_bits: 8, type: int, symmetric: true, strategy: channel}
-          input_activations: {num_bits: 8, symmetric: false, dynamic: false, strategy: channel, type: int}
+          input_activations: {num_bits: 8, symmetric: false, dynamic: false, strategy: tensor, type: int}
           targets: [Linear] 


### PR DESCRIPTION
SUMMARY:
- We only support per token and per tensor activations 
- Fix the recipe to reflect this
