### PR TITLE
fix: use topological ordering in FX graph cleanup to fix erase_node crash (Granite4 GPTQ)

### DIFF
--- a/src/llmcompressor/pipelines/sequential/transformers_helpers.py
+++ b/src/llmcompressor/pipelines/sequential/transformers_helpers.py
@@ -1478,6 +1478,8 @@ class HFTracer(Tracer):
                     to_delete = collections.OrderedDict()
                     while to_visit:
                         n = to_visit.pop(0)
+                        if n in to_delete:
+                            to_delete.move_to_end(n)
                         to_delete[n] = None
                         to_visit += list(n.users.keys())
 


### PR DESCRIPTION
## SUMMARY:
Fix the FX tracing crash reported as the second error in #2338. The BFS cleanup of concrete args did not maintain topological ordering — if a node was visited multiple times, its position in the deletion dict was not updated, causing dependents to be deleted before their dependencies (`RuntimeError: Tried to erase Node getitem_169`).

The fix uses `move_to_end` in the BFS traversal so that revisited nodes are moved to the end of the deletion dict, ensuring topological order.

Companion to #2425 (shape fix) and compressed-tensors #609 (3D pack/unpack). Together they resolve #2338.

## TEST PLAN:
Tested on Granite 4.0-h-small with a single layer, using all three fixes (#2425, #2426, compressed-tensors #609).

Script based on `test_gptq_no_exclusion.py` from #2338 with `model.model.layers = model.model.layers[:1]` added after model loading.

Command: `python test_gptq_no_exclusion.py --model-name ibm-granite/granite-4.0-h-small --output /workspace/test-output --calibration-samples 16`

Results:
- FX tracing completed — no `erase_node` crash
- 3D→2D conversion OK
- Cache preparation OK (16/16 samples)
- Calibration started but hit OOM on the Mamba layer (unrelated to the fix — naive Mamba path without `causal_conv1d` on a 31GB GPU)