### PR TITLE
Fix: Set TOKENIZERS_PARALLELISM to false

### DIFF
--- a/src/llmcompressor/__init__.py
+++ b/src/llmcompressor/__init__.py
@@ -6,6 +6,8 @@ post-training techniques.
 The library is designed to be flexible and easy to use on top of
 PyTorch and HuggingFace Transformers, allowing for quick experimentation.
 """
+import os
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 # ruff: noqa
 


### PR DESCRIPTION
Hi @kyleesays,

This PR is for Issue #2007.

I fixed the tokenizer warning by adding the `os.environ["TOKENIZERS_PARALLELISM"] = "false"` line to the `src/llmcompressor/__init__.py` file, like you suggested.

I couldn't get the warning to happen on my computer, but this fix should work.

Thanks.
