### PR TITLE
fix pydantic validation errors

### DIFF
--- a/tests/llmcompressor/modifiers/calibration/test_cache.py
+++ b/tests/llmcompressor/modifiers/calibration/test_cache.py
@@ -47,8 +47,8 @@ def test_is_quantized_cache_singleton():
 
 
 def test_update():
-    nbits = 8
-    args = QuantizationArgs(nbits=nbits, symmetric=True)
+    num_bits = 8
+    args = QuantizationArgs(num_bits=num_bits, symmetric=True)
     cache = QuantizedKVParameterCache(args)
 
     max_key_states_val = 1.0
@@ -62,7 +62,7 @@ def test_update():
     layer_idx = 0
 
     cache.update(key_states, value_states, layer_idx)
-    denom = (2 ** (nbits) - 1) / 2
+    denom = (2 ** (num_bits) - 1) / 2
     expected_k_scale = torch.tensor([max_key_states_val / denom])
     expected_v_scale = torch.tensor([max_value_states_val / denom])
 
@@ -83,8 +83,8 @@ def test_update():
 
 
 def test_cache_reset():
-    nbits = 8
-    args = QuantizationArgs(nbits=nbits, symmetric=True)
+    num_bits = 8
+    args = QuantizationArgs(num_bits=num_bits, symmetric=True)
     cache = QuantizedKVParameterCache(args)
 
     max_key_states_val = 1.0

--- a/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
+++ b/tests/llmcompressor/pytorch/modifiers/pruning/sparsegpt/test_pytorch.py
@@ -96,13 +96,11 @@ class TestSetQuantInGPTQ(unittest.TestCase):
                         "symmetric": False,
                         "strategy": "token",
                         "dynamic": True,
-                        "kwargs": {},
                     },
                     "weights": {
                         "num_bits": 4,
                         "symmetric": True,
                         "strategy": "channel",
-                        "kwargs": {},
                     },
                 }
             }

--- a/tests/llmcompressor/pytorch/utils/test_sparse.py
+++ b/tests/llmcompressor/pytorch/utils/test_sparse.py
@@ -19,7 +19,7 @@ class FakeQuantizedModel(Module):
         self.relu = ReLU()
 
         self.fc1.quantization_scheme = QuantizationScheme(
-            targets=["Linear"],
+            targets=["model.fc1"],
             weights=QuantizationArgs(
                 num_bits=8,
                 type=QuantizationType.INT,

--- a/tests/llmcompressor/pytorch/utils/test_sparse.py
+++ b/tests/llmcompressor/pytorch/utils/test_sparse.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme, QuantizationStrategy, QuantizationType
 from torch.nn import Linear, Module, ReLU
 
 from llmcompressor.pytorch.utils import ModuleSparsificationInfo
@@ -14,14 +14,16 @@ class FakeQuantizedModel(Module):
         self.relu = ReLU()
 
         self.fc1.quantization_scheme = QuantizationScheme(
-            targets=["model.fc1"],
-            weights=QuantizationArgs(
-                precision=8,
-                granularity="per_tensor",
-                algorithm="gptq",
-                blocksize=128,
-            ),
-        )
+                targets=["Linear"],
+                weights=QuantizationArgs(
+                    num_bits=4,
+                    type=QuantizationType.INT,
+                    group_size=128,
+                    strategy=QuantizationStrategy.GROUP,
+                    symmetric=True,
+                    dynamic=False,
+                )
+            )
 
 
 def test_module_quantization_info():

--- a/tests/llmcompressor/pytorch/utils/test_sparse.py
+++ b/tests/llmcompressor/pytorch/utils/test_sparse.py
@@ -21,7 +21,7 @@ class FakeQuantizedModel(Module):
         self.fc1.quantization_scheme = QuantizationScheme(
             targets=["Linear"],
             weights=QuantizationArgs(
-                num_bits=4,
+                num_bits=8,
                 type=QuantizationType.INT,
                 group_size=128,
                 strategy=QuantizationStrategy.GROUP,

--- a/tests/llmcompressor/pytorch/utils/test_sparse.py
+++ b/tests/llmcompressor/pytorch/utils/test_sparse.py
@@ -1,6 +1,11 @@
 import pytest
 import torch
-from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme, QuantizationStrategy, QuantizationType
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationScheme,
+    QuantizationStrategy,
+    QuantizationType,
+)
 from torch.nn import Linear, Module, ReLU
 
 from llmcompressor.pytorch.utils import ModuleSparsificationInfo
@@ -14,16 +19,16 @@ class FakeQuantizedModel(Module):
         self.relu = ReLU()
 
         self.fc1.quantization_scheme = QuantizationScheme(
-                targets=["Linear"],
-                weights=QuantizationArgs(
-                    num_bits=4,
-                    type=QuantizationType.INT,
-                    group_size=128,
-                    strategy=QuantizationStrategy.GROUP,
-                    symmetric=True,
-                    dynamic=False,
-                )
-            )
+            targets=["Linear"],
+            weights=QuantizationArgs(
+                num_bits=4,
+                type=QuantizationType.INT,
+                group_size=128,
+                strategy=QuantizationStrategy.GROUP,
+                symmetric=True,
+                dynamic=False,
+            ),
+        )
 
 
 def test_module_quantization_info():


### PR DESCRIPTION
SUMMARY:
[Recent changes to compressed-tensors](https://github.com/neuralmagic/compressed-tensors/pull/386) are causing some llm-compressor unit tests to fail. Fixing them on this branch


TEST PLAN:
tests pass
