### PR TITLE
[Oneshot] Add validation for empty dataset and enhance oneshot function parameters

### DIFF
--- a/src/llmcompressor/datasets/utils.py
+++ b/src/llmcompressor/datasets/utils.py
@@ -149,6 +149,12 @@ def format_calibration_data(
                 f"the provided dataset only has {safe_calibration_samples}. "
             )
 
+    if safe_calibration_samples == 0:
+        logger.error("Dataset is empty. Cannot create a calibration dataloader.")
+        raise ValueError(
+            "Dataset is empty. Cannot create a calibration dataloader with 0 samples."
+        )
+
     if do_shuffle:
         tokenized_dataset = tokenized_dataset.shuffle()
     tokenized_calibration = tokenized_dataset.select(range(safe_calibration_samples))


### PR DESCRIPTION
# Fix argument handling in oneshot function #1850 
## Issue Description
The `oneshot` function signature in `oneshot.py` was missing several parameters that exist in the underlying dataclasses (`DatasetArguments`, `ModelArguments`, `RecipeArguments`). This caused issues when users tried to use these parameters directly, particularly with:

- `sequential_targets`: Conflicts occurred between recipe modifiers and direct parameters
- `preprocessing_func`: Returns an error when the dataset is empty
- `pipeline`: Not properly validated against `sequential_targets`

## Changes Made

### Parameter Alignment:
- Updated the `oneshot` function signature to include all missing parameters from the argument dataclasses
- Ensured type hints and default values match those defined in the dataclasses
- Added missing parameters: `preprocessing_func`, `data_collator`, `raw_kwargs`, `max_train_samples`, `pipeline`, `tracing_ignore`, `sequential_targets`

### Validation Logic:
- Added validation to detect conflicting `sequential_targets` between recipe modifiers and direct parameters
- Added validation to prevent incompatible `pipeline` settings with `sequential_targets`
- Fixed error message formatting to comply with style guidelines

### Test Improvements:
- Updated the test fixture in `test_api_inputs.py` to handle all parameters correctly
- Added detection for potential parameter conflicts to make tests more robust

## Impact
These changes ensure that all parameters defined in the argument dataclasses can be used directly with the `oneshot` function without unexpected behavior. Users can now pass parameters like `sequential_targets` and `preprocessing_func` directly to `oneshot` without running into cryptic errors or unexpected behavior. The API is now more consistent with its underlying implementation, making it more intuitive to use.