### PR TITLE
Fix install issue due to librosa

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ setup(
             "trl>=0.10.1",
             "pandas<2.3.0",
             "torchvision",
-            "librosa>=0.11.0",
+            "librosa==0.11.0",
             "soundfile",
             "torchcodec",
             # linting, formatting, and type checking

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ setup(
             "trl>=0.10.1",
             "pandas<2.3.0",
             "torchvision",
-            "librosa",
+            "librosa>=0.11.0",
             "soundfile",
             "torchcodec",
             # linting, formatting, and type checking


### PR DESCRIPTION
SUMMARY:
Had to pin librosa version to 0.11.0 in order for installation with [dev] to work.


TEST PLAN:
A run here has passed the installation across the jobs: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/17083270223/job/48442139981
