### PR TITLE
Allow e2e tests to run vllm in a separate python environment

### DIFF
--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -4,21 +4,14 @@ import torch
 from vllm import LLM, SamplingParams
 
 
-opt_model = json.loads(sys.argv[1])
-logger = json.loads(sys.argv[2])
+llm_kwargs = json.loads(sys.argv[1])
+prompts = json.loads(sys.argv[2])
+logger = json.loads(sys.argv[3])
 
 sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
-llm_kwargs = {"model": opt_model.save_dir}
-
-if "W4A16_2of4" in opt_model.scheme:
-    # required by the kernel
-    llm_kwargs["dtype"] = torch.float16
-
-if opt_model.gpu_memory_utilization is not None:
-    llm_kwargs["gpu_memory_utilization"] = opt_model.gpu_memory_utilization
 
 llm = LLM(**llm_kwargs)
-outputs = llm.generate(opt_model.prompts, sampling_params)
+outputs = llm.generate(prompts, sampling_params)
 
 
 logger.info("================= vLLM GENERATION ======================")

--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -6,21 +6,11 @@ from vllm import LLM, SamplingParams
 
 llm_kwargs = json.loads(sys.argv[1])
 prompts = json.loads(sys.argv[2])
-logger = json.loads(sys.argv[3])
 
 sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
 
 llm = LLM(**llm_kwargs)
 outputs = llm.generate(prompts, sampling_params)
+json_outputs = json.dumps(outputs)
 
-
-logger.info("================= vLLM GENERATION ======================")
-for output in outputs:
-    assert output
-    prompt = output.prompt
-    generated_text = output.outputs[0].text
-
-    logger.info("PROMPT")
-    logger.info(prompt)
-    logger.info("GENERATED TEXT")
-    logger.info(generated_text)
+return json_outputs

--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -1,0 +1,33 @@
+import json
+import sys
+import torch
+from vllm import LLM, SamplingParams
+
+
+opt_model = json.loads(sys.argv[1])
+logger = json.loads(sys.argv[2])
+
+sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
+llm_kwargs = {"model": opt_model.save_dir}
+
+if "W4A16_2of4" in opt_model.scheme:
+    # required by the kernel
+    llm_kwargs["dtype"] = torch.float16
+
+if opt_model.gpu_memory_utilization is not None:
+    llm_kwargs["gpu_memory_utilization"] = opt_model.gpu_memory_utilization
+
+llm = LLM(**llm_kwargs)
+outputs = llm.generate(opt_model.prompts, sampling_params)
+
+
+logger.info("================= vLLM GENERATION ======================")
+for output in outputs:
+    assert output
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+
+    logger.info("PROMPT")
+    logger.info(prompt)
+    logger.info("GENERATED TEXT")
+    logger.info(generated_text)

--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -21,7 +21,7 @@ def main():
     del llm
     gc.collect()
 
-    print("VLLMOUTPUT"+str(json_outputs)+"VLLMOUTPUT")
+    print("VLLM OUTPUT:"+str(json_outputs))
 
 if __name__ == "__main__":
     llm_kwargs = json.loads(sys.argv[1])

--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -5,22 +5,26 @@ import torch
 from vllm import LLM, SamplingParams
 
 
-llm_kwargs = json.loads(sys.argv[1])
-prompts = json.loads(sys.argv[2])
+def main():
+    sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
 
-sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
+    llm = LLM(**llm_kwargs)
+    outputs = llm.generate(prompts, sampling_params)
 
-llm = LLM(**llm_kwargs)
-outputs = llm.generate(prompts, sampling_params)
+    json_outputs = {}
+    for output in outputs:
+        assert output
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        json_outputs[prompt] = generated_text
 
-json_outputs = {}
-for output in outputs:
-    assert output
-    prompt = output.prompt
-    generated_text = output.outputs[0].text
-    json_outputs[prompt] = generated_text
+    del llm
+    gc.collect()
 
-del llm
-gc.collect()
+    print("VLLMOUTPUT"+str(json_outputs)+"VLLMOUTPUT")
 
-print("VLLMOUTPUT"+str(json_outputs)+"VLLMOUTPUT")
+if __name__ == "__main__":
+    llm_kwargs = json.loads(sys.argv[1])
+    prompts = json.loads(sys.argv[2])
+
+    main()

