### PR TITLE
Remove `isort`, `black` and `flake8`, replace with `ruff`

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -24,8 +24,7 @@ make style
 make quality
 ```
 
-This will run automatic code styling using `ruff`, `flake8`, `black`, and `isort` to test that the
-repository's code matches its standards.
+This will run automatic code styling using `ruff` to test that the repository's code matches its standards.
 
 **EXAMPLE: test changes locally**
 

--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,12 @@ quality:
 	@echo "Running python quality checks";
 	ruff check $(CHECKDIRS);
 	ruff format --check $(CHECKDIRS);
-	isort --check-only $(CHECKDIRS);
-	flake8 $(CHECKDIRS) --max-line-length 88 --extend-ignore E203,W605;
 
 # style the code according to accepted standards for the repo
 style:
 	@echo "Running python styling";
+	ruff check --fix $(CHECKDIRS);
 	ruff format $(CHECKDIRS);
-	isort $(CHECKDIRS);
-	flake8 $(CHECKDIRS) --max-line-length 88 --extend-ignore E203,W605;
 
 # run tests for the repo
 test:

--- a/docs/developer/developing.md
+++ b/docs/developer/developing.md
@@ -29,8 +29,7 @@ make style
 make quality
 ```
 
-This will run automatic code styling using `ruff`, `flake8`, `black`, and `isort` to test that the
-repository's code matches its standards.
+This will run automatic code styling using `ruff` to test that the repository's code matches its standards.
 
 **EXAMPLE: test changes locally**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,27 +2,17 @@
 requires = ["setuptools", "wheel", "setuptools_scm==8.2.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-line-length = 88
-target-version = ['py38']
-
-[tool.isort]
-profile = "black"
-skip = ["src/llmcompressor/transformers/tracing/", "src/llmcompressor/version.py"]
-
 [tool.mypy]
 files = "src/guidellm"
 
 [tool.ruff]
-exclude = ["build", "dist", "env", ".venv", "src/llmcompressor/transformers/tracing/", "src/llmcompressor/version.py"]
-lint.select = ["E", "F", "W"]
+extend-exclude = ["env", "src/llmcompressor/transformers/tracing/", "src/llmcompressor/version.py"]
+line-length = 88
+lint.select = ["E", "F", "W", "I"]
 lint.extend-ignore = ["E203", "W605"]
 
-# flake8 configuration is non-functional, only exists for vscode extensions
-# for the true flake8 configuration, see `Makefile`
-[tool.flake8]
-max-line-length = 88
-extend-ignore = ["E203", "W605"]
+[tool.ruff.lint.isort]
+known-first-party = ["llmcompressor"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/setup.py
+++ b/setup.py
@@ -159,11 +159,8 @@ setup(
             "soundfile",
             "torchcodec",
             # linting, formatting, and type checking
-            "black~=24.4.2",
-            "isort~=5.13.2",
             "mypy~=1.10.0",
             "ruff~=0.4.8",
-            "flake8~=7.0.0",
             # pre commit hooks
             "pre-commit",
             # docs

--- a/src/llmcompressor/__init__.py
+++ b/src/llmcompressor/__init__.py
@@ -6,7 +6,7 @@ The library is designed to be flexible and easy to use on top of
 PyTorch and HuggingFace Transformers, allowing for quick experimentation.
 """
 
-# flake8: noqa
+# ruff: noqa
 
 from .logger import LoggerConfig, configure_logger, logger
 from .version import __version__, version

--- a/src/llmcompressor/args/__init__.py
+++ b/src/llmcompressor/args/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .dataset_arguments import DatasetArguments
 from .model_arguments import ModelArguments

--- a/src/llmcompressor/datasets/__init__.py
+++ b/src/llmcompressor/datasets/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .utils import (
     format_calibration_data,

--- a/src/llmcompressor/entrypoints/__init__.py
+++ b/src/llmcompressor/entrypoints/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 from .oneshot import Oneshot, oneshot
 from .train import train
 from .utils import post_process, pre_process

--- a/src/llmcompressor/metrics/__init__.py
+++ b/src/llmcompressor/metrics/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .logger import *

--- a/src/llmcompressor/metrics/utils/__init__.py
+++ b/src/llmcompressor/metrics/utils/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .frequency_manager import *

--- a/src/llmcompressor/modeling/__init__.py
+++ b/src/llmcompressor/modeling/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .fuse import *
 from .prepare import *

--- a/src/llmcompressor/modifiers/awq/__init__.py
+++ b/src/llmcompressor/modifiers/awq/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *
 from .mappings import *

--- a/src/llmcompressor/modifiers/distillation/__init__.py
+++ b/src/llmcompressor/modifiers/distillation/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .output import *

--- a/src/llmcompressor/modifiers/distillation/output/__init__.py
+++ b/src/llmcompressor/modifiers/distillation/output/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *

--- a/src/llmcompressor/modifiers/distillation/utils/pytorch/__init__.py
+++ b/src/llmcompressor/modifiers/distillation/utils/pytorch/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .kd_factory import *
 from .kd_wrapper import *

--- a/src/llmcompressor/modifiers/logarithmic_equalization/__init__.py
+++ b/src/llmcompressor/modifiers/logarithmic_equalization/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *

--- a/src/llmcompressor/modifiers/obcq/__init__.py
+++ b/src/llmcompressor/modifiers/obcq/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *

--- a/src/llmcompressor/modifiers/pruning/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .constant import *
 from .magnitude import *

--- a/src/llmcompressor/modifiers/pruning/constant/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/constant/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import ConstantPruningModifier

--- a/src/llmcompressor/modifiers/pruning/magnitude/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/magnitude/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import MagnitudePruningModifier

--- a/src/llmcompressor/modifiers/pruning/utils/pytorch/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/utils/pytorch/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .layer_mask import *
 from .mask_factory import *

--- a/src/llmcompressor/modifiers/pruning/wanda/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/wanda/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *

--- a/src/llmcompressor/modifiers/quantization/__init__.py
+++ b/src/llmcompressor/modifiers/quantization/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .cache import *
 from .gptq import *

--- a/src/llmcompressor/modifiers/quantization/gptq/__init__.py
+++ b/src/llmcompressor/modifiers/quantization/gptq/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *

--- a/src/llmcompressor/modifiers/quantization/quantization/__init__.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *
 from .mixin import *

--- a/src/llmcompressor/modifiers/smoothquant/__init__.py
+++ b/src/llmcompressor/modifiers/smoothquant/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *

--- a/src/llmcompressor/modifiers/transform/__init__.py
+++ b/src/llmcompressor/modifiers/transform/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .quip import QuIPModifier
 from .spinquant import SpinQuantModifier

--- a/src/llmcompressor/modifiers/transform/quip/__init__.py
+++ b/src/llmcompressor/modifiers/transform/quip/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *

--- a/src/llmcompressor/modifiers/transform/spinquant/__init__.py
+++ b/src/llmcompressor/modifiers/transform/spinquant/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import *

--- a/src/llmcompressor/modifiers/utils/__init__.py
+++ b/src/llmcompressor/modifiers/utils/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .constants import *
 from .helpers import *

--- a/src/llmcompressor/observers/__init__.py
+++ b/src/llmcompressor/observers/__init__.py
@@ -1,5 +1,4 @@
-# flake8: noqa
-# isort: skip_file
+# ruff: noqa
 
 from .helpers import *
 from .base import *

--- a/src/llmcompressor/pipelines/__init__.py
+++ b/src/llmcompressor/pipelines/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 # populate registry
 from .basic import *
 from .data_free import *

--- a/src/llmcompressor/pipelines/basic/__init__.py
+++ b/src/llmcompressor/pipelines/basic/__init__.py
@@ -1,2 +1,2 @@
-# flake8: noqa
+# ruff: noqa
 from .pipeline import *

--- a/src/llmcompressor/pipelines/data_free/__init__.py
+++ b/src/llmcompressor/pipelines/data_free/__init__.py
@@ -1,2 +1,2 @@
-# flake8: noqa
+# ruff: noqa
 from .pipeline import *

--- a/src/llmcompressor/pipelines/independent/__init__.py
+++ b/src/llmcompressor/pipelines/independent/__init__.py
@@ -1,2 +1,2 @@
-# flake8: noqa
+# ruff: noqa
 from .pipeline import *

--- a/src/llmcompressor/pipelines/layer_sequential/__init__.py
+++ b/src/llmcompressor/pipelines/layer_sequential/__init__.py
@@ -1,2 +1,2 @@
-# flake8: noqa
+# ruff: noqa
 from .pipeline import *

--- a/src/llmcompressor/pipelines/sequential/__init__.py
+++ b/src/llmcompressor/pipelines/sequential/__init__.py
@@ -1,2 +1,2 @@
-# flake8: noqa
+# ruff: noqa
 from .pipeline import *

--- a/src/llmcompressor/pytorch/utils/__init__.py
+++ b/src/llmcompressor/pytorch/utils/__init__.py
@@ -2,7 +2,7 @@
 Generic code used as utilities and helpers for PyTorch
 """
 
-# flake8: noqa
+# ruff: noqa
 
 from .helpers import *
 from .sparsification import *

--- a/src/llmcompressor/transformers/__init__.py
+++ b/src/llmcompressor/transformers/__init__.py
@@ -2,9 +2,8 @@
 Tools for integrating LLM Compressor with transformers training flows
 """
 
-# flake8: noqa
+# ruff: noqa
 
-# isort: skip_file
 # (import order matters for circular import avoidance)
 from .utils import *
 

--- a/src/llmcompressor/transformers/finetune/__init__.py
+++ b/src/llmcompressor/transformers/finetune/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .data import TextGenerationDataset
 from .session_mixin import SessionManagerMixIn

--- a/src/llmcompressor/transformers/finetune/data/__init__.py
+++ b/src/llmcompressor/transformers/finetune/data/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 from .base import TextGenerationDataset
 from .c4 import C4Dataset

--- a/src/llmcompressor/transformers/sparsification/__init__.py
+++ b/src/llmcompressor/transformers/sparsification/__init__.py
@@ -3,5 +3,5 @@ Objects, classes, and methods for applying sparsification algorithms to
 Hugging Face transformers flows
 """
 
-# flake8: noqa
+# ruff: noqa
 from .sparse_model import *

--- a/src/llmcompressor/transformers/utils/__init__.py
+++ b/src/llmcompressor/transformers/utils/__init__.py
@@ -2,5 +2,5 @@
 Utilities for applying sparsification algorithms to Hugging Face transformers flows
 """
 
-# flake8: noqa
+# ruff: noqa
 from .helpers import *

--- a/src/llmcompressor/utils/__init__.py
+++ b/src/llmcompressor/utils/__init__.py
@@ -2,7 +2,7 @@
 General utility functions used throughout llmcompressor
 """
 
-# flake8: noqa
+# ruff: noqa
 
 from .dev import *
 from .helpers import *

--- a/src/llmcompressor/utils/fsdp/__init__.py
+++ b/src/llmcompressor/utils/fsdp/__init__.py
@@ -1,1 +1,1 @@
-# flake8: noqa
+# ruff: noqa

--- a/src/llmcompressor/utils/pytorch/__init__.py
+++ b/src/llmcompressor/utils/pytorch/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .module import *

--- a/tests/llmcompressor/helpers.py
+++ b/tests/llmcompressor/helpers.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 
 def valid_recipe_strings():

--- a/tests/llmcompressor/pytorch/__init__.py
+++ b/tests/llmcompressor/pytorch/__init__.py
@@ -1,1 +1,1 @@
-# flake8: noqa
+# ruff: noqa

--- a/tests/llmcompressor/pytorch/utils/__init__.py
+++ b/tests/llmcompressor/pytorch/utils/__init__.py
@@ -1,1 +1,1 @@
-# flake8: noqa
+# ruff: noqa

--- a/tests/test_timer/__init__.py
+++ b/tests/test_timer/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa
+# ruff: noqa
 
 from .timer import Timer


### PR DESCRIPTION
SUMMARY:
Ruff supports import sorting, formatting, and linting. We already use if for formatting (`black` is listed as a dev dependency but isn't used) and linting.

In this pr:
- 6af05b191ba171a0cc66c92088a768a2d5a8226b
  - Cleans up `pyproject.toml`, removing old configs/updating ruff configs to also check import sorting
  - Updates `Makefile` to just call `ruff` in `make quality` and `make style`
  - Removes `black`, `flake8`, and `isort` from dev dependencies
  - Updates dev docs description of `make quality` command
- 796a5b8632e88ca0d33e14737fba684ef97aa863
  - Replaces `flake8: noqa` file wide markers with `ruff: noqa` (not strictly necessary since `ruff` will respect the `flake8: noqa` markers but for cleanliness)
  - Removes unnecessary `isort: skip_file` markers

Note: this is builds off changes from #1807 