### PR TITLE
[MoE] Add conditional expert calibration

### DIFF
--- a/src/llmcompressor/modeling/deepseek_v3.py
+++ b/src/llmcompressor/modeling/deepseek_v3.py
@@ -10,12 +10,18 @@ class DeepseekV3MoECalibrate(torch.nn.Module):
     Patched DeepseekV3MoE which sends all tokens to all experts for calibration
     """
 
-    def __init__(self, config: DeepseekV3Config, original: OriginalDeepseekV3MoE):
+    def __init__(
+        self,
+        config: DeepseekV3Config,
+        original: OriginalDeepseekV3MoE,
+        calibrate_all_experts: bool,
+    ):
         super().__init__()
         self.config = config
         self.experts = original.experts
         self.gate = original.gate
         self.shared_experts = original.shared_experts
+        self.calibrate_all_experts = calibrate_all_experts
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         residuals = hidden_states
@@ -30,18 +36,28 @@ class DeepseekV3MoECalibrate(torch.nn.Module):
         )
         expert_mask = expert_mask.permute(2, 0, 1)
 
-        for expert_idx in range(len(self.experts)):
-            expert = self.experts[expert_idx]
-            mask = expert_mask[expert_idx]
-            token_indices, weight_indices = torch.where(mask)
+        for expert_idx, expert in enumerate(self.experts):
+            token_indices, weight_indices = torch.where(expert_mask[expert_idx])
+            has_tokens = token_indices.numel() > 0
 
-            expert_weights = topk_weights[token_indices, weight_indices]
-            expert_input = hidden_states[token_indices]
-            expert_output = expert(expert_input)
-            weighted_output = expert_output * expert_weights.unsqueeze(-1)
+            if self.calibrate_all_experts:
+                expert_input = hidden_states
+                expert_output = expert(expert_input)
 
-            if token_indices.numel() > 0:
-                final_hidden_states.index_add_(0, token_indices, weighted_output)
+                if has_tokens:
+                    expert_weights = topk_weights[token_indices, weight_indices]
+                    routed_output = expert_output[
+                        token_indices
+                    ] * expert_weights.unsqueeze(-1)
+                    final_hidden_states.index_add_(0, token_indices, routed_output)
+            else:
+                # Normal MoE: only process tokens routed to this expert
+                if has_tokens:
+                    expert_input = hidden_states[token_indices]
+                    expert_output = expert(expert_input)
+                    expert_weights = topk_weights[token_indices, weight_indices]
+                    routed_output = expert_output * expert_weights.unsqueeze(-1)
+                    final_hidden_states.index_add_(0, token_indices, routed_output)
         # End MoE
 
         hidden_states = final_hidden_states.type(hidden_states.dtype).view(*orig_shape)
@@ -49,5 +65,11 @@ class DeepseekV3MoECalibrate(torch.nn.Module):
         return hidden_states
 
 
-def replace(config: DeepseekV3Config, module: OriginalDeepseekV3MoE):
-    return DeepseekV3MoECalibrate(config=config, original=module)
+def replace(
+    config: DeepseekV3Config,
+    module: OriginalDeepseekV3MoE,
+    calibrate_all_experts: bool,
+):
+    return DeepseekV3MoECalibrate(
+        config=config, original=module, calibrate_all_experts=calibrate_all_experts
+    )

--- a/tests/llmcompressor/modeling/test_calib_deepseek_v3.py
+++ b/tests/llmcompressor/modeling/test_calib_deepseek_v3.py
@@ -1,0 +1,49 @@
+from functools import partial
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+
+from llmcompressor.modeling.deepseek_v3 import DeepseekV3MoECalibrate
+from llmcompressor.modeling.prepare import replace_modules_for_calibration
+from llmcompressor.utils.dev import skip_weights_download
+
+
+@pytest.mark.parametrize("model_stub", ["unsloth/DeepSeek-R1-0528-BF16"])
+def test_calib_replace_deepseekv3moe_all_experts(model_stub):
+    with skip_weights_download():
+        model = AutoModelForCausalLM.from_pretrained(model_stub)
+
+    replace_modules_for_calibration(model, calibrate_all_experts=True)
+
+    # Find a Deepseek MoE layer
+    moe_layer = None
+    for _, module in model.named_modules():
+        if isinstance(module, DeepseekV3MoECalibrate):
+            moe_layer = module
+            break
+
+    assert moe_layer is not None
+
+    num_experts = len(moe_layer.experts)
+    expert_triggered = [False for _ in range(num_experts)]
+
+    # Define the hook function
+    def hook_fn(i, module, input, output):
+        expert_triggered[i] = True
+
+    # Attach hooks using functools.partial to bind each index
+    for i, expert in enumerate(moe_layer.experts):
+        expert.register_forward_hook(partial(hook_fn, i))
+
+    # Create dummy input tensor that simulates hidden_states
+    hidden_dim = model.config.hidden_size
+    batch, seq_len = 4, 32
+    sample = torch.randn(batch, seq_len, hidden_dim, dtype=torch.float32)
+
+    # Forward through the MoE layer directly
+    with torch.no_grad():
+        _ = moe_layer(sample)
+
+    # Assert all experts are used
+    assert all(expert_triggered), f"Not all experts were triggered: {expert_triggered}"

--- a/tests/llmcompressor/modeling/test_calib_llama4.py
+++ b/tests/llmcompressor/modeling/test_calib_llama4.py
@@ -1,0 +1,51 @@
+from functools import partial
+
+import pytest
+import torch
+from transformers import Llama4ForConditionalGeneration
+
+from llmcompressor.modeling.llama4 import SequentialLlama4TextMoe
+from llmcompressor.modeling.prepare import replace_modules_for_calibration
+from llmcompressor.utils.dev import skip_weights_download
+
+
+@pytest.mark.parametrize("model_stub", ["meta-llama/Llama-4-Scout-17B-16E-Instruct"])
+def test_calib_replace_llama4_moe_all_experts(model_stub):
+    with skip_weights_download(Llama4ForConditionalGeneration):
+        model = Llama4ForConditionalGeneration.from_pretrained(
+            model_stub, torch_dtype="auto"
+        )
+
+    replace_modules_for_calibration(model, calibrate_all_experts=True)
+
+    # Find a Llama4 MoE layer
+    moe_layer = None
+    for _, module in model.named_modules():
+        if isinstance(module, SequentialLlama4TextMoe):
+            moe_layer = module
+            break
+
+    assert moe_layer is not None
+
+    num_experts = len(moe_layer.experts)
+    expert_triggered = [False for _ in range(num_experts)]
+
+    # Define the hook function
+    def hook_fn(i, module, input, output):
+        expert_triggered[i] = True
+
+    # Attach hooks using functools.partial to bind each index
+    for i, expert in enumerate(moe_layer.experts):
+        expert.register_forward_hook(partial(hook_fn, i))
+
+    # Create dummy input tensor that simulates hidden_states
+    hidden_dim = model.config.hidden_size
+    batch, seq_len = 4, 32
+    sample = torch.randn(batch, seq_len, hidden_dim, dtype=torch.float32)
+
+    # Forward through the MoE layer directly
+    with torch.no_grad():
+        _ = moe_layer(sample)
+
+    # Assert all experts are used
+    assert all(expert_triggered), f"Not all experts were triggered: {expert_triggered}"

--- a/tests/llmcompressor/modeling/test_calib_qwen3.py
+++ b/tests/llmcompressor/modeling/test_calib_qwen3.py
@@ -1,0 +1,58 @@
+import contextlib
+from functools import partial
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+
+from llmcompressor.modeling.prepare import moe_calibration_context
+from llmcompressor.modeling.qwen3_moe import Qwen3MoeSparseMoeBlock
+from llmcompressor.utils.dev import skip_weights_download
+from llmcompressor.utils.helpers import DisableQuantization, calibration_forward_context
+
+
+@pytest.mark.parametrize("model_stub", ["Qwen/Qwen3-30B-A3B"])
+def test_calib_replace_qwen3moe_all_experts(model_stub):
+    with skip_weights_download():
+        model = AutoModelForCausalLM.from_pretrained(model_stub)
+
+    # Qwen3MoE layer replacement is temporary within the context
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(calibration_forward_context(model))
+        stack.enter_context(DisableQuantization(model))
+
+        moe_calibration_context(model, stack, calibrate_all_experts=True)
+
+        # Find one MoE layer
+        moe_layer = None
+        for _, module in model.named_modules():
+            if isinstance(module, Qwen3MoeSparseMoeBlock):
+                moe_layer = module
+                break
+
+        assert moe_layer is not None
+
+        num_experts = len(moe_layer.experts)
+        expert_triggered = [False for _ in range(num_experts)]
+
+        # Define the hook function
+        def hook_fn(i, module, input, output):
+            expert_triggered[i] = True
+
+        # Attach hooks using functools.partial to bind each index
+        for i, expert in enumerate(moe_layer.experts):
+            expert.register_forward_hook(partial(hook_fn, i))
+
+        # Create dummy input tensor that simulates hidden_states
+        hidden_dim = model.config.hidden_size
+        batch, seq_len = 4, 32
+        sample = torch.randn(batch, seq_len, hidden_dim, dtype=torch.float32)
+
+        # Forward through the MoE layer directly
+        with torch.no_grad():
+            _ = moe_layer(sample)
+
+        # Assert all experts are used
+        assert all(
+            expert_triggered
+        ), f"Not all experts were triggered: {expert_triggered}"


### PR DESCRIPTION
## Purpose ##
- Add calibrate_all_experts option to improve MoE calibration

## Changes ##
- Add `calibrate_all_experts` flag to MoE layers
- Update `replace_modules_for_calibration` and `moe_calibration_context`
  to propagate the flag into modules
- Modify expert forward passes:
  * Normal mode (default): compute output only for tokens routed to
    top-k experts, and combine their weighted results in the final
    output
  * Calibration mode (`calibrate_all_experts=True`): compute output for
    all tokens on every expert, but still apply the top-k gating to
    decide which token outputs contribute to the final result.

## Testing ##
- Add unit test to verify all experts are triggered during MoE calibration
