### PR TITLE
Updating API docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.smartsymbols
   - pymdownx.snippets
+  - pymdownx.magiclink
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
@@ -85,6 +86,9 @@ markdown_extensions:
 plugins:
   - api-autonav:
       modules: ['src/llmcompressor']
+      exclude:
+        - "llmcompressor.version"
+        - "llmcompressor.typing"
   - gen-files:
       scripts:
         - docs/scripts/gen_files.py
@@ -96,7 +100,21 @@ plugins:
       handlers:
         python:
           options:
-            docstring_style: sphinx
+            docstring_section_style: list
+            show_if_no_docstring: false
+            docstring_style: "sphinx"
+            filters:
+              - "!docstring"
+              - "!^_"
+            heading_level: 1
+            merge_init_into_class: true
+            parameter_headings: true
+            separate_signature: true
+            show_root_heading: true
+            show_signature_annotations: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            summary: true
   - search
   - section-index
   - social

--- a/src/llmcompressor/__init__.py
+++ b/src/llmcompressor/__init__.py
@@ -1,6 +1,7 @@
 """
-A library for compressing large language models utilizing the latest techniques and
-research in the field for both training aware and post training techniques.
+LLM Compressor is a library for compressing large language models utilizing
+the latest techniques and research in the field for both training aware and
+post-training techniques.
 
 The library is designed to be flexible and easy to use on top of
 PyTorch and HuggingFace Transformers, allowing for quick experimentation.

--- a/src/llmcompressor/args/__init__.py
+++ b/src/llmcompressor/args/__init__.py
@@ -1,5 +1,12 @@
 # ruff: noqa
 
+"""
+Arguments package for LLM Compressor.
+
+Defines structured argument classes for datasets, models, training, and
+recipes, along with utilities for parsing them.
+"""
+
 from .dataset_arguments import DatasetArguments
 from .model_arguments import ModelArguments
 from .recipe_arguments import RecipeArguments

--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -1,3 +1,12 @@
+"""
+Dataset argument classes for LLM compression workflows.
+
+This module defines dataclass-based argument containers for configuring dataset
+loading, preprocessing, and calibration parameters across different dataset
+sources and processing pipelines. Supports various input formats including
+HuggingFace datasets, custom JSON/CSV files, and DVC-managed datasets.
+"""
+
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Union
 

--- a/src/llmcompressor/args/model_arguments.py
+++ b/src/llmcompressor/args/model_arguments.py
@@ -1,3 +1,12 @@
+"""
+Model argument classes for LLM compression workflows.
+
+This module defines dataclass-based argument containers for configuring model
+loading, tokenization, and preprocessing parameters. Supports various model
+sources including HuggingFace model hub, local paths, and custom
+configurations for compression workflows.
+"""
+
 from dataclasses import dataclass, field
 from typing import Optional
 

--- a/src/llmcompressor/args/recipe_arguments.py
+++ b/src/llmcompressor/args/recipe_arguments.py
@@ -1,3 +1,11 @@
+"""
+Recipe argument classes for LLM compression workflows.
+
+Defines dataclass-based argument containers for configuring sparsification
+recipes, compression sessions, and stage-based execution parameters used in
+model compression and optimization workflows.
+"""
+
 from dataclasses import dataclass, field
 from typing import List, Optional
 

--- a/src/llmcompressor/args/training_arguments.py
+++ b/src/llmcompressor/args/training_arguments.py
@@ -1,3 +1,12 @@
+"""
+Training argument classes for LLM compression workflows.
+
+This module defines dataclass-based argument containers for configuring
+training and one-shot calibration workflows. Extends HuggingFace's
+TrainingArguments with additional parameters specific to compression and
+stage-based execution.
+"""
+
 from dataclasses import dataclass, field
 from typing import Optional
 

--- a/src/llmcompressor/args/utils.py
+++ b/src/llmcompressor/args/utils.py
@@ -1,3 +1,12 @@
+"""
+Utility functions for parsing and processing argument classes.
+
+Provides helper functions for parsing command-line arguments and
+configuration dictionaries into structured argument dataclasses used in
+LLM compression workflows. Handles argument validation, deprecation
+warnings, and processor resolution.
+"""
+
 from typing import Tuple
 
 from loguru import logger

--- a/src/llmcompressor/core/__init__.py
+++ b/src/llmcompressor/core/__init__.py
@@ -1,3 +1,11 @@
+"""
+Provides the core compression framework for LLM Compressor.
+
+The core API manages compression sessions, tracks state changes, handles events
+during compression, and Provides lifecycle hooks for the compression
+process.
+"""
+
 from llmcompressor.core.events import Event, EventType
 from llmcompressor.core.lifecycle import CompressionLifecycle
 from llmcompressor.core.model_layer import ModelParameterizedLayer

--- a/src/llmcompressor/core/helpers.py
+++ b/src/llmcompressor/core/helpers.py
@@ -1,3 +1,11 @@
+"""
+Helper functions for core compression operations.
+
+Provides utility functions for logging model information and state
+management during compression workflows. Includes functionality for
+conditional logging and parameter tracking.
+"""
+
 from typing import Any, Generator, Optional, Tuple, Union
 
 from llmcompressor.core.state import State

--- a/src/llmcompressor/core/lifecycle.py
+++ b/src/llmcompressor/core/lifecycle.py
@@ -1,8 +1,8 @@
 """
 Module for managing the compression lifecycle in the LLM Compressor.
 
