### PR TITLE
Replace uses of deprecated `find_name_or_class_matches` fn

### DIFF
--- a/src/llmcompressor/pipelines/layer_sequential/helpers.py
+++ b/src/llmcompressor/pipelines/layer_sequential/helpers.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Tuple
 
 import torch
 import tqdm
-from compressed_tensors.quantization import find_name_or_class_matches
+from compressed_tensors.utils.match import match_targets
 from torch.nn import Module
 from torch.utils.data.dataloader import DataLoader
 
@@ -33,7 +33,7 @@ def match_modules(model: Module, target_names: List[str]) -> List[Module]:
     names_layers = [
         (name, module)
         for name, module in model.named_modules()
-        if find_name_or_class_matches(name, module, target_names)
+        if match_targets(name, module, target_names)
     ]
 
     names_layers = sorted(names_layers, key=lambda name_layer: name_layer[0])

--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tupl
 
 import torch
 from accelerate.hooks import remove_hook_from_module
-from compressed_tensors.quantization import find_name_or_class_matches
 from compressed_tensors.utils import (
     has_offloaded_params,
     offloaded_dispatch,
     remove_dispatch,
 )
+from compressed_tensors.utils.match import match_targets
 from loguru import logger
 from torch.fx import Graph, GraphModule, Node
 from torch.fx.graph import PythonCode
@@ -424,7 +424,7 @@ def match_modules(model: Module, target_names: List[str]) -> Set[Module]:
     return set(
         module
         for name, module in model.named_modules()
-        if find_name_or_class_matches(name, module, target_names)
+        if match_targets(name, module, target_names)
     )
 
 


### PR DESCRIPTION
SUMMARY:
`find_name_or_class_matches` was deprecated in https://github.com/neuralmagic/compressed-tensors/pull/406 and replaced by `match_targets`. 

This pr update llm-compressor to use the new fn. 


TEST PLAN:
`match_targets` should be a direct replacement. Testing is left to CI
