### PR TITLE
[AWQ] Minor updates and example bugfixes

### DIFF
--- a/examples/awq/llama_example.py
+++ b/examples/awq/llama_example.py
@@ -66,9 +66,7 @@ oneshot(
 print("\n\n")
 print("========== SAMPLE GENERATION ==============")
 dispatch_for_generation(model)
-input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(
-    model.device
-)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
 output = model.generate(input_ids, max_new_tokens=100)
 print(tokenizer.decode(output[0]))
 print("==========================================\n\n")

--- a/examples/awq/qwen3_moe_example.py
+++ b/examples/awq/qwen3_moe_example.py
@@ -71,9 +71,7 @@ oneshot(
 print("\n\n")
 print("========== SAMPLE GENERATION ==============")
 dispatch_for_generation(model)
-input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(
-    model.device
-)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
 output = model.generate(input_ids, max_new_tokens=100)
 print(tokenizer.decode(output[0]))
 print("==========================================\n\n")


### PR DESCRIPTION
SUMMARY:
- [x] Improve raised Exception message
- [x] Update comment on why quantization must be disabled
- [x] Fix llama_example.py
- [x] Fix qwen3_moe_example.py. Diagnosis: A small subset of experts are appearing on `meta` device, whereas the rest are on `cuda` device. When all the weight are concatenated in apply_smoothing, this errors out. By moving `align_modules` up to top of apply_smoothing, we avoid this issue


TEST PLAN:
Examples are running now. 
_Qwen 3 example takes ~4-5 hours to complete with the given 256 samples with sequence legnth of 512._
