### PR TITLE
Update dependency bounds for llmcompressor 0.9 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,6 +129,7 @@ setup(
         ),
         ("datasets>=4.0.0,<=4.4.1" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
         (
+            # auto-round 0.9.1 cannot work with accelerate <1.10.0
             "auto-round>=0.9.2,<=0.9.2"
             if BUILD_TYPE == "release"
             else "auto-round>=0.9.2"


### PR DESCRIPTION
SUMMARY:
Update dependency bounds based on their latest releases.


TEST PLAN:
All nightly tests.

Run with upper bounds: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/19864870462
Run with lower bounds: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/19867046299