### PR TITLE
Add GSM8K evaluation script and AWQ+FP8 results

### DIFF
--- a/examples/awq/RESULTS.md
+++ b/examples/awq/RESULTS.md
@@ -22,6 +22,15 @@ This PR adds `RESULTS.md` with reproducible workflow for evaluating AWQ+FP8 quan
 - Batch size: 16
 - Model: Meta-Llama-3-8B-Instruct
 
+## Discussion
+
+This behavior where FP8_BLOCK underperforms FP8_DYNAMIC contradicts our expectation since for RTN FP8_BLOCK outperforms FP8_DYNAMIC, however there are 2 important things to notice.
+1) FP8_BLOCK quantization creates quantization `groups` whose size is equivalent to the number of elements in a block, whereas FP8_DYNAMIC quantization creates quantization `groups`
+   whose size is equal to the in_features. Thus as long as in_features is less than the block size (128x128=16384) the number of weight scales will actually be higher for per channel quantization.
+   For Meta-Llama-3-8B-Instruct the per-channel weight quantization of the FP8_DYNAMIC scheme has more scales than FP8_BLOCK for every weight.
+2) Its also noteworthy that for AWQ, the scale factors being searched for during AWQ align directly with the quantization scales of the per channel weight quantization, this is likely why AWQ yields
+   such a large improvement for FP8_DYNAMIC
+   
 ## Model Checkpoints
 
 - FP8_DYNAMIC: https://huggingface.co/nm-testing/Meta-Llama-3-8B-Instruct-awq-asym-fp8-dynamic


### PR DESCRIPTION
This PR adds GSM8K evaluation results for AWQ+FP8 quantization as requested in #2305.

## What's included

**RESULTS.md** - Evaluation results comparing FP8_DYNAMIC vs FP8_BLOCK quantization schemes on Meta-Llama-3-8B-Instruct

## Results

| Scheme | Strict Match | Flexible Extract |
|--------|-------------|------------------|
| **FP8_DYNAMIC** | **76.42%** | **76.19%** |
| **FP8_BLOCK** | 75.21% | 74.98% |

- **Model:** Meta-Llama-3-8B-Instruct
- **Hardware:** 8x NVIDIA A100-SXM4-80GB
- FP8_DYNAMIC outperforms FP8_BLOCK by ~1.2% on strict match

## DIscussion
This behavior where FP8_BLOCK underperforms FP8_DYNAMIC contradicts our expectation since for RTN FP8_BLOCK outperforms FP8_DYNAMIC, however there are 2 important things to notice.
1) FP8_BLOCK quantization creates quantization `groups` whose size is equivalent to the number of elements in a block, whereas FP8_DYNAMIC quantization creates quantization `groups`
   whose size is equal to the in_features. Thus as long as in_features is less than the block size (128x128=16384) the number of weight scales will actually be higher for per channel quantization.
   For Meta-Llama-3-8B-Instruct the per-channel weight quantization of the FP8_DYNAMIC scheme has more scales than FP8_BLOCK for every weight.
2) Its also noteworthy that for AWQ, the scale factors being searched for during AWQ align directly with the quantization scales of the per channel weight quantization, this is likely why AWQ yields
   such a large improvement for FP8_DYNAMIC

## Evaluation command

```bash
lm_eval \
  --model hf \
  --model_args pretrained=<model_path>,dtype=auto \
  --tasks gsm8k \
  --batch_size 16 \
  --output_path <output_dir>
```

**Note:** `batch_size=16` is important — the default `auto` picks 1, significantly increasing evaluation time.

## Model Checkpoints (from @HDCharles)

- FP8_DYNAMIC: https://huggingface.co/nm-testing/Meta-Llama-3-8B-Instruct-awq-asym-fp8-dynamic
- FP8_BLOCK: https://huggingface.co/nm-testing/Meta-Llama-3-8B-Instruct-awq-asym-fp8-block