### PR TITLE
Update untie embedding function and usage

### DIFF
--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -177,8 +177,9 @@ class QuantizationMixin(HooksMixin):
 
     def start_calibration(self, model: torch.nn.Module):
         """
-        Attach observers, untie_shared_embeddings (if necessary), register activation calibration hooks (including
-        kv_cache quantization) and enable quantization as we calibrate
+        Attach observers, untie_shared_embeddings (if necessary), register activation
+        calibration hooks (including kv_cache quantization) and
+        enable quantization as we calibrate
 
         :param model: model to prepare for calibration
         """
@@ -187,7 +188,9 @@ class QuantizationMixin(HooksMixin):
             self._calibration_hooks |= self._initialize_hooks(module)
             apply_calibration_status(module)
 
-        untie_if_target_shared_embedding(model, match_named_modules(model, self.resolved_targets, self.ignore))
+        untie_if_target_shared_embedding(
+            model, match_named_modules(model, self.resolved_targets, self.ignore)
+        )
 
         model.apply(enable_quantization)  # quantize at the same time as calibrate
 

--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -203,7 +203,8 @@ def _get_embeddings_or_warn(
 
 
 def untie_if_target_shared_embedding(
-    model: torch.nn.Module, matched_module_generator: Generator[torch.nn.Module | tuple[str, torch.nn.Module]]
+    model: torch.nn.Module,
+    matched_module_generator: Generator[torch.nn.Module | tuple[str, torch.nn.Module]],
 ):
     """
     Helper method that checks for shared input/output embedding and unties them
@@ -212,7 +213,7 @@ def untie_if_target_shared_embedding(
     :param model: model to untie if embeddings are shared and targeted by
         matched_module_generator
     :param matched_module_generator: Generator of all modules which
-            will be modified by quantization or transformation. 
+            will be modified by quantization or transformation.
             Needs to generate modules or [name, module] tuples.
     """
     input_embeddings, output_embeddings = _get_embeddings_or_warn(model)


### PR DESCRIPTION
SUMMARY:
1) making this function a little more forgiving so you can optionally just pass in the normal name, module generator.
2) improve docstring for QuantizationMixin so it mentions the untieing


TEST PLAN:
see CI
