### PR TITLE
fix(examples): correct W8A16 -> W4A16 in Qwen3-VL AWQ example save dir

### DIFF
--- a/examples/awq/qwen3-vl-30b-a3b-Instruct-example.py
+++ b/examples/awq/qwen3-vl-30b-a3b-Instruct-example.py
@@ -111,6 +111,6 @@ print(processor.decode(output[0]))
 print("==========================================")
 
 # Save to disk in compressed-tensors format.
-SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-AWQ-W8A16-mse-seq"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-AWQ-W4A16-mse-seq"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 processor.save_pretrained(SAVE_DIR)


### PR DESCRIPTION
SUMMARY:
The AWQ recipe in this example uses num_bits=4 for weights (W4A16).

However the save directory name incorrectly uses "W8A16":

    -AWQ-W8A16-mse-seq

This PR updates it to:

    -AWQ-W4A16-mse-seq

to match the actual quantization configuration and the comment above the recipe.


TEST PLAN:
Not applicable. This PR only fixes an incorrect save directory string in the example script.
No functional code paths are changed.
