### PR TITLE
AWQ CohereForCausalLM mappings

### DIFF
--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -74,7 +74,31 @@ _phi_mappings = [
     ),
 ]
 
+
+# Cohere architecture is similar to default, with a very fundamental difference.
+# The MLP block is executed in parallel to the attention. So the tensor goes
+# through input_layernorm and then from there it goes directly to the attention
+# module and to the MLP module.
+_cohere_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm$",
+        [
+            "re:.*self_attn.q_proj$",
+            "re:.*self_attn.k_proj$",
+            "re:.*self_attn.v_proj$",
+            "re:.*mlp.gate_proj$",
+            "re:.*mlp.up_proj$",
+        ],
+    ),
+    AWQMapping("re:.*v_proj$", ["re:.*o_proj$"]),
+    AWQMapping(
+        "re:.*up_proj$",
+        ["re:.*down_proj$"],
+    ),
+]
+
 AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
+    "CohereForCausalLM": _cohere_mappings,
     "LlamaForCausalLM": _default_mappings,
     "MistralForCausalLM": _default_mappings,
     "Phi3ForCausalLM": _phi_mappings,


### PR DESCRIPTION
SUMMARY:
Add AWQ mappings for `CohereForCausalLM` models, which don't have a post_attention_layernorm and instead run MLP and self_attn computations in parallel

Resolves #1566 (in addition to changes landed since 0.5.1 release)

TODOs:
- [ ] Don't land until after 0.6.0 release
- [ ] Validate full run on `CohereLabs/c4ai-command-r-plus`

TEST PLAN:
Running awq on `CohereLabs/c4ai-command-r-plus`
