### PR TITLE
Fix quant_model_reload test

### DIFF
--- a/tests/llmcompressor/transformers/compression/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/compression/test_compress_tensor_utils.py
@@ -175,7 +175,7 @@ def test_quant_model_reload(format, dtype, tmp_path):
         concatenate_data=concatenate_data,
         splits=splits,
         precision=dtype,
-        clear_sparse_session=False,
+        tie_word_embeddings=False,
     )
 
     # Fetch the oneshot model


### PR DESCRIPTION
SUMMARY:
- Remove old unused argument
- Set tie_word_embeddings to false to account for what the test is targeting