### PR TITLE
[Testing] Set `VLLM_WORKER_MULTIPROC_METHOD` for e2e testing

### DIFF
--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -30,7 +30,7 @@ TEST_DATA_FILE = os.environ.get(
 )
 SKIP_HF_UPLOAD = os.environ.get("SKIP_HF_UPLOAD", "")
 TIMINGS_DIR = os.environ.get("TIMINGS_DIR", "timings/e2e-test_vllm")
-
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 EXPECTED_SAVED_FILES = [
     "config.json",
     r"^model(?:-\d{5}-of-\d{5})?\.safetensors$",


### PR DESCRIPTION
SUMMARY:
- Set `VLLM_WORKER_MULTIPROC_METHOD` fo e2e vllm testing, as per https://github.com/vllm-project/vllm/issues/14535#issuecomment-2709353961
- With that, our e2e is green: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/15739077015/job/44359835739