### PR TITLE
Update upper bounds for some dependencies to be compatible with their new release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
         ("pyyaml>=6.0.1,<=6.0.2" if BUILD_TYPE == "release" else "pyyaml>=6.0.1"),
         # librosa dependency numba is currently not compatible with numpy>=2.3
         # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
-        ("numpy>=2.0.0,<=2.3.2" if BUILD_TYPE == "release" else "numpy>=2.0.0"),
+        ("numpy>=2.0.0,<=2.3.3" if BUILD_TYPE == "release" else "numpy>=2.0.0"),
         (
             "requests>=2.32.2,<=2.32.5"
             if BUILD_TYPE == "release"
@@ -123,18 +123,18 @@ setup(
         ("tqdm>=4.66.3,<=4.67.1" if BUILD_TYPE == "release" else "tqdm>=4.66.3"),
         ("torch>=2.7.0,<=2.8.0" if BUILD_TYPE == "release" else "torch>=2.7.0"),
         (
-            "transformers>=4.53.0,<=4.55.2"
+            "transformers>=4.53.0,<=4.56.1"
             if BUILD_TYPE == "release"
             else "transformers>=4.53.0"
         ),
-        ("datasets>=4.0.0,<=4.0.0" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
+        ("datasets==4.0.0" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
         (
             "accelerate>=1.6.0,<=1.10.0"
             if BUILD_TYPE == "release"
             else "accelerate>=1.6.0"
         ),
-        ("pynvml>=11.5.3,<=12.0.0" if BUILD_TYPE == "release" else "pynvml>=11.5.3"),
-        ("pillow>=10.4.0,<=10.4.0" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
+        ("pynvml>=11.5.3,<=13.0.1" if BUILD_TYPE == "release" else "pynvml>=11.5.3"),
+        ("pillow>=10.4.0,<=11.3.0" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
         (
             "compressed-tensors==0.11.0"
             if BUILD_TYPE == "release"

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
             if BUILD_TYPE == "release"
             else "transformers>=4.53.0"
         ),
-        ("datasets==4.0.0" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
+        ("datasets>=4.0.0,<=4.1.0" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
         (
             "accelerate>=1.6.0,<=1.10.0"
             if BUILD_TYPE == "release"

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
         ),
         ("datasets>=4.0.0,<=4.1.0" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
         (
-            "accelerate>=1.6.0,<=1.10.0"
+            "accelerate>=1.6.0,<=1.10.1"
             if BUILD_TYPE == "release"
             else "accelerate>=1.6.0"
         ),


### PR DESCRIPTION
SUMMARY:
There are a few dependencies having new release lately and we want to be compatible. To be specific:

numpy: https://pypi.org/project/numpy/2.3.3/
transformers: https://pypi.org/project/transformers/4.56.1/
datasets: https://pypi.org/project/datasets/4.1.0/
accelerate: https://pypi.org/project/accelerate/1.10.1/
pynvml: https://pypi.org/project/pynvml/13.0.1/
pillow: https://pypi.org/project/pillow/11.3.0/

Updated the upper bounds of these dependencies in the setup.py.

TEST PLAN:
Ran nightly tests with the latest version of these dependencies and tests passed: 
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/17803108635/job/50607909450
