### PR TITLE
Add MoE calibration module for GlmMoeDsa (GLM-5)

### DIFF
--- a/examples/quantizing_moe/glm5_example.py
+++ b/examples/quantizing_moe/glm5_example.py
@@ -1,0 +1,82 @@
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modeling.glm_moe_dsa import CalibrationGlmMoeDsaMoE  # noqa: F401
+from llmcompressor.modifiers.awq import AWQModifier
+
+# Load the model
+model_id = "ZhipuAI/GLM-5"
+model = AutoModelForCausalLM.from_pretrained(model_id, dtype="auto")
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+# MoE calibration is now handled automatically by the pipeline.
+# The `CalibrationGlmMoeDsaMoE` modules (from `llmcompressor.modeling.glm_moe_dsa`)
+# will be applied during calibration to enable proper expert calibration.
+# These permanently unpack the fused 3D expert weights into individual nn.Linear
+# layers for quantization target matching and vLLM compatibility.
+
+# Select calibration dataset.
+DATASET_ID = "HuggingFaceH4/ultrachat_200k"
+DATASET_SPLIT = "train_sft"
+
+# Select number of samples. 512 samples is a good place to start.
+# Increasing the number of samples can improve accuracy.
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+# Load dataset and preprocess.
+ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {
+        "text": tokenizer.apply_chat_template(
+            example["messages"],
+            tokenize=False,
+        )
+    }
+
+
+ds = ds.map(preprocess)
+
+
+# Tokenize inputs.
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+moe_ignores = [
+    # Layers 0-2: Dense layers - ignore entire layers
+    "model.layers.0.*",
+    "model.layers.1.*",
+    "model.layers.2.*",
+    # Ignore the output head
+    "lm_head",
+]
+
+# Configure the quantization algorithm to run.
+#   * quantize the weights to 4 bit with AWQ with a group size 128
+recipe = AWQModifier(targets="Linear", scheme="W4A16", ignore=moe_ignores)
+
+# Apply algorithms.
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+# Save to disk compressed.
+SAVE_DIR = model_id.rstrip("/").split("/")[-1] + "-W4A16-G128"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/src/llmcompressor/modeling/__init__.py
+++ b/src/llmcompressor/modeling/__init__.py
@@ -12,6 +12,7 @@ needed for efficient compression.
 # trigger registration
 from .deepseek_v3 import CalibrationDeepseekV3MoE  # noqa: F401
 from .glm4_moe import CalibrationGlm4MoeMoE  # noqa: F401
+from .glm_moe_dsa import CalibrationGlmMoeDsaMoE  # noqa: F401
 from .llama4 import SequentialLlama4TextMoe  # noqa: F401
 from .qwen3_moe import CalibrationQwen3MoeSparseMoeBlock  # noqa: F401
 from .qwen3_vl_moe import CalibrateQwen3VLMoeTextSparseMoeBlock  # noqa: F401

