### PR TITLE
Run `ruff format` twice in `make style`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,13 @@ quality:
 	ruff format --check $(CHECKDIRS);
 
 # style the code according to accepted standards for the repo
+# Note: We run `ruff format` twice. Once to fix long lines before lint check
+# and again to fix any formatting issues introduced by ruff check --fix
 style:
 	@echo "Running python styling";
+	ruff format $(CHECKDIRS); 
 	ruff check --fix $(CHECKDIRS);
-	ruff format $(CHECKDIRS);
+	ruff format --silent $(CHECKDIRS); 
 
 # run tests for the repo
 test:


### PR DESCRIPTION
There was an issue where `ruff check --fix` will fail on too long files before `ruff format` has a chance to fix them. To fix this, we now call `ruff format` before `ruff check --fix` but we also run formatting a second in case the lint fix introduces formatting issues.
