### PR TITLE
[AWQ] fixes to matching logic and #1742 bugfix

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 from compressed_tensors.quantization import disable_quantization
 from compressed_tensors.utils import (
-    align_module_device,
     align_modules,
     get_execution_device,
     match_named_modules,


### PR DESCRIPTION
SUMMARY:
- [x] I introduced a bug in #1742 that caused `lm_eval` awq test to fail. This reverts that change, re-setting the original state dict of the parent module in the grid search for best scales. 
- [x] This also updates to the new module matching API, excluding from the resolved mappings any modules that match the list in `ignore`. This should resolve a user issue with command-a-vision, which has k_proj etc. layers in the vision_encoder that we want to exclude in our resolved mappings.


TEST PLAN:
awq lm_eval test is passing now. Running command-a-vision check
