### PR TITLE
Enable interactive debugging in llm-compressor by skipping self-references in locals

### DIFF
--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -302,10 +302,10 @@ def oneshot(
     """
 
     # pass all args directly into Oneshot
-    clean_local_args = {
+    local_args = {
         k: v for k, v in locals().items() if k not in ("local_args", "kwargs")
     }
-    one_shot = Oneshot(**clean_local_args, **kwargs)
+    one_shot = Oneshot(**local_args, **kwargs)
     one_shot()
 
     return one_shot.model


### PR DESCRIPTION
If one tries to run interactive debugging session in e.g. VSCode, LLM-Compressor would crash with the following error:

```
ValueError: Some keys are not used by the HfArgumentParser: ['kwargs', 'local_args']
```

This happens because dictionary `local_args = locals()` contains `local_args` and `kwargs` as keys (due to different execution context in debugpy compared to the standard "script mode" with `python quantize.py`), which HF argument parser in OneShot can't handle. This doesn't happens when LLM-Compressor is used in a "script mode" with `python quantize_my_model.py`.

This patch makes it explicit that `local_args` and `kwargs` shouldn't be in local_args and makes interactive session with LLM-Compressor possible. 