### PR TITLE
[Transform] SpinQuant fix OOM

### DIFF
--- a/src/llmcompressor/modifiers/transform/spinquant/base.py
+++ b/src/llmcompressor/modifiers/transform/spinquant/base.py
@@ -144,6 +144,7 @@ class SpinQuantModifier(Modifier, use_enum_values=True):
 
         return True
 
+    @torch.no_grad()
     def on_start(self, state: State, event: Event, **kwargs):
         self.started_ = True
 


### PR DESCRIPTION

SUMMARY:
"When using SpinQuantModifier for some fuse operations, it is necessary to add the torch.no_grad decorator. Otherwise, PyTorch will capture the grad graph by default, leading to a gradual increase in memory usage. I encountered a CUDA OOM issue when rotating the MOE model, and the OOM problem was resolved after fixing it."


TEST PLAN:
"Performed code quality evaluation locally"
