### PR TITLE
[Testing] Use a slightly larger model that works with group_size 128

### DIFF
--- a/tests/llmcompressor/transformers/gptq/test_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_oneshot.py
@@ -65,7 +65,7 @@ class TestGPTQOneShotWithFullScheme(unittest.TestCase):
         import torch
 
         self.output = "./oneshot_output"
-        self.model = "roneneldan/TinyStories-1M"
+        self.model = "Xenova/llama2.c-stories110M"
         self.dataset = "open_platypus"
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
@@ -106,7 +106,8 @@ class TestGPTQOneShotWithFullScheme(unittest.TestCase):
         assert weight_args.num_bits == 4
 
         # Check a specific layer is quantized
-        targetted_linear_layer = model_loaded.transformer.h[0].attn.attention.k_proj
+        print(model_loaded)
+        targetted_linear_layer = model_loaded.model.layers[0].self_attn.k_proj
         assert hasattr(targetted_linear_layer, "quantization_scheme")
 
         # Check lm-head is not quantized

--- a/tests/llmcompressor/transformers/gptq/test_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_oneshot.py
@@ -106,7 +106,6 @@ class TestGPTQOneShotWithFullScheme(unittest.TestCase):
         assert weight_args.num_bits == 4
 
         # Check a specific layer is quantized
-        print(model_loaded)
         targetted_linear_layer = model_loaded.model.layers[0].self_attn.k_proj
         assert hasattr(targetted_linear_layer, "quantization_scheme")
 


### PR DESCRIPTION
SUMMARY:
- The previous model was too small for group_size 128; update to use a larger one
- The point of the test  is to validate the preset schemes (which include 128 as the group_size) so chose to update the model instead of the recipe