### PR TITLE
Replace nm-testing/llama2.c-stories15M with `nm-testing/tinysmokellama-3.2`

### DIFF
--- a/tests/llmcompressor/transformers/compression/configs/channelwise_15m.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/channelwise_15m.yaml
@@ -1,4 +1,4 @@
 cadence: "commit"
 test_type: "regression"
-model_stub: "nm-testing/llama2.c-stories15M"
+model_stub: "nm-testing/tinysmokellama-3.2"
 new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_channel.yaml"

--- a/tests/llmcompressor/transformers/compression/configs/fp8_15m.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/fp8_15m.yaml
@@ -1,4 +1,4 @@
 cadence: "commit"
 test_type: "regression"
-model_stub: "nm-testing/llama2.c-stories15M"
+model_stub: "nm-testing/tinysmokellama-3.2"
 new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_fp8.yaml"

--- a/tests/llmcompressor/transformers/compression/configs/inputs_15m.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/inputs_15m.yaml
@@ -1,4 +1,4 @@
 cadence: "commit"
 test_type: "regression"
-model_stub: "nm-testing/llama2.c-stories15M"
+model_stub: "nm-testing/tinysmokellama-3.2"
 new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_full.yaml"

--- a/tests/llmcompressor/transformers/compression/configs/weights_only_15m.yaml
+++ b/tests/llmcompressor/transformers/compression/configs/weights_only_15m.yaml
@@ -1,4 +1,4 @@
 cadence: "commit"
 test_type: "regression"
-model_stub: "nm-testing/llama2.c-stories15M"
+model_stub: "nm-testing/tinysmokellama-3.2"
 new_recipe: "tests/llmcompressor/transformers/compression/recipes/new_quant_weight.yaml"

--- a/tests/llmcompressor/transformers/finetune/data/conftest.py
+++ b/tests/llmcompressor/transformers/finetune/data/conftest.py
@@ -6,7 +6,7 @@ from llmcompressor.args import ModelArguments
 
 @pytest.fixture
 def tiny_llama_path():
-    return "nm-testing/llama2.c-stories15M"
+    return "nm-testing/tinysmokellama-3.2"
 
 
 @pytest.fixture

--- a/tests/llmcompressor/transformers/finetune/finetune_custom/config1.yaml
+++ b/tests/llmcompressor/transformers/finetune/finetune_custom/config1.yaml
@@ -1,5 +1,5 @@
 cadence: "commit"
 test_type: "sanity"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 file_extension: json
 num_train_epochs: 1

--- a/tests/llmcompressor/transformers/finetune/finetune_custom/config2.yaml
+++ b/tests/llmcompressor/transformers/finetune/finetune_custom/config2.yaml
@@ -1,5 +1,5 @@
 cadence: "commit"
 test_type: "sanity"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 file_extension: csv
 num_train_epochs: 1

--- a/tests/llmcompressor/transformers/finetune/finetune_generic/config1.yaml
+++ b/tests/llmcompressor/transformers/finetune/finetune_generic/config1.yaml
@@ -1,4 +1,4 @@
 cadence: "nightly"
 test_type: "regression"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus

--- a/tests/llmcompressor/transformers/finetune/finetune_oneshot_configs/config.yaml
+++ b/tests/llmcompressor/transformers/finetune/finetune_oneshot_configs/config.yaml
@@ -1,6 +1,6 @@
 cadence: "commit"
 test_type: "sanity"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: wikitext
 dataset_config_name: "wikitext-2-raw-v1"
 recipe: "tests/llmcompressor/transformers/finetune/test_alternate_recipe.yaml"

--- a/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
+++ b/tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py
@@ -113,7 +113,7 @@ class TestFinetuneNoRecipeCustomDataset(unittest.TestCase):
 @pytest.mark.integration
 @parameterized_class(parse_params(CONFIGS_DIRECTORY))
 class TestOneshotCustomDatasetSmall(TestFinetuneNoRecipeCustomDataset):
-    model = None  # "nm-testing/llama2.c-stories15M"
+    model = None  # "nm-testing/tinysmokellama-3.2"
     file_extension = None  # ["json", "csv"]
     num_train_epochs = None
 

