### PR TITLE
regex raw string when backslash is used

### DIFF
--- a/examples/multimodal_vision/gemma3_example.py
+++ b/examples/multimodal_vision/gemma3_example.py
@@ -32,8 +32,8 @@ recipe = [
         scheme="W4A16",
         ignore=[
             "lm_head",
-            "re:model\.vision_tower.*",
-            "re:model\.multi_modal_projector.*",
+            r"re:model\.vision_tower.*",
+            r"re:model\.multi_modal_projector.*",
         ],
     ),
 ]


### PR DESCRIPTION
SUMMARY:
Resolves #1776 

The `gemma3_example.py` script was not correctly escaping the `\` character in its regexes. This adds the `r"` prefix to the string, so that python knows it is a raw string that needs to be escaped, avoiding warnings.

It appears to be isolated to this example, I couldn't find other regexes with `\` characters that weren't being properly escaped.


TEST PLAN:
Example runs successfully after changes.
