### PR TITLE
[Example] Fix Qwen VL ignore list

### DIFF
--- a/examples/multimodal_vision/qwen2_vl_example.py
+++ b/examples/multimodal_vision/qwen2_vl_example.py
@@ -83,7 +83,7 @@ recipe = [
         targets="Linear",
         scheme="W4A16",
         sequential_targets=["Qwen2VLDecoderLayer"],
-        ignore=["lm_head", "re:visual.*"],
+        ignore=["lm_head", "re:visual.*","re:model.visual.*"],
     ),
 ]
 

--- a/examples/multimodal_vision/qwen2_vl_example.py
+++ b/examples/multimodal_vision/qwen2_vl_example.py
@@ -83,7 +83,7 @@ recipe = [
         targets="Linear",
         scheme="W4A16",
         sequential_targets=["Qwen2VLDecoderLayer"],
-        ignore=["lm_head", "re:visual.*","re:model.visual.*"],
+        ignore=["lm_head", "re:visual.*", "re:model.visual.*"],
     ),
 ]
 

--- a/examples/multimodal_vision/qwen_2_5_vl_example.py
+++ b/examples/multimodal_vision/qwen_2_5_vl_example.py
@@ -77,7 +77,7 @@ recipe = [
         targets="Linear",
         scheme="W4A16",
         sequential_targets=["Qwen2_5_VLDecoderLayer"],
-        ignore=["lm_head", "re:visual.*"],
+        ignore=["lm_head", "re:visual.*", "re:model.visual.*"],
     ),
 ]
 


### PR DESCRIPTION
**SUMMARY:**

- Transformers v4.52 will map weights name for Qwen2-VL/Qwen2.5-VL: https://github.com/huggingface/transformers/blob/de4cf5a38e9678b9e465867a8a6b88ea727bea52/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L1359-L1362
- So the qwen2-vl/qwen2.5-vl checkpoints saved after transformers v4.52 will have different weights name. 
- Update the ignore list to prevent the vision model from being quantized

**CHANGES**

- Add "model.visual." to ignore list


**TEST PLAN:**
Run [qwen2_vl_example.py](https://github.com/vllm-project/llm-compressor/blob/main/examples/multimodal_vision/qwen2_vl_example.py)
Run [qwen_2_5_vl_example.py](https://github.com/vllm-project/llm-compressor/blob/main/examples/multimodal_vision/qwen_2_5_vl_example.py)