--- a/tests/llmcompressor/transformers/finetune/test_oneshot_then_finetune.py
+++ b/tests/llmcompressor/transformers/finetune/test_oneshot_then_finetune.py
@@ -21,7 +21,7 @@ class TestOneshotThenFinetune(unittest.TestCase):
     def test_oneshot_sparsification_then_finetune(self):
         recipe_str = "tests/llmcompressor/transformers/obcq/recipes/test_tiny2.yaml"
         model = AutoModelForCausalLM.from_pretrained(
-            "nm-testing/llama2.c-stories15M", torch_dtype="auto"
+            "nm-testing/tinysmokellama-3.2", torch_dtype="auto"
         )
         dataset = "open_platypus"
         concatenate_data = False
@@ -51,7 +51,7 @@ class TestOneshotThenFinetune(unittest.TestCase):
             quantization_config=self.quantization_config,
         )
         distill_teacher = AutoModelForCausalLM.from_pretrained(
-            "nm-testing/llama2.c-stories15M", torch_dtype="auto"
+            "nm-testing/tinysmokellama-3.2", torch_dtype="auto"
         )
         dataset = "open_platypus"
         concatenate_data = False

--- a/tests/llmcompressor/transformers/finetune/test_session_mixin.py
+++ b/tests/llmcompressor/transformers/finetune/test_session_mixin.py
@@ -32,7 +32,7 @@ class MixInTest(SessionManagerMixIn, Trainer):
 
 @pytest.mark.unit
 def test_mixin_init():
-    model_state_path = "nm-testing/llama2.c-stories15M"
+    model_state_path = "nm-testing/tinysmokellama-3.2"
     model = AutoModelForCausalLM.from_pretrained(model_state_path)
     recipe = "tests/llmcompressor/transformers/finetune/test_quantization.yaml"
 
@@ -45,7 +45,7 @@ def test_mixin_init():
 
 @pytest.fixture
 def mixin_trainer():
-    model_state_path = "nm-testing/llama2.c-stories15M"
+    model_state_path = "nm-testing/tinysmokellama-3.2"
     model = AutoModelForCausalLM.from_pretrained(model_state_path)
     recipe = "tests/llmcompressor/transformers/finetune/test_quantization.yaml"
     train_dataset = "open-platypus"

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/completion/tiny_llama_quant.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/completion/tiny_llama_quant.yaml
@@ -1,6 +1,6 @@
 cadence: "nightly"
 test_type: "sanity"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus
 recipe: "tests/llmcompressor/transformers/obcq/recipes/quant.yaml"
 num_samples: 32

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/completion/tiny_llama_quant_and_sparse.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/completion/tiny_llama_quant_and_sparse.yaml
@@ -1,6 +1,6 @@
 cadence: "nightly"
 test_type: "sanity"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus
 recipe: "tests/llmcompressor/transformers/obcq/recipes/quant_and_sparse.yaml"
 num_samples: 32

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/consec_runs/tiny_llama_consec_runs.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/consec_runs/tiny_llama_consec_runs.yaml
@@ -1,6 +1,6 @@
 cadence: "commit"
 test_type: "sanity"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus
 first_recipe: "tests/llmcompressor/transformers/obcq/recipes/quant_and_sparse.yaml"
 second_recipe: "tests/llmcompressor/transformers/obcq/recipes/additional_sparsity.yaml"

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/mask_structure/tiny_llama_mask_structure_preservation.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/mask_structure/tiny_llama_mask_structure_preservation.yaml
@@ -1,6 +1,6 @@
 cadence: "commit"
 test_type: "sanity"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus
 initial_pruning_only_recipe: "tests/llmcompressor/transformers/obcq/recipes/sparse_with_mask_structure.yaml"
 initial_sparsity: 0.5

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/sparse/tiny_llama_sparse.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/sparse/tiny_llama_sparse.yaml
@@ -1,6 +1,6 @@
 cadence: "commit"
 test_type: "sanity"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus
 recipe: "tests/llmcompressor/transformers/obcq/recipes/sparse.yaml"
 sparsity: 0.3

--- a/tests/llmcompressor/transformers/obcq/obcq_configs/sparsity_generic/config.yaml
+++ b/tests/llmcompressor/transformers/obcq/obcq_configs/sparsity_generic/config.yaml
@@ -1,4 +1,4 @@
 cadence: "nightly"
 test_type: "regression"
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus

--- a/tests/llmcompressor/transformers/obcq/test_obcq_infer_targets.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_infer_targets.py
@@ -9,7 +9,7 @@ from llmcompressor.modifiers.obcq import SparseGPTModifier
 def test_infer_targets():
     modifier = SparseGPTModifier(sparsity=0.0)
     with init_empty_weights():
