### PR TITLE
Add concurrency marker to transformers workflow

### DIFF
--- a/.github/workflows/test-check-transformers.yaml
+++ b/.github/workflows/test-check-transformers.yaml
@@ -16,6 +16,10 @@ env:
   CADENCE: "commit"
   HF_TOKEN: ${{ secrets.HF_TOKEN_READ }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
SUMMARY:
Currently if you open a pr and mark it as ready the transformers check workflow will run. If you then push more commits to the pr, it will re-run the workflow but won't cancel the existing workflow run.

Since we only care about the results of the most recent push to the pr branch, this change will make it so that we cancel pre-existing runs that have the same branch.

Ref: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-using-concurrency-and-the-default-behavior


Note: only adding this to the transformers workflow because it takes the longest (~30 mins) and uses custom runners. 