### PR TITLE
[Deps] pin `cmarkgfm` until build issue resolved

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,9 @@ setup(
             "lm_eval==0.4.5",
             # test dependencies
             "beautifulsoup4~=4.12.3",
-            "cmarkgfm>=2024.1.14",
+            # Pin cmarkgfm until issue resolved
+            # https://github.com/theacodes/cmarkgfm/issues/83
+            "cmarkgfm>=2024.1.14,<2025.10.20",
             "trl>=0.10.1",
             "pandas<2.3.0",
             "torchvision",


### PR DESCRIPTION
SUMMARY:
Cmarkgfm 2025.10.20 was released today, but the wheel build for linux is failing -- https://github.com/theacodes/cmarkgfm/actions/runs/18653185184

Pinning our version until this is resolved, as it breaks all ci/cd checks. Resolution likely in the next couple days.


TEST PLAN:
ci/cd passes on this branch
