### PR TITLE
[Example] [Bugfix] Fix Gemma ignore list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,14 @@ quality:
 	@echo "Running python quality checks";
 	ruff check $(CHECKDIRS);
 	isort --check-only $(CHECKDIRS);
-	flake8 $(CHECKDIRS) --max-line-length 88 --extend-ignore E203;
+	flake8 $(CHECKDIRS) --max-line-length 88 --extend-ignore E203,W605;
 
 # style the code according to accepted standards for the repo
 style:
 	@echo "Running python styling";
 	ruff format $(CHECKDIRS);
 	isort $(CHECKDIRS);
-	flake8 $(CHECKDIRS) --max-line-length 88 --extend-ignore E203;
+	flake8 $(CHECKDIRS) --max-line-length 88 --extend-ignore E203,W605;
 
 # run tests for the repo
 test:

--- a/examples/multimodal_vision/gemma3_example.py
+++ b/examples/multimodal_vision/gemma3_example.py
@@ -31,7 +31,11 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        ignore=["re:*.lm_head", "re:vision_tower.*", "re:multi_modal_projector.*"],
+        ignore=[
+            "re:*.lm_head",
+            "re:model.vision_tower.*",
+            "re:model.multi_modal_projector.*",
+        ],
     ),
 ]
 

--- a/examples/multimodal_vision/gemma3_example.py
+++ b/examples/multimodal_vision/gemma3_example.py
@@ -32,9 +32,9 @@ recipe = [
         targets="Linear",
         scheme="W4A16",
         ignore=[
-            "re:*.lm_head",
-            "re:model.vision_tower.*",
-            "re:model.multi_modal_projector.*",
+            "lm_head",
+            "re:model\.vision_tower.*",
+            "re:model\.multi_modal_projector.*",
         ],
     ),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ files = "src/guidellm"
 [tool.ruff]
 exclude = ["build", "dist", "env", ".venv", "src/llmcompressor/transformers/tracing/"]
 lint.select = ["E", "F", "W"]
+lint.extend-ignore = ["E203", "W605"]
 
 [tool.flake8]
 max-line-length = 88


### PR DESCRIPTION
## Purpose ##
* Fix invalid regexes, prevent the vision tower from being quantized

## Changes ##
* Add `model.` to beginning of ignore list
* Because `"re:model\.vision_tower.*"` is a proper way to escape regex, but an improper way of escaping strings, `W605` triggers. Let's ignore this linting warning.

## Testing ##
* Ran gemma3 example