### PR TITLE
[Bugfix] Remove actorder field from AWQ test

### DIFF
--- a/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_group_quant_asym_awq.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_group_quant_asym_awq.yaml
@@ -2,7 +2,6 @@ quant_stage:
   quant_modifiers:
     AWQModifier:
       ignore: [lm_head]
-      actorder: null
       config_groups:
         group_0:
           weights: {num_bits: 4, type: int, symmetric: false, strategy: "group", group_size: 128}


### PR DESCRIPTION
## Purpose ##
* Fix CI failure where `actorder` is not a valid field for AWQ