-        model = AutoModelForCausalLM.from_pretrained("nm-testing/llama2.c-stories15M")
+        model = AutoModelForCausalLM.from_pretrained("nm-testing/tinysmokellama-3.2")
 
     inferred = modifier._infer_sequential_targets(model)
     assert inferred == ["LlamaDecoderLayer"]

--- a/tests/llmcompressor/transformers/obcq/test_obcq_lm_head.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_lm_head.py
@@ -16,7 +16,7 @@ class TestLMHead(unittest.TestCase):
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
         self.model = AutoModelForCausalLM.from_pretrained(
-            "nm-testing/llama2.c-stories15M", device_map=self.device
+            "nm-testing/tinysmokellama-3.2", device_map=self.device
         )
 
         self.kwargs = {

--- a/tests/llmcompressor/transformers/obcq/test_obcq_owl.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_owl.py
@@ -21,7 +21,7 @@ def test_infer_owl_layer_sparsity():
         modifier = SparseGPTModifier(
             sparsity=0.7, sparsity_profile="owl", owl_m=5, owl_lmbda=0.05
         )
-        model = AutoModelForCausalLM.from_pretrained("nm-testing/llama2.c-stories15M")
+        model = AutoModelForCausalLM.from_pretrained("nm-testing/tinysmokellama-3.2")
 
         dataset = Dataset.from_dict(
             {"input_ids": torch.randint(0, vocab_size, (ds_size, seq_len))}

--- a/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
+++ b/tests/llmcompressor/transformers/obcq/test_obcq_sparsity.py
@@ -41,7 +41,7 @@ class TestSparsities(unittest.TestCase):
         )
 
         layer_1_sparse = tensor_sparsity(model.model.layers[1].self_attn.k_proj.weight)
-        assert math.isclose(layer_1_sparse.item(), self.sparsity, rel_tol=1e-4)
+        assert math.isclose(layer_1_sparse.item(), self.sparsity, rel_tol=1e-3)
         layer_2_dense = tensor_sparsity(model.model.layers[2].self_attn.k_proj.weight)
         assert math.isclose(layer_2_dense.item(), 0.0, rel_tol=1e-4)
 

--- a/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf1.yaml
+++ b/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf1.yaml
@@ -1,7 +1,7 @@
 cadence: "commit"
 test_type: "smoke"
 tokenize: False
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus
 recipe: |
   test_stage:

--- a/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf2.yaml
+++ b/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf2.yaml
@@ -1,6 +1,6 @@
 cadence: "commit"
 test_type: "smoke"
 tokenize: False
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus
 recipe: "tests/llmcompressor/transformers/oneshot/oneshot_configs/recipes/recipe.yaml"

--- a/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf3.yaml
+++ b/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf3.yaml
@@ -1,7 +1,7 @@
 cadence: "commit"
 test_type: "smoke"
 tokenize: False
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: "gsm8k"
 dataset_config_name: "main"
 recipe: "tests/llmcompressor/transformers/oneshot/oneshot_configs/recipes/recipe.yaml"

--- a/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf4.yaml
+++ b/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf4.yaml
@@ -1,7 +1,7 @@
 cadence: "commit"
 test_type: "smoke"
 tokenize: False
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: "gsm8k"
 dataset_config_name: "main"
 recipe: |

--- a/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf5.yaml
+++ b/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf5.yaml
@@ -1,6 +1,6 @@
 cadence: "commit"
 test_type: "smoke"
 tokenize: True
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: open_platypus
 recipe: "tests/llmcompressor/transformers/oneshot/oneshot_configs/recipes/recipe.yaml"

--- a/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf6.yaml
+++ b/tests/llmcompressor/transformers/oneshot/oneshot_configs/tiny_stories_conf6.yaml
@@ -1,6 +1,6 @@
 cadence: "commit"
 test_type: "smoke"
 tokenize: True
-model: "nm-testing/llama2.c-stories15M"
+model: "nm-testing/tinysmokellama-3.2"
 dataset: "gsm8k"
 recipe: "tests/llmcompressor/transformers/oneshot/oneshot_configs/recipes/recipe.yaml"

--- a/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/sparsification/test_compress_tensor_utils.py
@@ -46,7 +46,7 @@ from tests.testing_utils import requires_gpu
 def test_sparse_model_reload(compressed, config, dtype, tmp_path):
     recipe_str = "tests/llmcompressor/transformers/obcq/recipes/test_tiny2.yaml"
     expected_sparsity = 0.5
-    model_path = "nm-testing/llama2.c-stories15M"
+    model_path = "nm-testing/tinysmokellama-3.2"
     dataset = "open_platypus"
     concatenate_data = False
     num_calibration_samples = 64
@@ -124,7 +124,7 @@ def test_sparse_model_reload(compressed, config, dtype, tmp_path):
 def test_dense_model_save(tmp_path, skip_compression_stats, save_compressed):
     reset_session()
 
-    model_path = "nm-testing/llama2.c-stories15M"
+    model_path = "nm-testing/tinysmokellama-3.2"
     model = AutoModelForCausalLM.from_pretrained(model_path)
 
     inferred_global_sparsity = SparsityConfigMetadata.infer_global_sparsity(model)
@@ -161,7 +161,7 @@ def test_quant_model_reload(format, dtype, tmp_path):
     recipe_str = (
         "tests/llmcompressor/transformers/compression/recipes/new_quant_simple.yaml"
     )
-    model_path = "nm-testing/llama2.c-stories15M"
+    model_path = "nm-testing/tinysmokellama-3.2"
     device = "cuda:0" if not torch.cuda.is_available() else "cpu"
     dataset = "open_platypus"
     concatenate_data = False
@@ -240,7 +240,7 @@ def test_quant_model_reload(format, dtype, tmp_path):
     ],
 )
 def test_model_reload(offload, torch_dtype, tie_word_embeddings, device, tmp_path):
