### PR TITLE
[Qwen3Next] Add calibration support and NVFP4 Example

### DIFF
--- a/examples/quantization_w4a4_fp4/qwen3_next_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_next_example.py
@@ -55,7 +55,13 @@ ds = ds.map(tokenize, remove_columns=ds.column_names)
 #   * calibrate a global_scale for activations, which will be used to
 #       quantize activations to fp4 on the fly
 recipe = QuantizationModifier(
-    targets="Linear", scheme="NVFP4", ignore=['lm_head', 're:.*mlp.gate$', 're:.*mlp.shared_expert_gate$', 're:.*linear_attn.*']
+    targets="Linear",
+    scheme="NVFP4",
+    ignore=['lm_head',
+        're:.*mlp.gate$',
+        're:.*mlp.shared_expert_gate$',
+        're:.*linear_attn.*'
+    ]
 )
 
 # Apply quantization.

--- a/examples/quantization_w4a4_fp4/qwen3_next_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_next_example.py
@@ -1,0 +1,91 @@
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.utils import dispatch_for_generation
+
+MODEL_ID = "/proving-grounds/engine/hub_cache/models--Qwen--Qwen3-Next-80B-A3B-Instruct/snapshots/609718eef2e2279fd6654e39cec856ec70906535"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+
+DATASET_ID = "HuggingFaceH4/ultrachat_200k"
+DATASET_SPLIT = "train_sft"
+
+# Select number of samples
+NUM_CALIBRATION_SAMPLES = 20
+MAX_SEQUENCE_LENGTH = 2048
+
+# Load dataset and preprocess.
+ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {
+        "text": tokenizer.apply_chat_template(
+            example["messages"],
+            tokenize=False,
+        )
+    }
+
+
+ds = ds.map(preprocess)
+
+
+# Tokenize inputs.
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+# Configure the quantization algorithm and scheme.
+# In this case, we:
+#   * quantize the weights to fp4 with per group 16 via ptq
+#   * calibrate a global_scale for activations, which will be used to
+#       quantize activations to fp4 on the fly
+recipe = QuantizationModifier(
+    targets="Linear", scheme="NVFP4", ignore=['lm_head', 're:.*mlp.gate$', 're:.*mlp.shared_expert_gate$', 're:.*linear_attn.*']
+)
+
+# Apply quantization.
+# We see `calibrate_moe_context` to True to update all `Qwen3MoeSparseMoeBlock`
+# during calibration.
+# Feel free to update the definition under
+# llm-compressor/src/llmcompressor/modeling/qwen3_moe.py` to play around with
+# this behaviour and evaluate its impact on quantization performance
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    calibrate_moe_context=True,
+)
+
+
+print("\n\n")
+print("========== SAMPLE GENERATION ==============")
+dispatch_for_generation(model)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(
+    model.device
+)
+output = model.generate(input_ids, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================\n\n")
+
+
+# Save to disk in compressed-tensors format.
+SAVE_DIR = "/proving-grounds/engine/hub_cache/Qwen3-Next-80B-A3B-Instruct" + "-NVFP4-Today"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/examples/quantization_w4a4_fp4/qwen3_next_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_next_example.py
@@ -5,7 +5,10 @@ from llmcompressor import oneshot
 from llmcompressor.modifiers.quantization import QuantizationModifier
 from llmcompressor.utils import dispatch_for_generation
 
-MODEL_ID = "/proving-grounds/engine/hub_cache/models--Qwen--Qwen3-Next-80B-A3B-Instruct/snapshots/609718eef2e2279fd6654e39cec856ec70906535"
+# NOTE: Qwen3-Next-80B-A3B-Instruct support is not in transformers<=4.56.2
+# you may need to install transformers from source
+
+MODEL_ID = "Qwen/Qwen3-Next-80B-A3B-Instruct"
 
 # Load model.
 model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
@@ -57,11 +60,12 @@ ds = ds.map(tokenize, remove_columns=ds.column_names)
 recipe = QuantizationModifier(
     targets="Linear",
     scheme="NVFP4",
-    ignore=['lm_head',
-        're:.*mlp.gate$',
-        're:.*mlp.shared_expert_gate$',
-        're:.*linear_attn.*'
-    ]
+    ignore=[
+        "lm_head",
+        "re:.*mlp.gate$",
+        "re:.*mlp.shared_expert_gate$",
+        "re:.*linear_attn.*",
+    ],
 )
 
 # Apply quantization.
@@ -92,6 +96,6 @@ print("==========================================\n\n")
 
 
 # Save to disk in compressed-tensors format.
-SAVE_DIR = "/proving-grounds/engine/hub_cache/Qwen3-Next-80B-A3B-Instruct" + "-NVFP4-Today"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-NVFP4"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)

--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -201,6 +201,7 @@ class DatasetArguments(CustomDatasetArguments):
             "_prepare_4d_causal_attention_mask",
             "_prepare_fsmt_decoder_inputs",
             "_prepare_4d_causal_attention_mask_with_cache_position",
+            "_update_linear_attn_mask"
         ],
         metadata={
             "help": "List of functions to ignore during tracing, either "

--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -201,7 +201,7 @@ class DatasetArguments(CustomDatasetArguments):
             "_prepare_4d_causal_attention_mask",
             "_prepare_fsmt_decoder_inputs",
             "_prepare_4d_causal_attention_mask_with_cache_position",
-            "_update_linear_attn_mask"
+            "_update_linear_attn_mask",
         ],
         metadata={
             "help": "List of functions to ignore during tracing, either "

--- a/src/llmcompressor/modeling/prepare.py
+++ b/src/llmcompressor/modeling/prepare.py
@@ -5,6 +5,7 @@ from transformers import PreTrainedModel
 from llmcompressor.modeling.deepseek_v3 import replace as replace_deepseekv3
 from llmcompressor.modeling.llama4 import replace as replace_llama4
 from llmcompressor.modeling.qwen3_moe import replace as replace_Qwen3MoE
+from llmcompressor.modeling.qwen3_next_moe import replace as replace_Qwen3NextMoE
 from llmcompressor.utils.helpers import patch_attr
 
 __all__ = ["replace_modules_for_calibration"]
@@ -36,26 +37,38 @@ def replace_modules_for_calibration(
 # ------------------- module replacements; during calibration --------------------
 
 
-def update_qwen3_moe(model, stack, calibrate_all_experts):
-    for module in model.modules():
-        cls_name = module.__class__.__name__
-        if cls_name == "Qwen3MoeDecoderLayer":
-            # Optionally update the model.config to pass in other arguments
-            stack.enter_context(
-                patch_attr(
-                    module,
-                    "mlp",
-                    replace_Qwen3MoE(
-                        config=model.config,
-                        module=module.mlp,
-                        calibrate_all_experts=calibrate_all_experts,
-                    ),
-                )
+def update_qwen3_moe(model, module, stack, calibrate_all_experts):
+    cls_name = module.__class__.__name__
+    if cls_name == "Qwen3MoeDecoderLayer" and module.mlp.__class__.__name__ == "Qwen3MoeSparseMoeBlock":
+        stack.enter_context(
+            patch_attr(
+                module,
+                "mlp",
+                replace_Qwen3MoE(config=model.config,
+                                module=module.mlp,
+                                calibrate_all_experts=calibrate_all_experts),
             )
+        )
 
+
+def update_qwen3_next_moe(model, module, stack, calibrate_all_experts):
+    cls_name = module.__class__.__name__
+    if cls_name == "Qwen3NextDecoderLayer" and module.mlp.__class__.__name__ == "Qwen3NextSparseMoeBlock":
+        stack.enter_context(
+            patch_attr(
+                module,
+                "mlp",
+                replace_Qwen3NextMoE(
+                    config=model.config,
+                    module=module.mlp,
+                    calibrate_all_experts=calibrate_all_experts,
+                ),
+            )
+        )
 
 moe_context = {
     "Qwen3MoeForCausalLM": update_qwen3_moe,
+    "Qwen3NextForCausalLM": update_qwen3_next_moe,
 }
 
 
@@ -66,6 +79,7 @@ def moe_calibration_context(
 ):
     # Temporarily updates the MoE modules within the context
     # Once the context exists, parameter updates persist
-    cls_name = model.__class__.__name__
-    if cls_name in moe_context:
-        moe_context.get(cls_name)(model, stack, calibrate_all_experts)
+    model_name = model.__class__.__name__
+    if model_name in moe_context:
+        for module in model.modules():
+            moe_context(model_name)(model, module, stack, calibrate_all_experts)

--- a/src/llmcompressor/modeling/prepare.py
+++ b/src/llmcompressor/modeling/prepare.py
@@ -21,8 +21,6 @@ replacements = {
 }
 
 
-
-
 def replace_modules_for_calibration(
     model: PreTrainedModel,
     calibrate_all_experts: bool = True,
@@ -45,21 +43,29 @@ def replace_modules_for_calibration(
 
 def update_qwen3_moe(model, module, stack, calibrate_all_experts):
     cls_name = module.__class__.__name__
-    if (cls_name == "Qwen3MoeDecoderLayer" and module.mlp.__class__.__name__ == "Qwen3MoeSparseMoeBlock"):
+    if (
+        cls_name == "Qwen3MoeDecoderLayer"
+        and module.mlp.__class__.__name__ == "Qwen3MoeSparseMoeBlock"
+    ):
         stack.enter_context(
             patch_attr(
                 module,
                 "mlp",
-                replace_Qwen3MoE(config=model.config,
-                                module=module.mlp,
-                                calibrate_all_experts=calibrate_all_experts),
+                replace_Qwen3MoE(
+                    config=model.config,
+                    module=module.mlp,
+                    calibrate_all_experts=calibrate_all_experts,
+                ),
             )
         )
 
 
 def update_qwen3_next_moe(model, module, stack, calibrate_all_experts):
     cls_name = module.__class__.__name__
-    if (cls_name == "Qwen3NextDecoderLayer" and module.mlp.__class__.__name__ == "Qwen3NextSparseMoeBlock"):
+    if (
+        cls_name == "Qwen3NextDecoderLayer"
+        and module.mlp.__class__.__name__ == "Qwen3NextSparseMoeBlock"
+    ):
         stack.enter_context(
             patch_attr(
                 module,
@@ -71,6 +77,7 @@ def update_qwen3_next_moe(model, module, stack, calibrate_all_experts):
                 ),
             )
         )
+
 
 moe_context = {
     "Qwen3MoeForCausalLM": update_qwen3_moe,

--- a/src/llmcompressor/modeling/qwen3_next_moe.py
+++ b/src/llmcompressor/modeling/qwen3_next_moe.py
@@ -1,0 +1,96 @@
+# coding=utf-8
+# Copyright 2025 The Qwen team, Alibaba Group and the HuggingFace Inc. team.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from transformers.models import Qwen3NextConfig
+from transformers.models.qwen3_next.modeling_qwen3_next import (
+    Qwen3NextSparseMoeBlock as OriginalQwen3NextMoeSparseMoeBlock,
+)
+
+
+class Qwen3NextSparseMoeBlock(torch.nn.Module):
+    def __init__(
+        self,
+        config: Qwen3NextConfig,
+        original: OriginalQwen3NextMoeSparseMoeBlock,
+        calibrate_all_experts: bool,
+    ):
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.top_k = config.top_k
+        self.norm_topk_prob = config.norm_topk_prob
+
+        # gating
+        self.calibrate_all_experts = calibrate_all_experts
+        self.gate = original.gate
+        self.experts = original.experts
+
+        self.shared_expert = original.shared_expert
+        self.shared_expert_gate = original.shared_expert_gate
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """ """
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        # router_logits: (batch * sequence_length, n_experts)
+        router_logits = self.gate(hidden_states)
+
+        routing_weights = torch.nn.functional.softmax(router_logits, dim=1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        if self.norm_topk_prob:
+            routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+        # we cast back to the input dtype
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        final_hidden_states = torch.zeros(
+            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+        )
+
+        # One hot encode the selected experts to create an expert mask
+        # this will be used to easily index which expert is going to be sollicitated
+        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+
+        # Loop over all available experts in the model and perform the computation on each expert
+        #expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+        for expert_idx, expert_layer in enumerate(self.experts):
+            idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
+
+            if self.calibrate_all_experts:
+                expert_out = expert_layer(hidden_states)[top_x]
+            else:
+                expert_out = expert_layer(hidden_states[top_x])
+
+            # Index the correct hidden states and compute the expert hidden state for
+            # the current expert. We need to make sure to multiply the output hidden
+            # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
+            if len(top_x) > 0:
+                current_hidden_states = expert_out * routing_weights[top_x, idx, None]
+                final_hidden_states.index_add_(
+                    0, top_x, current_hidden_states.to(hidden_states.dtype)
+                )
+
+        shared_expert_output = self.shared_expert(hidden_states)
+        shared_expert_output = torch.nn.functional.sigmoid(self.shared_expert_gate(hidden_states)) * shared_expert_output
+
+        final_hidden_states = final_hidden_states + shared_expert_output
+
+        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+        return final_hidden_states, router_logits
+
+
+def replace(config: Qwen3NextConfig, module: OriginalQwen3NextMoeSparseMoeBlock, calibrate_all_experts: bool):
+    return Qwen3NextSparseMoeBlock(config=config, original=module, calibrate_all_experts=calibrate_all_experts)

--- a/src/llmcompressor/modeling/qwen3_next_moe.py
+++ b/src/llmcompressor/modeling/qwen3_next_moe.py
@@ -88,9 +88,7 @@ class Qwen3NextSparseMoeBlock(torch.nn.Module):
             # the output hidden states by `routing_weights` on the
             # corresponding tokens (top-1 and top-2)
             if len(top_x) > 0:
-                current_hidden_states = (
-                    expert_out * routing_weights[top_x, idx, None]
-                )
+                current_hidden_states = expert_out * routing_weights[top_x, idx, None]
                 final_hidden_states.index_add_(
                     0,
                     top_x,
@@ -99,9 +97,7 @@ class Qwen3NextSparseMoeBlock(torch.nn.Module):
 
         shared_expert_output = self.shared_expert(hidden_states)
         shared_expert_output = (
-            torch.nn.functional.sigmoid(
-                self.shared_expert_gate(hidden_states)
-            )
+            torch.nn.functional.sigmoid(self.shared_expert_gate(hidden_states))
             * shared_expert_output
         )
 
@@ -112,6 +108,11 @@ class Qwen3NextSparseMoeBlock(torch.nn.Module):
         return final_hidden_states, router_logits
 
 
-
-def replace(config: Qwen3NextConfig, module: OriginalQwen3NextMoeSparseMoeBlock, calibrate_all_experts: bool):
-    return Qwen3NextSparseMoeBlock(config=config, original=module, calibrate_all_experts=calibrate_all_experts)
+def replace(
+    config: Qwen3NextConfig,
+    module: OriginalQwen3NextMoeSparseMoeBlock,
+    calibrate_all_experts: bool,
+):
+    return Qwen3NextSparseMoeBlock(
+        config=config, original=module, calibrate_all_experts=calibrate_all_experts
+    )

--- a/src/llmcompressor/modeling/qwen3_next_moe.py
+++ b/src/llmcompressor/modeling/qwen3_next_moe.py
@@ -42,29 +42,38 @@ class Qwen3NextSparseMoeBlock(torch.nn.Module):
         self.shared_expert_gate = original.shared_expert_gate
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        """ """
         batch_size, sequence_length, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
         # router_logits: (batch * sequence_length, n_experts)
         router_logits = self.gate(hidden_states)
 
-        routing_weights = torch.nn.functional.softmax(router_logits, dim=1, dtype=torch.float)
-        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights = torch.nn.functional.softmax(
+            router_logits, dim=1, dtype=torch.float
+        )
+        routing_weights, selected_experts = torch.topk(
+            routing_weights, self.top_k, dim=-1
+        )
         if self.norm_topk_prob:
             routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
         # we cast back to the input dtype
         routing_weights = routing_weights.to(hidden_states.dtype)
 
         final_hidden_states = torch.zeros(
-            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+            (batch_size * sequence_length, hidden_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
         )
 
         # One hot encode the selected experts to create an expert mask
-        # this will be used to easily index which expert is going to be sollicitated
-        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+        # this will be used to easily index which expert is going to be
+        # sollicitated
+        expert_mask = torch.nn.functional.one_hot(
+            selected_experts, num_classes=self.num_experts
+        ).permute(2, 1, 0)
 
-        # Loop over all available experts in the model and perform the computation on each expert
-        #expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+        # Loop over all available experts in the model and perform the
+        # computation on each expert
+        # expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
 
         for expert_idx, expert_layer in enumerate(self.experts):
             idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
@@ -74,22 +83,34 @@ class Qwen3NextSparseMoeBlock(torch.nn.Module):
             else:
                 expert_out = expert_layer(hidden_states[top_x])
 
-            # Index the correct hidden states and compute the expert hidden state for
-            # the current expert. We need to make sure to multiply the output hidden
-            # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
+            # Index the correct hidden states and compute the expert hidden
+            # state for the current expert. We need to make sure to multiply
+            # the output hidden states by `routing_weights` on the
+            # corresponding tokens (top-1 and top-2)
             if len(top_x) > 0:
-                current_hidden_states = expert_out * routing_weights[top_x, idx, None]
+                current_hidden_states = (
+                    expert_out * routing_weights[top_x, idx, None]
+                )
                 final_hidden_states.index_add_(
-                    0, top_x, current_hidden_states.to(hidden_states.dtype)
+                    0,
+                    top_x,
+                    current_hidden_states.to(hidden_states.dtype),
                 )
 
         shared_expert_output = self.shared_expert(hidden_states)
-        shared_expert_output = torch.nn.functional.sigmoid(self.shared_expert_gate(hidden_states)) * shared_expert_output
+        shared_expert_output = (
+            torch.nn.functional.sigmoid(
+                self.shared_expert_gate(hidden_states)
+            )
+            * shared_expert_output
+        )
 
         final_hidden_states = final_hidden_states + shared_expert_output
-
-        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+        final_hidden_states = final_hidden_states.reshape(
+            batch_size, sequence_length, hidden_dim
+        )
         return final_hidden_states, router_logits
+
 
 
 def replace(config: Qwen3NextConfig, module: OriginalQwen3NextMoeSparseMoeBlock, calibrate_all_experts: bool):


### PR DESCRIPTION
SUMMARY:
- Add calibration support for Qwen3-Next
- Add an NVFP4 example
- Update moe calibration context to support the model


TEST PLAN:

For Qwen3-30B-A3B-NVFP4:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8825|±  |0.0089|
|     |       |strict-match    |     5|exact_match|↑  |0.8802|±  |0.0089|
```

Qwen3-Next - >96% recovery

Base
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8514|±  |0.0098|
|     |       |strict-match    |     5|exact_match|↑  |0.8089|±  |0.0108|
```

NVFP4:
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8400|±  |0.0101|
|     |       |strict-match    |     5|exact_match|↑  |0.7733|±  |0.0115|
```
