### PR TITLE
add DeepseekV3 AWQ mapping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "tqdm>=4.0.0",
         # torch 1.10 and 1.11 do not support quantized onnx export
         "torch>=1.7.0,!=1.10,!=1.11",
-        "transformers>=4.52.0",
+        "transformers>4.0",
         "datasets",
         "accelerate>=0.20.3,!=1.1.0",
         "pynvml",

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "tqdm>=4.0.0",
         # torch 1.10 and 1.11 do not support quantized onnx export
         "torch>=1.7.0,!=1.10,!=1.11",
-        "transformers>4.0",
+        "transformers>=4.52.0",
         "datasets",
         "accelerate>=0.20.3,!=1.1.0",
         "pynvml",

--- a/src/llmcompressor/modeling/llama4.py
+++ b/src/llmcompressor/modeling/llama4.py
@@ -1,8 +1,10 @@
 from typing import Tuple
 
 import torch
-from transformers.models import Llama4Config
-from transformers.models.llama4.configuration_llama4 import Llama4TextConfig
+from transformers.models.llama4.configuration_llama4 import (
+    Llama4Config,
+    Llama4TextConfig,
+)
 from transformers.models.llama4.modeling_llama4 import (
     Llama4TextExperts,
     Llama4TextMLP,

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -465,11 +465,13 @@ class AWQModifier(Modifier, QuantizationMixin):
             # Calculates the relative magnitude of the weights within
             # each of the quantization groups, and rescales each group
             # individually so that each group has weights on a 0-1 scale.
-            w_scale = weight.abs() / (weight.abs().amax(dim=1, keepdim=True) + 1e-6)
+            weight.abs_()
+            weight.div_(weight.amax(dim=1, keepdim=True) + 1e-6)
             # Resizes the rescaled weight matrix back up to its original dimensions
-            w_scale = w_scale.view(org_shape)
+            weight = weight.view(org_shape)
             # Gets the average rescaled magnitude for each output channel
-            w_mean = w_scale.mean(0)
+            w_mean = weight.mean(0)
+            del weight
 
             with calibration_forward_context(model), HooksMixin.disable_hooks():
                 # [STEP 3]: Compute output of module

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -116,6 +116,21 @@ _cohere_mappings = [
     ),
 ]
 
+# DeepseekV3
+_deepseek_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm$",
+        ["re:.*q_a_proj$", "re:.*kv_a_proj_with_mqa$"],
+    ),
+    AWQMapping("re:.*q_a_layernorm$", ["re:.*q_b_proj$"]),
+    AWQMapping("re:.*kv_a_layernorm$", ["re:.*kv_b_proj$"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm$",
+        ["re:.*gate_proj$", "re:.*up_proj$"],
+    ),
+    AWQMapping("re:.*up_proj$", ["re:.*down_proj$"]),
+]
+
 AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "CohereForCausalLM": _cohere_mappings,
     "Cohere2ForCausalLM": _cohere_mappings,
@@ -131,6 +146,7 @@ AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "Qwen2MoeForCausalLM": _moe_default_mappings,
     "Qwen3ForCausalLM": _default_mappings,
     "Qwen3MoeForCausalLM": _moe_default_mappings,
