### PR TITLE
[Workflows][CI] Mark PRs as stale and close if no activity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,12 +1,11 @@
-name: 'Close inactive issues and PRs'
+name: 'Close inactive PRs'
 
 on:
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '0 17 * * *'
 
 jobs:
-  close-issues-and-pull-requests:
-    # Prevents triggering on forks or other repos
+  close-pull-requests:
     if: github.repository == 'vllm-project/llm-compressor'
     permissions:
       issues: write
@@ -14,10 +13,8 @@ jobs:
       actions: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1
+      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d
         with:
-          # Increasing this value ensures that changes to this workflow
-          # propagate to all issues and PRs in days rather than months
           operations-per-run: 1000
           exempt-draft-pr: true
 
@@ -26,10 +23,8 @@ jobs:
           stale-pr-label: 'stale'
           stale-pr-message: >
             This pull request has been automatically marked as stale because it
-            has not had any activity within 90 days. It will be automatically
-            closed if no further activity occurs within 30 days. Leave a comment
-            if you feel this pull request should remain open. Thank you!
+            has not had any activity within 60 days. It will be automatically
+            closed if no further activity occurs within 30 days.
           close-pr-message: >
             This pull request has been automatically closed due to inactivity.
             Please feel free to reopen if you intend to continue working on it.
-            Thank you!


### PR DESCRIPTION
Summary
- Marks PRs as stale if no activity for the past 60 days
- Closes them if still no activity after 30 additional days
- Does not impact drafts