### PR TITLE
Remove tracing blame when encountering runtime errors

### DIFF
--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -74,8 +74,6 @@ class Subgraph:
             raise RuntimeError(
                 "Raised an exception during execution of the following code:\n"
                 f"```\n{add_line_numbers(self._code.src)}\n```\n"
-                "This is likely due to a violation of shape assumptions made when "
-                "tracing"
             ) from exception
 
         return outputs


### PR DESCRIPTION
## Purpose ##
* Make debugging easier by not assuming that runtime errors are always the fault of tracing
  * The new autowrapper logic has made tracing issues much less likely to occur
