### PR TITLE
Update lm_eval version to 0.4.9.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
             "pytest>=6.0.0",
             "pytest-mock>=3.6.0",
             "pytest-rerunfailures>=13.0",
-            "lm_eval==0.4.9",
+            "lm_eval==0.4.9.2",
             # test dependencies
             "beautifulsoup4~=4.12.3",
             "cmarkgfm>=2024.1.14",


### PR DESCRIPTION
SUMMARY:
- I am not sure if this is the source of the regression but this version is giving me consistent eval results
- Older version has a bug with cli lm-eval as well