### PR TITLE
Add rule for automatic documentation labeling

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,4 +1,19 @@
 pull_request_rules:
+- name: label-documentation
+  description: Automatically apply documentation label
+  conditions:
+    - label != stale
+    - or:
+      - files~=^[^/]+\.md$
+      - files~=^docs/
+      - files~=^examples/
+  actions:
+    label:
+      add:
+        - documentation
+    comment:
+      message: "Documentation update"
+      
 - name: ping author on conflicts and add 'needs-rebase' label
   conditions:
     - label != stale


### PR DESCRIPTION
Added a rule to automatically label documentation updates.

SUMMARY:
"please provide a brief summary"


TEST PLAN:
"please outline how the changes were tested"
