### PR TITLE
Add concurrency check to all pr workflows

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -9,6 +9,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-check.yaml
+++ b/.github/workflows/quality-check.yaml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ main, 'release/*' ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   UV_SYSTEM_PYTHON: 1
   UV_TORCH_BACKEND: "auto"

--- a/.github/workflows/ready-label-check.yaml
+++ b/.github/workflows/ready-label-check.yaml
@@ -9,6 +9,10 @@ on:
       - opened
       - reopened
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ready-label-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -17,6 +17,11 @@ env:
   UV_SYSTEM_PYTHON: 1
   UV_TORCH_BACKEND: "auto"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
 
   base-tests:


### PR DESCRIPTION
SUMMARY:
We typically only care about the test results for the final commit in a pr. This pr will reduce the load on github actions runners by cancelling all jobs except for the one on the latest commit.

For example, if the following commits are all uploaded one at a time quickly in a row:
Commit A1 uploaded, job A1 starts
Commit B1 (separate pr) uploaded, job B1 queued
Commit A2 uploaded, job A1 cancelled, job A2 queued, job B1 started
Job B1 finishes, job A1 starts

Note: this is the same concurrency logic we already have on `test-check-transformers.yaml`
