### PR TITLE
[Pipelines] Add `propagate_error` argument

### DIFF
--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -171,6 +171,7 @@ class DatasetArguments(CustomDatasetArguments):
             "will execute code present on the Hub on your local machine."
         },
     )
+    # --- pipeline arguments --- #
     pipeline: Optional[str] = field(
         default="independent",
         metadata={
@@ -194,5 +195,15 @@ class DatasetArguments(CustomDatasetArguments):
             "Not specifying this argument will cause the sequential pipeline to "
             "default to using the `no_split_params` specified by the HF model "
             "definition"
+        },
+    )
+    propagate_error: Optional[bool] = field(
+        default=True,
+        metadata={
+            "help": "A True value means that the activations used to calibrate layers "
+            "will reflect the error induced by the quantization/optimization of "
+            "previous layers of the model. A False value means that activations will "
+            "be the same as activations produced by the original, full precision base "
+            "model. Deafults to True"
         },
     )

--- a/src/llmcompressor/pipelines/basic/pipeline.py
+++ b/src/llmcompressor/pipelines/basic/pipeline.py
@@ -1,5 +1,5 @@
 import contextlib
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 import torch
 import tqdm
@@ -25,7 +25,7 @@ class BasicPipeline(CalibrationPipeline):
     def __call__(
         model: torch.nn.Module,
         dataloader: DataLoader,
-        dataset_args: Union["DatasetArguments", None],
+        dataset_args: "DatasetArguments",
     ):
         """
         Run a basic data pipeline.
@@ -58,5 +58,7 @@ class BasicPipeline(CalibrationPipeline):
 
 
 def run_calibration(model: torch.nn.Module, dataloader: DataLoader):
+    from llmcompressor.args.dataset_arguments import DatasetArguments
+
     pipeline = BasicPipeline()
-    pipeline(model, dataloader, None)
+    pipeline(model, dataloader, DatasetArguments())


### PR DESCRIPTION
## Purpose ##
* Add research option to allow models to be calibrated using full precision values or values that reflect quantization error

```python3
propagate_error: Optional[bool] = field(
  default=True,
  metadata={
    "help": "A True value means that the activations used to calibrate layers "
    "will reflect the error induced by the quantization/optimization of "
    "previous layers of the model. A False value means that activations will "
    "be the same as activations produced by the original, full precision base "
    "model. Deafults to True"
  },
)
```

## Changes ##
* Add `propagate_error` argument, defaults to True
* Modify basic, sequential, and layer sequential pipelines to conditionally propagate error induced by modifiers