### PR TITLE
pin numpy<2.3 in dev dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
             "trl>=0.10.1",
             "pandas<2.3.0",
             "torchvision",
-            # librosa depdency numba is currently not compatible with numpy>=2.3
+            # librosa dependency numba is currently not compatible with numpy>=2.3
             # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
             "librosa",
             "numpy<2.3",

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,9 @@ setup(
     install_requires=[
         "loguru",
         "pyyaml>=5.0.0",
-        "numpy>=1.17.0",
+        # librosa dependency numba is currently not compatible with numpy>=2.3
+        # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
+        "numpy>=1.17.0,<2.3",
         "requests>=2.0.0",
         "tqdm>=4.0.0",
         # torch 1.10 and 1.11 do not support quantized onnx export
@@ -142,10 +144,7 @@ setup(
             "trl>=0.10.1",
             "pandas<2.3.0",
             "torchvision",
-            # librosa dependency numba is currently not compatible with numpy>=2.3
-            # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
             "librosa",
-            "numpy<2.3",
             "soundfile",
             # linting, formatting, and type checking
             "black~=24.4.2",

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,10 @@ setup(
             "trl>=0.10.1",
             "pandas<2.3.0",
             "torchvision",
+            # librosa depdency numba is currently not compatible with numpy>=2.3
+            # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
             "librosa",
+            "numpy<2.3",
             "soundfile",
             # linting, formatting, and type checking
             "black~=24.4.2",


### PR DESCRIPTION
SUMMARY:
Python 3.11+ can not install current `llm-compressor[dev]` because librosa dependency numba is not compatible with `numpy<2.3`. This adds a constraint to the dev extras_require to fix installation:

We could alternatively add this to the `install_requires`, but librosa is a dev dependency.

Resolves `INFERENG-1009`

TEST PLAN:
on main:
```
uv pip install -e "/Users/briandellabetta/projects/llm-compressor[dev]"
Resolved 128 packages in 1.13s
  × Failed to build `llvmlite==0.36.0`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File "/Users/briandellabetta/.cache/uv/builds-v0/.tmpLrH27j/lib/python3.11/site-packages/setuptools/build_meta.py", line 331, in
      get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/briandellabetta/.cache/uv/builds-v0/.tmpLrH27j/lib/python3.11/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/Users/briandellabetta/.cache/uv/builds-v0/.tmpLrH27j/lib/python3.11/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/Users/briandellabetta/.cache/uv/builds-v0/.tmpLrH27j/lib/python3.11/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 55, in <module>
        File "<string>", line 52, in _guard_py_ver
      RuntimeError: Cannot install on Python version 3.11.11; only versions >=3.6,<3.10 are supported.

      hint: This usually indicates a problem with the package or the build environment.
  help: `llvmlite` (v0.36.0) was included because `llmcompressor[dev]` (v0.6.1.dev12+g121c7016) depends on `librosa` (v0.11.0) which depends on `numba`
        (v0.53.1) which depends on `llvmlite`
```

on this branch, `uv pip install -e "/Users/briandellabetta/projects/llm-compressor[dev]"` succeeds
