### PR TITLE
lmeval threshold p1

### DIFF
--- a/tests/lmeval/configs/fp8_dynamic_per_token.yaml
+++ b/tests/lmeval/configs/fp8_dynamic_per_token.yaml
@@ -5,3 +5,6 @@ lmeval:
   metrics:
     exact_match,flexible-extract: 0.75
     exact_match,strict-match: 0.75
+    #option 1
+    exact_match_stderr,strict-match: 0.013807775152234192
+    exact_match_stderr,flexible-extract: 0.013807775152234194

--- a/tests/lmeval/test_lmeval.py
+++ b/tests/lmeval/test_lmeval.py
@@ -170,15 +170,15 @@ class TestLMEval:
             if std_err is None:
                 logger.info(
                     f"Comparing {metric_key}: Expecting {expected_val} "
-                    f"relative tolerance ±5%, Got {actual_val}. "
+                    f"relative tolerance ±3%, Got {actual_val}. "
                     f"Higher is better: {higher_is_better}"
                 )
                 # If higher is better, assert actual val >= expected val * (1 - stderr)
                 if higher_is_better:
-                    assert actual_val >= expected_val * (0.95)
+                    assert actual_val >= expected_val * (0.97)
                 # If higher is worse, assert actual val <= expected val * (1 + stderr)
                 else:
-                    assert actual_val <= expected_val * (1.05)
+                    assert actual_val <= expected_val * (1.03)
 
             else:
                 logger.info(


### PR DESCRIPTION
SUMMARY:
There are 2 options to change the threshold for lm_eval tests.

    Add stderr to each tests, as shown in diff for tests/lmeval/configs/fp8_dynamic_per_token.yaml. This would require re-running all tests and grabbing it
    Reduce threshold from default 5% to 3% (or lower?).

I am unsure how we want to handle this, so posing the two options for now

TEST PLAN:
"please outline how the changes were tested"

