### PR TITLE
[Qwen3.5] Calibration support and NVFP4 Example

### DIFF
--- a/examples/quantization_w4a4_fp4/qwen3_5_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_5_example.py
@@ -1,0 +1,86 @@
+from datasets import load_dataset
+from transformers import AutoTokenizer, Qwen3_5MoeForConditionalGeneration
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+# NOTE: This example requires transformers >= v5
+
+MODEL_ID = "Qwen/Qwen3.5-122B-A10B"
+
+# Load model.
+model = Qwen3_5MoeForConditionalGeneration.from_pretrained(MODEL_ID, dtype="auto")
+processor = AutoTokenizer.from_pretrained(MODEL_ID)
+
+
+recipe = QuantizationModifier(
+    targets="Linear",
+    scheme="NVFP4",
+    ignore=[
+        "re:.*lm_head",
+        "re:visual.*",
+        "re:model.visual.*",
+        "re:.*mlp.gate$",
+        "re:.*embed_tokens$",
+        "re:.*shared_expert_gate$",
+        "re:.*linear_attn.*",
+    ],
+)
+
+NUM_CALIBRATION_SAMPLES = 256
+MAX_SEQUENCE_LENGTH = 4096
+
+# Load datasets and preprocess.
+# Use half from each source for a diverse calibration set.
+samples_per_dataset = NUM_CALIBRATION_SAMPLES
+
+ds_ultrachat = load_dataset(
+    "HuggingFaceH4/ultrachat_200k",
+    split=f"train_sft[:{samples_per_dataset}]",
+)
+
+# Both datasets share a "messages" column with the same chat format.
+# Keep only that column so we can concatenate them.
+ds = ds_ultrachat.select_columns(["messages"])
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {
+        "text": processor.apply_chat_template(
+            example["messages"],
+            tokenize=False,
+        )
+    }
+
+
+ds = ds.map(preprocess)
+
+
+# Tokenize inputs.
+def tokenize(sample):
+    return processor(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+# Apply quantization.
+oneshot(
+    model=model,
+    recipe=recipe,
+    dataset=ds,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    moe_calibrate_all_experts=True,
+)
+
+# Save to disk in compressed-tensors format.
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-NVFP4"
+model.save_pretrained(SAVE_DIR)
+processor.save_pretrained(SAVE_DIR)

--- a/examples/quantization_w4a4_fp4/qwen3_5_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_5_example.py
@@ -31,7 +31,6 @@ NUM_CALIBRATION_SAMPLES = 256
 MAX_SEQUENCE_LENGTH = 4096
 
 # Load datasets and preprocess.
-# Use half from each source for a diverse calibration set.
 samples_per_dataset = NUM_CALIBRATION_SAMPLES
 
 ds_ultrachat = load_dataset(

--- a/src/llmcompressor/modeling/__init__.py
+++ b/src/llmcompressor/modeling/__init__.py
@@ -15,8 +15,9 @@ from .glm4_moe import CalibrationGlm4MoeMoE  # noqa: F401
 from .glm_moe_dsa import CalibrationGlmMoeDsaMoE  # noqa: F401
 from .llama4 import SequentialLlama4TextMoe  # noqa: F401
 from .qwen3_moe import CalibrationQwen3MoeSparseMoeBlock  # noqa: F401
+from .qwen3_5_moe import CalibrationQwen3_5MoeSparseMoeBlock
 from .qwen3_vl_moe import CalibrateQwen3VLMoeTextSparseMoeBlock  # noqa: F401
 from .qwen3_next_moe import CalibrationQwen3NextSparseMoeBlock  # noqa: F401
-# TODO: add granite4, Qwen3Next
+# TODO: add granite4
 
 from .fuse import *

--- a/src/llmcompressor/modeling/qwen3_5_moe.py
+++ b/src/llmcompressor/modeling/qwen3_5_moe.py
@@ -36,7 +36,7 @@ class CalibrationQwen3_5MoeSparseMoeBlock(MoECalibrationModule):
         super().__init__()
         text_config = getattr(config, "text_config", config)
 
-        self.calibrate_all_experts = True
+        self.calibrate_all_experts = calibrate_all_experts
 
         # Use plain Linear for gate so module_type() returns "Linear"
         # This ensures gates appear in the ignore list when config is saved

--- a/src/llmcompressor/modeling/qwen3_5_moe.py
+++ b/src/llmcompressor/modeling/qwen3_5_moe.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn.functional as F
+
+from llmcompressor.modeling.moe_context import MoECalibrationModule
+from llmcompressor.utils.dev import skip_weights_initialize
+
+if TYPE_CHECKING:
+    from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+        Qwen3_5MoeSparseMoeBlock,
+    )
+
+
+@MoECalibrationModule.register("Qwen3_5MoeSparseMoeBlock")
+class CalibrationQwen3_5MoeSparseMoeBlock(MoECalibrationModule):
+    """
+    Calibration version of Qwen3_5MoeSparseMoeBlock that unfuses 3D expert
+    parameters into individual MLP modules (nn.Linear) so they can be
+    individually quantized. Sends all tokens to all experts during calibration.
+
+    is_permanent = True because the unfused structure must persist for
+    quantization to target the individual nn.Linear expert weights.
+    """
+
+    is_permanent = True
+
+    def __init__(
+        self,
+        original: Qwen3_5MoeSparseMoeBlock,
+        config,
+        calibrate_all_experts: bool = True,
+    ):
+        super().__init__()
+        text_config = getattr(config, "text_config", config)
+
+        self.calibrate_all_experts = True
+
+        # Use plain Linear for gate so module_type() returns "Linear"
+        # This ensures gates appear in the ignore list when config is saved
+        original_weight = original.gate.weight.data
+        self.gate = torch.nn.Linear(
+            text_config.hidden_size, text_config.num_experts, bias=False
+        )
+        self.gate.weight.data = self.gate.weight.data.to(original_weight.dtype)
+        self.gate.weight.data.copy_(original_weight)
+
+        # Store routing parameters needed for forward pass
+        self.top_k = text_config.num_experts_per_tok
+        self.num_experts = text_config.num_experts
+        self.hidden_dim = text_config.hidden_size
+        self.hidden_size = text_config.hidden_size
+
+        self.shared_expert = original.shared_expert
+        self.shared_expert_gate = original.shared_expert_gate
+        self.experts = SequentialQwen3_5MoeExperts(text_config, original.experts)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states_reshaped = hidden_states.view(-1, hidden_dim)
+
+        # Perform routing (previously in Qwen3VLMoeTextTopKRouter.forward)
+        router_logits = F.linear(hidden_states_reshaped, self.gate.weight)
+        router_logits = F.softmax(router_logits, dtype=torch.float, dim=-1)
+        routing_weights, selected_experts = torch.topk(
+            router_logits, self.top_k, dim=-1
+        )
+        routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = routing_weights.to(router_logits.dtype)
+
+        # expert mask: (num_experts, top_k, num_tokens)
+        expert_mask = F.one_hot(selected_experts, num_classes=self.num_experts).permute(
+            2, 1, 0
+        )
+
+        final_hidden_states = torch.zeros(
+            (batch_size * sequence_length, hidden_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        for expert_idx, expert_layer in enumerate(self.experts):
+            idx, token_idx = torch.where(expert_mask[expert_idx])
+
+            if self.calibrate_all_experts:
+                expert_out = expert_layer(hidden_states_reshaped)[token_idx]
+            else:
+                expert_out = expert_layer(hidden_states_reshaped[token_idx])
+
+            if len(token_idx) > 0:
+                current_hidden_states = (
+                    expert_out * routing_weights[token_idx, idx, None]
+                )
+                final_hidden_states.index_add_(
+                    0,
+                    token_idx,
+                    current_hidden_states.to(hidden_states.dtype),
+                )
+
+        # shared expert
+        shared_expert_output = self.shared_expert(hidden_states_reshaped)
+        shared_expert_output = (
+            F.sigmoid(self.shared_expert_gate(hidden_states_reshaped))
+            * shared_expert_output
+        )
+        final_hidden_states = final_hidden_states + shared_expert_output
+
+        final_hidden_states = final_hidden_states.reshape(
+            batch_size, sequence_length, hidden_dim
+        )
+        return final_hidden_states
+
+    def restore(self, original: torch.nn.Module) -> torch.nn.Module:
+        return self
+
+
+class SequentialQwen3_5MoeExperts(torch.nn.ModuleList):
+    """
+    Unfuses 3D expert parameter tensors into individual Qwen3_5MoeMLP modules
+    so that each expert's weights are nn.Linear and can be targeted by
+    quantization with targets="Linear".
+    """
+
+    def __init__(self, config, original):
+        from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+            Qwen3_5MoeMLP,
+        )
+
+        self.num_experts = config.num_experts
+        intermediate_size = config.moe_intermediate_size
+
+        with skip_weights_initialize():
+            super().__init__(
+                [
+                    Qwen3_5MoeMLP(config, intermediate_size=intermediate_size)
+                    for _ in range(self.num_experts)
+                ]
+            )
+
+        gate_up_data = original.gate_up_proj.data  # [num_experts, 2*inter, hidden]
+        down_data = original.down_proj.data  # [num_experts, hidden, inter]
+
+        for i in range(self.num_experts):
+            gate_up = gate_up_data[i]  # [2*intermediate, hidden]
+            down = down_data[i]  # [hidden, intermediate]
+
+            # gate_up_proj stores [gate; up] stacked along dim 0
+            # nn.Linear weight is [out_features, in_features]
+            self[i].gate_proj.weight.data = (
+                gate_up[:intermediate_size, :].clone().contiguous()
+            )
+            self[i].up_proj.weight.data = (
+                gate_up[intermediate_size:, :].clone().contiguous()
+            )
+            self[i].down_proj.weight.data = down.clone().contiguous()

--- a/src/llmcompressor/utils/dev.py
+++ b/src/llmcompressor/utils/dev.py
@@ -12,7 +12,13 @@ from huggingface_hub import snapshot_download
 from loguru import logger
 from safetensors.torch import save_file
 from transformers import AutoModelForCausalLM, PreTrainedModel
-from transformers.modeling_utils import TORCH_INIT_FUNCTIONS
+
+try:
+    # Transformers < v5 support
+    from transformers.modeling_utils import TORCH_INIT_FUNCTIONS
+except ImportError:
+    # Transformers v5 support
+    from transformers.initialization import TORCH_INIT_FUNCTIONS
 from transformers.utils import SAFE_WEIGHTS_INDEX_NAME, WEIGHTS_INDEX_NAME
 
 __all__ = [

--- a/src/llmcompressor/utils/pytorch/module.py
+++ b/src/llmcompressor/utils/pytorch/module.py
@@ -136,7 +136,12 @@ def get_no_split_params(model: PreTrainedModel) -> Union[str, List[str]]:
 
     :return: list of class names that shouldn't be split
     """
-    no_split_modules = model._get_no_split_modules("auto")
+    try:
+        # Transformers < v5 support
+        no_split_modules = model._get_no_split_modules("auto")
+    except AttributeError:
+        # Transformers v5 support
+        no_split_modules = model._no_split_modules
     if len(no_split_modules) <= 0:
         return ALL_TARGET
 


### PR DESCRIPTION
# SUMMARY:
- Add Qwen3.5 modeling support and an nvfp4 example
- Specifically unstack 3D weights
- Handle mlp.gates being Parameters in the original definition and therefore not originally added to the ignore list
- This model has some dead weights and therefore requires: https://github.com/vllm-project/compressed-tensors/pull/637
- Updates some functionality to be compatible with transformers v5, which is required for this model. You will need to update to transformers v5 to use this example

Closes: https://github.com/vllm-project/llm-compressor/issues/2458

# Checkpoint:
https://huggingface.co/RedHatAI/Qwen3.5-122B-A10B-NVFP4


# Next Steps:
- Add a step to include MTP layers to the final checkpoint which are in the original checkpoint but not loaded through the AutoModel pathway
