### PR TITLE
bump up requirement for compressed-tensors to 0.10.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,9 +122,9 @@ setup(
         "pynvml",
         "pillow",
         (
-            "compressed-tensors==0.10.1"
+            "compressed-tensors==0.10.2"
             if BUILD_TYPE == "release"
-            else "compressed-tensors>=0.10.2a2"
+            else "compressed-tensors>=0.10.3a2"
         ),
     ],
     extras_require={


### PR DESCRIPTION
SUMMARY:
Update version requirement for compressed-tensor on latest main setup.py for 0.6.0 release


TEST PLAN:
Run all tests