-This module provides a class for defining and managing the lifecycle of compression
-events, including initialization, finalization, and event handling.
+Provides a class for defining and managing the lifecycle of compression events,
+including initialization, finalization, and event handling.
 """
 
 from dataclasses import dataclass, field

--- a/src/llmcompressor/core/model_layer.py
+++ b/src/llmcompressor/core/model_layer.py
@@ -1,3 +1,11 @@
+"""
+Model layer utility classes for LLM compression workflows.
+
+Provides dataclass containers for managing model layers and their associated
+parameters during compression operations. Facilitates tracking and manipulation
+of specific model components and their parameters.
+"""
+
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/llmcompressor/core/session.py
+++ b/src/llmcompressor/core/session.py
@@ -1,3 +1,11 @@
+"""
+Compression session management for LLM compression workflows.
+
+Provides the main CompressionSession class for managing compression
+workflows, including lifecycle management, event handling, callback
+registration, and state tracking.
+"""
+
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -47,7 +55,7 @@ class CompressionSession:
     def lifecycle(self) -> CompressionLifecycle:
         """
         Lifecycle is used to keep track of where we are in the compression
-        process and what modifiers are active. It also provides the ability
+        process and what modifiers are active. It also Provides the ability
         to invoke events on the lifecycle.
 
         :return: the lifecycle for the session

--- a/src/llmcompressor/core/session.py
+++ b/src/llmcompressor/core/session.py
@@ -55,7 +55,7 @@ class CompressionSession:
     def lifecycle(self) -> CompressionLifecycle:
         """
         Lifecycle is used to keep track of where we are in the compression
-        process and what modifiers are active. It also Provides the ability
+        process and what modifiers are active. It also provides the ability
         to invoke events on the lifecycle.
 
         :return: the lifecycle for the session

--- a/src/llmcompressor/core/session_functions.py
+++ b/src/llmcompressor/core/session_functions.py
@@ -1,3 +1,10 @@
+"""
+Session management functions for LLM compression workflows.
+
+Provides global session management functionality including session
+creation, activation, reset operations, and lifecycle callback management.
+"""
+
 import threading
 from contextlib import contextmanager
 from typing import Any, Generator, Optional

--- a/src/llmcompressor/core/state.py
+++ b/src/llmcompressor/core/state.py
@@ -1,7 +1,7 @@
 """