--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -11,17 +11,16 @@ def main():
     llm = LLM(**llm_kwargs)
     outputs = llm.generate(prompts, sampling_params)
 
-    json_outputs = {}
+    print("================= vLLM GENERATION ======================")
     for output in outputs:
         assert output
-        prompt = output.prompt
-        generated_text = output.outputs[0].text
-        json_outputs[prompt] = generated_text
+        print("PROMPT")
+        print(output.prompt)
+        print("GENERATED TEXT")
+        print(output.outputs[0].text)
 
     del llm
     gc.collect()
-
-    print("VLLM OUTPUT:"+str(json_outputs))
 
 if __name__ == "__main__":
     llm_kwargs = json.loads(sys.argv[1])

--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -1,9 +1,10 @@
-import gc
 import json
 import sys
-import torch
 from vllm import LLM, SamplingParams
 
+
+llm_kwargs = json.loads(sys.argv[1])
+prompts = json.loads(sys.argv[2])
 
 def main():
     sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
@@ -11,7 +12,7 @@ def main():
     llm = LLM(**llm_kwargs)
     outputs = llm.generate(prompts, sampling_params)
 
-    print("================= vLLM GENERATION ======================")
+    print("================= vLLM GENERATION =================")
     for output in outputs:
         assert output
         print("PROMPT")
@@ -19,12 +20,5 @@ def main():
         print("GENERATED TEXT")
         print(output.outputs[0].text)
 
-    del llm
-    gc.collect()
-
 if __name__ == "__main__":
-
-    llm_kwargs = json.loads(sys.argv[1])
-    prompts = json.loads(sys.argv[2])
-
     main()

--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import sys
 import torch
@@ -11,6 +12,15 @@ sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
 
 llm = LLM(**llm_kwargs)
 outputs = llm.generate(prompts, sampling_params)
-json_outputs = json.dumps(outputs)
 
-return json_outputs
+json_outputs = {}
+for output in outputs:
+    assert output
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    json_outputs[prompt] = generated_text
+
+del llm
+gc.collect()
+
+print("VLLMOUTPUT"+str(json_outputs)+"VLLMOUTPUT")

--- a/tests/e2e/vLLM/run_vllm.py
+++ b/tests/e2e/vLLM/run_vllm.py
@@ -23,6 +23,7 @@ def main():
     gc.collect()
 
 if __name__ == "__main__":
+
     llm_kwargs = json.loads(sys.argv[1])
     prompts = json.loads(sys.argv[2])
 

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -155,18 +155,20 @@ class TestvLLM:
         if VLLM_IN_SAME_ENV.lower() == "yes":
             logger.info("================= RUNNING vLLM in the same python env =========================")
 
-            outputs = self._run_vllm()
+            self._run_vllm_separate(logger=logger)
 
-            logger.info("================= vLLM GENERATION ======================")
-            for output in outputs:
-                assert output
-                prompt = output.prompt
-                generated_text = output.outputs[0].text
+            #outputs = self._run_vllm()
 
-                logger.info("PROMPT")
-                logger.info(prompt)
-                logger.info("GENERATED TEXT")
-                logger.info(generated_text)
+            #logger.info("================= vLLM GENERATION ======================")
+            #for output in outputs:
+            #    assert output
+            #    prompt = output.prompt
+            #    generated_text = output.outputs[0].text
+
+            #    logger.info("PROMPT")
+            #    logger.info(prompt)
+            #    logger.info("GENERATED TEXT")
+            #    logger.info(generated_text)
         else:
             logger.info("================= RUNNING vLLM in a separate python env =========================")
 

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -153,17 +153,6 @@ class TestvLLM:
             )
 
         if VLLM_IN_SAME_ENV.lower() == "yes":
-            try:
-                from vllm import LLM, SamplingParams
-
-                vllm_installed = True
-            except ImportError:
-                vllm_installed = False
-
-            if vllm_installed is False:
-                logger.error("ERROR: Expecting vLLM in the same env but it is not installed.")
-                pytest.fail("FAILED: Expecting vLLM in the same env but it is not installed, failing test")
-
             logger.info("================= RUNNING vLLM in the same python env =========================")
 
             outputs = self._run_vllm()
