### PR TITLE
[Performance] Speed up DataLoader with Multiple DataLoader Workers

### DIFF
--- a/src/llmcompressor/datasets/utils.py
+++ b/src/llmcompressor/datasets/utils.py
@@ -10,7 +10,7 @@ from transformers.data import default_data_collator
 from llmcompressor.args import DatasetArguments
 from llmcompressor.transformers.finetune.data import TextGenerationDataset
 from llmcompressor.typing import Processor
-
+import multiprocessing
 
 def get_processed_dataset(
     dataset_args: DatasetArguments,
@@ -138,6 +138,7 @@ def format_calibration_data(
         tokenized_dataset = tokenized_dataset.shuffle()
     tokenized_calibration = tokenized_dataset.select(range(safe_calibration_samples))
 
+    num_workers = min(8, multiprocessing.cpu_count() // 2)
     dataloader_params = {
         "batch_size": 1,
         "sampler": RandomSampler(tokenized_calibration)
@@ -145,6 +146,7 @@ def format_calibration_data(
         else SequentialSampler(tokenized_calibration),
         "collate_fn": collate_fn,
         "pin_memory": True,
+        "num_workers": num_workers,
     }
 
     calibration_dataloader = DataLoader(tokenized_calibration, **dataloader_params)

--- a/src/llmcompressor/datasets/utils.py
+++ b/src/llmcompressor/datasets/utils.py
@@ -1,5 +1,5 @@
-import re
 import multiprocessing
+import re
 from typing import Any, Callable, Dict, List, Optional
 
 import torch
@@ -11,6 +11,7 @@ from transformers.data import default_data_collator
 from llmcompressor.args import DatasetArguments
 from llmcompressor.transformers.finetune.data import TextGenerationDataset
 from llmcompressor.typing import Processor
+
 
 def get_processed_dataset(
     dataset_args: DatasetArguments,


### PR DESCRIPTION
when the  dataset is  too large, it should be speeded up to min(8x,cpu//2) times

SUMMARY:

When the dataset is large, using the default DataLoader is too slow. In my experiment, it took 1.5 hours to prepare the cache. After setting num_workers to min(8, cpu // 2), the time was reduced to 7 minutes.

TEST PLAN:

Tested with a 5K dataset, comparing the performance between this patch and the original implementation.

