### PR TITLE
[Refactor] Rename offload_model and  dispatch_for_sequential to set_onload_device

### DIFF
--- a/docs/scripts/zensical_gen_files.py
+++ b/docs/scripts/zensical_gen_files.py
@@ -42,6 +42,7 @@ def find_project_root() -> Path:
         current = current.parent
     raise FileNotFoundError("Could not find zensical.toml")
 
+
 # ---------------------------------------------------------------------------
 # Copy files into docs/
 # ---------------------------------------------------------------------------
@@ -112,13 +113,9 @@ def generate_copied_files(project_root: Path):
     specs: list[CopySpec] = []
 
     # Examples and experimental READMEs
+    specs.extend(_collect_readmes(project_root / "examples", "examples", project_root))
     specs.extend(
-        _collect_readmes(project_root / "examples", "examples", project_root)
-    )
-    specs.extend(
-        _collect_readmes(
-            project_root / "experimental", "experimental", project_root
-        )
+        _collect_readmes(project_root / "experimental", "experimental", project_root)
     )
 
     copy_files(specs, project_root)
@@ -265,9 +262,7 @@ def _expand_glob_dir(
             if (subdir / "index.md").exists():
                 title = _get_title_from_file(subdir / "index.md")
             else:
-                title = (
-                    subdir.name.replace("-", " ").replace("_", " ").title()
-                )
+                title = subdir.name.replace("-", " ").replace("_", " ").title()
             entries.append({title: children})
 
     for f in regular_files:
@@ -322,9 +317,7 @@ def _process_nav_item(
                 child_explicit = _collect_explicit_paths(value)
                 children = []
                 for child in value:
-                    children.extend(
-                        _process_nav_item(child, docs_dir, child_explicit)
-                    )
+                    children.extend(_process_nav_item(child, docs_dir, child_explicit))
                 results.append({title: children})
             elif value is None:
                 results.append({title: []})

--- a/experimental/mxfp8/qwen3_example_w8a16_mxfp8.py
+++ b/experimental/mxfp8/qwen3_example_w8a16_mxfp8.py
@@ -13,9 +13,7 @@ tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 # Configure the quantization algorithm and scheme.
 # In this case, we:
 #   * quantize the weights to mxfp8 via ptq
-recipe = QuantizationModifier(
-    targets="Linear", scheme="MXFP8A16", ignore=["lm_head"]
-)
+recipe = QuantizationModifier(targets="Linear", scheme="MXFP8A16", ignore=["lm_head"])
 
 # Apply quantization.
 oneshot(model=model, recipe=recipe)
@@ -34,4 +32,3 @@ print("==========================================")
 SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-MXFP8A16"
 model.save_pretrained(SAVE_DIR)
 tokenizer.save_pretrained(SAVE_DIR)
-

--- a/experimental/mxfp8/qwen3_example_w8a8_mxfp8.py
+++ b/experimental/mxfp8/qwen3_example_w8a8_mxfp8.py
@@ -13,9 +13,7 @@ tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 # Configure the quantization algorithm and scheme.
 # In this case, we:
 #   * quantize the weights and activations to mxfp8 via ptq
-recipe = QuantizationModifier(
-    targets="Linear", scheme="MXFP8", ignore=["lm_head"]
-)
+recipe = QuantizationModifier(targets="Linear", scheme="MXFP8", ignore=["lm_head"])
 
 # Apply quantization.
 oneshot(model=model, recipe=recipe)
@@ -34,4 +32,3 @@ print("==========================================")
 SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-MXFP8"
 model.save_pretrained(SAVE_DIR)
 tokenizer.save_pretrained(SAVE_DIR)
-

--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -470,7 +470,6 @@ def get_sequential_ancestors(model: Module, targets: set[Module]) -> set[Module]
     return ancestors
 
 
-
 def _get_autowrap_functions() -> tuple[Callable[[Any], Any], ...]:
     try:
         from transformers.masking_utils import LAYER_PATTERN_TO_MASK_FUNCTION_MAPPING

--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -4,11 +4,11 @@ from collections import deque
 from dataclasses import dataclass
 from functools import wraps
 from types import FunctionType, MethodType
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 import torch
 from accelerate.hooks import remove_hook_from_module
-from compressed_tensors.offload import disable_onloading, offload_model
+from compressed_tensors.offload import disable_onloading
 from compressed_tensors.utils import patch_attr
 from compressed_tensors.utils.match import match_named_modules
 from loguru import logger
@@ -21,7 +21,6 @@ from transformers.configuration_utils import PretrainedConfig
 
 from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.pipelines.sequential.transformers_helpers import HFTracer
-from llmcompressor.utils.dev import get_main_device
 from llmcompressor.utils.helpers import calibration_forward_context
 
 from .ast_helpers import append_autowrap_source_on_fail, autowrap_forwards
@@ -32,7 +31,6 @@ if TYPE_CHECKING:
 __all__ = [
     "trace_subgraphs",
     "Subgraph",
-    "dispatch_for_sequential",
     "handle_sequential_oom",
 ]
 
@@ -471,23 +469,6 @@ def get_sequential_ancestors(model: Module, targets: set[Module]) -> set[Module]
     is_ancestor(model)
     return ancestors
 
-
-def dispatch_for_sequential(
-    model: PreTrainedModel,
-    onload_device: Optional[torch.device | str] = None,
-    offload_device: Optional[torch.device | str] = None,
-) -> PreTrainedModel:
-    """
-    Dispatch a model for sequential calibration using a sequential pipeline.
-    The model will be offloaded to the CPU and dispatched to CUDA/XPU device
-    if available. Removes any existing hooks.
-
-    :param model: model to dispatch
-    :return: dispatched model
-    """
-    if onload_device is None:
-        onload_device = get_main_device()
-    return offload_model(model, onload_device, offload_device)
 
 
 def _get_autowrap_functions() -> tuple[Callable[[Any], Any], ...]:

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -2,6 +2,7 @@ import contextlib
 from typing import TYPE_CHECKING, Iterator
 
 import torch
+from compressed_tensors.offload import set_onload_device
 from compressed_tensors.utils import disable_offloading
 from torch.utils.data.dataloader import DataLoader
 from tqdm import tqdm
@@ -11,7 +12,6 @@ from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.pipelines.cache import IntermediatesCache
 from llmcompressor.pipelines.registry import CalibrationPipeline
 from llmcompressor.pipelines.sequential.helpers import (
-    dispatch_for_sequential,
     handle_sequential_oom,
     trace_subgraphs,
 )
@@ -89,7 +89,7 @@ class SequentialPipeline(CalibrationPipeline):
         # prepare model for sequential onloading
         onload_device = get_main_device()
         offload_device = torch.device(dataset_args.sequential_offload_device)
-        dispatch_for_sequential(model, onload_device)
+        set_onload_device(model, onload_device)
 
         # prepare to trace subgraphs
         sequential_targets = infer_sequential_targets(

--- a/tests/llmcompressor/utils/test_helpers.py
+++ b/tests/llmcompressor/utils/test_helpers.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from compressed_tensors.offload import dispatch_model, offload_model
+from compressed_tensors.offload import dispatch_model, set_onload_device
 from transformers import (
     AutoModelForCausalLM,
     MllamaForConditionalGeneration,
@@ -71,7 +71,7 @@ def test_disable_cache(model_cls, model_stub):
 def test_disable_lm_head(offload):
     model = AutoModelForCausalLM.from_pretrained("nm-testing/tinysmokellama-3.2")
     if offload == "sequential":
-        offload_model(model, "cuda")
+        set_onload_device(model, "cuda")
     if offload == "basic":
         dispatch_model(model)
     if offload == "none":


### PR DESCRIPTION
## Summary
  - Deleted `dispatch_for_sequential` from
  `pipelines/sequential/helpers.py` — it was a thin wrapper
  around `offload_model` with no additional logic              
  - Updated `SequentialPipeline` to call `set_onload_device`
  directly from `compressed_tensors.offload`                   
  - Updated `tests/llmcompressor/utils/test_helpers.py` to use 
  `set_onload_device` 

Closes #2483                                         
                                                               
## Notes        
Companion PR in compressed-tensors: vllm-project/compressed-tensors#643