### PR TITLE
[Misc] Squelch excessive warnings

### DIFF
--- a/src/llmcompressor/modifiers/quantization/calibration.py
+++ b/src/llmcompressor/modifiers/quantization/calibration.py
@@ -66,13 +66,15 @@ def initialize_observer(
         observer = "memoryless_minmax"
         logger.warning(
             "Overriding weight observer for lower memory usage "
-            f"({args.observer} -> {observer})"
+            f"({args.observer} -> {observer})",
+            log_once=True,
         )
     if base_name == "weight" and args.observer in ("mse",):
         observer = "memoryless_mse"
         logger.warning(
             "Overriding weight observer for lower memory usage "
-            f"({args.observer} -> {observer})"
+            f"({args.observer} -> {observer})",
+            log_once=True,
         )
 
     if args is not None and args.dynamic is not True:


### PR DESCRIPTION
Before
```
2026-01-22T01:36:44.325049+0000 | initialize_observer | WARNING - Overriding weight observer for lower memory usage (minmax -> memoryless_minmax)
2026-01-22T01:36:44.325208+0000 | initialize_observer | WARNING - Overriding weight observer for lower memory usage (minmax -> memoryless_minmax)
2026-01-22T01:36:44.325354+0000 | initialize_observer | WARNING - Overriding weight observer for lower memory usage (minmax -> memoryless_minmax)
2026-01-22T01:36:44.325503+0000 | initialize_observer | WARNING - Overriding weight observer for lower memory usage (minmax -> memoryless_minmax)
2026-01-22T01:36:44.325648+0000 | initialize_observer | WARNING - Overriding weight observer for lower memory usage (minmax -> memoryless_minmax)
2026-01-22T01:36:44.325790+0000 | initialize_observer | WARNING - Overriding weight observer for lower memory usage (minmax -> memoryless_minmax)
...
```

Now
```
2026-01-22T01:38:38.560023+0000 | initialize_observer | WARNING - Overriding weight observer for lower memory usage (minmax -> memoryless_minmax)
```