### PR TITLE
[Sequential] Deprecate `sequential_targets` on modifiers

### DIFF
--- a/examples/multimodal_vision/idefics3_example.py
+++ b/examples/multimodal_vision/idefics3_example.py
@@ -31,7 +31,6 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        sequential_targets=["LlamaDecoderLayer"],
         ignore=["re:.*lm_head", "re:model.vision_model.*", "re:model.connector.*"],
     ),
 ]
@@ -91,6 +90,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     trust_remote_code_model=True,
     data_collator=data_collator,
+    sequential_targets=["LlamaDecoderLayer"],
 )
 
 # Confirm generations of the quantized model look sane.

--- a/examples/multimodal_vision/llava_example.py
+++ b/examples/multimodal_vision/llava_example.py
@@ -30,7 +30,6 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        sequential_targets=["LlamaDecoderLayer"],
         ignore=["re:.*lm_head", "re:vision_tower.*", "re:multi_modal_projector.*"],
     ),
 ]
@@ -46,6 +45,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     trust_remote_code_model=True,
     data_collator=data_collator,
+    sequential_targets=["LlamaDecoderLayer"],
 )
 
 # Confirm generations of the quantized model look sane.

--- a/examples/multimodal_vision/mistral3_example.py
+++ b/examples/multimodal_vision/mistral3_example.py
@@ -43,7 +43,6 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        sequential_targets=["MistralDecoderLayer"],
         ignore=["re:.*lm_head", "re:vision_tower.*", "re:multi_modal_projector.*"],
     ),
 ]
@@ -59,6 +58,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     trust_remote_code_model=True,
     data_collator=data_collator,
+    sequential_targets=["MistralDecoderLayer"],
 )
 
 # Confirm generations of the quantized model look sane.

--- a/examples/multimodal_vision/mllama_example.py
+++ b/examples/multimodal_vision/mllama_example.py
@@ -30,7 +30,6 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        sequential_targets=["MllamaSelfAttentionDecoderLayer"],
         ignore=["re:.*lm_head", "re:multi_modal_projector.*", "re:vision_model.*"],
     ),
 ]
@@ -46,6 +45,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     trust_remote_code_model=True,
     data_collator=data_collator,
+    sequential_targets=["MllamaSelfAttentionDecoderLayer"],
 )
 
 # Confirm generations of the quantized model look sane.

--- a/examples/multimodal_vision/phi3_vision_example.py
+++ b/examples/multimodal_vision/phi3_vision_example.py
@@ -75,7 +75,6 @@ def data_collator(batch):
 recipe = GPTQModifier(
     targets="Linear",
     scheme="W4A16",
-    sequential_targets=["Phi3DecoderLayer"],
     ignore=["lm_head", "re:model.vision_embed_tokens.*"],
 )
 
@@ -88,6 +87,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     trust_remote_code_model=True,
     data_collator=data_collator,
+    sequential_targets=["Phi3DecoderLayer"],
 )
 
 # Confirm generations of the quantized model look sane.

--- a/examples/multimodal_vision/pixtral_example.py
+++ b/examples/multimodal_vision/pixtral_example.py
@@ -36,7 +36,6 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        sequential_targets=["MistralDecoderLayer"],
         ignore=["re:.*lm_head", "re:vision_tower.*", "re:multi_modal_projector.*"],
     ),
 ]
@@ -52,6 +51,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     trust_remote_code_model=True,
     data_collator=data_collator,
+    sequential_targets=["MistralDecoderLayer"],
 )
 
 # Confirm generations of the quantized model look sane.

--- a/examples/multimodal_vision/qwen2_vl_example.py
+++ b/examples/multimodal_vision/qwen2_vl_example.py
@@ -79,7 +79,6 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        sequential_targets=["Qwen2VLDecoderLayer"],
         ignore=["lm_head", "re:visual.*", "re:model.visual.*"],
     ),
 ]
@@ -94,6 +93,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     trust_remote_code_model=True,
     data_collator=data_collator,
+    sequential_targets=["Qwen2VLDecoderLayer"],
 )
 
 # Confirm generations of the quantized model look sane.

--- a/examples/multimodal_vision/qwen_2_5_vl_example.py
+++ b/examples/multimodal_vision/qwen_2_5_vl_example.py
@@ -73,7 +73,6 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        sequential_targets=["Qwen2_5_VLDecoderLayer"],
         ignore=["lm_head", "re:visual.*", "re:model.visual.*"],
     ),
 ]
