### PR TITLE
[Training] Fix `tokenizer` attribute of `SessionMixin`

### DIFF
--- a/src/llmcompressor/transformers/finetune/session_mixin.py
+++ b/src/llmcompressor/transformers/finetune/session_mixin.py
@@ -399,13 +399,12 @@ class SessionManagerMixIn:
         # is True by default to avoid high runtime cost
         self.save_state()
         if self.accelerator.is_main_process:
-            processor = getattr(self, "processing_class", self.tokenizer)
             # TODO: need to port over all saving parameters so that all
             # checkpoints are saved in the same way
             save_checkpoint(
                 output_dir,
                 model=self.model,
-                processor=processor,
+                processor=self.processing_class,
                 save_safetensors=self.args.save_safetensors,
                 save_compressed=self.model_args.save_compressed,
                 skip_sparsity_compression_stats=skip_sparsity_compression_stats,


### PR DESCRIPTION
## Purpose ##
* Fix failing nightly training tests

```
2025-10-01T16:00:34.3410069Z FAILED tests/llmcompressor/transformers/finetune/test_finetune_no_recipe_custom_dataset.py::test_oneshot_then_finetune_gpu[config0] - AttributeError: 'Trainer' object has no attribute 'tokenizer'
2025-10-01T16:00:34.3411515Z FAILED tests/llmcompressor/transformers/finetune/test_finetune_without_recipe.py::test_finetune_without_recipe[config0] - AttributeError: 'Trainer' object has no attribute 'tokenizer'
2025-10-01T16:00:34.3412858Z FAILED tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py::test_oneshot_and_finetune_gpu[config0] - AttributeError: 'Trainer' object has no attribute 'tokenizer'
2025-10-01T16:00:34.3414275Z FAILED tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune_with_tokenizer.py::test_oneshot_and_finetune_with_tokenizer[config0] - AttributeError: 'Trainer' object has no attribute 'tokenizer'
2025-10-01T16:00:34.3415633Z FAILED tests/llmcompressor/transformers/finetune/test_safetensors.py::test_safetensors[config0] - AttributeError: 'Trainer' object has no attribute 'tokenizer'
```

## Changes ##
* Do not attempt to use `Trainer.tokenizer`, which has be removed for a long time now

## Testing ##
* Failing tests pass now