### PR TITLE
[Tracing] Dispatch after tracing

### DIFF
--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -59,10 +59,6 @@ class SequentialPipeline(CalibrationPipeline):
         """
         session = active_session()
 
-        # prepare model for sequential onloading
-        dispatch_for_sequential(model)
-        model_device = get_execution_device(model)
-
         # prepare to trace subgraphs
         modifiers = session.lifecycle.recipe.modifiers
         sequential_targets = get_sequential_targets(modifiers, model, dataset_args)
@@ -72,6 +68,10 @@ class SequentialPipeline(CalibrationPipeline):
         sample_input = next(iter(dataloader))
         subgraphs = trace_subgraphs(model, sample_input, sequential_targets, ignore)
         num_subgraphs = len(subgraphs)
+
+        # prepare model for sequential onloading
+        dispatch_for_sequential(model)
+        model_device = get_execution_device(model)
 
         LifecycleCallbacks.calibration_epoch_start()
 


### PR DESCRIPTION
## Purpose ##
* Avoid complications from dispatch+tracing by dispatching after tracing
* Prepare for TorchOffloader to replace accelerate

## Background ##
Originally, we dispatched the model for sequential onloading before tracing the model. This was so that any onloading behavior would also be reflected in the trace. However, accelerate's onloading implementation is not traceable anyways (we skip it via wrapping sequential targets), so clearly dispatching has no interaction with tracing.

There is a patch required to get TorchOffloader to work with tracing, but it's easier to avoid the problem entirely and trace the model on cpu (no actual cpu calculations are performed during tracing).

All of the tracing tests were not dispatching the model anyways.

## Changes ##
* Dispatch after tracing

## Testing ##
* Tested the following models e2e:
  * `Meta-Llama-3-8B-Instruct`
* Traced `Llama-3.3-70B-Instruct` in 0.07 seconds (used to take 0.33 seconds)
* Tracing tests pass