### PR TITLE
Move model parameters and buffers to CPU before offloading to prevent…

### DIFF
--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -542,7 +542,7 @@ def dispatch_for_sequential(
         for name, param in module._parameters.items():
             if param is not None and param.device.type != "cpu":
                 module._parameters[name] = torch.nn.Parameter(
-                    param.data.to("cpu"), requires_grad=param.requires_grad
+                    param.detach().to("cpu"), requires_grad=param.requires_grad
                 )
         for name, buf in module._buffers.items():
             if buf is not None and buf.device.type != "cpu":


### PR DESCRIPTION
## Summary

This pull request fixes an out-of-memory (OOM) issue in the sequential calibration pipeline when running large MoE models (e.g., Qwen3.5-122B-A10B) with `compressed_tensors` offload on multi-GPU setups.

## Bug

Running `oneshot` with the sequential pipeline consistently failed with:

```
torch.OutOfMemoryError: CUDA out of memory ...
Sequential pipeline ran out of memory. Please consider choosing a smaller module for `sequential_targets` argument, ex. 'Linear'
```

The OOM occurred inside `dispatch_for_sequential` when it invoked `compressed_tensors.offload.offload_model`:

- `offload_model` iterates over all modules.
- For CUDA-resident modules, `get_module_device` returns their current device and `DeviceCache` is selected as the `OffloadCache`.
- `DeviceCache.__init__` sets `self.offload_device = self.onload_device`, so parameters are "offloaded" to the same CUDA device they are onloaded from.
- With a model initially sharded across multiple GPUs, this can consolidate parameters from multiple devices onto a single GPU during sequential pipeline setup, causing a hard OOM for large models.

Adjusting `max_memory` at `from_pretrained` time did not fix the issue because the consolidation happened later, during the pipeline dispatch step.

## Fix

### 1. Sequential pipeline dispatch

In `dispatch_for_sequential`:

- Resolve `onload_device` if not provided.
- **Before** calling `offload_model`, normalize the model to CPU:
  - Iterate over all modules in the model.
  - Remove any existing accelerate `device_map` hooks from each module.
  - For each parameter:
    - If not `None` and not on CPU, move it to CPU and preserve `requires_grad`.
  - For each buffer:
    - If not `None` and not on CPU, move it to CPU.
- Call `torch.cuda.empty_cache()` to free GPU memory.
- Then call `offload_model(model, onload_device, offload_device)`.

Effect:

- When `offload_model` runs, modules are CPU-resident, so `CPUCache` is selected instead of `DeviceCache`.
- Parameters remain offloaded on CPU by default and are only onloaded to the target GPU for the currently processed subgraph.
- This avoids consolidating all parameters onto a single GPU and prevents the OOM in the sequential pipeline.

### 2. Example script adjustments (`qwen3_5_moe.py`)

In the example Qwen3.5 MoE calibration script:

- **Fix `max_memory` mapping** to use integer keys, as expected by `accelerate`:

```python
devices = torch.cuda.device_count()
max_memory = {i: "85GB" for i in range(devices)}
```

- **Pass `max_memory` to model loading**:

```python
model = AutoModelForImageTextToText.from_pretrained(
    MODEL_ID,
    dtype="auto",
    device_map="auto",
    max_memory=max_memory,
    local_files_only=True,
)
```

This ensures we cap memory usage per device at load time, while the main OOM fix is handled by the updated sequential dispatch logic.

## Testing

- Ran the `qwen3_5_moe.py` example end-to-end:
  - Model loads successfully with `device_map="auto"` and `max_memory` applied.
  - Sequential calibration pipeline completes without CUDA OOM.
  - Post-calibration sample generation runs and produces outputs.