### PR TITLE
[Tests] Add tests for "quantization_w4a4_fp4" examples

### DIFF
--- a/tests/examples/test_quantization_w4a4_fp4.py
+++ b/tests/examples/test_quantization_w4a4_fp4.py
@@ -1,0 +1,56 @@
+
+import shlex
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from tests.examples.utils import (
+    copy_and_run_script,
+    gen_cmd_fail_message,
+    requires_gpu_count,
+)
+
+
+@pytest.fixture
+def example_dir() -> str:
+    return "examples/quantization_w4a4_fp4"
+
+
+@requires_gpu_count(1)
+@pytest.mark.example
+class TestQuantizationW4A4_FP4:
+    """
+    Tests for examples in the "quantization_w4a4_fp4" example folder.
+    """
+
+    @pytest.mark.parametrize(
+        "script_filename",
+        [
+            pytest.param("llama3_example.py"),
+            pytest.param("llama4_example.py"),
+            pytest.param("qwen_30b_a3b.py"),
+        ],
+    )
+    def test_quantization_w4a4_fp4_example_script(
+        self, script_filename: str, example_dir: str, tmp_path: Path
+    ):
+        """
+        Tests the example scripts in the folder.
+        """
+        command, result = copy_and_run_script(tmp_path, example_dir, script_filename)
+
+        assert result.returncode == 0, gen_cmd_fail_message(command, result)
+
+        # verify that the expected directory got generated
+        nvfp4_dirs: List[Path] = list(Path.cwd().glob("*-NVFP4"))
+        assert(len(nvfp4_dirs)) == 1, (
+            f"unexpectedly found more than one generated folder: {nvfp4_dirs}"
+        )
+        print("generated model directory:/n")
+        print(list(nvfp4_dirs[0].iterdir()))
+
+        # is the generated content in the expected format?
+        config_json = Path(nvfp4_dirs[0] / "config.json").read_text()
+        config_format = config_json["quantization_config"]["format"]
+        assert(config_format == "nvfp4-pack-quantized")

--- a/tests/examples/test_quantization_w4a4_fp4.py
+++ b/tests/examples/test_quantization_w4a4_fp4.py
@@ -1,4 +1,5 @@
 
+import json
 import shlex
 from pathlib import Path
 from typing import List
@@ -51,6 +52,6 @@ class TestQuantizationW4A4_FP4:
         print(list(nvfp4_dirs[0].iterdir()))
 
         # is the generated content in the expected format?
-        config_json = Path(nvfp4_dirs[0] / "config.json").read_text()
+        config_json = json.loads(Path(nvfp4_dirs[0] / "config.json").read_text())
         config_format = config_json["quantization_config"]["format"]
         assert(config_format == "nvfp4-pack-quantized")

--- a/tests/examples/test_quantization_w4a4_fp4.py
+++ b/tests/examples/test_quantization_w4a4_fp4.py
@@ -1,6 +1,4 @@
-
 import json
-import shlex
 from pathlib import Path
 from typing import List
 
@@ -26,7 +24,7 @@ class TestQuantizationW4A4_FP4:
     """
 
     @pytest.mark.parametrize(
-        "script_filename",
+        ("script_filename"),
         [
             pytest.param("llama3_example.py"),
             pytest.param("llama4_example.py"),
@@ -43,15 +41,13 @@ class TestQuantizationW4A4_FP4:
 
         assert result.returncode == 0, gen_cmd_fail_message(command, result)
 
-        # verify that the expected directory got generated
-        nvfp4_dirs: List[Path] = list(Path.cwd().glob("*-NVFP4"))
-        assert(len(nvfp4_dirs)) == 1, (
-            f"unexpectedly found more than one generated folder: {nvfp4_dirs}"
-        )
-        print("generated model directory:/n")
-        print(list(nvfp4_dirs[0].iterdir()))
+        # verify the expected directory was generated
+        nvfp4_dirs: List[Path] = list(tmp_path.rglob("*-NVFP4"))
+        assert (
+            len(nvfp4_dirs)
+        ) == 1, f"did not find exactly one generated folder: {nvfp4_dirs}"
 
-        # is the generated content in the expected format?
-        config_json = json.loads(Path(nvfp4_dirs[0] / "config.json").read_text())
+        # verify the format in the generated config
+        config_json = json.loads((nvfp4_dirs[0] / "config.json").read_text())
         config_format = config_json["quantization_config"]["format"]
-        assert(config_format == "nvfp4-pack-quantized")
+        assert config_format == "nvfp4-pack-quantized"


### PR DESCRIPTION
SUMMARY:
Adds tests for the example scripts in the `examples/quantization_w4a4_fp4` folder.

TEST PLAN:
Internal examples test run with just the new tests: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/16831501387/job/47709542536

The failure appears to be a legitimate issue, not a test issue, and has been reported.
