### PR TITLE
[Oneshot] Add validation for empty dataset and enhance oneshot function parameters (Supersedes PR #1957)

### DIFF
--- a/tests/llmcompressor/transformers/oneshot/test_api_inputs.py
+++ b/tests/llmcompressor/transformers/oneshot/test_api_inputs.py
@@ -1,9 +1,14 @@
+import logging
+
 import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from tests.llmcompressor.transformers.oneshot.dataset_processing import get_data_utils
 from tests.testing_utils import parse_params
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 CONFIGS_DIRECTORY = "tests/llmcompressor/transformers/oneshot/oneshot_configs"
 
@@ -41,6 +46,16 @@ def one_shot_args(request):
         recipe=config["recipe"],
         dataset_config_name=config.get("dataset_config_name"),
     )
+
+    args["pipeline"] = config.get("pipeline", "independent")
+    args["sequential_targets"] = config.get("sequential_targets", None)
+    args["tracing_ignore"] = config.get("tracing_ignore", [])
+    args["raw_kwargs"] = config.get("raw_kwargs", {})
+    args["preprocessing_func"] = config.get("preprocessing_func", None)
+    args["remove_columns"] = config.get("remove_columns", None)
+    args["dvc_data_repository"] = config.get("dvc_data_repository", None)
+    args["splits"] = config.get("splits", {"calibration": "train[:50]"})
+    args["log_dir"] = config.get("log_dir", "sparse_logs")
 
     return args
 


### PR DESCRIPTION
<h2>Issue Description</h2>
<p>The <b>oneshot</b> function signature in <b>oneshot.py</b> was missing several parameters that exist in the underlying dataclasses (<b>DatasetArguments</b>, <b>ModelArguments</b>, <b>RecipeArguments</b>). This caused issues when users tried to use these parameters directly, particularly with:</p>

<ul>
  <li><b>sequential_targets</b>: Conflicts occurred between recipe modifiers and direct parameters</li>
  <li><b>preprocessing_func</b>: Returns an error when the dataset is empty</li>
  <li><b>pipeline</b>: Not properly validated against <b>sequential_targets</b></li>
</ul>

<hr />

<h2>Changes Made</h2>

<h3>Parameter Alignment:</h3>
<ul>
  <li>Updated the <b>oneshot</b> function signature to include all missing parameters from the argument dataclasses</li>
  <li>Ensured type hints and default values match those defined in the dataclasses</li>
  <li>Added missing parameters: <b>preprocessing_func</b>, <b>data_collator</b>, <b>raw_kwargs</b>, <b>max_train_samples</b>, <b>pipeline</b>, <b>tracing_ignore</b>, <b>sequential_targets</b></li>
</ul>

<h3>Validation Logic:</h3>
<ul>
  <li>Added validation to detect conflicting <b>sequential_targets</b> between recipe modifiers and direct parameters</li>
  <li>Added validation to prevent incompatible <b>pipeline</b> settings with <b>sequential_targets</b></li>
  <li>Fixed error message formatting to comply with style guidelines</li>
</ul>

<h3>Test Improvements:</h3>
<ul>
  <li>Updated the test fixture in <b>test_api_inputs.py</b> to handle all parameters correctly</li>
  <li>Added detection for potential parameter conflicts to make tests more robust</li>
</ul>

<hr />

<h2>Impact</h2>
<p>These changes ensure that all parameters defined in the argument dataclasses can be used directly with the <b>oneshot</b> function without unexpected behavior. Users can now pass parameters, such as <b>sequential_targets</b> and <b>preprocessing_func</b>, directly to <b>oneshot</b> without encountering cryptic errors or unexpected behavior. The API is now more consistent with its underlying implementation, making it more intuitive to use.</p>