### PR TITLE
fix variable names to align with the new transformer version

### DIFF
--- a/src/llmcompressor/modifiers/quantization/calibration.py
+++ b/src/llmcompressor/modifiers/quantization/calibration.py
@@ -247,7 +247,7 @@ def calibrate_kv_cache_input_hook(
     kv_cache to singleton QuantizedKVParameterCache.
     """
     kv_cache = getattr(module, "kv_cache")
-    kwargs["past_key_value"] = kv_cache
+    kwargs["past_key_values"] = kv_cache
     kwargs["use_cache"] = False
     return args, kwargs
 


### PR DESCRIPTION
SUMMARY:
Update past_key_value to past_key_values. 


TEST PLAN:
This should resolve the first three kv cache failures. I'm looking into the last one related to meta device. 
