### PR TITLE
[Examples] Fix ignore layers for Qwen2.5-VL

### DIFF
--- a/examples/multimodal_vision/qwen_2_5_vl_example.py
+++ b/examples/multimodal_vision/qwen_2_5_vl_example.py
@@ -73,7 +73,7 @@ recipe = [
     GPTQModifier(
         targets="Linear",
         scheme="W4A16",
-        ignore=["lm_head", "re:visual.*", "re:model.visual.*"],
+        ignore=["lm_head", "re:model.visual.*"],
     ),
 ]
 


### PR DESCRIPTION
SUMMARY:
Oneshot() prints the following warning:
Some layers that were to be ignored were not found in the model: {'re:visual.*'} as the vision module in Qwen2.5-vl is in model.visual


TEST PLAN:
Removing re:visual.* from the list of modules to be ignored did not result in any warning or error