--- a/src/llmcompressor/modeling/glm_moe_dsa.py
+++ b/src/llmcompressor/modeling/glm_moe_dsa.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from llmcompressor.modeling.moe_context import MoECalibrationModule
+
+if TYPE_CHECKING:
+    from transformers.models.glm_moe_dsa.configuration_glm_moe_dsa import (
+        GlmMoeDsaConfig,
+    )
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        GlmMoeDsaMoE,
+        GlmMoeDsaNaiveMoe,
+    )
+from llmcompressor.utils.dev import skip_weights_initialize
+
+
+@MoECalibrationModule.register("GlmMoeDsaMoE")
+class CalibrationGlmMoeDsaMoE(MoECalibrationModule):
+    """
+    Calibration version of GlmMoeDsaMoE that unpacks experts for sequential
+    processing.
+
+    This module:
+    1. Unpacks the packed expert weights (3D -> 2D) for calibration
+    2. Optionally sends all tokens to all experts during calibration
+    3. Stays in unpacked form (permanent) for vLLM compatibility
+    """
+
+    is_permanent = True
+
+    def __init__(
+        self,
+        original: GlmMoeDsaMoE,
+        config: GlmMoeDsaConfig,
+        calibrate_all_experts: bool = True,
+    ):
+        super().__init__()
+        self.top_k = config.num_experts_per_tok
+        self.num_experts = config.num_local_experts
+        self.n_routed_experts = config.n_routed_experts
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.norm_topk_prob = config.norm_topk_prob
+        self.routed_scaling_factor = config.routed_scaling_factor
+
+        self.experts = SequentialGlmMoeDsaExperts(config, original.experts)
+        self.gate = original.gate
+        self.shared_experts = original.shared_experts
+        self.calibrate_all_experts = calibrate_all_experts
+
+    def route_tokens_to_experts(self, router_logits):
+        router_logits = router_logits.sigmoid()
+        router_logits_for_choice = router_logits + self.gate.e_score_correction_bias
+        group_scores = (
+            router_logits_for_choice.view(
+                -1, self.n_group, self.n_routed_experts // self.n_group
+            )
+            .topk(2, dim=-1)[0]
+            .sum(dim=-1)
+        )
+        group_idx = torch.topk(group_scores, k=self.topk_group, dim=-1, sorted=False)[1]
+        group_mask = torch.zeros_like(group_scores)
+        group_mask.scatter_(1, group_idx, 1)
+        score_mask = (
+            group_mask.unsqueeze(-1)
+            .expand(-1, self.n_group, self.n_routed_experts // self.n_group)
+            .reshape(-1, self.n_routed_experts)
+        )
+        scores_for_choice = router_logits_for_choice.masked_fill(
+            ~score_mask.bool(), 0.0
+        )
+        topk_indices = torch.topk(
+            scores_for_choice, k=self.top_k, dim=-1, sorted=False
+        )[1]
+        topk_weights = router_logits.gather(1, topk_indices)
+        if self.norm_topk_prob:
+            denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
+            topk_weights /= denominator
+        topk_weights = topk_weights * self.routed_scaling_factor
+        return topk_indices, topk_weights
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        router_logits = self.gate(hidden_states)
+        topk_indices, topk_weights = self.route_tokens_to_experts(router_logits)
+        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+
+        final_hidden_states = torch.zeros_like(hidden_states, dtype=topk_weights.dtype)
+        with torch.no_grad():
+            expert_mask = torch.nn.functional.one_hot(
+                topk_indices, num_classes=self.num_experts
+            )
+            expert_mask = expert_mask.permute(2, 1, 0)
+
+        for i in range(self.num_experts):
+            top_k_pos, token_idx = torch.where(expert_mask[i])
+            has_tokens = token_idx.numel() > 0
+
+            if self.calibrate_all_experts:
+                expert_out_all = self.experts[i](hidden_states)
+                if not has_tokens:
+                    continue
+                expert_out = expert_out_all[token_idx]
+            else:
+                if not has_tokens:
+                    continue
+                expert_out = self.experts[i](hidden_states[token_idx])
+
+            weighted_output = expert_out * topk_weights[token_idx, top_k_pos, None]
+            final_hidden_states.index_add_(
+                0, token_idx, weighted_output.to(final_hidden_states.dtype)
+            )
+
+        hidden_states = final_hidden_states.type(hidden_states.dtype).view(*orig_shape)
+        hidden_states = hidden_states + self.shared_experts(residuals)
+        return hidden_states
+
+
+class SequentialGlmMoeDsaExperts(torch.nn.ModuleList):
+    def __init__(self, config: GlmMoeDsaConfig, original: GlmMoeDsaNaiveMoe):
+        from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import GlmMoeDsaMLP
+
+        self.num_experts = config.num_local_experts
+        with skip_weights_initialize():
+            super().__init__(
+                [
+                    GlmMoeDsaMLP(config, intermediate_size=config.moe_intermediate_size)
+                    for _ in range(self.num_experts)
+                ]
+            )
+
+        for i in range(self.num_experts):
+            gate_up = original.gate_up_proj[i]
+            down = original.down_proj[i]
+
+            gate_proj, up_proj = gate_up.chunk(2, dim=0)
+
+            self[i].gate_proj.weight.data = gate_proj.contiguous()
+            self[i].up_proj.weight.data = up_proj.contiguous()
+            self[i].down_proj.weight.data = down.contiguous()

--- a/tests/llmcompressor/modeling/test_calib_glm_moe_dsa.py
+++ b/tests/llmcompressor/modeling/test_calib_glm_moe_dsa.py
@@ -1,0 +1,113 @@
+from functools import partial
+
+import pytest
+import torch
+
+_glm_cfg = pytest.importorskip(
+    "transformers.models.glm_moe_dsa.configuration_glm_moe_dsa",
+    reason="glm_moe_dsa requires transformers >= 5.x",
+)
+_glm_mod = pytest.importorskip(
+    "transformers.models.glm_moe_dsa.modeling_glm_moe_dsa",
+    reason="glm_moe_dsa requires transformers >= 5.x",
+)
+GlmMoeDsaConfig = _glm_cfg.GlmMoeDsaConfig
+GlmMoeDsaMoE = _glm_mod.GlmMoeDsaMoE
+
+from llmcompressor.modeling.glm_moe_dsa import CalibrationGlmMoeDsaMoE  # noqa: E402
+from llmcompressor.utils.helpers import calibration_forward_context  # noqa: E402
+from tests.testing_utils import requires_gpu  # noqa: E402
+
+
+def _tiny_config():
+    """Small config for fast unit tests (8 experts instead of 256)."""
+    return GlmMoeDsaConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        n_routed_experts=8,
+        num_experts_per_tok=2,
+        n_shared_experts=1,
+        n_group=1,
+        topk_group=1,
+        num_hidden_layers=4,
+    )
+
+
+@requires_gpu
+def test_calib_glm_moe_dsa_all_experts_triggered():
+    config = _tiny_config()
+    with torch.device("cuda"):
+        original = GlmMoeDsaMoE(config)
+        for param in original.parameters():
+            param.data.normal_(mean=0.0, std=0.02)
+
+    module = CalibrationGlmMoeDsaMoE(original, config, calibrate_all_experts=True)
+
+    num_experts = len(module.experts)
+    expert_triggered = [False for _ in range(num_experts)]
+
+    def hook_fn(i, module, input, output):
+        expert_triggered[i] = True
+
+    for i, expert in enumerate(module.experts):
+        expert.register_forward_hook(partial(hook_fn, i))
+
+    hidden_dim = config.hidden_size
+    batch, seq_len = 4, 32
+    sample = torch.randn(batch, seq_len, hidden_dim, device="cuda")
+
+    with calibration_forward_context(module):
+        with torch.no_grad():
+            _ = module(sample)
+
+    assert all(expert_triggered), f"Not all experts were triggered: {expert_triggered}"
+
+
+@requires_gpu
+def test_calib_glm_moe_dsa_output_matches():
+    config = _tiny_config()
+    with torch.device("cuda"):
+        original = GlmMoeDsaMoE(config)
+        for param in original.parameters():
+            param.data.normal_(mean=0.0, std=0.02)
+
+    hidden_dim = config.hidden_size
+    batch, seq_len = 4, 32
+    sample = torch.randn(batch, seq_len, hidden_dim, device="cuda")
+
+    with calibration_forward_context(original):
+        true_out = original(sample)
+
+    module = CalibrationGlmMoeDsaMoE(original, config, calibrate_all_experts=True)
+    with calibration_forward_context(module):
+        out = module(sample)
+        assert torch.nn.functional.mse_loss(true_out, out) < 0.1
+
+    module = CalibrationGlmMoeDsaMoE(original, config, calibrate_all_experts=False)
+    with calibration_forward_context(module):
+        out = module(sample)
+        assert torch.nn.functional.mse_loss(true_out, out) < 0.1
+
+
+@requires_gpu
+def test_calib_glm_moe_dsa_experts_are_linear():
+    """Verify that after unpacking, experts contain nn.Linear modules
+    visible to named_modules(), which is the whole point of this fix."""
+    config = _tiny_config()
+    with torch.device("cuda"):
+        original = GlmMoeDsaMoE(config)
+
+    module = CalibrationGlmMoeDsaMoE(original, config, calibrate_all_experts=True)
+
+    linear_names = [
+        name for name, mod in module.named_modules() if isinstance(mod, torch.nn.Linear)
+    ]
+    # Each expert should have gate_proj, up_proj, down_proj = 3 Linear per expert
+    # Plus shared_experts has 3 Linear
+    expected_expert_linears = config.num_local_experts * 3
+    expected_shared_linears = 3
+    assert len(linear_names) == expected_expert_linears + expected_shared_linears, (
+        f"Expected {expected_expert_linears + expected_shared_linears} Linear modules, "
+        f"found {len(linear_names)}: {linear_names}"
+    )


### PR DESCRIPTION
SUMMARY:
GlmMoeDsaNaiveMoe uses packed 3D nn.Parameter tensors instead of nn.Linear modules, causing targets=["Linear"] to match nothing in MoE experts during AWQ/GPTQ quantization.

This PR permanently unpacks the fused expert weights into individual nn.Linear layers, following the same calibration pattern as glm4_moe with dtype handling aligned.

Key differences from glm4_moe: is_permanent=True (experts must be unpacked for quantization targets to match), DeepSeek-style routing with groups/topk_group/norm, and SequentialGlmMoeDsaExperts for 3D->2D weight unpacking.

Closes #2430

TEST PLAN:
pytest.importorskip: tests skip gracefully on transformers < 5.x
3 unit tests: all experts triggered, output matches original, experts converted to nn.Linear
Full e2e validation pending transformers 5.x compatibility
No smaller GLM-5 checkpoint available for e2e testing (744B only)