### PR TITLE
[Tests] Fix wikitext tests

### DIFF
--- a/tests/llmcompressor/transformers/data/test_dataset_helpers.py
+++ b/tests/llmcompressor/transformers/data/test_dataset_helpers.py
@@ -8,7 +8,7 @@ from llmcompressor.transformers.data.data_helpers import get_raw_dataset
 @pytest.mark.unit
 def test_combined_datasets():
     dataset_args = DatasetArguments(
-        dataset="wikitext", dataset_config_name="wikitext-2-raw-v1"
+        dataset="Salesforce/wikitext", dataset_config_name="wikitext-2-raw-v1"
     )
     raw_wikitext2 = get_raw_dataset(dataset_args)
     datasets = {"all": raw_wikitext2}
@@ -23,7 +23,7 @@ def test_combined_datasets():
 def test_separate_datasets():
     splits = {"train": "train[:5%]", "validation": "train[10%:20%]"}
     dataset_args = DatasetArguments(
-        dataset="wikitext", dataset_config_name="wikitext-2-raw-v1"
+        dataset="Salesforce/wikitext", dataset_config_name="wikitext-2-raw-v1"
     )
     datasets = {}
     for split_name, split_str in splits.items():


### PR DESCRIPTION
Summary
- We are already using the `Salesforce/wikitext` dataset for the `WikiTextDataset` but not in some individual data processing tests
- Update those tests to use this as well 