### PR TITLE
[BugFix] Pin transformers to <4.54.0 to fix Qwen2.5-VL FP8 accuracy regression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,8 @@ setup(
         "tqdm>=4.0.0",
         # torch 1.10 and 1.11 do not support quantized onnx export
         "torch>=1.7.0,!=1.10,!=1.11",
-        "transformers>4.0",
+        # Pin to <4.54.0 for Qwen2.5-VL FP8 quantization (see issue #1727)
+        "transformers>4.0,<4.54.0",
         "datasets>=3.0.0",
         "accelerate>=0.20.3,!=1.1.0",
         "pynvml>=11.5.3",


### PR DESCRIPTION
## Summary

This PR temporarily pins transformers to versions before 4.54.0 to address a 10% accuracy regression when quantizing Qwen2.5-VL models with FP8 dynamic quantization.

## Problem

- Transformers 4.54.0+ causes Qwen2.5-VL FP8 quantization to drop from 83.33% to 73.33% accuracy on MMMU literature task
- All versions 4.53.x work correctly
- All versions 4.54.0+ exhibit the regression

## Solution

Pin transformers to `<4.54.0` as a temporary workaround while the root cause is investigated.

## Testing

- Confirmed test passes with transformers 4.53.3
- Confirmed test fails with transformers 4.54.0, 4.54.1, and 4.55.0

Fixes #1727