### PR TITLE
Fix SpinQuant -> Quip link

### DIFF
--- a/examples/transform/README.md
+++ b/examples/transform/README.md
@@ -41,7 +41,7 @@ recipe = [
 ]
 ```
 
-Note that `QuIPModifier` can be customized. For a full list of the available arguments, see the [docstring](/src/llmcompressor/modifiers/transform/spinquant/base.py) or documentation.
+Note that `QuIPModifier` can be customized. For a full list of the available arguments, see the [docstring](/src/llmcompressor/modifiers/transform/quip/base.py) or documentation.
 
 * `rotations` determines which of the input rotation (v) or output rotations (u) should be used.
 * `transform_block_size` determines the size of the hadamard. Smaller hadamards require less cost at runtime.


### PR DESCRIPTION
The link in the Quip README is pointing to SpinQuant.

Note: We might want to link directly to the relevant lines but:
- we need to say "as of llmcompressor vXX.X, the parameters are --> link-with-git-tag, possibly sending people to outdated configuration a year from now.
- or we don't git tag and the line might change with refactoring.