-Module for managing the state of the LLM Compressor.
+Module for managing LLM Compressor state.
 
-This module provides classes for holding and updating the state information
+Provides classes for holding and updating the state information
 related to data, hardware, and model compression.
 """
 

--- a/src/llmcompressor/datasets/__init__.py
+++ b/src/llmcompressor/datasets/__init__.py
@@ -1,5 +1,12 @@
 # ruff: noqa
 
+"""
+Provides dataset utilities for model calibration and processing.
+
+Includes functions to format calibration data, create dataloaders,
+process datasets, and split datasets for quantization workflows.
+"""
+
 from .utils import (
     format_calibration_data,
     get_calibration_dataloader,

--- a/src/llmcompressor/datasets/utils.py
+++ b/src/llmcompressor/datasets/utils.py
@@ -1,3 +1,12 @@
+"""
+Dataset utility functions for LLM compression workflows.
+
+Provides helper functions for loading, processing, and formatting datasets used
+in model compression pipelines. Handles dataset splitting, tokenization,
+calibration data preparation, and dataloader creation for both training and
+one-shot calibration workflows.
+"""
+
 import multiprocessing
 import re
 from typing import Any, Callable, Dict, List, Optional

--- a/src/llmcompressor/entrypoints/__init__.py
+++ b/src/llmcompressor/entrypoints/__init__.py
@@ -1,4 +1,12 @@
 # ruff: noqa
+
+"""
+Provides entry points for model compression workflows.
+
+Includes oneshot compression, training, and pre and post-processing utilities
+for model optimization tasks.
+"""
+
 from .oneshot import Oneshot, oneshot
 from .train import train
 from .utils import post_process, pre_process

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -1,3 +1,12 @@
+"""
+Oneshot compression entrypoint for post-training model optimization.
+
+Provides the main oneshot compression entry point for applying
+quantization, pruning, and other compression techniques to pre-trained
+models without additional training. Supports calibration-based compression
+with various pipeline configurations for efficient model optimization.
+"""
+
 import os
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Union

--- a/src/llmcompressor/entrypoints/train.py
+++ b/src/llmcompressor/entrypoints/train.py
@@ -1,3 +1,12 @@
+"""
+Training entrypoint for fine-tuning models with compression support.
+
+Provides the main training entry point that supports both vanilla
+fine-tuning and compression-aware training workflows. Integrates with
+HuggingFace transformers and supports knowledge distillation, pruning,
+and quantization during the training process.
+"""
+
 import math
 import os
 

--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -1,3 +1,12 @@
+"""
+Utility functions for entrypoint pre and post-processing operations.
+
+Provides common utility functions used by training and one-shot
+compression entrypoints. Includes model loading, configuration setup,
+preprocessing steps, and post-processing operations for compression
+workflows.
+"""
+
 import inspect
 import os
 from pathlib import PosixPath

--- a/src/llmcompressor/logger.py
+++ b/src/llmcompressor/logger.py
@@ -1,21 +1,24 @@
 """
-Logger configuration for LLM Compressor.
+Provides a flexible logging configuration for LLM Compressor.
 
-This module provides a flexible logging configuration using the loguru library.
-It supports console and file logging with options to configure via environment
-variables or direct function calls.
+Using the loguru library, Logger supports console and file logging with options
+to configure via environment variables or direct function calls.
 
-Environment Variables:
-    - LLM_COMPRESSOR_LOG_DISABLED: Disable logging (default: false).
-    - LLM_COMPRESSOR_CLEAR_LOGGERS: Clear existing loggers from loguru (default: true).
-    - LLM_COMPRESSOR_LOG_LEVEL: Log level for console logging
-        (default: none, options: DEBUG, INFO, WARNING, ERROR, CRITICAL).
-    - LLM_COMPRESSOR_LOG_FILE: Path to the log file for file logging
-        (default: llm-compressor.log if log file level set else none)
-    - LLM_COMPRESSOR_LOG_FILE_LEVEL: Log level for file logging
-        (default: INFO if log file set else none).
+**Environment Variables**
 