+    "DeepseekV3ForCausalLM": _deepseek_mappings,
 }
 
 

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -121,7 +121,7 @@ _deepseek_mappings = [
     AWQMapping(
         "re:.*input_layernorm$",
         # Some models use q_proj instead of q_a_proj
-        ["re:.*q_proj$", "re:.*q_a_proj$", "re:.*kv_a_proj_with_mqa$"],
+        ["re:.*(q|q_a)_proj$", "re:.*kv_a_proj_with_mqa$"],
     ),
     AWQMapping("re:.*q_a_layernorm$", ["re:.*q_b_proj$"]),
     AWQMapping("re:.*kv_a_layernorm$", ["re:.*kv_b_proj$"]),

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -120,7 +120,7 @@ _cohere_mappings = [
 _deepseek_mappings = [
     AWQMapping(
         "re:.*input_layernorm$",
-        # Some models use q_proj
+        # Some models use q_proj instead of q_a_proj
         ["re:.*q_proj$", "re:.*q_a_proj$", "re:.*kv_a_proj_with_mqa$"],
     ),
     AWQMapping("re:.*q_a_layernorm$", ["re:.*q_b_proj$"]),

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -120,7 +120,8 @@ _cohere_mappings = [
 _deepseek_mappings = [
     AWQMapping(
         "re:.*input_layernorm$",
-        ["re:.*q_a_proj$", "re:.*kv_a_proj_with_mqa$"],
+        # Some models use q_proj
+        ["re:.*q_proj$", "re:.*q_a_proj$", "re:.*kv_a_proj_with_mqa$"],
     ),
     AWQMapping("re:.*q_a_layernorm$", ["re:.*q_b_proj$"]),
     AWQMapping("re:.*kv_a_layernorm$", ["re:.*kv_b_proj$"]),

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -134,6 +134,7 @@ _deepseek_mappings = [
 AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "CohereForCausalLM": _cohere_mappings,
     "Cohere2ForCausalLM": _cohere_mappings,
+    "DeepseekV3ForCausalLM": _deepseek_mappings,
     "Gemma2ForCausalLM": _gemma_mappings,
     "Gemma3ForCausalLM": _gemma_mappings,
     "Gemma3ForConditionalGeneration": _gemma_mappings,
@@ -146,7 +147,6 @@ AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "Qwen2MoeForCausalLM": _moe_default_mappings,
     "Qwen3ForCausalLM": _default_mappings,
     "Qwen3MoeForCausalLM": _moe_default_mappings,
-    "DeepseekV3ForCausalLM": _deepseek_mappings,
 }
 
 


### PR DESCRIPTION
SUMMARY:

Add AWQ activation-smooth mapping for `DeepseekV3ForCausalLM`.


TEST PLAN:

[examples/quantizing_moe/deepseek_r1_example.py](./examples/quantizing_moe/deepseek_r1_example.py) but recipe adapted to use `AWQModifier` instead:

```python
from datasets import load_dataset
from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer

from llmcompressor.modeling import prepare_for_calibration
from llmcompressor.modifiers.awq import AWQModifier
from llmcompressor.transformers import oneshot

# Select model and load it.

# This script takes about 48 hours on 1xA100 to complete.
# Future improvements will reduce this runtime (#1561, #1558).

# For DeepSeek-R1, we require a full precision model in order to properly calibrate
# `DeepSeek-R1-0528-BF16` is a DeepSeek-V3 FP8 model which has been converted to BF16

model_id = "unsloth/DeepSeek-R1-0528-BF16"
config = AutoConfig.from_pretrained(model_id)
del config.quantization_config  # fp8 qconfig no longer appplies to bf16 model
model = AutoModelForCausalLM.from_pretrained(
    model_id, torch_dtype="auto", config=config
)
tokenizer = AutoTokenizer.from_pretrained(model_id)
model = prepare_for_calibration(model)

# Select calibration dataset.
DATASET_ID = "HuggingFaceH4/ultrachat_200k"
DATASET_SPLIT = "train_sft"

# Select number of samples. 512 samples is a good place to start.
# Increasing the number of samples can improve accuracy.
NUM_CALIBRATION_SAMPLES = 512
MAX_SEQUENCE_LENGTH = 2048

# Load dataset and preprocess.
ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
ds = ds.shuffle(seed=42)


def preprocess(example):
    return {
        "text": tokenizer.apply_chat_template(
            example["messages"],
            tokenize=False,
        )
    }


ds = ds.map(preprocess)


# Tokenize inputs.
def tokenize(sample):
    return tokenizer(
        sample["text"],
        padding=False,
        max_length=MAX_SEQUENCE_LENGTH,
        truncation=True,
        add_special_tokens=False,
    )


ds = ds.map(tokenize, remove_columns=ds.column_names)

# Configure the quantization algorithm to run.
# since the MoE gate layers are sensitive to quantization, we add them to the ignore
# list so they remain at full precision
recipe = AWQModifier(
    targets="Linear", scheme="W4A16", ignore=["lm_head", "re:.*mlp.gate$"]
)

# Apply algorithms.
# due to the large size of DeepSeekV3, we specify sequential targets such that
# only one MLP is loaded into GPU memory at a time
oneshot(
    model=model,
    dataset=ds,
    recipe=recipe,
    max_seq_length=MAX_SEQUENCE_LENGTH,
    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
    sequential_targets=["DeepseekV3Attention", "DeepseekV3MLP"],
)

# Save to disk compressed.
SAVE_DIR = model_id.rstrip("/").split("/")[-1] + "-W4A16-G128"
model.save_pretrained(SAVE_DIR, save_compressed=True)
tokenizer.save_pretrained(SAVE_DIR)

```