### PR TITLE
[Release 0.9.0.2] bump up pillow upper bound to 12.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ setup(
             if BUILD_TYPE == "release"
             else "nvidia-ml-py>=12.560.30"
         ),
-        ("pillow>=10.4.0,<=12.0.0" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
+        ("pillow>=10.4.0,<=12.1.1" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
         (
             "compressed-tensors==0.13.0"
             if BUILD_TYPE == "release"


### PR DESCRIPTION
SUMMARY:
Bump up pillow to 12.1.1 to fix the CVE issue reported in the model-opt image.


TEST PLAN:
Unit tests: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/21966299130
E2e tests: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/21989966171/job/63534063938
