### PR TITLE
AWQ minor performance improvements to smoothing

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -480,9 +480,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                     )
                     del self._smooth_activation_means[mapping.smooth_name]
                     continue
-                if not all(
-                    [fp16_output.isfinite().all() for fp16_output in fp16_outputs]
-                ):
+                if not fp16_output.isfinite().all():
                     logger.warning(
                         f"Skipping smooth_layer {mapping.smooth_name}, NaN or inf "
                         "outputs found during forward pass of the parent module "


### PR DESCRIPTION
SUMMARY:
I wanted to investigate how the runtime for `apply_smoothing` in AWQ could be decreased with torch.compile and removing python for loops. These changes reduce the runtime of `apply_smoothing` by about 8-10%, by vectorizing the loss computation.


TEST PLAN:
Confirmed wikitext PPL scores are virtually the same when running AWQ on `"meta-llama/Llama-3.2-3B-Instruct"` and `"Qwen/Qwen2.5-7B-Instruct"`
