### PR TITLE
[AWQ] Allow users to disable quantization during AWQ

### DIFF
--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional
 
 from loguru import logger
 from torch.nn import Module
@@ -143,7 +142,7 @@ _bloom_mappings = [
     #     ["re:.*dense$"]
     # ),
 ]
-AWQ_MAPPING_REGISTRY: Dict[str, list[AWQMapping]] = {
+AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "BloomForCausalLM": _bloom_mappings,
     "CohereForCausalLM": _cohere_mappings,
     "Cohere2ForCausalLM": _cohere_mappings,
@@ -186,13 +185,13 @@ class ResolvedMapping:
 
     smooth_name: str
     smooth_layer: Module
-    balance_layers: List[Module]
-    balance_names: Optional[List[str]] = None
-    parent: Optional[Module] = None
-    parent_name: Optional[str] = None
+    balance_layers: list[Module]
+    balance_names: list[str]
+    parent: Module
+    parent_name: str
 
 
-def get_layer_mappings_from_architecture(architecture: str) -> List[AWQMapping]:
+def get_layer_mappings_from_architecture(architecture: str) -> list[AWQMapping]:
     """
     :param architecture: str: The architecture of the model
     :return: list: The layer mappings for the given architecture

--- a/tests/llmcompressor/modifiers/awq/test_base.py
+++ b/tests/llmcompressor/modifiers/awq/test_base.py
@@ -228,3 +228,9 @@ def test_get_lowest_common_parent():
         ["embed_tokens", "decoder.self_attn.v_proj"], model
     )
     assert parent_name == "" and parent == model
+
+
+def test_awq_supports_disabling_quantization():
+    awq = AWQModifier(scheme="W4A16", targets=None)
+
+    assert len(awq.resolved_config.config_groups) == 0

--- a/tests/llmcompressor/modifiers/quantization/test_base.py
+++ b/tests/llmcompressor/modifiers/quantization/test_base.py
@@ -3,7 +3,7 @@ from contextlib import nullcontext
 import pytest
 from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
 
-from llmcompressor.modifiers.quantization import GPTQModifier
+from llmcompressor.modifiers.quantization import GPTQModifier, QuantizationModifier
 
 
 @pytest.fixture
@@ -211,3 +211,11 @@ def test_resolved_targets(
         )
 
         assert modifier.resolved_targets == resolved_targets
+
+
+def test_does_not_support_disabling_quantization():
+    with pytest.raises(ValueError):
+        GPTQModifier(scheme="W4A16", targets=None).resolve_quantization_config()
+
+    with pytest.raises(ValueError):
+        QuantizationModifier(scheme="W4A16", targets=None).resolve_quantization_config()


### PR DESCRIPTION
SUMMARY:
We want to provide users the ability to disable quantization in `AWQModifier`, so the best scales are found and applied to the weights without round-to-nearest quantization. This is useful when someone wants to run AWQ and GPTQ, before ultimately quantizing weights. This is a draft solution, see #1972 for discussion


TEST PLAN:
"please outline how the changes were tested"