-Usage:
+- `LLM_COMPRESSOR_LOG_DISABLED`: Disable logging.
+    Default: `False`.
+- `LLM_COMPRESSOR_CLEAR_LOGGERS`: Clear existing loggers from loguru.
+    Default: `True`.
+- `LLM_COMPRESSOR_LOG_LEVEL`: Log level for console logging.
+    Default: `None`. Options: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`.
+- `LLM_COMPRESSOR_LOG_FILE`: Path to the log file for file logging.
+    Default: `llm-compressor.log` if log file level set, otherwise `None`.
+- `LLM_COMPRESSOR_LOG_FILE_LEVEL`: Log level for file logging.
+    Default: `INFO` if log file is set, otherwise `None`.
+
+**Usage**
+
     from llmcompressor import logger, configure_logger, LoggerConfig
 
     # Configure metrics with default settings
@@ -60,10 +63,11 @@ class LoggerConfig:
 def configure_logger(config: Optional[LoggerConfig] = None) -> None:
     """
     Configure the logger for LLM Compressor.
+
     This function sets up the console and file logging
     as per the specified or default parameters.
 
-    Note: Environment variables take precedence over the function parameters.
+    **Note**: Environment variables take precedence over function parameters.
 
     :param config: The configuration for the logger to use.
     :type config: LoggerConfig

--- a/src/llmcompressor/metrics/__init__.py
+++ b/src/llmcompressor/metrics/__init__.py
@@ -1,3 +1,12 @@
 # ruff: noqa
 
+"""
+Metrics logging and monitoring framework for compression workflows.
+
+Provides comprehensive metrics collection, logging, and monitoring
+capabilities for model compression operations. Includes base loggers,
+frequency management, and specialized metrics tracking for training and
+inference performance during compression.
+"""
+
 from .logger import *

--- a/src/llmcompressor/metrics/logger.py
+++ b/src/llmcompressor/metrics/logger.py
@@ -1,5 +1,6 @@
 """
-Contains code for loggers that help visualize the information from each modifier
+Contains code for loggers that help visualize the information from each
+modifier.
 """
 
 import os

--- a/src/llmcompressor/metrics/utils/frequency_manager.py
+++ b/src/llmcompressor/metrics/utils/frequency_manager.py
@@ -1,3 +1,12 @@
+"""
+Frequency management utilities for metrics logging.
+
+Provides classes and functions for managing logging frequencies
+and determining when metrics should be recorded during training and
+compression workflows. Supports both epoch-based and step-based logging
+with configurable modes and intervals.
+"""
+
 from typing import Literal, Optional, Union
 
 __all__ = [

--- a/src/llmcompressor/modeling/__init__.py
+++ b/src/llmcompressor/modeling/__init__.py
@@ -1,4 +1,13 @@
 # ruff: noqa
 
+"""
+Model preparation and fusion utilities for compression workflows.
+
+Provides tools for preparing models for compression including
+layer fusion, module preparation, and model structure optimization.
+Handles pre-compression transformations and architectural modifications
+needed for efficient compression.
+"""
+
 from .fuse import *
 from .prepare import *

--- a/src/llmcompressor/modifiers/__init__.py
+++ b/src/llmcompressor/modifiers/__init__.py
@@ -1,3 +1,12 @@
+"""
+Compression modifiers for applying various optimization techniques.
+
+Provides the core modifier system for applying compression techniques like
+quantization, pruning, distillation, and other optimization methods to neural
+networks. Includes base classes, factory patterns, and interfaces for
+extensible compression workflows.
+"""
+
 from .factory import ModifierFactory
 from .interface import ModifierInterface
 from .modifier import Modifier

--- a/src/llmcompressor/modifiers/distillation/__init__.py
+++ b/src/llmcompressor/modifiers/distillation/__init__.py
@@ -1,3 +1,9 @@
 # ruff: noqa
 
+"""
+Provides model distillation functionality, specifically importing output-based
+    distillation modifiers for transferring knowledge from teacher to student
+    models during compression.
+"""
+
 from .output import *

--- a/src/llmcompressor/modifiers/pruning/helpers.py
+++ b/src/llmcompressor/modifiers/pruning/helpers.py
@@ -1,3 +1,11 @@
+"""
+Helper functions and utilities for pruning modifiers.
+
+Provides scheduling functions, factory classes, and configuration
+utilities for pruning operations. Includes linear and cubic schedulers,
+custom scheduler creation, and settings management for structured and
+"""
+
 import math
 import re
 from dataclasses import dataclass

--- a/src/llmcompressor/modifiers/quantization/cache.py
+++ b/src/llmcompressor/modifiers/quantization/cache.py
@@ -1,3 +1,12 @@
+"""
+Quantized key-value cache implementation for efficient inference.
+
+Provides quantized KV cache classes extending HuggingFace's
+DynamicCache with quantization support. Enables memory-efficient attention
+mechanisms by quantizing cached key and value tensors during model
+inference with configurable quantization strategies.
+"""
+
 from typing import Any, Dict, List, Optional, Tuple
 
 from compressed_tensors.quantization.lifecycle import KVCacheScaleType

--- a/src/llmcompressor/modifiers/utils/constants.py
+++ b/src/llmcompressor/modifiers/utils/constants.py
@@ -1,3 +1,11 @@
+"""
+Constants for modifier operations and compression thresholds.
+
+This module defines global constants used throughout the compression
+framework for determining sparsity thresholds, pruning criteria, and
+other modifier-specific parameters.
+"""
+
 __all__ = ["SPARSITY_THRESHOLD"]
 
 SPARSITY_THRESHOLD: float = 0.05

--- a/src/llmcompressor/modifiers/utils/helpers.py
+++ b/src/llmcompressor/modifiers/utils/helpers.py
@@ -1,3 +1,12 @@
+"""
+Helper functions for modifier operations and weight management.
+
+Provides utility functions for updating layer weights, managing
+global scales for quantization, and handling fused layer operations in
+neural network compression workflows. Supports specialized quantization
+strategies like NVFP4.
+"""
+
 from typing import List
 
 import torch

--- a/src/llmcompressor/modifiers/utils/pytorch_helpers.py
+++ b/src/llmcompressor/modifiers/utils/pytorch_helpers.py
@@ -1,3 +1,12 @@
+"""
+PyTorch-specific helper functions for model compression.
+
+Provides utility functions for PyTorch model operations including
+batch processing, padding mask application, and model architecture
+detection. Supports MoE (Mixture of Experts) models and specialized
+tensor operations for compression workflows.
+"""
+
 from typing import Dict
 
 import torch

--- a/src/llmcompressor/observers/__init__.py
+++ b/src/llmcompressor/observers/__init__.py
@@ -1,5 +1,14 @@
 # ruff: noqa
 
+"""
+Framework for monitoring and analyzing model behavior during compression.
+
+Provides observers for tracking tensor statistics, activation
+ranges, and model behavior during compression workflows. Includes
+min-max observers, MSE observers, and helper utilities for quantization
+and other compression techniques.
+"""
+
 from .helpers import *
 from .base import *
 from .min_max import *

--- a/src/llmcompressor/observers/helpers.py
+++ b/src/llmcompressor/observers/helpers.py
@@ -1,3 +1,12 @@
+"""
+Helper functions for observer token counting and analysis.
+
+Provides utility functions for analyzing observer statistics
+and token counts across model modules. Used for monitoring compression
+effects and understanding model behavior during quantization and
+pruning operations.
+"""
+
 from collections import Counter
 
 import torch

--- a/src/llmcompressor/pipelines/__init__.py
+++ b/src/llmcompressor/pipelines/__init__.py
@@ -1,4 +1,14 @@
 # ruff: noqa
+
+"""
+Compression pipelines for orchestrating different compression strategies.
+
+Provides various compression pipelines including basic, sequential,
+independent, layer-sequential, and data-free approaches. Each pipeline
+coordinates different compression techniques and workflows for optimal
+model optimization based on specific requirements and constraints.
+"""
+
 # populate registry
 from .basic import *
 from .data_free import *

--- a/src/llmcompressor/pytorch/__init__.py
+++ b/src/llmcompressor/pytorch/__init__.py
@@ -1,0 +1,8 @@
+"""
+PyTorch-specific utilities and tools for model compression workflows.
+
+Provides PyTorch-specific functionality including model loading,
+sparsification utilities, and PyTorch tensor operations optimized for
+compression workflows. Includes utilities for handling PyTorch models
+and tensors during compression operations.
+"""

--- a/src/llmcompressor/recipe/__init__.py
+++ b/src/llmcompressor/recipe/__init__.py
@@ -1,3 +1,12 @@
+"""
+Recipe system for defining and managing compression workflows.
+
+Provides the recipe framework for specifying compression
+configurations, including metadata tracking, recipe parsing, and
+workflow orchestration. Supports stage-based execution and flexible
+parameter management for complex compression pipelines.
+"""
+
 from .metadata import DatasetMetaData, LayerMetaData, ModelMetaData, ParamMetaData
 from .recipe import Recipe, RecipeArgsInput, RecipeInput, RecipeStageInput
 

--- a/src/llmcompressor/recipe/metadata.py
+++ b/src/llmcompressor/recipe/metadata.py
@@ -1,3 +1,11 @@
+"""
+Metadata classes for recipe and model information tracking.
+
+This module defines Pydantic models for capturing and validating metadata about
+datasets, parameters, layers, and models used in compression recipes. Provides
+structured data containers for recipe configuration and execution tracking.
+"""
+
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field

--- a/src/llmcompressor/sentinel.py
+++ b/src/llmcompressor/sentinel.py
@@ -1,3 +1,11 @@
+"""
+Sentinel value implementation for LLM compression workflows.
+
+Provides unique sentinel values following PEP 661 with Pydantic validation
+support. Used for creating distinct marker objects that can be safely compared
+by identity across the compression framework.
+"""
+
 import inspect
 
 from pydantic_core import core_schema

--- a/src/llmcompressor/transformers/__init__.py
+++ b/src/llmcompressor/transformers/__init__.py
@@ -1,5 +1,5 @@
 """
-Tools for integrating LLM Compressor with transformers training flows
+Tools for integrating LLM Compressor with transformers training flows.
 """
 
 # ruff: noqa

--- a/src/llmcompressor/transformers/finetune/callbacks.py
+++ b/src/llmcompressor/transformers/finetune/callbacks.py
@@ -1,3 +1,12 @@
+"""
+Training callbacks for compression-aware fine-tuning workflows.
+
+This module provides custom trainer callbacks that integrate compression
+session management with HuggingFace training loops. Handles precision
+control, training loop monitoring, and compression lifecycle events
+during model fine-tuning.
+"""
+
 import math
 
 from transformers import TrainerCallback, TrainerControl, TrainingArguments

--- a/src/llmcompressor/transformers/finetune/data/base.py
+++ b/src/llmcompressor/transformers/finetune/data/base.py
@@ -1,3 +1,12 @@
+"""
+Base classes for text generation dataset handling and processing.
+
+This module provides the foundational TextGenerationDataset class with
+registry support for different dataset types. Handles dataset loading,
+tokenization, preprocessing, and text generation specific formatting
+for fine-tuning workflows.
+"""
+
 import inspect
 from functools import cached_property
 from inspect import _ParameterKind as Kind

--- a/src/llmcompressor/transformers/finetune/data/custom.py
+++ b/src/llmcompressor/transformers/finetune/data/custom.py
@@ -1,3 +1,12 @@
+"""
+Custom dataset implementation for JSON and CSV data sources.
+
+This module provides a CustomDataset class for loading and processing
+local JSON and CSV files for text generation fine-tuning. Supports
+flexible data formats and custom preprocessing pipelines for
+user-provided datasets.
+"""
+
 from llmcompressor.transformers.finetune.data import TextGenerationDataset
 
 

--- a/src/llmcompressor/transformers/finetune/trainer.py
+++ b/src/llmcompressor/transformers/finetune/trainer.py
@@ -1,3 +1,12 @@
+"""
+Enhanced trainer class for fine-tuning with compression support.
+
+This module provides a Trainer class that extends HuggingFace's Trainer with
+LLM compression session management capabilities. Integrates compression
+workflows into the standard training loop for seamless model optimization
+during fine-tuning.
+"""
+
 from transformers import Trainer as HFTransformersTrainer
 
 from llmcompressor.transformers.finetune.session_mixin import SessionManagerMixIn

--- a/src/llmcompressor/transformers/utils/preprocessing_functions.py
+++ b/src/llmcompressor/transformers/utils/preprocessing_functions.py
@@ -1,3 +1,12 @@
+"""
+Dataset preprocessing functions for text generation tasks.
+
+This module provides a registry of preprocessing functions for various
+datasets used in fine-tuning workflows. Includes chat templates,
+instruction formatting, and dataset-specific transformations for
+popular training datasets.
+"""
+
 from typing import TYPE_CHECKING, Dict
 
 from compressed_tensors.registry import RegistryMixin

--- a/src/llmcompressor/typing.py
+++ b/src/llmcompressor/typing.py
@@ -1,3 +1,7 @@
+"""
+Defines type aliases for the llm-compressor library.
+"""
+
 from typing import Union
 
 from datasets import Dataset, DatasetDict, IterableDataset

--- a/src/llmcompressor/utils/__init__.py
+++ b/src/llmcompressor/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-General utility functions used throughout llmcompressor
+General utility functions used throughout LLM Compressor.
 """
 
 # ruff: noqa

--- a/src/llmcompressor/utils/metric_logging.py
+++ b/src/llmcompressor/utils/metric_logging.py
@@ -1,3 +1,12 @@
+"""
+Utility functions for metrics logging and GPU memory monitoring.
+
+This module provides functions for tracking GPU memory usage, measuring model
+layer sizes, and comprehensive logging during compression workflows.
+Supports both NVIDIA and AMD GPU monitoring with detailed memory
+statistics and performance metrics.
+"""
+
 import time
 from typing import List, Tuple
 


### PR DESCRIPTION
1. Updated `mkdocs.yml` with the following changes:

    * Added `pymdownx.magiclink` extension - automatic URL linking

    * Excluded utility modules (`llmcompressor.version`, `llmcompressor.typing`) from auto-generated docs

    * Updated mkdocstrings config with new options:
        - `docstring_section_style`: list - Added list section formatting
        - `filters`: ["!^_"] - Hide private/internal methods from docs
        - `merge_init_into_class`: true - Merge class documentation
        - `separate_signature`: true - Function signature display
        - `show_root_heading`: true - Clear module headers
        - `show_signature_annotations`: true - Type hint visibility
        - `show_symbol_type_heading`: true - Clear type indicators
        - `summary`: true - Include summary sections

        https://mkdocstrings.github.io/python/reference/api/

2. Added high level doc strings to most modules.

    **Note**: Used Claude to summarize and create new docstrings.
    
Preview:
https://vllm--1787.org.readthedocs.build/projects/llm-compressor/en/1787/