### PR TITLE
[Performance] Memoryless observers for weights

### DIFF
--- a/src/llmcompressor/modifiers/quantization/calibration.py
+++ b/src/llmcompressor/modifiers/quantization/calibration.py
@@ -64,8 +64,16 @@ def initialize_observer(
     # training is no longer supported: always use memoryless for weights
     if base_name == "weight" and args.observer in ("static_minmax", "minmax"):
         observer = "memoryless_minmax"
+        logger.warning(
+            "Overriding weight observer for lower memory usage "
+            f"({args.observer} -> {observer})"
+        )
     if base_name == "weight" and args.observer in ("mse",):
         observer = "memoryless_mse"
+        logger.warning(
+            "Overriding weight observer for lower memory usage "
+            f"({args.observer} -> {observer})"
+        )
 
     if args is not None and args.dynamic is not True:
         observer = Observer.load_from_registry(


### PR DESCRIPTION
## Purpose ##
* Reduce memory usage when calibrating weights

## Changes ##
* Always use `memoryless_minmax` and `memoryless_mse` when performing weight quantization

## Testing ##
* lm-eval 🟢: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/20797105387/job/59733406907