### PR TITLE
fix trust remote code error handling

### DIFF
--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -241,7 +241,7 @@ def initialize_processor_from_path(
         )
 
     except ValueError as exception:
-        if "trust_remote_code=True" in exception.value:
+        if any(["trust_remote_code=True" in arg for arg in exception.args]):
             raise ValueError(
                 f"The repository for {processor_src} contains custom code which must "
                 "be executed to correctly load the tokenizer/processor. You can "

--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -241,7 +241,7 @@ def initialize_processor_from_path(
         )
 
     except ValueError as exception:
-        if any(["trust_remote_code=True" in arg for arg in exception.args]):
+        if any("trust_remote_code=True" in arg for arg in exception.args):
             raise ValueError(
                 f"The repository for {processor_src} contains custom code which must "
                 "be executed to correctly load the tokenizer/processor. You can "


### PR DESCRIPTION
SUMMARY:
Our error handling logic for when `trust_remote_code=True` is flawed. Currently I hit the following error when trying out `tencent/Hunyuan-A13B-Instruct`:

```
Traceback (most recent call last):
  File "/home/bdellabe/projects/_scratch/awq_one_shot.py", line 91, in <module>
    oneshot(
  File "/home/bdellabe/projects/llm-compressor/src/llmcompressor/entrypoints/oneshot.py", line 308, in oneshot
    one_shot = Oneshot(**clean_local_args, **kwargs)
  File "/home/bdellabe/projects/llm-compressor/src/llmcompressor/entrypoints/oneshot.py", line 128, in __init__
    pre_process(model_args)
  File "/home/bdellabe/projects/llm-compressor/src/llmcompressor/entrypoints/utils.py", line 59, in pre_process
    model_args.processor = initialize_processor_from_path(
  File "/home/bdellabe/projects/llm-compressor/src/llmcompressor/entrypoints/utils.py", line 244, in initialize_processor_from_path
    if "trust_remote_code=True" in exception.value:
AttributeError: 'ValueError' object has no attribute 'value'
```

This updates to fix the error message using the `.args` field on an instance of `ValueError`. No `.value` field exists in python 3.10.



TEST PLAN:
Now error is reported correctly:


```
Traceback (most recent call last):
  File "/home/bdellabe/projects/_scratch/awq_one_shot.py", line 91, in <module>
    oneshot(
  File "/home/bdellabe/projects/llm-compressor/src/llmcompressor/entrypoints/oneshot.py", line 307, in oneshot
    one_shot = Oneshot(**local_args, **kwargs)
  File "/home/bdellabe/projects/llm-compressor/src/llmcompressor/entrypoints/oneshot.py", line 128, in __init__
    pre_process(model_args)
  File "/home/bdellabe/projects/llm-compressor/src/llmcompressor/entrypoints/utils.py", line 59, in pre_process
    model_args.processor = initialize_processor_from_path(
  File "/home/bdellabe/projects/llm-compressor/src/llmcompressor/entrypoints/utils.py", line 245, in initialize_processor_from_path
    raise ValueError(
ValueError: The repository for tencent/Hunyuan-A13B-Instruct contains custom code which must be executed to correctly load the tokenizer/processor. You can inspect the repository content at https://hf.co/tencent/Hunyuan-A13B-Instruct.
Please pass the argument `trust_remote_code_model=True`.
```
