### PR TITLE
Cap transformers version for hotfix 0.6.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,11 +116,7 @@ setup(
         "requests>=2.0.0",
         "tqdm>=4.0.0",
         "torch>=1.7.0",
-        (
-            "transformers>4.0,<=4.52.4"
-            if BUILD_TYPE == "release"
-            else "transformers>4.0,<5.0"
-        ),
+        "transformers>4.0,<=4.52.4",
         "datasets",
         "accelerate>=0.20.3,!=1.1.0",
         "pynvml",


### PR DESCRIPTION
SUMMARY:
Cap transformers version to 4.52.4 for hotfix 0.6.0.1.


TEST PLAN:
All tests