### PR TITLE
Added observer type for test_min_max

### DIFF
--- a/tests/llmcompressor/observers/test_min_max.py
+++ b/tests/llmcompressor/observers/test_min_max.py
@@ -35,7 +35,7 @@ def make_dummy_g_idx(columns: int, group_size: int) -> torch.Tensor:
 def test_min_max_observer(symmetric, expected_scale, expected_zero_point):
     tensor = torch.tensor([1, 1, 1, 1, 1])
     num_bits = 8
-    
+
     weights = QuantizationArgs(num_bits=num_bits,
                                symmetric=symmetric,
                                observer="minmax")

--- a/tests/llmcompressor/observers/test_min_max.py
+++ b/tests/llmcompressor/observers/test_min_max.py
@@ -35,7 +35,7 @@ def make_dummy_g_idx(columns: int, group_size: int) -> torch.Tensor:
 def test_min_max_observer(symmetric, expected_scale, expected_zero_point):
     tensor = torch.tensor([1, 1, 1, 1, 1])
     num_bits = 8
-    weights = QuantizationArgs(num_bits=num_bits, symmetric=symmetric)
+    weights = QuantizationArgs(num_bits=num_bits, symmetric=symmetric, observer="minmax")
 
     observer = weights.observer
     observer = Observer.load_from_registry(observer, quantization_args=weights)

--- a/tests/llmcompressor/observers/test_min_max.py
+++ b/tests/llmcompressor/observers/test_min_max.py
@@ -35,6 +35,7 @@ def make_dummy_g_idx(columns: int, group_size: int) -> torch.Tensor:
 def test_min_max_observer(symmetric, expected_scale, expected_zero_point):
     tensor = torch.tensor([1, 1, 1, 1, 1])
     num_bits = 8
+    
     weights = QuantizationArgs(num_bits=num_bits,
                                symmetric=symmetric,
                                observer="minmax")

--- a/tests/llmcompressor/observers/test_min_max.py
+++ b/tests/llmcompressor/observers/test_min_max.py
@@ -35,7 +35,9 @@ def make_dummy_g_idx(columns: int, group_size: int) -> torch.Tensor:
 def test_min_max_observer(symmetric, expected_scale, expected_zero_point):
     tensor = torch.tensor([1, 1, 1, 1, 1])
     num_bits = 8
-    weights = QuantizationArgs(num_bits=num_bits, symmetric=symmetric, observer="minmax")
+    weights = QuantizationArgs(num_bits=num_bits,
+                               symmetric=symmetric,
+                               observer="minmax")
 
     observer = weights.observer
     observer = Observer.load_from_registry(observer, quantization_args=weights)


### PR DESCRIPTION
SUMMARY:
Added observer type in QuantizationArgs


TEST PLAN:
Reran the tests:

pytest tests/llmcompressor/observers/test_min_max.py 
```bash
========================================================= test session starts ==========================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/hzhao/llm-compressor
configfile: pyproject.toml
plugins: anyio-4.9.0, rerunfailures-15.0, mock-3.14.0
collected 5 items                                                                                                                      

tests/llmcompressor/observers/test_min_max.py .....                                                                              [100%]

========================================================== 5 passed in 5.15s ===========================================================
```