### PR TITLE
[Example] [Bugfix] Fix Gemma3 Generation

### DIFF
--- a/examples/multimodal_vision/gemma3_example.py
+++ b/examples/multimodal_vision/gemma3_example.py
@@ -63,8 +63,9 @@ prompt = processor.apply_chat_template(messages, add_generation_prompt=True)
 image_url = "http://images.cocodataset.org/train2017/000000231895.jpg"
 raw_image = Image.open(requests.get(image_url, stream=True).raw)
 
+# Note: compile is disabled: https://github.com/huggingface/transformers/issues/38333
 inputs = processor(images=raw_image, text=prompt, return_tensors="pt").to("cuda")
-output = model.generate(**inputs, max_new_tokens=100)
+output = model.generate(**inputs, max_new_tokens=100, disable_compile=True)
 print(processor.decode(output[0], skip_special_tokens=True))
 print("==========================================")
 


### PR DESCRIPTION
## Purpose ##
* Fix Gemma3 example

## Background ##
* Transformers `torch.compile`s the model function before running generation. However, some models fail to compile properly. As of the latest transformers version, Gemma3 is one of those models https://github.com/huggingface/transformers/issues/38333

## Changes ##
* Disable compilation when generating with Gemma3 in example