### PR TITLE
[e2e][Tests] Remove marlin e2e configs

### DIFF
--- a/tests/e2e/vLLM/configs/w4a16_2of4_channel_quant.yaml
+++ b/tests/e2e/vLLM/configs/w4a16_2of4_channel_quant.yaml
@@ -1,7 +1,0 @@
-cadence: "nightly"
-test_type: "regression"
-model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
-scheme: W4A16_2of4_channel
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
-recipe: tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_recipe.yaml

--- a/tests/e2e/vLLM/configs/w4a16_2of4_grouped_quant.yaml
+++ b/tests/e2e/vLLM/configs/w4a16_2of4_grouped_quant.yaml
@@ -1,7 +1,0 @@
-cadence: "nightly"
-test_type: "regression"
-model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
-scheme: W4A16_2of4
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
-recipe: tests/e2e/vLLM/recipes/WNA16_2of4/2of4_w4a16_group-128_recipe.yaml


### PR DESCRIPTION
SUMMARY:
- Remove as no longer supported in vLLM and deprecated in CT / LLM Comp