### PR TITLE
refactor: modernize type hints in src/llmcompressor/modifiers/pruning/wanda

### DIFF
--- a/src/llmcompressor/modifiers/pruning/wanda/base.py
+++ b/src/llmcompressor/modifiers/pruning/wanda/base.py
@@ -1,5 +1,3 @@
-from typing import Dict, Tuple
-
 import torch
 from compressed_tensors.utils import (
     align_module_device,
@@ -66,15 +64,15 @@ class WandaPruningModifier(SparsityModifierBase):
     """
 
     # private variables
-    _row_scalars: Dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
+    _row_scalars: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
         default_factory=dict
     )
-    _num_samples: Dict[torch.nn.Module, int] = PrivateAttr(default_factory=dict)
+    _num_samples: dict[torch.nn.Module, int] = PrivateAttr(default_factory=dict)
 
     def calibrate_module(
         self,
         module: torch.nn.Module,
-        args: Tuple[torch.Tensor, ...],
+        args: tuple[torch.Tensor, ...],
         _output: torch.Tensor,
     ):
         """


### PR DESCRIPTION
### Description
This PR modernizes the type hints in `src/llmcompressor/modifiers/pruning/wanda/base.py` to align with Python 3.10+ syntax standards (PEP 585).

**Specific updates performed:**
- Replaced `Dict[K, V]` with built-in `dict[K, V]`.
- Replaced `Tuple[...]` with built-in `tuple[...]`.
- Removed unused imports from `typing` (`Dict`, `Tuple`).

### Related Issue
Part of #1927

### Testing
- [x] **Code Quality**: Ran `make quality` and passed (Ruff formatting & linting).
- [x] **Unit Tests**: Ran `pytest tests/llmcompressor/modifiers -v` locally.
    - Result: **117 passed**, verifying that the type hint changes did not break the Wanda modifier logic.

### Checklist
- [x] I have read the contributing guidelines.
- [x] My code follows the code style of this project.
- [x] I have verified that `make quality` passes locally.