### PR TITLE
Update upper bounds for some dependencies 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,11 +123,11 @@ setup(
         ("tqdm>=4.66.3,<=4.67.1" if BUILD_TYPE == "release" else "tqdm>=4.66.3"),
         ("torch>=2.7.0,<=2.8.0" if BUILD_TYPE == "release" else "torch>=2.7.0"),
         (
-            "transformers>=4.53.0,<=4.56.1"
+            "transformers>=4.53.0,<=4.56.2"
             if BUILD_TYPE == "release"
             else "transformers>=4.53.0"
         ),
-        ("datasets>=4.0.0,<=4.1.0" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
+        ("datasets>=4.0.0,<=4.1.1" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
         (
             "accelerate>=1.6.0,<=1.10.1"
             if BUILD_TYPE == "release"

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
     ),
     install_requires=[
         ("loguru>=0.7.2,<=0.7.3" if BUILD_TYPE == "release" else "loguru>=0.7.2"),
-        ("pyyaml>=6.0.1,<=6.0.2" if BUILD_TYPE == "release" else "pyyaml>=6.0.1"),
+        ("pyyaml>=6.0.1,<=6.0.3" if BUILD_TYPE == "release" else "pyyaml>=6.0.1"),
         # librosa dependency numba is currently not compatible with numpy>=2.3
         # https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
         ("numpy>=2.0.0,<=2.3.3" if BUILD_TYPE == "release" else "numpy>=2.0.0"),

--- a/setup.py
+++ b/setup.py
@@ -140,9 +140,9 @@ setup(
         ),
         ("pillow>=10.4.0,<=11.3.0" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
         (
-            "compressed-tensors==0.11.0"
+            "compressed-tensors==0.12.0"
             if BUILD_TYPE == "release"
-            else "compressed-tensors>=0.11.1a2"
+            else "compressed-tensors>=0.12.1a2"
         ),
     ],
     extras_require={


### PR DESCRIPTION
SUMMARY:
Some dependencies have new release lately, need to bump up their upper bounds to catch up with the latest release.

Will update compressed-tensors a bit later once 0.12.0 goes out.


TEST PLAN:
Run all tests.
