### PR TITLE
[Examples] Create qwen_2_5_vl_example.py

### DIFF
--- a/examples/quantization_w8a8_fp8/qwen_2_5_vl_example.py
+++ b/examples/quantization_w8a8_fp8/qwen_2_5_vl_example.py
@@ -1,0 +1,37 @@
+from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.utils import dispatch_for_generation
+
+MODEL_ID = "Qwen/Qwen2.5-VL-7B-Instruct"
+
+# Load model.
+model = Qwen2_5_VLForConditionalGeneration.from_pretrained(MODEL_ID, torch_dtype="auto")
+processor = AutoProcessor.from_pretrained(MODEL_ID)
+
+# Configure the quantization algorithm and scheme.
+# In this case, we:
+#   * quantize the weights to fp8 with per channel via ptq
+#   * quantize the activations to fp8 with dynamic per token
+recipe = QuantizationModifier(
+    targets="Linear",
+    scheme="FP8_DYNAMIC",
+    ignore=["re:.*lm_head", "re:visual.*"],
+)
+
+# Apply quantization and save to disk in compressed-tensors format.
+oneshot(model=model, recipe=recipe)
+
+# Confirm generations of the quantized model look sane.
+print("========== SAMPLE GENERATION ==============")
+dispatch_for_generation(model)
+input_ids = processor(text="Hello my name is", return_tensors="pt").input_ids.to("cuda")
+output = model.generate(input_ids, max_new_tokens=20)
+print(processor.decode(output[0]))
+print("==========================================")
+
+# Save to disk in compressed-tensors format.
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-FP8-Dynamic"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+processor.save_pretrained(SAVE_DIR)


### PR DESCRIPTION
SUMMARY:
Add Qwen2.5-VL support for W8A8 FP8 quantization example
This PR adds support for Qwen2.5-VL model in the W8A8 FP8 quantization examples. While Qwen2-VL is still available, Qwen2.5-VL has gained more popularity among users. This addition provides users with an example for FP8 quantization of Qwen's newer vision-language model alongside the existing Qwen2-VL support.


TEST PLAN:
This is a low-risk change that simply adapts the existing Qwen2-VL example for Qwen2.5-VL:
Simple Adaptation: Only changed the model ID from Qwen2-VL to Qwen2.5-VL - no structural changes to the quantization logic
Proven Feasibility: The code has been tested and verified to work correctly with Qwen2.5-VL
Consistency: Follows the exact same pattern as other Qwen2.5-VL examples already in the repository
No Risk: This is a straightforward model ID update that maintains all existing functionality
