### PR TITLE
[Examples] Add AWQ W4AFP8 Llama 3 8B example

### DIFF
--- a/examples/awq/w4a8_fp8_llama_example.py
+++ b/examples/awq/w4a8_fp8_llama_example.py
@@ -71,5 +71,7 @@ print("==========================================\n\n")
 # Save to disk compressed.
 # Use quantization_format="pack-quantized" for vLLM compatibility
 SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-awq-w4a8-fp8"
-model.save_pretrained(SAVE_DIR, save_compressed=True, quantization_format="pack-quantized")
+model.save_pretrained(
+    SAVE_DIR, save_compressed=True, quantization_format="pack-quantized"
+)
 tokenizer.save_pretrained(SAVE_DIR)


### PR DESCRIPTION
Add end-to-end example demonstrating W4AFP8 quantization (INT4 weights + FP8 dynamic activations) using AWQ for Llama 3 8B.

This example uses the new `W4AFP8` preset scheme from compressed-tensors (see vllm-project/compressed-tensors#542).

## Test Plan

- [x] Verify the example runs successfully with the updated compressed-tensors
- [x] Validate the quantized checkpoint loads in vLLM
- [x] Run GSM8K evaluation on the quantized model

## Related Issues

Closes #2237
Relates to #2235

## Dependencies

Requires vllm-project/compressed-tensors#542 to be merged first (adds the `W4AFP8` preset scheme).