@@ -211,6 +200,7 @@ class TestvLLM:
     @log_time
     def _run_vllm(self):
         import torch
+        from vllm import LLM, SamplingParams
 
         sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
         llm_kwargs = {"model": self.save_dir}

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -222,11 +222,19 @@ class TestvLLM:
         import json
         import subprocess
 
-        json_opt_model = json.dumps(self)
+        llm_kwargs = {"model": self.save_dir}
+        if "W4A16_2of4" in self.scheme:
+            # required by the kernel
+            llm_kwargs["dtype"] = torch.float16
+        if self.gpu_memory_utilization is not None:
+            llm_kwargs["gpu_memory_utilization"] = self.gpu_memory_utilization
+
+        json_llm_kwargs = json.dumps(llm_kwargs)
+        json_prompts = json.dumps(self.prompts)
         json_logger = json.dumps(logger)
 
         result = subprocess.run(
-            [self.vllm_env, "run_vllm.py", json_opt_model, json_logger],
+            [self.vllm_env, "run_vllm.py", json_llm_kwargs, json_prompts, json_logger],
             capture_output=True,
             text=True,
             check=True

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -231,14 +231,24 @@ class TestvLLM:
 
         json_llm_kwargs = json.dumps(llm_kwargs)
         json_prompts = json.dumps(self.prompts)
-        json_logger = json.dumps(logger)
 
         result = subprocess.run(
-            [self.vllm_env, "run_vllm.py", json_llm_kwargs, json_prompts, json_logger],
+            [self.vllm_env, "run_vllm.py", json_llm_kwargs, json_prompts],
             capture_output=True,
             text=True,
             check=True
         )
+        outputs = json.loads(result)
+        logger.info("================= vLLM GENERATION ======================")
+        for output in outputs:
+            assert output
+            prompt = output.prompt
+            generated_text = output.outputs[0].text
+
+            logger.info("PROMPT")
+            logger.info(prompt)
+            logger.info("GENERATED TEXT")
+            logger.info(generated_text)
 
     def _check_session_contains_recipe(self) -> None:
         session = active_session()

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -238,8 +238,11 @@ class TestvLLM:
         json_llm_kwargs = json.dumps(llm_kwargs)
         json_prompts = json.dumps(self.prompts)
 
+        test_file_dir = os.path.dirname(os.path.abspath(__file__))
+        run_file_path = os.path.join(test_file_dir, "run_vllm.py")
+
         result = subprocess.run(
-            [self.vllm_env, "run_vllm.py", json_llm_kwargs, json_prompts],
+            [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
             capture_output=True,
             text=True,
             check=True

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -24,7 +24,7 @@ TEST_DATA_FILE = os.environ.get(
 SKIP_HF_UPLOAD = os.environ.get("SKIP_HF_UPLOAD", "")
 # if vllm is installed in the same python environment or not; if not,
 # pass the path of the virtual env where vllm is installed separately
-VLLM_IN_SAME_ENV = os.environ.get("VLLM_IN_SAME_ENV","yes")
+VLLM_IN_SAME_ENV = os.environ.get("VLLM_IN_SAME_ENV", "yes")
 TIMINGS_DIR = os.environ.get("TIMINGS_DIR", "timings/e2e-test_vllm")
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 EXPECTED_SAVED_FILES = [

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -241,13 +241,21 @@ class TestvLLM:
         test_file_dir = os.path.dirname(os.path.abspath(__file__))
         run_file_path = os.path.join(test_file_dir, "run_vllm.py")
 
-        #result = subprocess.run(
-        #    [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
-        #    capture_output=True,
-        #    text=True,
-        #    check=True
-        #)
+        logger.info("TRY subprocess.run():")
+        result1 = subprocess.run(
+            [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        logger.info("VLLM1 log:")
+        logger.info(result1.stdout)
+        logger.info("VLLM1 returncode:")
+        logger.info(result1.returncode)
+        logger.info("VLLM1 error:")
+        logger.info(result1.stderr)
 
+        logger.info("TRY subprocess.Popen():")
         result = subprocess.Popen(
             [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
             stdout=subprocess.PIPE,
@@ -271,12 +279,12 @@ class TestvLLM:
         if match:
             output_str = match.group(1)  # the vllm output
 
-        logger.info("================= vLLM GENERATION ======================")
-        for prompt, generated_text in output_str.items():
-            logger.info("PROMPT")
-            logger.info(prompt)
-            logger.info("GENERATED TEXT")
-            logger.info(generated_text)
+            logger.info("================= vLLM GENERATION ======================")
+            for prompt, generated_text in output_str.items():
+                logger.info("PROMPT")
+                logger.info(prompt)
+                logger.info("GENERATED TEXT")
+                logger.info(generated_text)
 
     def _check_session_contains_recipe(self) -> None:
         session = active_session()

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -170,14 +170,14 @@ class TestvLLM:
         else:
             logger.info("================= RUNNING vLLM in a separate python env =========================")
 
-            outputs = self._run_vllm_separate()
+            outputs = self._run_vllm_separate(logger)
 
-            logger.info("================= vLLM GENERATION ======================")
-            for prompt, generated_text in outputs.items():
-                logger.info("PROMPT")
-                logger.info(prompt)
-                logger.info("GENERATED TEXT")
-                logger.info(generated_text)
+            #logger.info("================= vLLM GENERATION ======================")
+            #for prompt, generated_text in outputs.items():
+            #    logger.info("PROMPT")
+            #    logger.info(prompt)
+            #    logger.info("GENERATED TEXT")
+            #    logger.info(generated_text)
 
         self.tear_down()
 
@@ -223,7 +223,7 @@ class TestvLLM:
         outputs = llm.generate(self.prompts, sampling_params)
         return outputs
 
-    def _run_vllm_separate(self):
+    def _run_vllm_separate(self, logger):
         import json
         import re
         import subprocess
@@ -247,11 +247,23 @@ class TestvLLM:
             text=True,
             check=True
         )
-        match = re.search(r"VLLMOUTPUT(.*?)VLLMOUTPUT", result.stdout)
-        if match:
-            output_str = match.group(1)  # the vllm output
+        logger.info("VLLM log")
+        logger.info(result.stdout)
 
-        return output_str
+        if result.returncode != 0:
+            logger.error("ERROR: failed to run in vllm")
+            logger.error(result.stderr)
+        else:
+            match = re.search(r"VLLMOUTPUT(.*?)VLLMOUTPUT", result.stdout)
+            if match:
+                output_str = match.group(1)  # the vllm output
+
+            logger.info("================= vLLM GENERATION ======================")
+            for prompt, generated_text in output_str.items():
+                logger.info("PROMPT")
+                logger.info(prompt)
+                logger.info("GENERATED TEXT")
+                logger.info(generated_text)
 
     def _check_session_contains_recipe(self) -> None:
         session = active_session()

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -80,7 +80,7 @@ class TestvLLM:
         self.gpu_memory_utilization = eval_config.get("gpu_memory_utilization")
         # vllm separate env
         if VLLM_IN_SAME_ENV.lower() != "yes":
-            self.vllm_env = os.path.join(VLLM_IN_SAME_ENV, "bin/python")
+            self.vllm_env = VLLM_IN_SAME_ENV
         else:
             self.vllm_env = sys.executable
 

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -241,7 +241,7 @@ class TestvLLM:
             [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
             text=True
         )
-
+        result.communicate()
         if result.returncode != 0:
             logger.error("ERROR: model failed to run in vllm")
         else:

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -245,8 +245,7 @@ class TestvLLM:
         result1 = subprocess.run(
             [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
             capture_output=True,
-            text=True,
-            check=True
+            text=True
         )
         logger.info("VLLM1 log:")
         logger.info(result1.stdout)

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -254,12 +254,13 @@ class TestvLLM:
             stderr=subprocess.PIPE,
             text=True
         )
+        output, error = result.communicate()
         logger.info("VLLM log:")
-        logger.info(result.stdout)
+        logger.info(output)
 
         if result.returncode != 0:
             logger.error("ERROR: failed to run in vllm")
-            logger.error(result.stderr)
+            logger.error(error)
         else:
             match = re.search(r"VLLMOUTPUT(.*?)VLLMOUTPUT", result.stdout)
             if match:

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -22,8 +22,7 @@ TEST_DATA_FILE = os.environ.get(
     "TEST_DATA_FILE", "tests/e2e/vLLM/configs/int8_dynamic_per_token.yaml"
 )
 SKIP_HF_UPLOAD = os.environ.get("SKIP_HF_UPLOAD", "")
-# if vllm is installed in the same python environment or not; if not,
-# pass the path of the virtual env where vllm is installed separately
+# vllm python environment
 VLLM_PYTHON_ENV = os.environ.get("VLLM_PYTHON_ENV", "same")
 TIMINGS_DIR = os.environ.get("TIMINGS_DIR", "timings/e2e-test_vllm")
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
@@ -78,7 +77,8 @@ class TestvLLM:
         self.max_seq_length = eval_config.get("max_seq_length", 2048)
         # GPU memory utilization - only set if explicitly provided in config
         self.gpu_memory_utilization = eval_config.get("gpu_memory_utilization")
-        # vllm python env
+        # vllm python env - if same, use the current python env, otherwise use
+        # the python passed in VLLM_PYTHON_ENV
         if VLLM_PYTHON_ENV.lower() != "same":
             self.vllm_env = VLLM_PYTHON_ENV
         else:
@@ -153,9 +153,9 @@ class TestvLLM:
             )
 
         if VLLM_PYTHON_ENV.lower() == "same":
-            logger.info("================= RUNNING vLLM in the same python env =========================")
+            logger.info("================= RUNNING vLLM in the same python env =================")
         else:
-            logger.info("================= RUNNING vLLM in a separate python env =========================")
+            logger.info("================= RUNNING vLLM in a separate python env =================")
 
         self._run_vllm(logger)
 
@@ -215,6 +215,7 @@ class TestvLLM:
         )
         stdout, stderr = result.communicate()
         logger.info(stdout)
+
         if result.returncode != 0:
             logger.error("ERROR: model failed to run in vllm")
             logger.error(stderr)

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -219,7 +219,6 @@ class TestvLLM:
 #    @log_time
     def _run_vllm(self, logger):
         import json
-        import re
         import subprocess
 
         llm_kwargs = {"model": self.save_dir}
@@ -248,17 +247,6 @@ class TestvLLM:
         if result.returncode != 0:
             logger.error("ERROR: model failed to run in vllm")
             logger.error(stderr)
-        else:
-            match = re.search(r"VLLM OUTPUT:(.*?)", stdout)
-            if match:
-                output = match.group(1)  # the vllm output
-
-            logger.info("================= vLLM GENERATION ======================")
-            for prompt, generated_text in output.items():
-                logger.info("PROMPT")
-                logger.info(prompt)
-                logger.info("GENERATED TEXT")
-                logger.info(generated_text)
 
     def _check_session_contains_recipe(self) -> None:
         session = active_session()

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -275,8 +275,8 @@ class TestvLLM:
         logger.info("TRY subprocess.Popen():")
         result = subprocess.Popen(
             [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            #stdout=subprocess.PIPE,
+            #stderr=subprocess.PIPE,
             text=True
         )
         stdout, stderr = result.communicate()

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -258,20 +258,25 @@ class TestvLLM:
         logger.info("VLLM log:")
         logger.info(output)
 
-        if result.returncode != 0:
-            logger.error("ERROR: failed to run in vllm")
-            logger.error(error)
-        else:
-            match = re.search(r"VLLMOUTPUT(.*?)VLLMOUTPUT", result.stdout)
-            if match:
-                output_str = match.group(1)  # the vllm output
+        logger.info("VLLM returned code:")
+        logger.info(str(result.returncode))
+        logger.info("VLLM error:")
+        logger.info(error)
 
-            logger.info("================= vLLM GENERATION ======================")
-            for prompt, generated_text in output_str.items():
-                logger.info("PROMPT")
-                logger.info(prompt)
-                logger.info("GENERATED TEXT")
-                logger.info(generated_text)
+        #if result.returncode != 0:
+        #    logger.error("ERROR: failed to run in vllm")
+        #    logger.error(error)
+        #else:
+        match = re.search(r"VLLMOUTPUT(.*?)VLLMOUTPUT", output)
+        if match:
+            output_str = match.group(1)  # the vllm output
+
+        logger.info("================= vLLM GENERATION ======================")
+        for prompt, generated_text in output_str.items():
+            logger.info("PROMPT")
+            logger.info(prompt)
+            logger.info("GENERATED TEXT")
+            logger.info(generated_text)
 
     def _check_session_contains_recipe(self) -> None:
         session = active_session()

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -235,7 +235,8 @@ class TestvLLM:
         test_file_dir = os.path.dirname(os.path.abspath(__file__))
         run_file_path = os.path.join(test_file_dir, "run_vllm.py")
 
-        logger.info("TRY subprocess.Popen():")
+        logger.info("Run vllm in subprocess.Popen() using python env:")
+        logger.info(self.vllm_env)
         result = subprocess.Popen(
             [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
             text=True

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -78,7 +78,7 @@ class TestvLLM:
         self.max_seq_length = eval_config.get("max_seq_length", 2048)
         # GPU memory utilization - only set if explicitly provided in config
         self.gpu_memory_utilization = eval_config.get("gpu_memory_utilization")
-        # vllm separate env
+        # vllm python env
         if VLLM_PYTHON_ENV.lower() != "same":
             self.vllm_env = VLLM_PYTHON_ENV
         else:
@@ -154,19 +154,6 @@ class TestvLLM:
 
         if VLLM_PYTHON_ENV.lower() == "same":
             logger.info("================= RUNNING vLLM in the same python env =========================")
-
-            #outputs = self._run_vllm()
-
-            #logger.info("================= vLLM GENERATION ======================")
-            #for output in outputs:
-            #    assert output
-            #    prompt = output.prompt
-            #    generated_text = output.outputs[0].text
-
-            #    logger.info("PROMPT")
-            #    logger.info(prompt)
-            #    logger.info("GENERATED TEXT")
-            #    logger.info(generated_text)
         else:
             logger.info("================= RUNNING vLLM in a separate python env =========================")
 
@@ -197,34 +184,17 @@ class TestvLLM:
         )
         tokenizer.save_pretrained(self.save_dir)
 
-#    @log_time
-#    def _run_vllm(self):
-#        import torch
-#        from vllm import LLM, SamplingParams
-#
-#        sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
-#        llm_kwargs = {"model": self.save_dir}
-#
-#        if "W4A16_2of4" in self.scheme:
-#            # required by the kernel
-#            llm_kwargs["dtype"] = torch.float16
-#
-#        if self.gpu_memory_utilization is not None:
-#            llm_kwargs["gpu_memory_utilization"] = self.gpu_memory_utilization
-#
-#        llm = LLM(**llm_kwargs)
-#        outputs = llm.generate(self.prompts, sampling_params)
-#        return outputs
-
-#    @log_time
+    @log_time
     def _run_vllm(self, logger):
         import json
         import subprocess
 
         llm_kwargs = {"model": self.save_dir}
+
         if "W4A16_2of4" in self.scheme:
             # required by the kernel
             llm_kwargs["dtype"] = torch.float16
+
         if self.gpu_memory_utilization is not None:
             llm_kwargs["gpu_memory_utilization"] = self.gpu_memory_utilization
 
@@ -236,6 +206,7 @@ class TestvLLM:
 
         logger.info("Run vllm in subprocess.Popen() using python env:")
         logger.info(self.vllm_env)
+
         result = subprocess.Popen(
             [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
             stdout=subprocess.PIPE,

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -241,13 +241,20 @@ class TestvLLM:
         test_file_dir = os.path.dirname(os.path.abspath(__file__))
         run_file_path = os.path.join(test_file_dir, "run_vllm.py")
 
-        result = subprocess.run(
+        #result = subprocess.run(
+        #    [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
+        #    capture_output=True,
+        #    text=True,
+        #    check=True
+        #)
+
+        result = subprocess.Popen(
             [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
-            capture_output=True,
-            text=True,
-            check=True
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
         )
-        logger.info("VLLM log")
+        logger.info("VLLM log:")
         logger.info(result.stdout)
 
         if result.returncode != 0:

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -239,13 +239,17 @@ class TestvLLM:
         logger.info(self.vllm_env)
         result = subprocess.Popen(
             [self.vllm_env, run_file_path, json_llm_kwargs, json_prompts],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True
         )
-        result.communicate()
+        stdout, stderr = result.communicate()
+        logger.info(stdout)
         if result.returncode != 0:
             logger.error("ERROR: model failed to run in vllm")
+            logger.error(stderr)
         else:
-            match = re.search(r"VLLM OUTPUT:(.*?)", result)
+            match = re.search(r"VLLM OUTPUT:(.*?)", stdout)
             if match:
                 output = match.group(1)  # the vllm output
 

--- a/tests/e2e/vLLM/test_vllm.py
+++ b/tests/e2e/vLLM/test_vllm.py
@@ -155,22 +155,23 @@ class TestvLLM:
         if VLLM_IN_SAME_ENV.lower() == "yes":
             logger.info("================= RUNNING vLLM in the same python env =========================")
 
-            outputs = self._run_vllm()
+            #outputs = self._run_vllm()
+            self._run_vllm_separate(logger)
 
-            logger.info("================= vLLM GENERATION ======================")
-            for output in outputs:
-                assert output
-                prompt = output.prompt
-                generated_text = output.outputs[0].text
+            #logger.info("================= vLLM GENERATION ======================")
+            #for output in outputs:
+            #    assert output
+            #    prompt = output.prompt
+            #    generated_text = output.outputs[0].text
 
-                logger.info("PROMPT")
-                logger.info(prompt)
-                logger.info("GENERATED TEXT")
-                logger.info(generated_text)
+            #    logger.info("PROMPT")
+            #    logger.info(prompt)
+            #    logger.info("GENERATED TEXT")
+            #    logger.info(generated_text)
         else:
             logger.info("================= RUNNING vLLM in a separate python env =========================")
 
-            outputs = self._run_vllm_separate(logger)
+            self._run_vllm_separate(logger)
 
             #logger.info("================= vLLM GENERATION ======================")
             #for prompt, generated_text in outputs.items():


### PR DESCRIPTION
SUMMARY:
Currently the e2e tests assume vllm is installed into the same python environment as llmcompressor and run vllm validation after model is optimized. This can be problematic due to following factors:

- vllm might have conflicting dependencies from llmcompressor and they cannot co-install into the same python env.
- in the upcoming RHAIIS release, llmcompressor will contain its own image and only llmcompressor and its dependencies will be installed in the image originally.

This PR is to address the issues above and allow the e2e tests to run the vllm validation using a different python env. This is achieved by packaging the vllm code into a separate run_vllm.py file, and using an env variable VLLM_PYTHON_ENV to control vllm code to run in the same or a different python env through subprocess.Popen(). 

By default, we still assume vllm and llmcompressor are installed into the same python env, and there is no changes to the way to set up or run the e2e tests, i.e.:

```
# install llmcompressor and vllm in current python env and run tests
bash tests/e2e/vLLM/run_tests.sh -c tests/e2e/vLLM/configs -t tests/e2e/vLLM/test_vllm.py
```

However if vllm is installed into a separate python env (e.g. through virtualenv, uv venv etc), an env variable VLLM_PYTHON_ENV needs to be set to the path of this separate python env, i.e.:

```
export VLLM_PYTHON_ENV=<path of the python env where vllm is installed separately>
# run tests in the llmcompressor python env
bash tests/e2e/vLLM/run_tests.sh -c tests/e2e/vLLM/configs -t tests/e2e/vLLM/test_vllm.py
```

Here is an example to set up and run the e2e tests using a separate vllm python env:

```
# create vllm python env and get its path
uv venv vllm-venv --python 3.12
source vllm-venv/bin/activate
uv pip install vllm
which python    # get the path from this command and use the output for the VLLM_PYTHON_ENV env var
deactivate

# set up llmcompressor python env to run tests
uv venv llmcompressor-venv --python 3.12
source llmcompressor-venv/bin/activate
uv pip install llmcompressor[dev]
cd llm-compressor
export VLLM_PYTHON_ENV=<path from the `which python` command above>
bash tests/e2e/vLLM/run_tests.sh -c tests/e2e/vLLM/configs -t tests/e2e/vLLM/test_vllm.py
```

This PR also removed the skip check for vllm in the tests so tests will fail if there is any issue with vllm, no matter it's due to installation or runtime issue. This allows us to track vllm setup issues rather than just skipping and not returning any errors.



TEST PLAN:
Run the e2e tests with the same and different python env for vllm and make sure tests all pass.
