### PR TITLE
Remove duplicate model id var from awq example recipe

### DIFF
--- a/examples/awq/llama_example.py
+++ b/examples/awq/llama_example.py
@@ -13,7 +13,6 @@ model = AutoModelForCausalLM.from_pretrained(
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
 
 # Select calibration dataset.
-MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
 DATASET_ID = "mit-han-lab/pile-val-backup"
 DATASET_SPLIT = "validation"
 


### PR DESCRIPTION
SUMMARY:
I noticed the MODELID var is declared twice in the AWQ example recipe, so i removed the second instance of it


TEST PLAN:
N/A
