### PR TITLE
feat: add iMatrix weighted MSE observer and IMatrixGatherer

### DIFF
--- a/examples/imatrix/README.md
+++ b/examples/imatrix/README.md
@@ -1,0 +1,70 @@
+# iMatrix Importance-Weighted Quantization
+
+`imatrix_mse` is an observer that uses per-channel activation importance (E[x²]) to weight quantization error during range selection. Channels that carry more signal get more careful range optimization.
+
+Two components work together:
+- **`IMatrixGatherer`**: triggers a calibration pass so the observer can collect importance data
+- **`imatrix_mse` observer**: collects E[x²] per input channel via forward pre-hooks and uses importance weighting in the MSE grid search: `err = sum(importance * |Q(w) - w|^p)`
+
+> See [RFC #2456](https://github.com/vllm-project/llm-compressor/discussions/2456) for the full design discussion.
+
+## Quickstart
+
+```bash
+python3 llama3_imatrix_example.py
+```
+
+The simplest setup uses `preset_name_to_scheme` to configure W4A16 and swaps in the `imatrix_mse` observer:
+
+```python
+from compressed_tensors.quantization import preset_name_to_scheme
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.modifiers.transform.imatrix import IMatrixGatherer
+
+scheme = preset_name_to_scheme("W4A16", ["Linear"])
+scheme.weights.observer = "imatrix_mse"
+
+recipe = [
+    IMatrixGatherer(ignore=["lm_head"]),
+    QuantizationModifier(
+        config_groups={"group_0": scheme},
+        ignore=["lm_head"],
+    ),
+]
+```
+
+## Composing with GPTQ
+
+iMatrix composes with GPTQ by providing importance-weighted ranges for the Hessian-based rounding:
+
+```python
+from llmcompressor.modifiers.gptq import GPTQModifier
+
+scheme = preset_name_to_scheme("W4A16", ["Linear"])
+scheme.weights.observer = "imatrix_mse"
+
+recipe = [
+    IMatrixGatherer(ignore=["lm_head"]),
+    GPTQModifier(
+        config_groups={"group_0": scheme},
+        ignore=["lm_head"],
+    ),
+]
+```
+
+## Results
+
+W4A16, Llama-3.1-8B, group_size=128, WikiText-2 token-level perplexity (141 chunks x 2048):
+
+| Config | PPL |
+|---|---|
+| FP16 baseline | 6.24 |
+| RTN `memoryless_minmax` | 6.96 |
+| GPTQ | 6.92 |
+| AWQ | 6.89 |
+| RTN `imatrix_mse` | 6.85 |
+| GPTQ + `imatrix_mse` | 6.83 |
+
+## Questions or Feature Request?
+
+Please open up an issue on `vllm-project/llm-compressor`

--- a/examples/imatrix/llama3_imatrix_example.py
+++ b/examples/imatrix/llama3_imatrix_example.py
@@ -1,0 +1,61 @@
+from compressed_tensors.offload import dispatch_model
+from compressed_tensors.quantization import preset_name_to_scheme
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.modifiers.transform.imatrix import IMatrixGatherer
+
+# Select model and load it.
+model_id = "meta-llama/Meta-Llama-3.1-8B"
+
+model = AutoModelForCausalLM.from_pretrained(model_id, dtype="auto")
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+# Select calibration dataset.
+DATASET_ID = "open_platypus"
+
+# Select number of samples. 512 samples is a good place to start.
+# Increasing the number of samples can improve accuracy.
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+# Configure the quantization algorithm to run.
+#   * trigger a calibration pass with IMatrixGatherer so the observer can collect E[x²]
+#   * quantize the weights to 4 bit with group size 128
+#   * use imatrix_mse observer to weight quantization error by channel importance
+scheme = preset_name_to_scheme("W4A16", ["Linear"])
+scheme.weights.observer = "imatrix_mse"
+
+recipe = [
+    IMatrixGatherer(ignore=["lm_head"]),
+    QuantizationModifier(
+        config_groups={"group_0": scheme},
+        ignore=["lm_head"],
+    ),
+]
+
+# Apply algorithms.
+oneshot(
+    model=model,
+    dataset=DATASET_ID,
+    splits={"calibration": "train[:5%]"},
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+# Confirm generations of the quantized model look sane.
+print("\n\n")
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================\n\n")
+
+# Save to disk compressed.
+SAVE_DIR = model_id.rstrip("/").split("/")[-1] + "-W4A16-G128-imatrix"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/examples/quantization_w4a16/README.md
+++ b/examples/quantization_w4a16/README.md
@@ -138,6 +138,3 @@ We can see the resulting scores look good!
 |     |       |strict-match    |     5|exact_match|↑  |0.720|±  |0.0285|
 ```
 
-### Questions or Feature Request?
-
-Please open up an issue on `vllm-project/llm-compressor`

--- a/src/llmcompressor/modifiers/quantization/calibration.py
+++ b/src/llmcompressor/modifiers/quantization/calibration.py
@@ -82,6 +82,7 @@ def initialize_observer(
             observer, base_name=base_name, args=args, module=module
         )
         module.register_module(f"{base_name}_observer", observer)
+        observer.attach(module)
 
 
 def call_observer(
@@ -264,6 +265,7 @@ def freeze_module_quantization(module: Module):
     for name in ("input", "weight", "output", "q", "k", "v"):
         obs_name = f"{name}_observer"
         if hasattr(module, obs_name):
+            getattr(module, obs_name).detach(module)
             delattr(module, obs_name)
 
     module.quantization_status = QuantizationStatus.FROZEN

--- a/src/llmcompressor/modifiers/transform/imatrix/__init__.py
+++ b/src/llmcompressor/modifiers/transform/imatrix/__init__.py
@@ -1,0 +1,3 @@
+# ruff: noqa
+
+from .base import *

--- a/src/llmcompressor/modifiers/transform/imatrix/base.py
+++ b/src/llmcompressor/modifiers/transform/imatrix/base.py
@@ -1,0 +1,134 @@
+from typing import Dict, List, Union
+
+from compressed_tensors.quantization import QuantizationArgs
+from compressed_tensors.utils import match_named_modules
+from pydantic import Field
+
+from llmcompressor.core import Event, EventType, State
+from llmcompressor.modifiers import Modifier
+from llmcompressor.observers.base import Observer
+
+__all__ = ["IMatrixGatherer"]
+
+
+class IMatrixGatherer(Modifier):
+    """
+    Lifecycle trigger for iMatrix importance collection.
+
+    Triggers a calibration pass so that ``IMatrixMSEObserver`` can collect
+    E[x²] via its ``attach()`` hook.  Does **not** quantize weights — the
+    actual quantization is done by the subsequent
+    ``QuantizationModifier`` / ``GPTQModifier``.
+
+    The observer's ``detach()`` method computes ``_imatrix_importance``
+    from the accumulated statistics and leaves it on the module for the
+    next quantization pass to consume.
+
+    Example recipe::
+
+        recipe:
+          - IMatrixGatherer:
+              ignore: ["lm_head"]
+          - QuantizationModifier:
+              config_groups:
+                group_0:
+                  targets: ["Linear"]
+                  weights:
+                    observer: imatrix_mse
+
+    Or composed with GPTQ::
+
+        recipe:
+          - IMatrixGatherer:
+              ignore: ["lm_head"]
+          - GPTQModifier:
+              config_groups:
+                group_0:
+                  targets: ["Linear"]
+                  weights:
+                    observer: imatrix_mse
+
+    .. note::
+        Auto-prepend (inserting the gatherer automatically when
+        ``imatrix_mse`` is detected in a recipe) is planned for a
+        follow-up PR.
+
+    :param targets: module types to instrument (default: ``["Linear"]``)
+    :param ignore: layer name patterns to skip (default: ``["lm_head"]``)
+    :param weight_observer: observer to attach during calibration.
+        Must be ``"imatrix_mse"`` (default).
+    """
+
+    targets: Union[str, List[str]] = Field(default_factory=lambda: ["Linear"])
+    ignore: List[str] = Field(default_factory=lambda: ["lm_head"])
+    weight_observer: str = "imatrix_mse"
+
+    # ------------------------------------------------------------------ #
+    #  Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def on_initialize(self, state: State, **kwargs) -> bool:
+        """
+        Attach iMatrix observers to target modules for E[x²] collection
+        """
+        self._resolved_targets = (
+            self.targets if isinstance(self.targets, list) else [self.targets]
+        )
+        self._observers: Dict[str, Observer] = {}
+
+        # Minimal QuantizationArgs — only used to instantiate the observer,
+        # no quantization config is applied to the model.
+        observer_args = QuantizationArgs(observer=self.weight_observer)
+
+        for name, module in match_named_modules(
+            state.model, self._resolved_targets, self.ignore
+        ):
+            observer = Observer.load_from_registry(
+                self.weight_observer,
+                base_name="weight",
+                args=observer_args,
+                module=module,
+            )
+            module.register_module("weight_observer", observer)
+            observer.attach(module)
+            self._observers[name] = observer
+
+        return True
+
+    def on_start(self, state: State, event: Event, **kwargs):
+        self.started_ = True
+
+    def on_event(self, state: State, event: Event, **kwargs):
+        if event.type_ == EventType.CALIBRATION_EPOCH_START:
+            if not self.started_:
+                self.on_start(state, None)
+
+        if event.type_ == EventType.CALIBRATION_EPOCH_END:
+            if not self.ended_:
+                self.on_end(state, None)
+
+    def on_end(self, state: State, event: Event, **kwargs):
+        self.ended_ = True
+        for name, observer in self._observers.items():
+            module = observer.module() if observer.module is not None else None
+            if module is not None:
+                observer.detach(module)
+                if hasattr(module, "weight_observer"):
+                    delattr(module, "weight_observer")
+        self._observers.clear()
+
+    def on_finalize(self, state: State, **kwargs) -> bool:
+        """
+        Clean up importance tensors so they don't end up in the checkpoint
+        """
+        if not self.ended_:
+            self.on_end(state, None)
+
+        # Clean up importance tensors so they don't end up in checkpoint
+        for _, module in match_named_modules(
+            state.model, self._resolved_targets, self.ignore
+        ):
+            if hasattr(module, "_imatrix_importance"):
+                del module._imatrix_importance
+
+        return True

--- a/src/llmcompressor/observers/__init__.py
+++ b/src/llmcompressor/observers/__init__.py
@@ -14,3 +14,4 @@ from .base import *
 from .moving_base import *
 from .min_max import *
 from .mse import *
+from .imatrix import *

--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -194,6 +194,24 @@ class Observer(InternalModule, RegistryMixin):
             global_scale=global_scale,
         )
 
+    def attach(self, module: torch.nn.Module) -> None:
+        """
+        Called when the observer is attached to a module.
+        Subclasses can override to register hooks or initialize state.
+
+        :param module: the module this observer is being attached to
+        """
+        pass
+
+    def detach(self, module: torch.nn.Module) -> None:
+        """
+        Called before the observer is deleted from a module.
+        Subclasses can override to remove hooks and clean up module attributes.
+
+        :param module: the module this observer is being removed from
+        """
+        pass
+
     def _check_has_global_scale(self, global_scale: Optional[torch.nn.Parameter]):
         if (
             self.args.strategy == QuantizationStrategy.TENSOR_GROUP

--- a/src/llmcompressor/observers/imatrix.py
+++ b/src/llmcompressor/observers/imatrix.py
@@ -1,0 +1,364 @@
+import math
+from typing import Optional
+
+import torch
+from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
+from compressed_tensors.quantization.lifecycle import fake_quantize
+from compressed_tensors.quantization.utils import calculate_qparams, generate_gparam
+from compressed_tensors.utils import patch_attr
+from loguru import logger
+
+from llmcompressor.observers.base import MinMaxTuple, Observer
+from llmcompressor.observers.helpers import flatten_for_calibration
+
+__all__ = ["IMatrixMSEObserver"]
+
+_GROUP_STRATEGIES = (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP)
+
+IMATRIX_PRECISION = torch.float32
+
+
+@Observer.register("imatrix_mse")
+class IMatrixMSEObserver(Observer):
+    """
+    MSE observer weighted by per-input-channel importance.
+
+    Supports CHANNEL, GROUP, and TENSOR_GROUP for weight-only Linear modules.
+    Falls back to uniform MSE for global_scale search.
+    Extra observer_kwargs: maxshrink, patience, grid, norm, strict.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        kw = self.args.observer_kwargs
+        self.maxshrink = kw.get("maxshrink", 0.95)
+        self.patience = kw.get("patience", 5)
+        self.grid = kw.get("grid", 20)
+        self.norm = kw.get("norm", 3.0)
+        self.strict = kw.get("strict", False)
+
+        if self.grid <= 0:
+            raise ValueError(f"grid must be > 0, got {self.grid}")
+        if self.patience < 0:
+            raise ValueError(f"patience must be >= 0, got {self.patience}")
+        if not (0 <= self.maxshrink <= 1):
+            raise ValueError(f"maxshrink must be in [0, 1], got {self.maxshrink}")
+        if (
+            not isinstance(self.norm, (int, float))
+            or not math.isfinite(self.norm)
+            or self.norm <= 0
+        ):
+            raise ValueError(f"norm must be a finite positive number, got {self.norm}")
+
+    # ------------------------------------------------------------------
+    # Hook lifecycle: collect E[x²] per input channel
+    # ------------------------------------------------------------------
+
+    def attach(self, module: torch.nn.Module) -> None:
+        """Attach a forward-pre hook to accumulate E[x²] per input channel.
+
+        If ``_imatrix_importance`` already exists on the module (second pass,
+        e.g. QuantizationModifier after IMatrixGatherer), skip hook attachment.
+        """
+        if hasattr(module, "_imatrix_importance"):
+            return
+
+        if not hasattr(module, "in_features"):
+            return
+
+        in_features = module.in_features
+        module._imatrix_sum = torch.zeros(in_features, dtype=IMATRIX_PRECISION)
+        module._imatrix_count = 0
+
+        def _hook(mod, args):
+            x = args[0] if isinstance(args, tuple) else args
+            if isinstance(x, tuple):
+                x = x[0]
+            if x is None or not isinstance(x, torch.Tensor):
+                return
+
+            x_f = x.detach().to(IMATRIX_PRECISION)
+            n_tokens = math.prod(x_f.shape[:-1])
+            token_sum = x_f.pow(2).sum(dim=list(range(x_f.dim() - 1)))
+
+            if mod._imatrix_sum.device != token_sum.device:
+                mod._imatrix_sum = mod._imatrix_sum.to(token_sum.device)
+
+            mod._imatrix_sum.add_(token_sum)
+            mod._imatrix_count += n_tokens
+
+        module._imatrix_hook = module.register_forward_pre_hook(_hook)
+
+    def detach(self, module: torch.nn.Module) -> None:
+        """Remove hooks and compute / clean up importance data.
+
+        Case 1 – accumulators present (``_imatrix_sum``): compute importance,
+        remove the hook and accumulators, **leave** ``_imatrix_importance`` on
+        the module so the next quantization pass can use it.
+
+        Case 2 – only ``_imatrix_importance`` present (no accumulators): this
+        is the final cleanup pass — delete it so it doesn't end up in the
+        checkpoint.
+        """
+        if hasattr(module, "_imatrix_sum"):
+            if module._imatrix_count > 0:
+                importance = module._imatrix_sum / module._imatrix_count
+                module._imatrix_importance = importance
+            if hasattr(module, "_imatrix_hook"):
+                module._imatrix_hook.remove()
+                del module._imatrix_hook
+            del module._imatrix_sum
+            del module._imatrix_count
+            return
+
+        if hasattr(module, "_imatrix_importance"):
+            del module._imatrix_importance
+
+    # ------------------------------------------------------------------
+
+    def get_min_max(self, observed: torch.Tensor) -> MinMaxTuple:
+        return _grid_search(
+            observed,
+            self.args,
+            self.maxshrink,
+            self.patience,
+            self.grid,
+            self.norm,
+            global_scale=self._get_module_param("global_scale"),
+            importance_weights=self._prepare_importance(observed),
+        )
+
+    def get_global_min_max(self, observed: torch.Tensor) -> MinMaxTuple:
+        # TODO: support importance weights here by deferring the reshape
+        # to the grid search call. Currently the base class reshapes
+        # observed to (1, 1, -1) which loses the channel layout needed
+        # for importance broadcasting.
+        return _grid_search(
+            observed,
+            self.args,
+            self.maxshrink,
+            self.patience,
+            self.grid,
+            self.norm,
+            optimize_global_scale=True,
+        )
+
+    # ------------------------------------------------------------------
+
+    def _prepare_importance(self, observed: torch.Tensor) -> Optional[torch.Tensor]:
+        """Validate → reorder (g_idx) → normalize → broadcast."""
+        imp = self._get_validated_importance(observed)
+        if imp is None:
+            return None
+
+        imp = imp.to(device=observed.device, dtype=torch.float32)
+        imp = imp / (imp.mean() + torch.finfo(torch.float32).tiny)
+
+        # Expand to weight shape and use flatten_for_calibration
+        # to handle all strategies and g_idx
+        module = self.module() if self.module is not None else None
+        if module is None or not hasattr(module, "weight"):
+            return None
+        out_features = module.weight.shape[0]
+        imp_2d = imp.unsqueeze(0).expand(out_features, -1)
+        g_idx = getattr(module, f"{self.base_name}_g_idx", None)
+        return flatten_for_calibration(imp_2d, self.base_name, self.args, g_idx)
+
+    def _get_validated_importance(
+        self, observed: torch.Tensor
+    ) -> Optional[torch.Tensor]:
+        """Return 1D importance tensor or None (with warning/raise)."""
+        if self.base_name != "weight":
+            if self.strict:
+                raise NotImplementedError(
+                    "imatrix_mse: only supported for weight observers"
+                )
+            logger.warning(
+                "imatrix_mse: only supported for weight observers."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+
+        module = self.module() if self.module is not None else None
+
+        if module is not None and not isinstance(module, torch.nn.Linear):
+            if self.strict:
+                raise TypeError(
+                    "imatrix_mse: only supported for Linear,"
+                    f" got {type(module).__name__}"
+                )
+            logger.warning(
+                "imatrix_mse: only supported for Linear,"
+                f" got {type(module).__name__}."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+
+        if self.args.strategy == QuantizationStrategy.TENSOR:
+            if self.strict:
+                raise NotImplementedError("imatrix_mse: TENSOR strategy not supported")
+            logger.warning(
+                "imatrix_mse: TENSOR strategy not supported."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+
+        imp = getattr(module, "_imatrix_importance", None) if module else None
+        if imp is None:
+            if self.strict:
+                raise ValueError("imatrix_mse: no _imatrix_importance on module")
+            logger.warning(
+                "imatrix_mse: no _imatrix_importance on module."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+        if imp.dim() != 1:
+            if self.strict:
+                raise ValueError(
+                    f"imatrix_mse: expected 1D, got shape {tuple(imp.shape)}"
+                )
+            logger.warning(
+                f"imatrix_mse: expected 1D, got shape {tuple(imp.shape)}."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+        if not torch.is_floating_point(imp):
+            imp = imp.float()
+        if not torch.isfinite(imp).all():
+            if self.strict:
+                raise ValueError("imatrix_mse: contains non-finite values")
+            logger.warning(
+                "imatrix_mse: contains non-finite values."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+        if (imp < 0).any():
+            if self.strict:
+                raise ValueError("imatrix_mse: contains negative values")
+            logger.warning(
+                "imatrix_mse: contains negative values."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+        if torch.all(imp == 0):
+            if self.strict:
+                raise ValueError("imatrix_mse: all zeros")
+            logger.warning(
+                "imatrix_mse: all zeros. Falling back to uniform MSE.", log_once=True
+            )
+            return None
+
+        if self.args.strategy == QuantizationStrategy.CHANNEL:
+            expected = observed.shape[-1]
+        elif self.args.strategy in _GROUP_STRATEGIES:
+            expected = observed.shape[2] * observed.shape[3]
+        else:
+            expected = None
+        if expected is None:
+            if self.strict:
+                raise NotImplementedError(
+                    f"imatrix_mse: unsupported strategy {self.args.strategy}"
+                )
+            logger.warning(
+                f"imatrix_mse: unsupported strategy {self.args.strategy}."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+        if imp.numel() != expected:
+            if self.strict:
+                raise ValueError(
+                    "imatrix_mse: size mismatch:"
+                    f" expected {expected}, got {imp.numel()}"
+                )
+            logger.warning(
+                "imatrix_mse: size mismatch:"
+                f" expected {expected}, got {imp.numel()}."
+                " Falling back to uniform MSE.",
+                log_once=True,
+            )
+            return None
+        return imp
+
+
+# ---------------------------------------------------------------------------
+# TODO: refactor to replace memoryless_mse's grid search, this function
+# subsumes it when importance_weights=None.
+# ---------------------------------------------------------------------------
+
+
+def _grid_search(
+    observed: torch.Tensor,
+    args: QuantizationArgs,
+    maxshrink: float,
+    patience: int,
+    grid: int,
+    norm: float,
+    global_scale: Optional[torch.Tensor] = None,
+    optimize_global_scale: bool = False,
+    importance_weights: Optional[torch.Tensor] = None,
+) -> MinMaxTuple:
+    """Grid search for min/max minimizing (importance-weighted) quant error."""
+    min_val = torch.amin(observed, dim=(0, -1))
+    max_val = torch.amax(observed, dim=(0, -1))
+    best_error = torch.full(
+        min_val.shape,
+        torch.finfo(torch.float32).max,
+        device=min_val.device,
+        dtype=torch.float32,
+    )
+    best_min = min_val.clone()
+    best_max = max_val.clone()
+
+    no_improve = 0
+    observed_f = observed.float()
+
+    shrink_steps = max(1, int(maxshrink * grid))
+    for i in range(shrink_steps + 1):
+        p = 1 - i / grid
+        shrink_min = p * min_val
+        shrink_max = p * max_val
+
+        if optimize_global_scale:
+            global_scale = generate_gparam(shrink_min, shrink_max)
+
+        scales, zps = calculate_qparams(
+            min_vals=shrink_min,
+            max_vals=shrink_max,
+            quantization_args=args,
+            global_scale=global_scale,
+        )
+
+        with patch_attr(args, "strategy", QuantizationStrategy.TOKEN):
+            q = fake_quantize(
+                observed,
+                scales.unsqueeze(-1),
+                zps.unsqueeze(-1),
+                args,
+                global_scale=global_scale,
+            ).float()
+
+        q.sub_(observed_f).abs_().pow_(norm)
+        if importance_weights is not None:
+            q.mul_(importance_weights)
+        err = q.sum(dim=(0, -1))
+
+        improved = err < best_error
+        if torch.any(improved):
+            best_error[improved] = err[improved]
+            best_min[improved] = shrink_min[improved]
+            best_max[improved] = shrink_max[improved]
+            no_improve = 0
+        else:
+            no_improve += 1
+            if patience > 0 and no_improve >= patience:
+                break
+
+    return best_min, best_max

--- a/tests/llmcompressor/modifiers/transform/imatrix/test_e2e_integration.py
+++ b/tests/llmcompressor/modifiers/transform/imatrix/test_e2e_integration.py
@@ -1,0 +1,261 @@
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.modifiers.transform.imatrix import IMatrixGatherer
+
+MODEL_ID = "nm-testing/tinysmokellama-3.2"
+DATASET = "open_platypus"
+NUM_CALIB_SAMPLES = 4
+MAX_SEQ_LEN = 128
+
+
+@pytest.fixture(scope="module")
+def model_and_tokenizer():
+    """Load the tiny model and tokenizer once per module."""
+    model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+    return model, tokenizer
+
+
+def _get_linear_layer_names(model, ignore=None):
+    """Return names of all nn.Linear modules not in the ignore list."""
+    ignore = ignore or []
+    names = []
+    for name, module in model.named_modules():
+        if isinstance(module, torch.nn.Linear):
+            if not any(pattern in name for pattern in ignore):
+                names.append(name)
+    return names
+
+
+def _get_module_by_name(model, name):
+    """Retrieve a submodule by dotted name."""
+    parts = name.split(".")
+    m = model
+    for part in parts:
+        m = getattr(m, part)
+    return m
+
+
+class TestGathererObserverIntegration:
+    """IMatrixGatherer + imatrix_mse observer end-to-end."""
+
+    @pytest.mark.smoke
+    @pytest.mark.integration
+    def test_pipeline_produces_quantized_model(self):
+        """Gatherer collects importance, observer consumes it, model is quantized."""
+        model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+
+        recipe = [
+            IMatrixGatherer(ignore=["lm_head"]),
+            QuantizationModifier(
+                config_groups={
+                    "group_0": {
+                        "targets": ["Linear"],
+                        "weights": {
+                            "num_bits": 4,
+                            "type": "int",
+                            "symmetric": True,
+                            "strategy": "group",
+                            "group_size": 32,
+                            "observer": "imatrix_mse",
+                            "observer_kwargs": {
+                                "norm": 2.4,
+                                "maxshrink": 0.7,
+                            },
+                        },
+                    }
+                },
+                ignore=["lm_head"],
+            ),
+        ]
+
+        oneshot(
+            model=model,
+            dataset=DATASET,
+            splits={"calibration": "train[:5%]"},
+            recipe=recipe,
+            num_calibration_samples=NUM_CALIB_SAMPLES,
+            max_seq_length=MAX_SEQ_LEN,
+        )
+
+        # Verify importance was cleaned up after finalization
+        targeted_names = _get_linear_layer_names(model, ignore=["lm_head"])
+        for name in targeted_names:
+            mod = _get_module_by_name(model, name)
+            assert not hasattr(
+                mod, "_imatrix_importance"
+            ), f"{name} should not have _imatrix_importance after finalization"
+
+        # Hooks should be cleaned up
+        total_hooks = sum(len(m._forward_pre_hooks) for m in model.modules())
+        assert (
+            total_hooks == 0
+        ), f"Expected 0 forward pre-hooks after completion, found {total_hooks}"
+
+        # Verify imatrix actually affected quantization by comparing scales
+        # with a run using imatrix_mse but WITHOUT the gatherer. Without
+        # the gatherer, the observer falls back to uniform MSE (no importance).
+        # Same observer, same kwargs — the only difference is the importance.
+        imatrix_scales = {
+            name: _get_module_by_name(model, name).weight_scale.clone()
+            for name in targeted_names
+            if hasattr(_get_module_by_name(model, name), "weight_scale")
+        }
+
+        model_no_gatherer = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+        recipe_no_gatherer = [
+            QuantizationModifier(
+                config_groups={
+                    "group_0": {
+                        "targets": ["Linear"],
+                        "weights": {
+                            "num_bits": 4,
+                            "type": "int",
+                            "symmetric": True,
+                            "strategy": "group",
+                            "group_size": 32,
+                            "observer": "imatrix_mse",
+                            "observer_kwargs": {
+                                "norm": 2.4,
+                                "maxshrink": 0.7,
+                            },
+                        },
+                    }
+                },
+                ignore=["lm_head"],
+            ),
+        ]
+        oneshot(
+            model=model_no_gatherer,
+            dataset=DATASET,
+            splits={"calibration": "train[:5%]"},
+            recipe=recipe_no_gatherer,
+            num_calibration_samples=NUM_CALIB_SAMPLES,
+            max_seq_length=MAX_SEQ_LEN,
+        )
+
+        differs = False
+        for name in imatrix_scales:
+            mod_no_gatherer = _get_module_by_name(model_no_gatherer, name)
+            if hasattr(mod_no_gatherer, "weight_scale"):
+                if not torch.equal(imatrix_scales[name], mod_no_gatherer.weight_scale):
+                    differs = True
+                    break
+
+        assert differs, (
+            "imatrix_mse with gatherer produced identical scales to "
+            "imatrix_mse without gatherer — importance was not collected"
+        )
+
+    @pytest.mark.smoke
+    @pytest.mark.integration
+    def test_gatherer_without_observer_no_crash(self):
+        """IMatrixGatherer alone should run without error and clean up after."""
+        model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+
+        recipe = [IMatrixGatherer(ignore=["lm_head"])]
+
+        oneshot(
+            model=model,
+            dataset=DATASET,
+            splits={"calibration": "train[:5%]"},
+            recipe=recipe,
+            num_calibration_samples=NUM_CALIB_SAMPLES,
+            max_seq_length=MAX_SEQ_LEN,
+        )
+
+        # Importance should be cleaned up after finalization
+        targeted_names = _get_linear_layer_names(model, ignore=["lm_head"])
+        assert len(targeted_names) > 0, "Model should have targeted Linear layers"
+
+        for name in targeted_names:
+            mod = _get_module_by_name(model, name)
+            assert not hasattr(
+                mod, "_imatrix_importance"
+            ), f"{name} should not have _imatrix_importance after finalization"
+
+    @pytest.mark.smoke
+    @pytest.mark.integration
+    def test_pipeline_with_regex_targets(self):
+        """Gatherer + observer with regex targets for specific attention projections."""
+        model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+
+        recipe = [
+            IMatrixGatherer(
+                ignore=["lm_head"],
+                targets=["re:.*self_attn.(q|k|v)_proj$"],
+            ),
+            QuantizationModifier(
+                config_groups={
+                    "group_0": {
+                        "targets": ["re:.*self_attn.(q|k|v)_proj$"],
+                        "weights": {
+                            "num_bits": 4,
+                            "type": "int",
+                            "symmetric": True,
+                            "strategy": "group",
+                            "group_size": 32,
+                            "observer": "imatrix_mse",
+                        },
+                    }
+                },
+                ignore=["lm_head"],
+            ),
+        ]
+
+        oneshot(
+            model=model,
+            dataset=DATASET,
+            splits={"calibration": "train[:5%]"},
+            recipe=recipe,
+            num_calibration_samples=NUM_CALIB_SAMPLES,
+            max_seq_length=MAX_SEQ_LEN,
+        )
+
+        # Verify importance was cleaned up after finalization
+        for name, module in model.named_modules():
+            assert not hasattr(
+                module, "_imatrix_importance"
+            ), f"{name} should not have _imatrix_importance after finalization"
+
+    @pytest.mark.smoke
+    @pytest.mark.integration
+    def test_observer_without_gatherer_fallback(self):
+        """
+        imatrix_mse observer without a gatherer should fall back to uniform MSE
+        (no _imatrix_importance available), completing without error.
+        """
+        model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+
+        recipe = [
+            QuantizationModifier(
+                config_groups={
+                    "group_0": {
+                        "targets": ["Linear"],
+                        "weights": {
+                            "num_bits": 4,
+                            "type": "int",
+                            "symmetric": True,
+                            "strategy": "group",
+                            "group_size": 32,
+                            "observer": "imatrix_mse",
+                        },
+                    }
+                },
+                ignore=["lm_head"],
+            ),
+        ]
+
+        # Should complete without error, falling back to uniform weighting
+        oneshot(
+            model=model,
+            dataset=DATASET,
+            splits={"calibration": "train[:5%]"},
+            recipe=recipe,
+            num_calibration_samples=NUM_CALIB_SAMPLES,
+            max_seq_length=MAX_SEQ_LEN,
+        )

--- a/tests/llmcompressor/modifiers/transform/imatrix/test_imatrix_gatherer.py
+++ b/tests/llmcompressor/modifiers/transform/imatrix/test_imatrix_gatherer.py
@@ -1,0 +1,291 @@
+import torch
+from torch import nn
+
+from llmcompressor.modifiers.transform.imatrix.base import (
+    IMatrixGatherer,
+)
+
+# ------------------------------------------------------------------ #
+#  Helpers
+# ------------------------------------------------------------------ #
+
+
+class TinyModel(nn.Module):
+    """Minimal model with two Linear layers + an lm_head."""
+
+    def __init__(self, hidden: int = 16):
+        super().__init__()
+        self.layer1 = nn.Linear(hidden, hidden, bias=False)
+        self.layer2 = nn.Linear(hidden, hidden, bias=False)
+        self.lm_head = nn.Linear(hidden, 32, bias=False)
+
+    def forward(self, x):
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.lm_head(x)
+        return x
+
+
+def _make_gatherer(**kwargs) -> IMatrixGatherer:
+    return IMatrixGatherer(**kwargs)
+
+
+def _run_gatherer(
+    model: nn.Module,
+    gatherer: IMatrixGatherer,
+    inputs: list[torch.Tensor],
+):
+    """Simulate the lifecycle: initialize → start → forwards → end."""
+
+    # Minimal State-like object
+    class _State:
+        def __init__(self, m):
+            self.model = m
+            self.data = None
+
+    state = _State(model)
+    gatherer.on_initialize(state)
+    gatherer.on_start(state, event=None)
+
+    model.eval()
+    with torch.no_grad():
+        for x in inputs:
+            model(x)
+
+    gatherer.on_end(state, event=None)
+
+
+# ------------------------------------------------------------------ #
+#  Tests
+# ------------------------------------------------------------------ #
+
+
+class TestBasicCollection:
+    """Verify that importance tensors are created with correct
+    shape, dtype, and positive values."""
+
+    def test_importance_exists(self):
+        model = TinyModel(hidden=16)
+        gatherer = _make_gatherer()
+        inputs = [torch.randn(2, 4, 16) for _ in range(10)]
+        _run_gatherer(model, gatherer, inputs)
+
+        assert hasattr(model.layer1, "_imatrix_importance")
+        assert hasattr(model.layer2, "_imatrix_importance")
+
+    def test_shape(self):
+        hidden = 16
+        model = TinyModel(hidden=hidden)
+        gatherer = _make_gatherer()
+        inputs = [torch.randn(2, 4, hidden) for _ in range(5)]
+        _run_gatherer(model, gatherer, inputs)
+
+        assert model.layer1._imatrix_importance.shape == (hidden,)
+        assert model.layer2._imatrix_importance.shape == (hidden,)
+
+    def test_dtype_float32(self):
+        model = TinyModel()
+        gatherer = _make_gatherer()
+        inputs = [torch.randn(1, 4, 16) for _ in range(5)]
+        _run_gatherer(model, gatherer, inputs)
+
+        assert model.layer1._imatrix_importance.dtype == torch.float32
+
+    def test_values_positive(self):
+        model = TinyModel()
+        gatherer = _make_gatherer()
+        inputs = [torch.randn(1, 4, 16) for _ in range(10)]
+        _run_gatherer(model, gatherer, inputs)
+
+        assert (model.layer1._imatrix_importance > 0).all()
+        assert (model.layer2._imatrix_importance > 0).all()
+
+
+class TestIgnoreList:
+    """Verify that ignored layers do NOT get importance attached."""
+
+    def test_lm_head_ignored_by_default(self):
+        model = TinyModel()
+        gatherer = _make_gatherer()
+        inputs = [torch.randn(1, 4, 16) for _ in range(5)]
+        _run_gatherer(model, gatherer, inputs)
+
+        assert not hasattr(model.lm_head, "_imatrix_importance")
+        assert hasattr(model.layer1, "_imatrix_importance")
+        assert hasattr(model.layer2, "_imatrix_importance")
+
+    def test_custom_ignore(self):
+        model = TinyModel()
+        gatherer = _make_gatherer(ignore=["layer1", "lm_head"])
+        inputs = [torch.randn(1, 4, 16) for _ in range(5)]
+        _run_gatherer(model, gatherer, inputs)
+
+        assert not hasattr(model.layer1, "_imatrix_importance")
+        assert not hasattr(model.lm_head, "_imatrix_importance")
+        assert hasattr(model.layer2, "_imatrix_importance")
+
+
+class TestAccumulationCorrectness:
+    """Verify numerical correctness of accumulated statistics."""
+
+    def test_ones_input(self):
+        """With input = 1.0 everywhere, E[x²] should be 1.0."""
+        model = TinyModel(hidden=8)
+        gatherer = _make_gatherer()
+        inputs = [torch.ones(1, 4, 8) for _ in range(5)]
+        _run_gatherer(model, gatherer, inputs)
+
+        imp = model.layer1._imatrix_importance
+        torch.testing.assert_close(
+            imp,
+            torch.ones(8),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    def test_channel_scaling(self):
+        """A channel with 10x input should have 100x importance."""
+        hidden = 8
+        model = TinyModel(hidden=hidden)
+        gatherer = _make_gatherer()
+
+        x = torch.ones(1, 4, hidden)
+        x[:, :, 0] = 10.0  # channel 0 is 10x
+        inputs = [x.clone() for _ in range(5)]
+        _run_gatherer(model, gatherer, inputs)
+
+        imp = model.layer1._imatrix_importance
+        ratio = imp[0] / imp[1]
+        assert abs(ratio.item() - 100.0) < 1e-3
+
+
+class TestHooksRemovedAfterEnd:
+    """Verify hooks are removed after on_end."""
+
+    def test_hooks_removed(self):
+        model = TinyModel()
+        gatherer = _make_gatherer()
+        inputs = [torch.randn(1, 4, 16) for _ in range(5)]
+        _run_gatherer(model, gatherer, inputs)
+
+        # After on_end, observers and hooks should be cleaned up
+        assert len(gatherer._observers) == 0
+        assert not hasattr(model.layer1, "weight_observer")
+        assert not hasattr(model.layer1, "_imatrix_hook")
+
+    def test_no_further_accumulation(self):
+        model = TinyModel(hidden=8)
+        gatherer = _make_gatherer()
+        inputs = [torch.ones(1, 4, 8) for _ in range(5)]
+        _run_gatherer(model, gatherer, inputs)
+
+        imp_before = model.layer1._imatrix_importance.clone()
+
+        # Extra forward pass after on_end
+        with torch.no_grad():
+            model(torch.randn(1, 4, 8) * 1000)
+
+        # Importance should not have changed
+        torch.testing.assert_close(model.layer1._imatrix_importance, imp_before)
+
+
+class TestNoQuantization:
+    """Verify that the gatherer does NOT modify model weights."""
+
+    def test_weights_unchanged(self):
+        model = TinyModel()
+        w1_before = model.layer1.weight.data.clone()
+        w2_before = model.layer2.weight.data.clone()
+        head_before = model.lm_head.weight.data.clone()
+
+        gatherer = _make_gatherer()
+        inputs = [torch.randn(1, 4, 16) for _ in range(10)]
+        _run_gatherer(model, gatherer, inputs)
+
+        torch.testing.assert_close(model.layer1.weight.data, w1_before)
+        torch.testing.assert_close(model.layer2.weight.data, w2_before)
+        torch.testing.assert_close(model.lm_head.weight.data, head_before)
+
+
+class TestOnEvent:
+    """Verify that on_event triggers the lifecycle correctly.
+
+    The real pipeline uses on_event(CALIBRATION_EPOCH_START) to trigger
+    on_start, not a direct call. This test ensures the gatherer responds
+    to events, which is how oneshot() drives the lifecycle.
+    """
+
+    def test_calibration_events_collect_importance(self):
+        """on_event must trigger start/end and collect importance."""
+        from llmcompressor.core import Event, EventType
+
+        model = TinyModel(hidden=128)
+        gatherer = _make_gatherer()
+
+        class _State:
+            def __init__(self, m):
+                self.model = m
+
+        state = _State(model)
+        gatherer.on_initialize(state)
+
+        # Trigger start via event (not direct call)
+        start_event = Event(type_=EventType.CALIBRATION_EPOCH_START)
+        gatherer.on_event(state, start_event)
+
+        model.eval()
+        with torch.no_grad():
+            for _ in range(5):
+                model(torch.ones(1, 4, 128))
+
+        # Trigger end via event
+        end_event = Event(type_=EventType.CALIBRATION_EPOCH_END)
+        gatherer.on_event(state, end_event)
+
+        assert hasattr(model.layer1, "_imatrix_importance")
+        assert (model.layer1._imatrix_importance > 0).all()
+
+    def test_event_does_not_double_start(self):
+        """Sending CALIBRATION_EPOCH_START twice must not crash."""
+        from llmcompressor.core import Event, EventType
+
+        model = TinyModel(hidden=128)
+        gatherer = _make_gatherer()
+
+        class _State:
+            def __init__(self, m):
+                self.model = m
+
+        state = _State(model)
+        gatherer.on_initialize(state)
+
+        start_event = Event(type_=EventType.CALIBRATION_EPOCH_START)
+        gatherer.on_event(state, start_event)
+        gatherer.on_event(state, start_event)  # second time — should be no-op
+
+        model.eval()
+        with torch.no_grad():
+            model(torch.ones(1, 4, 128))
+
+        end_event = Event(type_=EventType.CALIBRATION_EPOCH_END)
+        gatherer.on_event(state, end_event)
+
+        assert hasattr(model.layer1, "_imatrix_importance")
+
+
+class TestRecipeYAML:
+    """Verify that the gatherer can be created with recipe-style
+    kwargs and that parameters are parsed correctly."""
+
+    def test_default_params(self):
+        g = _make_gatherer()
+        assert g.ignore == ["lm_head"]
+        assert g.targets == ["Linear"]
+
+    def test_custom_params(self):
+        g = _make_gatherer(
+            ignore=["lm_head", "embed"],
+            targets=["Linear"],
+        )
+        assert "embed" in g.ignore
+        assert "lm_head" in g.ignore

--- a/tests/llmcompressor/observers/test_imatrix.py
+++ b/tests/llmcompressor/observers/test_imatrix.py
@@ -1,0 +1,356 @@
+import pytest
+import torch
+from compressed_tensors.quantization.quant_args import QuantizationArgs
+
+from llmcompressor.observers.base import Observer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_linear_with_importance(in_features=8, out_features=4, seed=42):
+    """Create a Linear module with non-uniform _imatrix_importance."""
+    torch.manual_seed(seed)
+    module = torch.nn.Linear(in_features, out_features)
+    # Non-uniform importance: channels 0-3 are 10x more important
+    importance = torch.ones(in_features)
+    importance[: in_features // 2] = 10.0
+    module._imatrix_importance = importance
+    return module
+
+
+def _make_observer(module, strategy="channel", group_size=None, **kwargs):
+    """Create an imatrix_mse observer for a given module."""
+    args = QuantizationArgs(
+        num_bits=4,
+        symmetric=True,
+        strategy=strategy,
+        group_size=group_size,
+        observer="imatrix_mse",
+        observer_kwargs=kwargs,
+    )
+    return Observer.load_from_registry(
+        "imatrix_mse", base_name="weight", args=args, module=module
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: get_global_min_max must not crash on TENSOR_GROUP
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalMinMaxTensorGroup:
+    """Regression test for bug #1: global_scale path with TENSOR_GROUP."""
+
+    def test_global_scale_tensor_group_does_not_crash(self):
+        """get_global_scale must complete without error on TENSOR_GROUP."""
+        module = _make_linear_with_importance(in_features=8, out_features=4)
+        args = QuantizationArgs(
+            num_bits=4,
+            symmetric=True,
+            strategy="tensor_group",
+            group_size=4,
+            observer="imatrix_mse",
+        )
+        observer = Observer.load_from_registry(
+            "imatrix_mse", base_name="weight", args=args, module=module
+        )
+
+        # This used to crash because _get_global_scale_with_minmax reshapes
+        # to (1, 1, -1), breaking importance broadcasting.
+        global_scale = observer.get_global_scale(module.weight)
+        assert global_scale is not None
+        assert global_scale.shape == (1,)
+        assert torch.isfinite(global_scale).all()
+
+    def test_global_scale_then_forward_tensor_group(self):
+        """Full flow: global_scale -> forward must produce valid qparams."""
+        module = _make_linear_with_importance(in_features=8, out_features=4)
+        args = QuantizationArgs(
+            num_bits=4,
+            symmetric=True,
+            strategy="tensor_group",
+            group_size=4,
+            observer="imatrix_mse",
+        )
+        observer = Observer.load_from_registry(
+            "imatrix_mse", base_name="weight", args=args, module=module
+        )
+
+        global_scale = observer.get_global_scale(module.weight)
+        module.weight_global_scale = global_scale
+        scale, zp = observer(module.weight)
+        assert torch.isfinite(scale).all()
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: importance must be reordered with g_idx (actorder)
+# ---------------------------------------------------------------------------
+
+
+class TestActorderReordering:
+    """Regression test for bug #2: g_idx alignment."""
+
+    def test_reorder_importance_with_g_idx(self):
+        """With g_idx set, importance must be reordered by argsort(g_idx)."""
+        in_features = 8
+        module = _make_linear_with_importance(in_features=in_features)
+
+        # Simulate actorder: g_idx assigns columns to groups in non-trivial order
+        g_idx = torch.tensor([1, 1, 0, 0, 1, 1, 0, 0])
+        module.weight_g_idx = g_idx
+
+        observer = _make_observer(module, strategy="group", group_size=4)
+
+        # Call through the observer — if reordering works, it should not crash
+        # and should produce valid scales
+        scale, zp = observer(module.weight)
+        assert torch.isfinite(scale).all()
+
+    def test_no_g_idx_still_works(self):
+        """Without g_idx, observer must work normally."""
+        module = _make_linear_with_importance(in_features=8)
+        observer = _make_observer(module, strategy="group", group_size=4)
+        scale, zp = observer(module.weight)
+        assert torch.isfinite(scale).all()
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: weight-only guard
+# ---------------------------------------------------------------------------
+
+
+class TestWeightOnlyGuard:
+    """Regression test for bug #3: base_name != 'weight' must be rejected."""
+
+    def test_non_weight_base_name_strict_raises(self):
+        """strict=True must raise NotImplementedError for non-weight."""
+        module = _make_linear_with_importance()
+        args = QuantizationArgs(
+            num_bits=8,
+            symmetric=True,
+            strategy="channel",
+            observer="imatrix_mse",
+            observer_kwargs={"strict": True},
+        )
+        observer = Observer.load_from_registry(
+            "imatrix_mse", base_name="input", args=args, module=module
+        )
+        observed = torch.randn(2, 1, 1, 8)
+        with pytest.raises(NotImplementedError, match="weight observers"):
+            observer.get_min_max(observed)
+
+    def test_non_weight_base_name_non_strict_falls_back(self):
+        """strict=False must fall back to uniform MSE (no crash)."""
+        module = _make_linear_with_importance()
+        args = QuantizationArgs(
+            num_bits=8,
+            symmetric=True,
+            strategy="channel",
+            observer="imatrix_mse",
+            observer_kwargs={"strict": False},
+        )
+        observer = Observer.load_from_registry(
+            "imatrix_mse", base_name="input", args=args, module=module
+        )
+        observed = torch.randn(2, 1, 1, 8)
+        min_val, max_val = observer.get_min_max(observed)
+        assert torch.isfinite(min_val).all()
+        assert torch.isfinite(max_val).all()
+
+
+# ---------------------------------------------------------------------------
+# Basic functionality (sanity checks)
+# ---------------------------------------------------------------------------
+
+
+class TestBasicFunctionality:
+    """Sanity checks for the happy path."""
+
+    def test_channel_strategy(self):
+        module = _make_linear_with_importance(in_features=8, out_features=4)
+        observer = _make_observer(module, strategy="channel")
+        scale, zp = observer(module.weight)
+        assert scale.shape == (4, 1)
+        assert torch.isfinite(scale).all()
+
+    def test_group_strategy(self):
+        module = _make_linear_with_importance(in_features=8, out_features=4)
+        observer = _make_observer(module, strategy="group", group_size=4)
+        scale, zp = observer(module.weight)
+        assert torch.isfinite(scale).all()
+
+    def test_tensor_group_strategy(self):
+        module = _make_linear_with_importance(in_features=8, out_features=4)
+        observer = _make_observer(module, strategy="tensor_group", group_size=4)
+        global_scale = observer.get_global_scale(module.weight)
+        module.weight_global_scale = global_scale
+        scale, zp = observer(module.weight)
+        assert torch.isfinite(scale).all()
+
+    def test_block_strategy(self):
+        module = _make_linear_with_importance(in_features=8, out_features=4)
+        args = QuantizationArgs(
+            num_bits=4,
+            symmetric=True,
+            strategy="block",
+            block_structure=[2, 4],
+            observer="imatrix_mse",
+        )
+        observer = Observer.load_from_registry(
+            "imatrix_mse", base_name="weight", args=args, module=module
+        )
+        scale, zp = observer(module.weight)
+        assert torch.isfinite(scale).all()
+
+    def test_no_importance_falls_back(self):
+        """Observer without _imatrix_importance must fall back gracefully."""
+        module = torch.nn.Linear(8, 4)
+        observer = _make_observer(module, strategy="channel")
+        scale, zp = observer(module.weight)
+        assert torch.isfinite(scale).all()
+
+    def test_importance_changes_result(self):
+        """Non-uniform importance must produce different scales than uniform."""
+        torch.manual_seed(123)
+        module_weighted = torch.nn.Linear(8, 4)
+        module_uniform = torch.nn.Linear(8, 4)
+        module_uniform.weight.data = module_weighted.weight.data.clone()
+
+        # Very skewed importance
+        importance = torch.tensor(
+            [1000.0, 1000.0, 1000.0, 1000.0, 0.01, 0.01, 0.01, 0.01]
+        )
+        module_weighted._imatrix_importance = importance
+
+        obs_w = _make_observer(module_weighted, strategy="channel")
+        obs_u = _make_observer(module_uniform, strategy="channel")
+
+        scale_w, _ = obs_w(module_weighted.weight)
+        scale_u, _ = obs_u(module_uniform.weight)
+
+        assert not torch.allclose(
+            scale_w, scale_u
+        ), "Extreme importance weighting should produce different scales"
+
+    def test_uniform_importance_matches_memoryless_mse(self):
+        """All-ones importance must match the uniform MSE observer."""
+        torch.manual_seed(123)
+        module_imatrix = torch.nn.Linear(8, 4)
+        module_mse = torch.nn.Linear(8, 4)
+        module_mse.weight.data.copy_(module_imatrix.weight.data)
+        module_mse.bias.data.copy_(module_imatrix.bias.data)
+        module_imatrix._imatrix_importance = torch.ones(8)
+
+        args_uniform = QuantizationArgs(
+            num_bits=4,
+            symmetric=True,
+            strategy="channel",
+            observer="memoryless_mse",
+            observer_kwargs={"grid": 20},
+        )
+        obs_imatrix = _make_observer(
+            module_imatrix, strategy="channel", norm=2.4, maxshrink=0.20
+        )
+        obs_uniform = Observer.load_from_registry(
+            "memoryless_mse", base_name="weight", args=args_uniform, module=module_mse
+        )
+
+        scale_i, zp_i = obs_imatrix(module_imatrix.weight)
+        scale_u, zp_u = obs_uniform(module_mse.weight)
+
+        assert torch.allclose(scale_i, scale_u)
+        assert torch.equal(zp_i, zp_u)
+
+
+# ---------------------------------------------------------------------------
+# Validation edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_strict_raises_on_missing_importance(self):
+        module = torch.nn.Linear(8, 4)
+        observer = _make_observer(module, strategy="channel", strict=True)
+        with pytest.raises(ValueError, match="imatrix_importance"):
+            observer(module.weight)
+
+    def test_strict_raises_on_wrong_size(self):
+        module = torch.nn.Linear(8, 4)
+        module._imatrix_importance = torch.ones(5)  # wrong size
+        observer = _make_observer(module, strategy="channel", strict=True)
+        with pytest.raises(ValueError, match="size mismatch"):
+            observer(module.weight)
+
+    @pytest.mark.parametrize(
+        ("importance", "match"),
+        [
+            (
+                torch.tensor([1.0, float("nan"), 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+                "non-finite",
+            ),
+            (torch.tensor([1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]), "negative"),
+            (torch.zeros(8), "all zeros"),
+        ],
+    )
+    def test_strict_raises_on_invalid_importance_values(self, importance, match):
+        module = torch.nn.Linear(8, 4)
+        module._imatrix_importance = importance
+        observer = _make_observer(module, strategy="channel", strict=True)
+        with pytest.raises(ValueError, match=match):
+            observer(module.weight)
+
+    @pytest.mark.parametrize(
+        "importance",
+        [
+            torch.tensor([1.0, float("nan"), 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            torch.tensor([1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+            torch.zeros(8),
+        ],
+    )
+    def test_non_strict_invalid_importance_falls_back_to_uniform_mse(self, importance):
+        module_imatrix = torch.nn.Linear(8, 4)
+        module_mse = torch.nn.Linear(8, 4)
+        module_mse.weight.data.copy_(module_imatrix.weight.data)
+        module_mse.bias.data.copy_(module_imatrix.bias.data)
+        module_imatrix._imatrix_importance = importance
+
+        args_uniform = QuantizationArgs(
+            num_bits=4,
+            symmetric=True,
+            strategy="channel",
+            observer="memoryless_mse",
+            observer_kwargs={"grid": 20},
+        )
+        obs_imatrix = _make_observer(module_imatrix, strategy="channel", strict=False)
+        obs_uniform = Observer.load_from_registry(
+            "memoryless_mse", base_name="weight", args=args_uniform, module=module_mse
+        )
+
+        scale_i, zp_i = obs_imatrix(module_imatrix.weight)
+        scale_u, zp_u = obs_uniform(module_mse.weight)
+
+        assert torch.allclose(scale_i, scale_u)
+        assert torch.equal(zp_i, zp_u)
+
+    @pytest.mark.parametrize("norm", [0, -1, float("inf"), float("nan")])
+    def test_invalid_norm_raises(self, norm):
+        module = _make_linear_with_importance()
+        with pytest.raises(ValueError, match="norm must be a finite positive number"):
+            _make_observer(module, strategy="channel", norm=norm)
+
+    def test_strict_raises_on_tensor_strategy(self):
+        module = _make_linear_with_importance()
+        args = QuantizationArgs(
+            num_bits=4,
+            symmetric=True,
+            strategy="tensor",
+            observer="imatrix_mse",
+            observer_kwargs={"strict": True},
+        )
+        observer = Observer.load_from_registry(
+            "imatrix_mse", base_name="weight", args=args, module=module
+        )
+        with pytest.raises(NotImplementedError, match="TENSOR strategy"):
+            observer(module.weight)


### PR DESCRIPTION
## SUMMARY

Adds `imatrix_mse`, a new weight observer that uses per-channel activation importance (E[x²]) to weight the quantization error during range selection. Channels that carry more signal get more careful range optimization.

Two components:

- **IMatrixGatherer** (`modifiers/transform/imatrix/base.py`): lightweight lifecycle trigger that orchestrates a calibration pass so the observer can collect E[x²]. Does not quantize, delegates to the subsequent `QuantizationModifier` / `GPTQModifier`.

- **imatrix_mse observer** (`observers/imatrix.py`): extends the MSE grid search with importance weighting: `err = sum(importance * |Q(w) - w|^p)`. Owns the E[x²] collection lifecycle via `Observer.attach(module)` / `Observer.detach(module)`. Supports CHANNEL, GROUP, TENSOR_GROUP, and BLOCK strategies via `flatten_for_calibration`. Falls back to uniform MSE when importance is unavailable (`strict=False` default).

### Usage
```yaml
recipe:
  - IMatrixGatherer:
      ignore: ["lm_head"]
  - QuantizationModifier:
      config_groups:
        group_0:
          targets: ["Linear"]
          weights:
            num_bits: 4
            observer: imatrix_mse
```

Composes with GPTQ:
```yaml
recipe:
  - IMatrixGatherer:
      ignore: ["lm_head"]
  - GPTQModifier:
      config_groups:
        group_0:
          targets: ["Linear"]
          weights:
            observer: imatrix_mse
```

### Results

W4A16, WikiText-2 token-level PPL, 141 chunks × 2048, open_platypus calibration 512 samples.

Llama-3.1-8B, group_size=128:

| Config | PPL |
|---|---|
| FP16 baseline | 6.24 |
| RTN `memoryless_minmax` | 6.96 |
| GPTQ | 6.92 |
| AWQ | 6.89 |
| RTN `imatrix_mse` | 6.85 |
| GPTQ + `imatrix_mse` | 6.83 |

Eval method: GPTQ paper (concatenate WikiText-2 test, non-overlapping segments of 2048 tokens, exp(mean(NLLs))).

RFC #2456

## TEST PLAN

45 tests added (all CPU, no GPU required):

- `test_imatrix.py` (26 tests): grid search with non-uniform importance, CHANNEL/GROUP/TENSOR_GROUP/BLOCK strategies, actorder g_idx reordering, strict vs non-strict fallback, validation (shape, dtype, finite, non-negative)
- `test_imatrix_gatherer.py` (15 tests): E[x²] collection, ignore list, accumulation correctness, hook cleanup, weight immutability, on_event lifecycle
- `test_e2e_integration.py` (4 tests): full pipeline via `oneshot()` on `nm-testing/tinysmokellama-3.2`, gatherer-only, observer fallback without gatherer, regex targets
```bash
python -m pytest tests/llmcompressor/observers/test_imatrix.py tests/llmcompressor/modifiers/transform/imatrix/ -v
```