### PR TITLE
[WIP] Add an awq_asym lm-eval test

### DIFF
--- a/tests/e2e/vLLM/recipes/AWQ/recipe_w4a16_awq_asym.yaml
+++ b/tests/e2e/vLLM/recipes/AWQ/recipe_w4a16_awq_asym.yaml
@@ -1,0 +1,22 @@
+quant_stage:
+  quant_modifiers:
+    AWQModifier:
+      mappings:
+        - smooth_layer: "re:.*input_layernorm$"
+          balance_layers: ["re:.*q_proj$", "re:.*k_proj$", "re:.*v_proj$"]
+        - smooth_layer: "re:.*v_proj$"
+          balance_layers: ["re:.*o_proj$"]
+        - smooth_layer: "re:.*post_attention_layernorm$"
+          balance_layers: ["re:.*gate_proj$", "re:.*up_proj$"]
+        - smooth_layer: "re:.*up_proj$"
+          balance_layers: ["re:.*down_proj$"]
+      ignore: ["lm_head"]
+      config_groups:
+        group_0:
+          weights:
+            num_bits: 4
+            type: "int"
+            symmetric: false
+            strategy: "group"
+            group_size: 128
+          targets: ["Linear"]

--- a/tests/lmeval/configs/w4a16_awq_asym.yaml
+++ b/tests/lmeval/configs/w4a16_awq_asym.yaml
@@ -1,0 +1,13 @@
+cadence: "weekly"
+model: meta-llama/Meta-Llama-3-8B-Instruct
+scheme: W4A16_ASYM
+recipe: tests/e2e/vLLM/recipes/AWQ/recipe_w4a16_awq_asym.yaml
+dataset_id: HuggingFaceH4/ultrachat_200k
+dataset_split: train_sft
+lmeval:
+  model: "vllm"
+  model_args:
+    add_bos_token: true
+  metrics:
+    exact_match,flexible-extract: 0.73
+    exact_match,strict-match: 0.73


### PR DESCRIPTION
SUMMARY:
In response to https://github.com/vllm-project/llm-compressor/issues/1688, add an awq_asym lm-eval test config.

TEST PLAN:
```
export CADENCE=weekly
export TEST_DATA_FILE=tests/lmeval/configs/w4a16_awq_asym.yaml
python -m pytest tests/lmeval/test_lmeval.py::TestLMEval::test_lm_eval -v
```

MISC:
As Llama is a gated model, I'm using a local model path instead of meta-llama/Meta-Llama-3-8B-Instruct during local testing. I'm not sure if this might affect the test flow / accuracy. It would be great if you could help me verify it. That's also why I've marked it as WIP.
