### PR TITLE
Fix wonky dependency range on datasets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,10 @@ setup(
             if BUILD_TYPE == "release"
             else "transformers>=4.53.0"
         ),
+        # `datasets==4.0.0` is latest release, so
+        # pin directly. NOTE: add range after new release
         (
-            "datasets>=4.0.0,<=4.0.0"
+            "datasets==4.0.0"
             if BUILD_TYPE == "release"
             else "datasets>=4.0.0"
         ),
@@ -163,7 +165,7 @@ setup(
             else "pynvml>=11.5.3"
         ),
         (
-            "pillow>=10.4.0,<=10.4.0"
+            "pillow>=10.4.0,<11.0.0"
             if BUILD_TYPE == "release"
             else "pillow>=10.4.0"
         ),


### PR DESCRIPTION
SUMMARY:
Fixes dependencies

- [`datasets>=4.0.0,<=4.0.0`](https://github.com/vllm-project/llm-compressor/pull/1734/files#r2277726469)
- [`pillow>=10.4.0,<=10.4.0`](https://github.com/vllm-project/llm-compressor/pull/1734/files#r2277726473)

TEST PLAN:
None