### PR TITLE
Add support for HunYuanMoE along with AWQ mapping

### DIFF
--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -131,6 +131,7 @@ AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
     "Qwen2MoeForCausalLM": _moe_default_mappings,
     "Qwen3ForCausalLM": _default_mappings,
     "Qwen3MoeForCausalLM": _moe_default_mappings,
+    "HunYuanMoEV1ForCausalLM": _moe_default_mappings,
 }
 
 

--- a/src/llmcompressor/transformers/finetune/data/base.py
+++ b/src/llmcompressor/transformers/finetune/data/base.py
@@ -53,6 +53,18 @@ class TextGenerationDataset(RegistryMixin):
         self.tokenizer = getattr(self.processor, "tokenizer", self.processor)
 
         if self.tokenizer is not None:
+            # special case: if tokenizer attribute exites but is not an expected object
+            # (e.g. tiktoken.Encoding for HY), try use the processor as a tokenizer
+            if not hasattr(self.tokenizer, "pad_token") and hasattr(
+                self.processor, "pad_token"
+            ):
+                self.tokenizer = self.processor
+                logger.warning(
+                    f"Using processor as tokenizer for "
+                    f"{self.processor.__class__.__name__} "
+                    "as the tokenizer attribute is not an expected object"
+                )
+
             # fill in pad token
             if not self.tokenizer.pad_token:
                 self.tokenizer.pad_token = self.tokenizer.eos_token


### PR DESCRIPTION
SUMMARY:
I encountered an ```AttributeError: 'Encoding' object has no attribute 'pad_token'``` when trying to compress the recently released HunyuanMoE model using llm-compressor. The error occurs in the ```TextGenerationDataset.__init__``` method when it tries to access tokenizer attributes.

I think it's because the HYTokenizer class has a ```self.tokenizer``` attribute that points to a ```tiktoken.Encoding``` object rather than an expected tokenizer interface. See [tokenization_hy.py](https://github.com/Tencent-Hunyuan/Hunyuan-A13B/blob/main/models/tokenization_hy.py).

Please review my patch and see if the change is reasonable. Thanks in advance!

TEST PLAN:
This script can be run successfully with awq model saved and proper outputs generated.
```
import re

from datasets import load_dataset
from transformers import AutoModelForCausalLM, AutoTokenizer

from llmcompressor import oneshot
from llmcompressor.modifiers.awq import AWQModifier
from llmcompressor.utils import dispatch_for_generation

# Select model and load it.
MODEL_ID = "/host/shangranlin/models/Hunyuan-A13B-Instruct"

model = AutoModelForCausalLM.from_pretrained(
    MODEL_ID,
    torch_dtype="auto",
    device_map="auto",
    trust_remote_code=True,
)
tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)

# Select calibration dataset.
DATASET_ID = "mit-han-lab/pile-val-backup"
DATASET_SPLIT = "validation"

# Select number of samples. 256 samples is a good place to start.
# Increasing the number of samples can improve accuracy.
NUM_CALIBRATION_SAMPLES = 256
MAX_SEQUENCE_LENGTH = 512

# Load dataset and preprocess.
ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
ds = ds.shuffle(seed=42)


def preprocess(example):
    return {
        "text": tokenizer.apply_chat_template(
            [{"role": "user", "content": example["text"]}],
            tokenize=False,
        )
    }


ds = ds.map(preprocess)


# Configure the quantization algorithm to run.
# NOTE: vllm currently does not support asym MoE, using symmetric here
recipe = [
    AWQModifier(
        ignore=["lm_head", "re:.*.mlp\.gate", "re:.*.shared_mlp"],
        scheme="W4A16",
        targets=["Linear"],
    ),
]

# Apply algorithms.
oneshot(
    model=model,
    dataset=ds,
    recipe=recipe,
    max_seq_length=MAX_SEQUENCE_LENGTH,
    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
    trust_remote_code_model=True,
)

# Save to disk compressed.
SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-awq-sym"
model.save_pretrained(SAVE_DIR, save_compressed=True)
tokenizer.save_pretrained(SAVE_DIR)

# Confirm generations of the quantized model look sane.
print("\n\n")
print("========== SAMPLE GENERATION ==============")
dispatch_for_generation(model)

messages = [
    {
        "role": "user",
        "content": "Write a short summary of the benefits of regular exercise",
    },
]
text = tokenizer.apply_chat_template(messages, tokenize=False, enable_thinking=True)
model_inputs = tokenizer([text], return_tensors="pt").to(model.device)
model_inputs.pop("token_type_ids", None)

outputs = model.generate(**model_inputs, max_new_tokens=4096)
output_text = tokenizer.decode(outputs[0])

think_pattern = r"<think>(.*?)</think>"
think_matches = re.findall(think_pattern, output_text, re.DOTALL)

answer_pattern = r"<answer>(.*?)</answer>"
answer_matches = re.findall(answer_pattern, output_text, re.DOTALL)

think_content = [match.strip() for match in think_matches][0]
answer_content = [match.strip() for match in answer_matches][0]

print(f"thinking_content: {think_content}\n\n")
print(f"answer_content: {answer_content}\n\n")
print("==========================================\n\n")

```
