### PR TITLE
[Bugfix][Examples] drop data_collator causing failures in trl init

### DIFF
--- a/examples/trl_mixin/ex_trl_distillation.py
+++ b/examples/trl_mixin/ex_trl_distillation.py
@@ -1,5 +1,5 @@
 from sft_trainer import SFTTrainer
-from transformers import AutoModelForCausalLM, AutoTokenizer, DefaultDataCollator
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor.args import DatasetArguments, ModelArguments
 from llmcompressor.transformers import TextGenerationDataset


### PR DESCRIPTION
SUMMARY:
[A recent update to trl](https://github.com/huggingface/trl/pull/3076/files) no longer allows data_collator to be set when padding_free=True, causing `examples/trl_mixin/ex_trl_distillation.py` to fail. This drops the default collator, which is not needed, to allow for performant packing.

Resolves INFERENG-959

TEST PLAN:
Resolved error in `examples/trl_mixin/ex_trl_distillation.py` in local check after this update.
