### PR TITLE
fix rest of the minmax tests

### DIFF
--- a/tests/llmcompressor/observers/test_min_max.py
+++ b/tests/llmcompressor/observers/test_min_max.py
@@ -53,7 +53,9 @@ def test_min_max_observer_symmetric_scale_range():
     tensor *= 127
 
     num_bits = 8
-    weights = QuantizationArgs(num_bits=num_bits, symmetric=True)
+    weights = QuantizationArgs(num_bits=num_bits,
+                               symmetric=True,
+                               observer="minmax")
 
     observer = weights.observer
     observer = Observer.load_from_registry(observer, quantization_args=weights)
@@ -82,7 +84,9 @@ def test_min_max_observer_value_update():
 
     tensor = inp
     num_bits = 8
-    weights = QuantizationArgs(num_bits=num_bits, symmetric=True)
+    weights = QuantizationArgs(num_bits=num_bits,
+                               symmetric=True,
+                               observer="minmax")
     observer = weights.observer
     observer = Observer.load_from_registry(observer, quantization_args=weights)
     curr_max = 1
@@ -107,7 +111,9 @@ def test_g_idx():
     group_size = 2
     input_shape = (128, 512)
     tensor = torch.rand(input_shape)
-    weights = QuantizationArgs(num_bits=8, group_size=group_size)
+    weights = QuantizationArgs(num_bits=8,
+                               group_size=group_size,
+                               observer="minmax")
     g_idx = make_dummy_g_idx(tensor.shape[1], group_size)
 
     observer = weights.observer

--- a/tests/llmcompressor/observers/test_min_max.py
+++ b/tests/llmcompressor/observers/test_min_max.py
@@ -36,9 +36,9 @@ def test_min_max_observer(symmetric, expected_scale, expected_zero_point):
     tensor = torch.tensor([1, 1, 1, 1, 1])
     num_bits = 8
 
-    weights = QuantizationArgs(num_bits=num_bits,
-                               symmetric=symmetric,
-                               observer="minmax")
+    weights = QuantizationArgs(
+        num_bits=num_bits, symmetric=symmetric, observer="minmax"
+    )
 
     observer = weights.observer
     observer = Observer.load_from_registry(observer, quantization_args=weights)
@@ -53,9 +53,7 @@ def test_min_max_observer_symmetric_scale_range():
     tensor *= 127
 
     num_bits = 8
-    weights = QuantizationArgs(num_bits=num_bits,
-                               symmetric=True,
-                               observer="minmax")
+    weights = QuantizationArgs(num_bits=num_bits, symmetric=True, observer="minmax")
 
     observer = weights.observer
     observer = Observer.load_from_registry(observer, quantization_args=weights)
@@ -84,9 +82,7 @@ def test_min_max_observer_value_update():
 
     tensor = inp
     num_bits = 8
-    weights = QuantizationArgs(num_bits=num_bits,
-                               symmetric=True,
-                               observer="minmax")
+    weights = QuantizationArgs(num_bits=num_bits, symmetric=True, observer="minmax")
     observer = weights.observer
     observer = Observer.load_from_registry(observer, quantization_args=weights)
     curr_max = 1
@@ -111,9 +107,7 @@ def test_g_idx():
     group_size = 2
     input_shape = (128, 512)
     tensor = torch.rand(input_shape)
-    weights = QuantizationArgs(num_bits=8,
-                               group_size=group_size,
-                               observer="minmax")
+    weights = QuantizationArgs(num_bits=8, group_size=group_size, observer="minmax")
     g_idx = make_dummy_g_idx(tensor.shape[1], group_size)
 
     observer = weights.observer

--- a/tests/llmcompressor/observers/test_mse.py
+++ b/tests/llmcompressor/observers/test_mse.py
@@ -46,7 +46,7 @@ def test_mse_observer_symmetric_scale_range():
     tensor *= 127
 
     num_bits = 8
-    weights = QuantizationArgs(num_bits=num_bits, symmetric=True)
+    weights = QuantizationArgs(num_bits=num_bits, symmetric=True, observer="mse")
 
     observer = weights.observer
     observer = Observer.load_from_registry(observer, quantization_args=weights)


### PR DESCRIPTION
SUMMARY:
Specify observer type for all tests to avoid future failures


TEST PLAN:
Test against default observer being MSE. All tests (test_min_max.py and test_mse.py) passed. 
```bash
(env) hzhao@janice:~/llm-compressor$ pytest -s -v tests/llmcompressor/observers/test_min_max.py 
================================================ test session starts =================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /home/hzhao/llm-compressor/env/bin/python3
cachedir: .pytest_cache
rootdir: /home/hzhao/llm-compressor
configfile: pyproject.toml
plugins: anyio-4.9.0, rerunfailures-15.0, mock-3.14.0
collected 5 items                                                                                                    

tests/llmcompressor/observers/test_min_max.py::test_min_max_observer[True-0.0078-0] 2025-05-22T17:10:01.027628-0400 | reset | INFO - Compression lifecycle reset
PASSED2025-05-22T17:10:01.029926-0400 | reset | INFO - Compression lifecycle reset

tests/llmcompressor/observers/test_min_max.py::test_min_max_observer[False-0.0039--128] 2025-05-22T17:10:01.030556-0400 | reset | INFO - Compression lifecycle reset
PASSED2025-05-22T17:10:01.031366-0400 | reset | INFO - Compression lifecycle reset

tests/llmcompressor/observers/test_min_max.py::test_min_max_observer_symmetric_scale_range 2025-05-22T17:10:01.031799-0400 | reset | INFO - Compression lifecycle reset
PASSED2025-05-22T17:10:01.032502-0400 | reset | INFO - Compression lifecycle reset

tests/llmcompressor/observers/test_min_max.py::test_min_max_observer_value_update 2025-05-22T17:10:01.032965-0400 | reset | INFO - Compression lifecycle reset
PASSED2025-05-22T17:10:01.034333-0400 | reset | INFO - Compression lifecycle reset

tests/llmcompressor/observers/test_min_max.py::test_g_idx 2025-05-22T17:10:01.034748-0400 | reset | INFO - Compression lifecycle reset
PASSED2025-05-22T17:10:01.286200-0400 | reset | INFO - Compression lifecycle reset


================================================= 5 passed in 5.20s ==================================================
```