### PR TITLE
refactor: modernize type hints in modifiers/pruning and utils

### DIFF
--- a/src/llmcompressor/modifiers/modifier.py
+++ b/src/llmcompressor/modifiers/modifier.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from typing import Optional
 
 from pydantic import ConfigDict
 
@@ -34,11 +33,11 @@ class Modifier(ModifierInterface, HooksMixin):
 
     model_config = ConfigDict(extra="forbid")
 
-    index: Optional[int] = None
-    group: Optional[str] = None
-    start: Optional[float] = None
-    end: Optional[float] = None
-    update: Optional[float] = None
+    index: int | None = None
+    group: str | None = None
+    start: float | None = None
+    end: float | None = None
+    update: float | None = None
 
     initialized_: bool = False
     finalized_: bool = False

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -1,5 +1,4 @@
 import contextlib
-from typing import Dict, Optional, Tuple
 
 import torch
 from compressed_tensors.utils import (
@@ -77,18 +76,18 @@ class SparseGPTModifier(SparsityModifierBase):
 
     # modifier arguments
     block_size: int = 128
-    dampening_frac: Optional[float] = 0.01
+    dampening_frac: float | None = 0.01
     preserve_sparsity_mask: bool = False
     offload_hessians: bool = False
 
     # private variables
-    _num_samples: Dict[torch.nn.Module, int] = PrivateAttr(default_factory=dict)
-    _hessians: Dict[torch.nn.Module, torch.Tensor] = PrivateAttr(default_factory=dict)
+    _num_samples: dict[torch.nn.Module, int] = PrivateAttr(default_factory=dict)
+    _hessians: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(default_factory=dict)
 
     def calibrate_module(
         self,
         module: torch.nn.Module,
-        args: Tuple[torch.Tensor, ...],
+        args: tuple[torch.Tensor, ...],
         _output: torch.Tensor,
     ):
         """

--- a/src/llmcompressor/modifiers/pruning/utils/pytorch/layer_mask.py
+++ b/src/llmcompressor/modifiers/pruning/utils/pytorch/layer_mask.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Dict
 
 import torch
 from torch.nn import Parameter
@@ -39,8 +38,8 @@ class ParameterizedLayerMaskSettings:
 
 
 class LayerParamMasking(HooksMixin):
-    _mask_settings: Dict[str, ParameterizedLayerMaskSettings] = {}
-    _masked_layer_params: Dict[str, ModelParameterizedLayer] = {}
+    _mask_settings: dict[str, ParameterizedLayerMaskSettings] = {}
+    _masked_layer_params: dict[str, ModelParameterizedLayer] = {}
     enabled_: bool = False
 
     def add_mask(

--- a/src/llmcompressor/modifiers/pruning/utils/pytorch/mask_factory.py
+++ b/src/llmcompressor/modifiers/pruning/utils/pytorch/mask_factory.py
@@ -1,6 +1,6 @@
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
 
 import torch
 from torch import Tensor
@@ -23,7 +23,7 @@ class PruningMaskCreatorArgs:
     parameter: Parameter
     sparsity: float
     scores: Tensor
-    prev_mask: Optional[Tensor] = None
+    prev_mask: Tensor | None = None
 
 
 MaskCreatorType = Callable[[PruningMaskCreatorArgs], Tensor]

--- a/src/llmcompressor/modifiers/utils/pytorch_helpers.py
+++ b/src/llmcompressor/modifiers/utils/pytorch_helpers.py
@@ -7,8 +7,6 @@ detection. Supports MoE (Mixture of Experts) models and specialized
 tensor operations for compression workflows.
 """
 
-from typing import Dict
-
 import torch
 from torch.nn import Module
 
@@ -18,7 +16,7 @@ __all__ = [
 ]
 
 
-def apply_pad_mask_to_batch(batch: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+def apply_pad_mask_to_batch(batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
     """
     Apply a mask to the input ids of a batch. This is used to zero out
     padding tokens so they do not contribute to the hessian calculation in the


### PR DESCRIPTION
### Description
This PR modernizes the type hints in multiple files under
`src/llmcompressor/modifiers/` to align with Python 3.10+ syntax
standards (PEP 585 and PEP 604).

**Files updated:**
- `modifiers/modifier.py`
- `modifiers/utils/pytorch_helpers.py`
- `modifiers/pruning/sparsegpt/base.py`
- `modifiers/pruning/utils/pytorch/layer_mask.py`
- `modifiers/pruning/utils/pytorch/mask_factory.py`

**Specific updates performed:**
- Replaced `Dict[K, V]` with built-in `dict[K, V]`.
- Replaced `Tuple[...]` with built-in `tuple[...]`.
- Replaced `Optional[X]` with `X | None`.
- Replaced `typing.Callable` with `collections.abc.Callable`.
- Removed unused imports from `typing` (`Dict`, `Tuple`, `Optional`, `Callable`).

### Related Issue
Part of #1927

### Testing
- [x] **Code Quality**: Ran `make quality` and passed (Ruff formatting &
linting).
- [x] **Unit Tests**: Ran `pytest tests/llmcompressor/modifiers -v`
locally.
- Result: **All tests passed**, verifying that the type hint changes did not
break any modifier logic.

### Checklist
- [x] I have read the contributing guidelines.
- [x] My code follows the code style of this project.
- [x] I have verified that `make quality` passes locally.