### PR TITLE
fix qwen 2.5 VL multimodal example

### DIFF
--- a/examples/multimodal_vision/qwen_2_5_vl_example.py
+++ b/examples/multimodal_vision/qwen_2_5_vl_example.py
@@ -20,7 +20,7 @@ processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
 
 # Oneshot arguments
 DATASET_ID = "lmms-lab/flickr30k"
-DATASET_SPLIT = {"calibration": "test[:512]"}
+DATASET_SPLIT = "test[:512]"
 NUM_CALIBRATION_SAMPLES = 512
 MAX_SEQUENCE_LENGTH = 2048
 


### PR DESCRIPTION
SUMMARY:
Fix a failing qwen 2.5 VL example, just had incorrect dataset split configuration.


TEST PLAN:
Runs on H100 on latest llm-compressor
