### PR TITLE
[Tests] Fix dynamic field to be a bool, not string

### DIFF
--- a/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
+++ b/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
@@ -95,7 +95,7 @@ class TestSetQuantInGPTQ(unittest.TestCase):
                         "num_bits": 8,
                         "symmetric": False,
                         "strategy": "token",
-                        "dynamic": "true",
+                        "dynamic": True,
                         "kwargs": {},
                     },
                     "weights": {


### PR DESCRIPTION
This is currently using a string which is incorrect

SUMMARY:
"please provide a brief summary"


TEST PLAN:
"please outline how the changes were tested"