@@ -88,6 +87,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
     trust_remote_code_model=True,
     data_collator=data_collator,
+    sequential_targets=["Qwen2_5_VLDecoderLayer"],
 )
 
 # Confirm generations of the quantized model look sane.

--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -186,3 +186,13 @@ class DatasetArguments(CustomDatasetArguments):
             "{module}.{method_name} or {function_name}"
         },
     )
+    sequential_targets: Optional[List[str]] = field(
+        default=None,
+        metadata={
+            "help": "List of layer targets for the sequential pipeline. "
+            "This is typically a single DecoderLayer. "
+            "Not specifying this argument will cause the sequential pipeline to "
+            "default to using the `no_split_params` specified by the HF model "
+            "definition"
+        },
+    )

--- a/src/llmcompressor/pipelines/layer_sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/layer_sequential/pipeline.py
@@ -16,7 +16,7 @@ from llmcompressor.pipelines.layer_sequential.helpers import (
     to_next_layer_kwargs,
 )
 from llmcompressor.pipelines.registry import CalibrationPipeline
-from llmcompressor.pipelines.sequential.helpers import get_targets_from_modifiers
+from llmcompressor.pipelines.sequential.helpers import get_sequential_targets
 from llmcompressor.utils.helpers import DisableQuantization, calibration_forward_context
 
 if TYPE_CHECKING:
@@ -68,7 +68,7 @@ class LayerSequentialPipeline(CalibrationPipeline):
 
         # find layers
         modifiers = session.get_modifiers()
-        sequential_targets, _ = get_targets_from_modifiers(modifiers, model)
+        sequential_targets = get_sequential_targets(modifiers, model, dataset_args)
         layers = match_modules(model, sequential_targets)
 
         LifecycleCallbacks.calibration_epoch_start()

--- a/src/llmcompressor/pipelines/registry.py
+++ b/src/llmcompressor/pipelines/registry.py
@@ -17,8 +17,12 @@ if TYPE_CHECKING:
 
 __all__ = ["CalibrationPipeline"]
 
-SEQUENTIAL_MODIFIERS = (AWQModifier, GPTQModifier, SparsityModifierBase)
-CALIBRATION_MODIFIERS = (SmoothQuantModifier, *SEQUENTIAL_MODIFIERS)
+CALIBRATION_MODIFIERS = (
+    SmoothQuantModifier,
+    AWQModifier,
+    GPTQModifier,
+    SparsityModifierBase,
+)
 
 
 class CalibrationPipeline(ABC, RegistryMixin):

--- a/src/llmcompressor/pipelines/sequential/__init__.py
+++ b/src/llmcompressor/pipelines/sequential/__init__.py
@@ -1,3 +1,2 @@
 # flake8: noqa
-from .helpers import get_targets_from_modifiers
 from .pipeline import *

--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -437,7 +437,7 @@ def get_sequential_targets(
     ]
 
     # deprecation warning
-    if len(modifier_targets) > 1:
+    if len(modifier_targets) >= 1:
         logger.warning(
             "Passing sequential targets through modifiers is deprecated, "
             "please use `oneshot(sequential_targets=...)`"

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -11,7 +11,7 @@ from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.pipelines.cache import IntermediatesCache
 from llmcompressor.pipelines.registry import CalibrationPipeline
 from llmcompressor.pipelines.sequential.helpers import (
-    get_targets_from_modifiers,
+    get_sequential_targets,
     trace_subgraphs,
 )
 from llmcompressor.utils.helpers import DisableQuantization, calibration_forward_context
@@ -64,7 +64,7 @@ class SequentialPipeline(CalibrationPipeline):
 
         # prepare to trace subgraphs
         modifiers = session.get_modifiers()
-        sequential_targets = get_targets_from_modifiers(modifiers, model)
+        sequential_targets = get_sequential_targets(modifiers, model, dataset_args)
         ignore = dataset_args.tracing_ignore
 
         # trace subgraphs


### PR DESCRIPTION
## Purpose ##
* Support choosing sequential targets in recipes not containing GPTQ or SparseGPT
  * In a future update release, `sequential_targets` will be removed entirely from modifiers

## Changes ##
* Add `sequential_targets` argument to oneshot
* Refactor sequential targets inference logic to accept be warn about modifier-passed targets
* Update examples to use the oneshot arg