### PR TITLE
[examples][awq] Update AWQ examples to stacked recipe pattern

### DIFF
--- a/examples/awq/README.md
+++ b/examples/awq/README.md
@@ -6,13 +6,32 @@ The AWQ implementation found in LLM Compressor is derived from the pioneering wo
 
 ## AWQ Recipe ##
 
-The AWQ recipe has been inferfaced as follows, where the `AWQModifier` adjusts model scales ahead of efficient weight quantization by the `QuantizationModifier`
+`AWQModifier` is a smoothing pre-pass (similar to `SmoothQuantModifier`). It adjusts model scales ahead of weight quantization but does not apply quantization itself. It must be stacked with a downstream quantization modifier:
+
+### AWQ + QuantizationModifier (RTN) ###
 
 ```python
 recipe = [
     AWQModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
+    QuantizationModifier(scheme="W4A16_ASYM", targets=["Linear"], ignore=["lm_head"]),
 ]
 ```
+
+See [`llama_example.py`](llama_example.py) for a full runnable example.
+
+### AWQ + GPTQModifier (higher accuracy) ###
+
+```python
+recipe = [
+    AWQModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
+    GPTQModifier(scheme="W4A16_ASYM", targets=["Linear"], ignore=["lm_head"]),
+]
+```
+
+See [`llama_gptq_example.py`](llama_gptq_example.py) for a full runnable example.
+
+> **Note**: The `scheme`, `targets`, and `ignore` arguments on `AWQModifier` are used
+> internally during scale search and should match those on the downstream quantization modifier.
 
 ## Compressing Your Own Model ##
 To use your own model, start with an existing example change the `model_id` to match your own model stub.

--- a/examples/awq/llama_gptq_example.py
+++ b/examples/awq/llama_gptq_example.py
@@ -4,7 +4,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.awq import AWQModifier
-from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.modifiers.quantization import GPTQModifier
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -52,12 +52,13 @@ def tokenize(sample):
 # Configure the quantization algorithm to run.
 # AWQModifier is a smoothing pre-pass: it computes and applies per-channel
 # activation scales but does NOT quantize weights itself.
-# QuantizationModifier performs the actual weight quantization using those scales.
+# GPTQModifier performs Hessian-based weight quantization on the smoothed model,
+# yielding higher accuracy than RTN at the cost of longer calibration time.
 recipe = [
     AWQModifier(
         ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"], duo_scaling="both"
     ),
-    QuantizationModifier(
+    GPTQModifier(
         scheme="W4A16_ASYM", targets=["Linear"], ignore=["lm_head"]
     ),
 ]
@@ -83,6 +84,6 @@ print(tokenizer.decode(output[0]))
 print("==========================================\n\n")
 
 # Save to disk compressed.
-SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-awq-asym"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-awq-gptq-asym"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)


### PR DESCRIPTION
## Summary
Updates AWQ examples and README to use the canonical stacked recipe pattern per #2327.
Depends on: #2327 (AWQModifier restructuring to decouple smoothing from quantization)

`AWQModifier` is a smoothing pre-pass (like `SmoothQuantModifier`). The correct usage is:
```python
recipe = [
    AWQModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
    QuantizationModifier(scheme="W4A16_ASYM", targets=["Linear"], ignore=["lm_head"]),
]
```

## Changes
- `llama_example.py`: updated to explicit `[AWQModifier, QuantizationModifier]` stack
- `llama_gptq_example.py`: new example showing `[AWQModifier, GPTQModifier]`
- `README.md`: documents both stacking patterns

## Related
Part of #2327