### PR TITLE
loosen lmeval assertions to upper or lower bound

### DIFF
--- a/tests/lmeval/test_lmeval.py
+++ b/tests/lmeval/test_lmeval.py
@@ -162,7 +162,7 @@ class TestLMEval:
                 continue
             actual_val = metrics.get(metric_key)
             higher_is_better = results["higher_is_better"][self.lmeval.task].get(
-                metric_key.split[","][0], True
+                metric_key.split(",")[0], True
             )
             stderr_key = metric_key.replace(",", "_stderr,")
             std_err = self.lmeval.metrics.get(stderr_key)


### PR DESCRIPTION
SUMMARY:
`lm_eval` end-to-end tests are occasionally failing when the actual value is higher than the expected value, when we really only care about if performance has regressed (example run [here](https://github.com/neuralmagic/llm-compressor-testing/actions/runs/15232878962/job/42842981702)). 

This PR loosens the check to only assert 
- actual value > expected value - error tolerance if higher score is better (generally the case)
- actual value < expected value + error tolerance if lower score is better (in case we have PPL checks or add in future)


TEST PLAN:
- [x] Rerun weekly lm-eval tests before merging this in -- https://github.com/neuralmagic/llm-compressor-testing/actions/runs/15281691638
