### PR TITLE
[AWQ]: Add mapping for Qwen3NextForCausalLM

### DIFF
--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -174,6 +174,7 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Qwen2MoeForCausalLM": _moe_default_mappings,
     "Qwen3ForCausalLM": _default_mappings,
     "Qwen3MoeForCausalLM": _moe_default_mappings,
+    "Qwen3NextForCausalLM": _moe_default_mappings,
     "Glm4MoeForCausalLM": _default_mappings,
     "SeedOssForCausalLM": _default_mappings,
     "Ernie4_5_MoeForCausalLM": _default_mappings,


### PR DESCRIPTION
## Description
Adds `Qwen3NextForCausalLM` to `AWQ_MAPPING_REGISTRY` with `_moe_default_mappings`.
Qwen3-Next-80B-A3B is a MoE (Mixture of Experts) architecture similar to `Qwen3MoeForCausalLM`. The model uses the same layer structure with `mlp.experts.*` pattern, so the existing `_moe_default_mappings` should work correctly.

## Related Issue
Fixes #2256 

## Testing
- [x] `make quality` passes
- [x] `pytest tests/llmcompressor/modifiers/ -v` passes (117 tests)

I don't have access to the 80B model for full end-to-end testing.

## Note on Shared Experts
While investigating this issue, I noticed that `Qwen3NextForCausalLM` has an additional `shared_expert` layer:
- `mlp.shared_expert.gate_proj`
- `mlp.shared_expert.up_proj`
- `mlp.shared_expert.down_proj`