-    model_path = "nm-testing/llama2.c-stories15M"
+    model_path = "nm-testing/tinysmokellama-3.2"
     save_path = tmp_path / "save_path"
 
     model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch_dtype)
@@ -292,7 +292,7 @@ def test_model_reload_gpu(offload, torch_dtype, tie_word_embeddings, device, tmp
 )
 def test_model_shared_tensors(offload, torch_dtype, tie_word_embeddings, device):
     # load model
-    model_path = "nm-testing/llama2.c-stories15M"
+    model_path = "nm-testing/tinysmokellama-3.2"
     model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch_dtype)
     if offload:
         model = dispatch_model(model, {"": device}, force_hooks=True)
@@ -333,7 +333,7 @@ def test_model_shared_tensors_gpu(offload, torch_dtype, tie_word_embeddings, dev
     "model_stub, recipe, sparse_format, quant_format",
     [
         (
-            "nm-testing/llama2.c-stories15M",
+            "nm-testing/tinysmokellama-3.2",
             "tests/llmcompressor/transformers/compression/recipes/sparse_24_fp8.yaml",
             CompressionFormat.sparse_24_bitmask.value,
             CompressionFormat.float_quantized.value,
@@ -414,7 +414,7 @@ def test_compressor_stacking(model_stub, recipe, sparse_format, quant_format, tm
     "model_stub, recipe, sparse_format",
     [
         (
-            "nm-testing/llama2.c-stories15M",
+            "nm-testing/tinysmokellama-3.2",
             "tests/llmcompressor/transformers/compression/recipes/sparse_24.yaml",
             CompressionFormat.sparse_24_bitmask.value,
         ),

--- a/tests/llmcompressor/utils/test_helpers.py
+++ b/tests/llmcompressor/utils/test_helpers.py
@@ -189,7 +189,7 @@ def test_patch_attr():
     "model_cls,model_stub",
     [
         (MllamaForConditionalGeneration, "meta-llama/Llama-3.2-11B-Vision-Instruct"),
-        (AutoModelForCausalLM, "nm-testing/llama2.c-stories15M"),
+        (AutoModelForCausalLM, "nm-testing/tinysmokellama-3.2"),
     ],
 )
 def test_disable_cache(model_cls, model_stub):


### PR DESCRIPTION
SUMMARY:
Created a new [model](https://huggingface.co/nm-testing/tinysmokellama-3.2) based off of a `LLama3.2` model for smoke testing. 

Note: the model is not properly trained, so outputs shouldn't be used, but the weights come from a real model's distribution "meta-llama/Llama-3.2-1B". 


TEST PLAN:
Ran the "transformers" checks locally + they will be rerun by CI. 
