### PR TITLE
skip tracing tests if token unavailable

### DIFF
--- a/tests/llmcompressor/transformers/tracing/test_models.py
+++ b/tests/llmcompressor/transformers/tracing/test_models.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from transformers import (
     AutoModelForCausalLM,
@@ -16,6 +18,10 @@ from llmcompressor.transformers.tracing.debug import trace
 from llmcompressor.utils.pytorch.module import get_no_split_params
 
 
+@pytest.mark.skipif(
+    os.getenv("HF_TOKEN") is None,
+    reason="Skipping tracing tests requiring gated model access",
+)
 @pytest.mark.parametrize(
     "model_id,model_class,targets,modality,backends",
     [


### PR DESCRIPTION
SUMMARY:
some tests in `tests/llmcompressor/transformers/tracing/test_models.py` requiring access to gated HF hub models will fail for community user PRs, because `HF_TOKEN` is not injected. This just skips the tests in question.

This update allows #1446 and #1445 to pass GHA checks so that they can be merged in 


TEST PLAN:
n/a
