### PR TITLE
[AWQ] Restructure AWQModifier as smoothing-only, decouple from Quanti…

### DIFF
--- a/examples/awq/README.md
+++ b/examples/awq/README.md
@@ -6,12 +6,24 @@ The AWQ implementation found in LLM Compressor is derived from the pioneering wo
 
 ## AWQ Recipe ##
 
-The AWQ recipe has been inferfaced as follows, where the `AWQModifier` adjusts model scales ahead of efficient weight quantization by the `QuantizationModifier`
+AWQ is a **pre-quantization transform** — it computes and applies smoothing scales to model weights, but does not produce final quantized weights on its own. A downstream quantizer (`QuantizationModifier` or `GPTQModifier`) must follow AWQ in the recipe to finalize quantization.
 
 ```python
+from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
 recipe = [
     AWQModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
+    QuantizationModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
 ]
+```
+
+The `scheme` on `AWQModifier` tells AWQ how the downstream quantizer will quantize, so that the grid search optimizes for the correct quantization format. It must match the downstream quantizer's scheme.
+
+AWQ can also be stacked with other transforms and quantizers:
+```python
+recipe = [AWQModifier(...), GPTQModifier(...)]
+recipe = [AWQModifier(...), QuantizationModifier(...)]
 ```
 
 ## Compressing Your Own Model ##

--- a/examples/awq/fp8_block_llama_example.py
+++ b/examples/awq/fp8_block_llama_example.py
@@ -51,11 +51,12 @@ def tokenize(sample):
 
 # Configure the quantization algorithm to run.
 # AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
+_ignore = ["lm_head"]
+_scheme = "FP8_BLOCK"
+_targets = ["Linear"]
 recipe = [
-    AWQModifier(
-        ignore=["lm_head"], scheme="FP8_BLOCK", targets=["Linear"], duo_scaling="both"
-    ),
-    QuantizationModifier(ignore=["lm_head"], scheme="FP8_BLOCK", targets=["Linear"]),
+    AWQModifier(ignore=_ignore, scheme=_scheme, targets=_targets, duo_scaling="both"),
+    QuantizationModifier(ignore=_ignore, scheme=_scheme, targets=_targets),
 ]
 
 # Apply algorithms.

--- a/examples/awq/fp8_block_llama_example.py
+++ b/examples/awq/fp8_block_llama_example.py
@@ -4,6 +4,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -49,10 +50,12 @@ def tokenize(sample):
 
 
 # Configure the quantization algorithm to run.
+# AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
 recipe = [
     AWQModifier(
         ignore=["lm_head"], scheme="FP8_BLOCK", targets=["Linear"], duo_scaling="both"
     ),
+    QuantizationModifier(ignore=["lm_head"], scheme="FP8_BLOCK", targets=["Linear"]),
 ]
 
 # Apply algorithms.

--- a/examples/awq/fp8_dynamic_llama_example.py
+++ b/examples/awq/fp8_dynamic_llama_example.py
@@ -51,11 +51,12 @@ def tokenize(sample):
 
 # Configure the quantization algorithm to run.
 # AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
+_ignore = ["lm_head"]
+_scheme = "FP8_DYNAMIC"
+_targets = ["Linear"]
 recipe = [
-    AWQModifier(
-        ignore=["lm_head"], scheme="FP8_DYNAMIC", targets=["Linear"], duo_scaling="both"
-    ),
-    QuantizationModifier(ignore=["lm_head"], scheme="FP8_DYNAMIC", targets=["Linear"]),
+    AWQModifier(ignore=_ignore, scheme=_scheme, targets=_targets, duo_scaling="both"),
+    QuantizationModifier(ignore=_ignore, scheme=_scheme, targets=_targets),
 ]
 
 # Apply algorithms.

--- a/examples/awq/fp8_dynamic_llama_example.py
+++ b/examples/awq/fp8_dynamic_llama_example.py
@@ -4,6 +4,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -49,10 +50,12 @@ def tokenize(sample):
 
 
 # Configure the quantization algorithm to run.
+# AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
 recipe = [
     AWQModifier(
         ignore=["lm_head"], scheme="FP8_DYNAMIC", targets=["Linear"], duo_scaling="both"
     ),
+    QuantizationModifier(ignore=["lm_head"], scheme="FP8_DYNAMIC", targets=["Linear"]),
 ]
 
 # Apply algorithms.

--- a/examples/awq/llama_example.py
+++ b/examples/awq/llama_example.py
@@ -51,11 +51,12 @@ def tokenize(sample):
 
 # Configure the quantization algorithm to run.
 # AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
+_ignore = ["lm_head"]
+_scheme = "W4A16_ASYM"
+_targets = ["Linear"]
 recipe = [
-    AWQModifier(
-        ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"], duo_scaling="both"
-    ),
-    QuantizationModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
+    AWQModifier(ignore=_ignore, scheme=_scheme, targets=_targets, duo_scaling="both"),
+    QuantizationModifier(ignore=_ignore, scheme=_scheme, targets=_targets),
 ]
 
 # Apply algorithms.

--- a/examples/awq/llama_example.py
+++ b/examples/awq/llama_example.py
@@ -4,6 +4,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -49,10 +50,12 @@ def tokenize(sample):
 
 
 # Configure the quantization algorithm to run.
+# AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
 recipe = [
     AWQModifier(
         ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"], duo_scaling="both"
     ),
+    QuantizationModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
 ]
 
 # Apply algorithms.

--- a/examples/awq/qwen3-vl-30b-a3b-Instruct-example.py
+++ b/examples/awq/qwen3-vl-30b-a3b-Instruct-example.py
@@ -5,6 +5,7 @@ from transformers import AutoProcessor, Qwen3VLMoeForConditionalGeneration
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
 
 MODEL_ID = "Qwen/Qwen3-VL-30B-A3B-Instruct"
 
@@ -60,37 +61,46 @@ def data_collator(batch):
     }
 
 
-# Configure AWQ quantization with smoothing and balancing
+# Configure AWQ smoothing + downstream quantization.
 # NOTE: This recipe uses W4A16 quantization with group_size=32
-# rather than the default preset with group_size=128
-recipe = AWQModifier(
-    ignore=[
-        "re:.*embed_tokens",
-        "re:.*input_layernorm$",
-        "re:.*mlp[.]gate$",
-        "re:.*post_attention_layernorm$",
-        "re:.*norm$",
-        "re:model[.]visual.*",
-        "re:visual.*",
-        "lm_head",
-    ],
-    duo_scaling=True,
-    config_groups={
-        "group_0": {
-            "targets": ["Linear"],
-            "weights": {
-                "num_bits": 4,
-                "type": "int",
-                "symmetric": True,
-                "group_size": 32,
-                "strategy": "group",
-                "dynamic": False,
-                "actorder": None,
-                "observer": "mse",
-            },
-        }
-    },
-)
+# rather than the default preset with group_size=128.
+# AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
+_ignore = [
+    "re:.*embed_tokens",
+    "re:.*input_layernorm$",
+    "re:.*mlp[.]gate$",
+    "re:.*post_attention_layernorm$",
+    "re:.*norm$",
+    "re:model[.]visual.*",
+    "re:visual.*",
+    "lm_head",
+]
+_config_groups = {
+    "group_0": {
+        "targets": ["Linear"],
+        "weights": {
+            "num_bits": 4,
+            "type": "int",
+            "symmetric": True,
+            "group_size": 32,
+            "strategy": "group",
+            "dynamic": False,
+            "actorder": None,
+            "observer": "mse",
+        },
+    }
+}
+recipe = [
+    AWQModifier(
+        ignore=_ignore,
+        duo_scaling=True,
+        config_groups=_config_groups,
+    ),
+    QuantizationModifier(
+        ignore=_ignore,
+        config_groups=_config_groups,
+    ),
+]
 
 # Apply AWQ quantization.
 oneshot(

--- a/examples/awq/qwen3_coder_moe_example.py
+++ b/examples/awq/qwen3_coder_moe_example.py
@@ -11,18 +11,12 @@ SAVE_DIR = MODEL_ID.split("/")[-1] + "-W4A16-awq"
 
 # Configure the quantization algorithm to run.
 # AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
+_ignore = ["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"]
+_scheme = "W4A16"
+_targets = ["Linear"]
 recipe = [
-    AWQModifier(
-        duo_scaling=False,
-        ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
-        scheme="W4A16",
-        targets=["Linear"],
-    ),
-    QuantizationModifier(
-        ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
-        scheme="W4A16",
-        targets=["Linear"],
-    ),
+    AWQModifier(duo_scaling=False, ignore=_ignore, scheme=_scheme, targets=_targets),
+    QuantizationModifier(ignore=_ignore, scheme=_scheme, targets=_targets),
 ]
 
 # Select calibration dataset.

--- a/examples/awq/qwen3_coder_moe_example.py
+++ b/examples/awq/qwen3_coder_moe_example.py
@@ -4,14 +4,21 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
 
 MODEL_ID = "Qwen/Qwen3-Coder-30B-A3B-Instruct"
 SAVE_DIR = MODEL_ID.split("/")[-1] + "-W4A16-awq"
 
 # Configure the quantization algorithm to run.
+# AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
 recipe = [
     AWQModifier(
         duo_scaling=False,
+        ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
+        scheme="W4A16",
+        targets=["Linear"],
+    ),
+    QuantizationModifier(
         ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
         scheme="W4A16",
         targets=["Linear"],

--- a/examples/awq/qwen3_moe_example.py
+++ b/examples/awq/qwen3_moe_example.py
@@ -52,17 +52,12 @@ def tokenize(sample):
 # Configure the quantization algorithm to run.
 # NOTE: vllm currently does not support asym MoE, using symmetric here
 # AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
+_ignore = ["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"]
+_scheme = "W4A16"
+_targets = ["Linear"]
 recipe = [
-    AWQModifier(
-        ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
-        scheme="W4A16",
-        targets=["Linear"],
-    ),
-    QuantizationModifier(
-        ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
-        scheme="W4A16",
-        targets=["Linear"],
-    ),
+    AWQModifier(ignore=_ignore, scheme=_scheme, targets=_targets),
+    QuantizationModifier(ignore=_ignore, scheme=_scheme, targets=_targets),
 ]
 
 # Apply algorithms.

--- a/examples/awq/qwen3_moe_example.py
+++ b/examples/awq/qwen3_moe_example.py
@@ -4,6 +4,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
 
 # Select model and load it.
 MODEL_ID = "Qwen/Qwen3-30B-A3B"
@@ -50,8 +51,14 @@ def tokenize(sample):
 
 # Configure the quantization algorithm to run.
 # NOTE: vllm currently does not support asym MoE, using symmetric here
+# AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
 recipe = [
     AWQModifier(
+        ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
+        scheme="W4A16",
+        targets=["Linear"],
+    ),
+    QuantizationModifier(
         ignore=["lm_head", "re:.*mlp.gate$", "re:.*mlp.shared_expert_gate$"],
         scheme="W4A16",
         targets=["Linear"],

--- a/examples/awq/w4a8_fp8_llama_example.py
+++ b/examples/awq/w4a8_fp8_llama_example.py
@@ -41,18 +41,12 @@ ds = ds.map(preprocess)
 # W4AFP8 scheme: 4-bit integer weights (group 128) + FP8 dynamic per-token activations
 # AWQ smooths the weights before quantization to reduce quantization error.
 # AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
+_ignore = ["lm_head"]
+_scheme = "W4AFP8"
+_targets = ["Linear"]
 recipe = [
-    AWQModifier(
-        ignore=["lm_head"],
-        scheme="W4AFP8",
-        targets=["Linear"],
-        duo_scaling=True,
-    ),
-    QuantizationModifier(
-        ignore=["lm_head"],
-        scheme="W4AFP8",
-        targets=["Linear"],
-    ),
+    AWQModifier(ignore=_ignore, scheme=_scheme, targets=_targets, duo_scaling=True),
+    QuantizationModifier(ignore=_ignore, scheme=_scheme, targets=_targets),
 ]
 
 # Apply algorithms.

--- a/examples/awq/w4a8_fp8_llama_example.py
+++ b/examples/awq/w4a8_fp8_llama_example.py
@@ -4,6 +4,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
 
 # Select model and load it.
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
@@ -39,12 +40,18 @@ ds = ds.map(preprocess)
 # Configure the quantization algorithm to run.
 # W4AFP8 scheme: 4-bit integer weights (group 128) + FP8 dynamic per-token activations
 # AWQ smooths the weights before quantization to reduce quantization error.
+# AWQModifier applies smoothing, then QuantizationModifier finalizes quantization.
 recipe = [
     AWQModifier(
         ignore=["lm_head"],
         scheme="W4AFP8",
         targets=["Linear"],
         duo_scaling=True,
+    ),
+    QuantizationModifier(
+        ignore=["lm_head"],
+        scheme="W4AFP8",
+        targets=["Linear"],
     ),
 ]
 

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -1,13 +1,21 @@
 import inspect
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from itertools import product
-from typing import Iterator, Literal
+from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Union
 
 import torch
 from compressed_tensors.offload.dist_utils import as_broadcastable, is_distributed
 from compressed_tensors.quantization import (
+    QuantizationConfig,
+    QuantizationScheme,
+    QuantizationStatus,
     QuantizationStrategy,
+    apply_quantization_config,
     disable_quantization,
     forward_quantize,
+    is_preset_scheme,
+    preset_name_to_scheme,
 )
 from compressed_tensors.utils import (
     align_modules,
@@ -20,7 +28,7 @@ from compressed_tensors.utils import (
     update_offload_parameter,
 )
 from loguru import logger
-from pydantic import ConfigDict, PrivateAttr, field_validator
+from pydantic import ConfigDict, Field, PrivateAttr, field_validator
 from torch import distributed as dist
 from torch.nn import Module
 from torch.utils._pytree import tree_leaves
@@ -35,10 +43,9 @@ from llmcompressor.modifiers.awq.mappings import (
 )
 from llmcompressor.modifiers.quantization.calibration import (
     call_observer,
-    update_weight_global_scale,
-    update_weight_zp_scale,
+    initialize_observer,
+    reset_quantization_status,
 )
-from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.modifiers.utils import update_fused_layer_weight_global_scales
 from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.modifiers.utils.pytorch_helpers import is_moe_model
@@ -53,25 +60,32 @@ from llmcompressor.utils.pytorch.module import (
 
 __all__ = ["AWQModifier"]
 
+_MISSING = object()  # sentinel for snapshot/restore of temp quant schemes
 
-class AWQModifier(Modifier, QuantizationMixin):
+
+@dataclass
+class AWQSearchResult:
+    """Result of a grid search for the best smoothing scales for a single mapping."""
+
+    best_scales: torch.Tensor
+    best_error: float
+    initial_error: float
+    best_ratio: float
+    history: list = field(default_factory=list)
+
+
+class AWQModifier(Modifier):
     """
-    Implements the AWQ (Activation-Weighted Quantization) algorithm,
-    as described in https://arxiv.org/pdf/2306.00978. The algorithm
-    significantly reduces quantization error by protecting only 1%
-    of the most salient weight channels.
+    Implements the AWQ (Activation-Weighted Quantization) smoothing algorithm,
+    as described in https://arxiv.org/pdf/2306.00978.
 
-    Instead of relying on raw weight values, AWQ identifies important channels by
-    analyzing activation patterns, focusing on the channels in the weight tensor that
-    are most responsive to the input. To reduce quantization error, it scales these
-    channels in a way that preserves the model's original behavior, using scaling
-    factors computed offline from activation statistics.
+    AWQ is a **pre-quantization transform**: it computes per-channel smoothing
+    scales that reduce quantization error, then applies those scales to model
+    weights in-place. It does **not** produce final quantized weights, scales,
+    or zero-points. A downstream quantizer (e.g. QuantizationModifier or
+    GPTQModifier) must follow AWQ in the recipe to finalize quantization.
 
-    Because this modifier manipulates the weights of the model, it can only be used in
-    in one-shot and not during training. Activation ranges are determined by running a
-    small set of calibration data through the model.
-
-    example recipe:
+    example recipe (stacked with a downstream quantizer):
     ```yaml
     AWQModifier:
       mappings:
@@ -84,88 +98,70 @@ class AWQModifier(Modifier, QuantizationMixin):
         # This change is only useful for MoE models with parallel transformer blocks,
         # and one should use the default value (None) in most cases.
       ignore: ["lm_head"]
-      config_groups:
-        group_0:
-          targets:
-            - "Linear"
-          input_activations: null
-          output_activations: null
-          weights:
-            num_bits: 4
-            type: int
-            symmetric: false
-            strategy: group
-            group_size: 128
+      scheme: "W4A16"
+    QuantizationModifier:
+      targets: ["Linear"]
+      scheme: "W4A16"
+      ignore: ["lm_head"]
     ```
 
     Lifecycle:
 
     - on_initialize
+        - validate recipe (downstream quantizer exists, config compatible)
         - resolve mappings
-        - capture kwargs needed for forward passes into modules
     - on_start
-        - set up activation cache hooks to capture input activations
-            to balance layers
-    - on sequential epoch end
-        - apply smoothing to each smoothing layer
-            - consume cached activations across all batches
-                - clear cached activations as they are used
-            - find best smoothing scale for each smoothing layer via grid search
-            - apply best scales to model weights
-            - raise error if any unused activations remain
+        - temporarily apply quant schemes for grid search
+        - set up activation cache hooks
+    - on sequential/calibration epoch end
+        - apply smoothing (grid search + scale application)
     - on_end
-        - re-run logic of sequential epoch end (in case of basic pipeline)
-        - set scales and zero points
-        - remove activation hooks
+        - strip temporary quant schemes (restore prior module state)
+        - remove hooks
     - on_finalize
-        - clear resolved mappings and captured activations
+        - clear caches and mappings
 
     :param sequential_targets: list of module names to compress in
         the same calibration pass
-    :param mappings: list activation layers to smooth, and which layers to
+    :param mappings: list of activation layers to smooth and which layers to
         scale the output such that activations are smoothed.
-        Each entry of the mapping list should be a list itself, in which the first
-        entry is a list of layers who share the same input activation (the one to be
-        to smoothed) and the second entry is the layer whose output is scaled to
-        achieve the smoothing.
         If regex is used, it matches layers with the largest overlap in module name.
         Each mapping may also include an ``activation_hook_target``: a dotted
         attribute path relative to the parent module (lowest common ancestor)
         specifying which submodule to hook for activation caching. This is useful
         for parallel transformer blocks where the default (hooking
         ``balance_layers[0]``) would capture the wrong activations.
-    :param ignore: list of layers to ignore during quantization (not smoothed).
-        It should match the name of layers whose outputs are scaled to achieve
-        smoothing (the second entry of the mappings list).
-    :param offload_device: offload cached args to this device, which reduces memory
-        requirements but requires more time to move data between cpu and execution
-        device. Defaults to None, so cached args are not offloaded. Consider setting
-        to torch.device("cpu") if you are encountering OOM errors
-    :param duo_scaling: whether to use duo scaling, which uses both input activations
-        and weights to determine the scaling factor. Defaults to True
-        If True, both activations and weights are used.
-        If False, only activations are used.
-        If "both", half the grid search is performed with duo_scaling=False and the
-        other half is performed with duo_scaling=True.
-    :param n_grid: when performing the best scales grid search for each mapping,
-        this specifies how many grid points should be used. To decrease the runtime,
-        at the possible cost of slightly worse scales, this can be decreased.
-        Defaults to 20
+    :param ignore: list of layers to ignore (not smoothed).
+    :param offload_device: offload cached args to this device to reduce memory.
+        Defaults to None (no offloading). Consider torch.device("cpu") for OOM.
+    :param duo_scaling: whether to use both activations and weights for scaling.
+        True: both used. False: activations only. "both": half grid each way.
+    :param n_grid: number of grid points for the smoothing scale search. Default 20.
+    :param scheme: quantization scheme used for pseudo-quantization during the
+        AWQ grid search. This does NOT apply final quantization. It tells AWQ
+        how the downstream quantizer will quantize, so AWQ can optimize for it.
+    :param config_groups: alternative to scheme for specifying quantization config.
+    :param targets: layer types targeted for quantization (for grid search only).
     """
 
-    # Allow arbitrary types because AWQMapping has fields of type torch.nn.Module
     model_config: ConfigDict = ConfigDict(arbitrary_types_allowed=True)
 
-    # User-provided vars (in addition to QuantizationMixin args)
+    # AWQ smoothing parameters
     sequential_targets: str | list[str] | None = None
     mappings: list[AWQMapping] | None = None
     offload_device: torch.device | None | Sentinel = Sentinel("not_provided")
     duo_scaling: bool | Literal["both"] = True
     n_grid: int = 20
 
-    # Private vars set during initialization, cleared during finalization
+    # Quantization config used ONLY for pseudo-quantization during grid search.
+    # AWQ does not own final quantization — a downstream quantizer does.
+    config_groups: Optional[Dict[str, QuantizationScheme]] = None
+    targets: Union[str, List[str]] = Field(default_factory=lambda: ["Linear"])
+    ignore: List[str] = Field(default_factory=list)
+    scheme: Optional[Union[str, Dict[str, Any]]] = None
+
+    # Private state
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
-    # Cache list of forward input args for each parent module, one dict for each batch
     _parent_args_cache: dict[Module, IntermediatesCache] = PrivateAttr(
         default_factory=dict
     )
@@ -173,39 +169,388 @@ class AWQModifier(Modifier, QuantizationMixin):
     _smooth_activation_stats: dict[str, list[torch.Tensor]] = PrivateAttr(
         default_factory=dict
     )
-    # List to store error metrics for each layer
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
+    _fp16_baseline_cache: dict[Module, IntermediatesCache] = PrivateAttr(
+        default_factory=dict
+    )
+    # Snapshot of module state before temp quant schemes were applied
+    _temp_quant_snapshot: dict[str, dict[str, Any]] = PrivateAttr(default_factory=dict)
+    _resolved_config: Optional[QuantizationConfig] = PrivateAttr(None)
+
+    # ------------------------------------------------------------------ #
+    #  Quantization config resolution (local, NOT from QuantizationMixin) #
+    # ------------------------------------------------------------------ #
+
+    @field_validator("targets", mode="before")
+    @classmethod
+    def validate_targets(cls, value: Union[str, List[str]]) -> List[str]:
+        if isinstance(value, str):
+            return [value]
+        return value
+
+    @field_validator("scheme", mode="before")
+    @classmethod
+    def validate_scheme(
+        cls, value: Optional[Union[str, Dict[str, Any]]]
+    ) -> Optional[Union[str, Dict[str, Any]]]:
+        if isinstance(value, str) and not is_preset_scheme(value):
+            raise ValueError(
+                "`scheme` must either be a preset scheme name or a dictionary "
+                "of preset scheme names"
+            )
+        if isinstance(value, dict):
+            for scheme_name in value.keys():
+                cls.validate_scheme(scheme_name)
+            for key, target in value.items():
+                value[key] = cls.validate_targets(target)
+        return value
+
+    @field_validator("duo_scaling")
+    @classmethod
+    def validate_duo_scaling(cls, v):
+        """Validate that duo_scaling is either True, False, or 'both' (lowercase)"""
+        if v not in (True, False, "both"):
+            raise ValueError(f"duo_scaling must be True, False, or 'both', got {v!r}")
+        return v
+
+    @property
+    def resolved_config(self) -> QuantizationConfig:
+        if self._resolved_config is None:
+            self._resolved_config = self._resolve_quantization_config()
+        return self._resolved_config
+
+    @property
+    def resolved_targets(self) -> Set[str]:
+        targets = set()
+        for config_group in self.resolved_config.config_groups.values():
+            for target in config_group.targets:
+                targets.add(target)
+        return targets
+
+    def _has_quant_config(self) -> bool:
+        return not (
+            self.config_groups is None
+            and self.targets == ["Linear"]
+            and self.ignore == []
+            and self.scheme is None
+        )
+
+    def _resolve_quantization_config(self) -> QuantizationConfig:
+        scheme = self.scheme
+        targets = self.targets
+        config_groups = self.config_groups
+        ignore = self.ignore
+
+        if scheme is not None and config_groups is not None:
+            raise ValueError("Please specify either `scheme` or `config_groups`")
+
+        if scheme is not None:
+            if isinstance(scheme, str) and is_preset_scheme(scheme):
+                scheme = {scheme: targets}
+            config_groups = {}
+            for idx, key in enumerate(scheme.keys()):
+                if is_preset_scheme(key):
+                    scheme_obj = preset_name_to_scheme(key, scheme[key])
+                else:
+                    scheme_obj = QuantizationScheme.model_validate(
+                        {"targets": scheme[key], **scheme}
+                    )
+                group_name = f"group_{idx}"
+                config_groups[group_name] = scheme_obj
+
+        if config_groups is None or len(config_groups) == 0:
+            default_quant_scheme = QuantizationScheme(targets=targets)
+            config_groups = {"group_0": default_quant_scheme}
+
+        return QuantizationConfig(
+            config_groups=config_groups,
+            quantization_status=QuantizationStatus.INITIALIZED,
+            ignore=ignore,
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Temporary quant scheme management (context-managed)               #
+    # ------------------------------------------------------------------ #
+
+    @contextmanager
+    def _temporary_quant_schemes(self, model: Module, with_observers: bool = False):
+        """
+        Apply quantization schemes to modules temporarily, restoring prior
+        state on exit regardless of success or failure.
+
+        This is the single code path for all temporary quant scheme usage in
+        AWQModifier. Both ``on_initialize`` (for mapping resolution and
+        duo_scaling validation) and ``_apply_smoothing`` (for the grid search)
+        go through this context manager so that snapshot/restore logic is never
+        duplicated.
+
+        :param model: the model whose modules will be temporarily modified
+        :param with_observers: if True, also initialize weight observers on
+            each targeted module after applying schemes. Required for the grid
+            search in ``_apply_smoothing``; not needed during ``on_initialize``
+            where we only need the scheme metadata on modules.
+
+        On entry:
+            1. Snapshots every quant-related attribute on every targeted module.
+            2. Resets any prior quantization status.
+            3. Applies AWQ's resolved quantization config.
+            4. Disables quantization (schemes present but forward pass unchanged).
+            5. Optionally initializes weight observers.
+
+        On exit:
+            For each targeted module, restores every snapshotted attribute:
+            - If the attribute did not exist before entry, it is deleted.
+            - If the attribute existed before entry, it is set back to the
+              prior value (even if AWQ overwrote it).
+            This guarantees that downstream modifiers' state is never lost.
+        """
+        snapshot: dict[str, dict[str, Any]] = {}
+        # All attributes that apply_quantization_config and initialize_observer
+        # may add to modules. We must snapshot and restore every one of them.
+        # apply_quantization_config also wraps the module's forward method
+        # by adding it to the instance __dict__, so we must track that too.
+        quant_attrs = (
+            "quantization_scheme",
+            "quantization_status",
+            "quantization_enabled",
+            "weight_scale",
+            "weight_zero_point",
+            "weight_observer",
+        )
+
+        # 1. Snapshot prior state for all modules we will touch
+        for name, module in match_named_modules(
+            model, self.resolved_targets, self.ignore
+        ):
+            prior = {}
+            for attr in quant_attrs:
+                prior[attr] = getattr(module, attr, _MISSING)
+            # forward may be overridden on the instance by apply_quantization_config
+            prior["forward"] = module.__dict__.get("forward", _MISSING)
+            snapshot[name] = prior
+
+        # 2-4. Apply temp quant config with quantization disabled
+        for _, module in match_named_modules(model, self.resolved_targets, self.ignore):
+            reset_quantization_status(module)
+
+        apply_quantization_config(model, self.resolved_config)
+        model.apply(disable_quantization)
+
+        # 5. Optionally initialize weight observers
+        if with_observers:
+            for _, module in match_named_modules(
+                model, self.resolved_targets, self.ignore
+            ):
+                if hasattr(module, "quantization_scheme"):
+                    scheme = module.quantization_scheme
+                    if scheme.weights is not None:
+                        initialize_observer(module, base_name="weight")
+
+        self._temp_quant_snapshot = snapshot
+        try:
+            yield
+        finally:
+            self._strip_temp_quant_schemes(model)
+
+    def _strip_temp_quant_schemes(self, model: Module):
+        """Restore modules to their state before temp quant schemes were applied."""
+        quant_attrs = (
+            "quantization_scheme",
+            "quantization_status",
+            "quantization_enabled",
+            "weight_scale",
+            "weight_zero_point",
+            "weight_observer",
+        )
+
+        for name, module in match_named_modules(
+            model, self.resolved_targets, self.ignore
+        ):
+            prior = self._temp_quant_snapshot.get(name, {})
+            for attr in quant_attrs:
+                prev_val = prior.get(attr, _MISSING)
+                if prev_val is _MISSING:
+                    # AWQ added this — remove it
+                    if hasattr(module, attr):
+                        delattr(module, attr)
+                else:
+                    # Restore prior value
+                    setattr(module, attr, prev_val)
+
+            # Restore or remove the instance-level forward override
+            prev_forward = prior.get("forward", _MISSING)
+            if prev_forward is _MISSING:
+                # forward was not overridden before — remove the override
+                module.__dict__.pop("forward", None)
+            else:
+                # Restore prior forward override
+                module.__dict__["forward"] = prev_forward
+
+        self._temp_quant_snapshot.clear()
+
+    # ------------------------------------------------------------------ #
+    #  Recipe validation                                                  #
+    # ------------------------------------------------------------------ #
+
+    def _validate_recipe(self, state: State):
+        """
+        Validate that the recipe contains a compatible downstream quantizer
+        after this AWQModifier, with matching targets/ignore/scheme.
+        """
+        from llmcompressor.core import active_session
+        from llmcompressor.modifiers.quantization.quantization import (
+            QuantizationMixin,
+        )
+
+        try:
+            modifiers = active_session().lifecycle.recipe.modifiers
+        except Exception:
+            modifiers = []
+        if not modifiers:
+            return
+
+        # Find our position in the modifier list
+        my_idx = None
+        for i, m in enumerate(modifiers):
+            if m is self:
+                my_idx = i
+                break
+
+        if my_idx is None:
+            return
+
+        # Find downstream quantizer (must come after AWQ)
+        downstream_quantizer = None
+        for m in modifiers[my_idx + 1 :]:
+            if isinstance(m, QuantizationMixin):
+                downstream_quantizer = m
+                break
+
+        # Check for reversed ordering (quantizer before AWQ)
+        for m in modifiers[:my_idx]:
+            if isinstance(m, QuantizationMixin):
+                logger.warning(
+                    "A quantizer modifier appears before AWQModifier in the recipe. "
+                    "AWQ smoothing should run before the quantizer for best results. "
+                    "Consider reordering your recipe."
+                )
+
+        if downstream_quantizer is None:
+            logger.warning(
+                "AWQModifier is used without a downstream quantizer. "
+                "AWQ only applies smoothing — add QuantizationModifier or "
+                "GPTQModifier after AWQ to produce a quantized model."
+            )
+            return
+
+        # Validate target/ignore compatibility if AWQ has quant config
+        if self._has_quant_config():
+            awq_targets = self.resolved_targets
+            ds_targets = downstream_quantizer.resolved_targets
+            awq_ignore = set(self.ignore) if self.ignore else set()
+            ds_ignore = (
+                set(downstream_quantizer.ignore)
+                if downstream_quantizer.ignore
+                else set()
+            )
+
+            # Check that AWQ targets are a subset of downstream targets
+            if awq_targets and ds_targets and not awq_targets.issubset(ds_targets):
+                diff = awq_targets - ds_targets
+                logger.warning(
+                    f"AWQModifier targets {diff} are not targeted by the "
+                    "downstream quantizer. These modules will be smoothed but "
+                    "not quantized."
+                )
+
+            # Check ignore alignment
+            if awq_ignore != ds_ignore:
+                logger.warning(
+                    f"AWQModifier ignore list {awq_ignore} differs from "
+                    f"downstream quantizer ignore list {ds_ignore}. "
+                    "Mismatched ignore lists may cause unexpected behavior."
+                )
+
+            # Validate weight quantization scheme compatibility
+            self._validate_scheme_compatibility(downstream_quantizer)
+
+    def _validate_scheme_compatibility(self, downstream_quantizer):
+        """
+        Validate that AWQ's quant config (used for grid search) matches the
+        downstream quantizer's config field-by-field.
+        """
+        awq_groups = self.resolved_config.config_groups
+        ds_groups = downstream_quantizer.resolved_config.config_groups
+
+        for group_name, awq_scheme in awq_groups.items():
+            if awq_scheme.weights is None:
+                continue
+
+            # Find a matching downstream scheme by target overlap
+            matched_ds_scheme = None
+            for ds_scheme in ds_groups.values():
+                if set(awq_scheme.targets) & set(ds_scheme.targets):
+                    matched_ds_scheme = ds_scheme
+                    break
+
+            if matched_ds_scheme is None or matched_ds_scheme.weights is None:
+                raise ValueError(
+                    f"AWQModifier config group '{group_name}' targets "
+                    f"{awq_scheme.targets} but no downstream quantizer scheme "
+                    "targets the same modules with weight quantization. "
+                    "Ensure the downstream quantizer covers the same targets."
+                )
+
+            awq_w = awq_scheme.weights
+            ds_w = matched_ds_scheme.weights
+
+            mismatches = []
+            if awq_w.num_bits != ds_w.num_bits:
+                mismatches.append(
+                    f"num_bits: AWQ={awq_w.num_bits}, downstream={ds_w.num_bits}"
+                )
+            if awq_w.symmetric != ds_w.symmetric:
+                mismatches.append(
+                    f"symmetric: AWQ={awq_w.symmetric}, downstream={ds_w.symmetric}"
+                )
+            if awq_w.strategy != ds_w.strategy:
+                mismatches.append(
+                    f"strategy: AWQ={awq_w.strategy}, downstream={ds_w.strategy}"
+                )
+            if (
+                awq_w.group_size is not None
+                and ds_w.group_size is not None
+                and awq_w.group_size != ds_w.group_size
+            ):
+                mismatches.append(
+                    f"group_size: AWQ={awq_w.group_size}, downstream={ds_w.group_size}"
+                )
+
+            if mismatches:
+                raise ValueError(
+                    f"AWQModifier quantization config does not match downstream "
+                    f"quantizer for targets {awq_scheme.targets}. Mismatches: "
+                    + ", ".join(mismatches)
+                    + ". The AWQ scheme must match the downstream quantizer "
+                    "so the grid search optimizes for the correct quantization."
+                )
+
+    # ------------------------------------------------------------------ #
+    #  Modifier lifecycle                                                 #
+    # ------------------------------------------------------------------ #
 
     def on_initialize(self, state: State, **kwargs) -> bool:
         """
-        Initialize AWQ on the given state
-        Initialize quantization, resolve mappings, cache module kwargs
+        Initialize AWQ: validate recipe, resolve mappings, validate config.
 
-        :param state: state to run AWQ on
-        :return: True on a successful run, False otherwise
+        Quant schemes are applied temporarily (via ``_temporary_quant_schemes``)
+        so that ``_set_resolved_mappings`` can identify which modules are
+        targeted for quantization and so that duo_scaling validation can inspect
+        the effective quantization strategy. The schemes are stripped on exit
+        from the context manager — they are re-applied later in
+        ``_apply_smoothing`` with observers for the actual grid search.
         """
-
-        # apply config to model and prepare calibration hooks
-        if QuantizationMixin.has_config(self):
-            QuantizationMixin.initialize_quantization(self, state.model)
-
-        # Validate that duo_scaling is only used with per-channel quantization
-        if self.duo_scaling is not False:
-            for _, module in match_named_modules(
-                state.model, self.resolved_targets, self.ignore
-            ):
-                if (
-                    hasattr(module, "quantization_scheme")
-                    and hasattr(module.quantization_scheme, "weights")
-                    and module.quantization_scheme.weights.strategy
-                    == QuantizationStrategy.TENSOR
-                ):
-                    raise ValueError(
-                        "duo_scaling is only supported with per-channel quantization "
-                        "strategies (group or channel), but found TENSOR strategy. "
-                        "Please set duo_scaling=False or use a per-channel "
-                        "quantization strategy."
-                    )
+        self._validate_recipe(state)
 
         if self.mappings is None:
             logger.info("No AWQModifier.mappings provided, inferring from model...")
@@ -215,7 +560,6 @@ class AWQModifier(Modifier, QuantizationMixin):
 
         # Set default offload_device
         if self.offload_device == Sentinel("not_provided"):
-            # Check if we have a MoE model
             if is_moe_model(state.model):
                 self.offload_device = torch.device("cpu")
                 logger.info(
@@ -224,13 +568,45 @@ class AWQModifier(Modifier, QuantizationMixin):
                     "setting offload_device in your recipe."
                 )
             else:
-                # For non-MoE models, convert sentinel to None
-                # (no offloading by default)
                 self.offload_device = None
 
-        self._set_resolved_mappings(state.model)
+        if self._has_quant_config():
+            # Temporarily apply quant schemes so that:
+            #   1. _set_resolved_mappings can resolve targeted_names
+            #   2. duo_scaling validation can inspect quantization strategies
+            # No observers needed — this is metadata-only.
+            with self._temporary_quant_schemes(state.model, with_observers=False):
+                self._set_resolved_mappings(state.model)
+                self._validate_duo_scaling(state.model)
+        else:
+            self._set_resolved_mappings(state.model)
 
         return True
+
+    def _validate_duo_scaling(self, model: Module):
+        """
+        Validate that duo_scaling is not used with TENSOR quantization strategy.
+
+        Must be called while temporary quant schemes are applied to the model
+        (i.e. inside the ``_temporary_quant_schemes`` context) so that
+        ``module.quantization_scheme`` is available for inspection.
+        """
+        if self.duo_scaling is False:
+            return
+
+        for _, module in match_named_modules(model, self.resolved_targets, self.ignore):
+            if (
+                hasattr(module, "quantization_scheme")
+                and hasattr(module.quantization_scheme, "weights")
+                and module.quantization_scheme.weights.strategy
+                == QuantizationStrategy.TENSOR
+            ):
+                raise ValueError(
+                    "duo_scaling is only supported with per-channel quantization "
+                    "strategies (group or channel), but found TENSOR strategy. "
+                    "Please set duo_scaling=False or use a per-channel "
+                    "quantization strategy."
+                )
 
     def on_start(self, state: State, event: Event, **kwargs):
         self.started_ = True
@@ -246,15 +622,6 @@ class AWQModifier(Modifier, QuantizationMixin):
                 "for MoE layers from the AWQ configuration."
             )
 
-        # register quantization calibration hooks
-        # assume quantization has been initialized by this modifier or one before it
-        QuantizationMixin.start_calibration(self, state.model)
-        # AWQ performs forward passes during _apply_smoothing
-        # before any scales or zero points are updated
-        # Quantization must be disabled, otherwise NaNs will
-        # appear in quantized forward method
-        state.model.apply(disable_quantization)
-
         self._setup_activation_cache_hooks()
 
     def on_event(self, state: State, event: Event, **kwargs):
@@ -263,11 +630,9 @@ class AWQModifier(Modifier, QuantizationMixin):
                 self.on_start(state, None)
 
         elif event.type_ == EventType.SEQUENTIAL_EPOCH_END:
-            # Run smoothing in case of sequential pipeline
             self._apply_smoothing(state.model)
 
         elif event.type_ == EventType.CALIBRATION_EPOCH_END:
-            # Run smoothing in case of basic pipeline
             self._apply_smoothing(state.model)
 
             if not self.ended_:
@@ -275,42 +640,14 @@ class AWQModifier(Modifier, QuantizationMixin):
 
     def on_end(self, state: State, event: Event, **kwargs):
         """
-        Finish calibrating by setting scales and zero-points,
-         removing observers and calibration hooks
+        Finish smoothing. AWQ does NOT set scales/zero-points or finalize
+        quantization — that is the downstream quantizer's responsibility.
         """
         self._assert_all_activations_consumed()
-
         self.ended_ = True
-
-        named_modules = list(
-            match_named_modules(state.model, self.resolved_targets, self.ignore)
-        )
-
-        # For TENSOR_GROUP (nvfp4), calculate global scales after smoothing
-        for _, module in tqdm(named_modules, desc="Updating global scales"):
-            update_weight_global_scale(module)
-
-        # For TENSOR_GROUP (nvfp4), fuse global scales for attention and MLP layers
-        # This is a requirement for vLLM inference.
-        for module in tqdm(state.model.modules(), desc="Fusing global scales"):
-            update_fused_layer_weight_global_scales(module)
-
-        # Calculate scales and zero points using the fused global scales
-        for _, module in tqdm(named_modules, desc="Calibrating weights"):
-            update_weight_zp_scale(module)
-
-        QuantizationMixin.end_calibration(self, state.model)
-
-        # remove activation hooks
         self.remove_hooks()
 
     def on_finalize(self, state: State, **kwargs) -> bool:
-        """
-        Clean up by clearing the activations and mapping data
-
-        :param state: unused
-        :return: True
-        """
         if not self.ended_:
             self.on_end(state, None)
 
@@ -323,20 +660,18 @@ class AWQModifier(Modifier, QuantizationMixin):
 
         return True
 
+    # ------------------------------------------------------------------ #
+    #  Mapping resolution                                                 #
+    # ------------------------------------------------------------------ #
+
     def _set_resolved_mappings(self, model: Module) -> None:
         """
         Transforms the list of activations to smooth and their corresponding weights
         into ResolvedMapping objects, resolving regular expressions.
-        Result is stored in _resolved_mappings.
-
-        For each activation in the mapping list, we find the corresponding weight to
-        balance by searching for the longest substring. For instance, if our balance
-        weight is ".*re:.*q_proj" and the activation is "re:.*self_attn_layer_norm" we
-        would match model.layer.0.p_proj to model.layer.0.self_attn_layer_norm and
-        repeat for model.layer.1 and so on
         """
         resolved_mappings: list[ResolvedMapping] = []
         module_to_name = get_module_to_name_dict(model)
+
         # Get names of modules targeted for quantization (excludes ignored)
         targeted_names = set(
             name
@@ -344,10 +679,8 @@ class AWQModifier(Modifier, QuantizationMixin):
                 model, self.resolved_targets, self.ignore
             )
         )
+
         for mapping in self.mappings:
-            # we deliberately don't use the ignore list when matching mappings,
-            # so that we can handle layers that need smoothing but not quantization
-            # we only skip if no layers in mapping are targeted for quantization.
             for smooth_layers, *nested_balance_layers in match_modules_set(
                 model, (mapping.smooth_layer, *mapping.balance_layers)
             ):
@@ -360,15 +693,12 @@ class AWQModifier(Modifier, QuantizationMixin):
                 smooth_layer = smooth_layers[0]
                 smooth_name = module_to_name.get(smooth_layer)
 
-                # [[b00, b01, b02...], [b10, b11, b12,...], ...] ↓
-                #                             [b00, b01, b02, ..., b10, b11, b12, ...]
                 balance_layers = tree_leaves(nested_balance_layers)
                 balance_names = [
                     module_to_name.get(balance_layer)
                     for balance_layer in balance_layers
                 ]
 
-                # Check if at least one layer is targeted for quantization
                 any_targeted = smooth_name in targeted_names or any(
                     bn in targeted_names for bn in balance_names
                 )
@@ -390,7 +720,6 @@ class AWQModifier(Modifier, QuantizationMixin):
                         f"skipping AWQ for {smooth_name} for mapping {mapping}"
                         + skip_message
                     )
-
                     continue
 
                 ancestor_name, ancestor = get_lowest_common_ancestor_with_avoid(
@@ -420,12 +749,14 @@ class AWQModifier(Modifier, QuantizationMixin):
                     )
                 )
         self._resolved_mappings = resolved_mappings
-        return
+
+    # ------------------------------------------------------------------ #
+    #  Activation caching hooks                                           #
+    # ------------------------------------------------------------------ #
 
     def _setup_activation_cache_hooks(self) -> None:
         """
-        Attach a forward hook to each activation we want to smooth. This allows us to
-        calculate the dynamic range during calibration
+        Attach forward hooks to cache parent kwargs and smooth activation means.
         """
 
         def cache_parent_kwargs_hook(
@@ -476,8 +807,6 @@ class AWQModifier(Modifier, QuantizationMixin):
             return cache_smooth_activations_hook
 
         for mapping in self._resolved_mappings:
-            # parent kwargs needed for future forward passes
-            # same parent may appear multiple times in resolved mappings
             if mapping.parent not in self._parent_args_cache:
                 self._parent_args_cache[mapping.parent] = IntermediatesCache(
                     None,
@@ -505,109 +834,88 @@ class AWQModifier(Modifier, QuantizationMixin):
                 "forward",
             )
 
+    # ------------------------------------------------------------------ #
+    #  Smoothing (grid search + scale application)                        #
+    # ------------------------------------------------------------------ #
+
     @torch.no_grad()
     def _apply_smoothing(self, model: Module) -> None:
         """
-        Calculate the best scaling factors for each layer to smooth activations and
-        apply the scaling factors to the weights of the next layer to offset the
-        smoothing
+        For each mapping: run grid search to find best smoothing scales,
+        then apply those scales to model weights in-place.
 
-        :param model: model to apply smoothing to
+        Quant schemes are applied temporarily via context manager for the
+        duration of the grid search, then stripped.
         """
-        # NOTE: When using SequentialPipeline, not all the mappings
-        # will have cached activations in the segment being updated
         mappings_to_smooth = [
             mapping
             for mapping in self._resolved_mappings
             if mapping.smooth_name in self._smooth_activation_stats
         ]
-        for mapping in tqdm(mappings_to_smooth, desc="Smoothing"):
-            smooth_layer = mapping.smooth_layer
-            balance_layers = mapping.balance_layers
-            parent_module = mapping.parent
 
-            with (
-                align_modules([parent_module, smooth_layer, *balance_layers]),
-                calibration_forward_context(model),
-                HooksMixin.disable_hooks(),
-            ):
-                # Compute output of unquantized module
-                fp16_outputs = self._run_samples(parent_module)
-                if len(fp16_outputs) == 0 or all(f.numel() == 0 for f in fp16_outputs):
-                    logger.info(
-                        f"Skipping smooth_layer {mapping.smooth_name}, no activations "
-                        "found to scale. This can occasionally occur in MoE models "
-                        "when certain experts are not activated by calibration samples."
-                    )
-                    del self._smooth_activation_stats[mapping.smooth_name]
-                    continue
-                if not all(
-                    [fp16_output.isfinite().all() for fp16_output in fp16_outputs]
+        if not mappings_to_smooth:
+            return
+
+        # Apply temp quant schemes with observers for pseudo-quantization
+        # during the grid search. Observers are needed so that
+        # _evaluate_candidate can call call_observer + forward_quantize.
+        with self._temporary_quant_schemes(model, with_observers=True):
+            for mapping in tqdm(mappings_to_smooth, desc="Smoothing"):
+                smooth_layer = mapping.smooth_layer
+                balance_layers = mapping.balance_layers
+                parent_module = mapping.parent
+
+                with (
+                    align_modules([parent_module, smooth_layer, *balance_layers]),
+                    calibration_forward_context(model),
+                    HooksMixin.disable_hooks(),
                 ):
-                    logger.warning(
-                        f"Skipping smooth_layer {mapping.smooth_name}, NaN or inf "
-                        "outputs found during forward pass of the parent module "
-                        f"{mapping.parent_name}. The model is either generating NaN "
-                        "output with provided calibration data set, or the mappings "
-                        "are incorrectly set and modifying the model in undesired "
-                        "ways. If you encounter this consistently, raise an issue at "
-                        "https://github.com/vllm-project/llm-compressor/issues"
-                    )
-                    del self._smooth_activation_stats[mapping.smooth_name]
-                    continue
-
-                orig_layer_weights = {
-                    balance_layer: balance_layer.weight.clone()
-                    for balance_layer in mapping.balance_layers
-                }
-
-                best_scales = self._compute_best_scale(
-                    mapping, fp16_outputs, orig_layer_weights
-                )
-
-                @torch.no_grad()
-                def _smooth(
-                    module: Module, orig_layer_weights: dict[Module, torch.Tensor]
-                ):
-                    scales = best_scales.to(module.weight.device)
-                    if module in balance_layers:
-                        update_offload_parameter(
-                            module,
-                            "weight",
-                            orig_layer_weights[module].to(module.weight.device)
-                            * scales.view(1, -1),
+                    # Compute output of unquantized module
+                    fp16_outputs = self._run_samples(parent_module)
+                    if len(fp16_outputs) == 0 or all(
+                        f.numel() == 0 for f in fp16_outputs
+                    ):
+                        logger.info(
+                            f"Skipping smooth_layer {mapping.smooth_name}, no "
+                            "activations found to scale. This can occasionally "
+                            "occur in MoE models when certain experts are not "
+                            "activated by calibration samples."
                         )
-                    elif module == smooth_layer:
-                        if module.weight.ndim == 1:
-                            update_offload_parameter(
-                                module,
-                                "weight",
-                                module.weight.div_(scales),
-                            )
-                        else:
-                            # NOTE: edge case when smooth layer number of out_features
-                            # is not equal to balance layer number of in_features
-                            # e.g. when fused qkv_proj is used to smooth o_proj
-                            # in this case, default to scaling the last output features
-                            # because the desired smooth layer is v_proj
-                            # https://github.com/casper-hansen/AutoAWQ/blob/main/awq/quantize/scale.py#L123
-                            weight = module.weight
-                            weight[-scales.size(0) :].div_(scales.view(-1, 1))
-                            update_offload_parameter(module, "weight", weight)
-                        if hasattr(module, "bias") and module.bias is not None:
-                            update_offload_parameter(
-                                module,
-                                "bias",
-                                module.bias.div_(scales),
-                            )
+                        del self._smooth_activation_stats[mapping.smooth_name]
+                        continue
+                    if not all(
+                        fp16_output.isfinite().all() for fp16_output in fp16_outputs
+                    ):
+                        logger.warning(
+                            f"Skipping smooth_layer {mapping.smooth_name}, NaN or "
+                            "inf outputs found during forward pass of the parent "
+                            f"module {mapping.parent_name}. The model is either "
+                            "generating NaN output with provided calibration data "
+                            "set, or the mappings are incorrectly set and modifying "
+                            "the model in undesired ways. If you encounter this "
+                            "consistently, raise an issue at "
+                            "https://github.com/vllm-project/llm-compressor/issues"
+                        )
+                        del self._smooth_activation_stats[mapping.smooth_name]
+                        continue
 
-                for layer in balance_layers:
-                    _smooth(layer, orig_layer_weights)
-                _smooth(smooth_layer, orig_layer_weights)
+                    orig_layer_weights = {
+                        balance_layer: balance_layer.weight.clone()
+                        for balance_layer in mapping.balance_layers
+                        if hasattr(balance_layer, "quantization_scheme")
+                        and hasattr(balance_layer.quantization_scheme, "weights")
+                    }
 
-                # remove caches needed to smooth this mapping
-                del self._smooth_activation_stats[mapping.smooth_name]
-                del orig_layer_weights
+                    search_result = self._select_best_scale(
+                        mapping, fp16_outputs, orig_layer_weights
+                    )
+
+                    self._apply_best_scales(
+                        mapping, search_result.best_scales, orig_layer_weights
+                    )
+
+                    del self._smooth_activation_stats[mapping.smooth_name]
+                    del orig_layer_weights
 
         for v in self._parent_args_cache.values():
             v.batch_intermediates.clear()
@@ -620,52 +928,133 @@ class AWQModifier(Modifier, QuantizationMixin):
         batch_iter = cache.iter_prefetch() if use_prefetch else cache
         outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
         return [
-            # If tuple, assume that first argument is the input
-            output[0] if isinstance(output, tuple) else output
-            for output in outputs
+            output[0] if isinstance(output, tuple) else output for output in outputs
         ]
 
-    def _compute_best_scale(
-        self,
-        mapping: ResolvedMapping,
-        fp16_outputs: list[torch.Tensor],
-        orig_layer_weights: dict[torch.nn.Module, torch.Tensor],
-    ) -> torch.Tensor:
+    # ------------------------------------------------------------------ #
+    #  Grid search — decomposed into pure helpers                         #
+    # ------------------------------------------------------------------ #
+
+    def _collect_activation_stats(
+        self, mapping: ResolvedMapping, device: torch.device
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
-        Select best scales for a given mapping in a grid search
-        Best scales are those that minimize MSE loss of quantized weight
-            outputs compared to fp16_outputs
+        Collect activation and weight statistics needed for scale generation.
 
-        L(s) = || Q(W * s) (s^-1 * X) - W * X ||
-        Q: weight quantization function | _pseudo_quantize_tensor(W * s)
-        X: inputs from calib dataset    | X
-        W: original weights in FP16     | layer
-        s: per channel scaling factor   | s^-1 * X
-
-        :param mapping: best scales will be found for the ResolvedMapping.
-        :param fp16_outputs: output of mapping.parent in unquantized case,
-            one tensor for each batch.
-        :return: tensor of best scales, one for each channel
+        :returns: (x_mean, w_mean) where w_mean is None if duo_scaling is False
         """
-        history = []
-        best_ratio = -1
-        best_scales = None
-        best_error = float("inf")
-        initial_error = None
-
-        device = get_execution_device(mapping.parent)
-
         x_sum, count = self._smooth_activation_stats[mapping.smooth_name]
         if is_distributed():
             x_sum, count = _allreduce_data_sum([x_sum, count])
         x_mean = x_sum.to(device) / count.to(device)
-
+        w_mean = None
         if self.duo_scaling:
             w_mean = self._compute_layer_means(mapping.balance_layers).to(device)
+        return x_mean, w_mean
+
+    @staticmethod
+    def _generate_scale_candidates(
+        x_mean: torch.Tensor,
+        w_mean: torch.Tensor | None,
+        n_grid: int,
+        duo_scalings: list[bool],
+    ) -> Iterator[tuple[float, bool, torch.Tensor]]:
+        """
+        Yield (ratio, use_duo_scaling, scales) for each grid point.
+        """
+        for grid_idx, use_duo_scaling in product(range(n_grid), duo_scalings):
+            ratio = grid_idx / n_grid
+
+            if use_duo_scaling and w_mean is not None:
+                scales = (x_mean.pow(ratio) / (w_mean.pow(1 - ratio) + 1e-4)).clamp(
+                    min=1e-4
+                )
+            else:
+                scales = x_mean.pow(ratio).clamp(min=1e-4).view(-1)
+
+            scales = scales / (scales.max() * scales.min()).sqrt()
+
+            # avoid scaling values that overflow
+            scales[torch.isinf(scales)] = 1
+            scales[torch.isnan(scales)] = 1
+
+            yield ratio, use_duo_scaling, scales
+
+    def _evaluate_candidate(
+        self,
+        mapping: ResolvedMapping,
+        scales: torch.Tensor,
+        fp16_outputs: list[torch.Tensor],
+        orig_layer_weights: dict[Module, torch.Tensor],
+        balance_layers_to_patch: list[Module],
+        device: torch.device,
+    ) -> float:
+        """
+        Pseudo-quantize weights with candidate scales, run forward, return MSE loss.
+        """
+        _scalesview = scales.view(1, -1).to(device)
+
+        # Q(W * s)
+        for balance_layer in balance_layers_to_patch:
+            if not hasattr(balance_layer, "quantization_scheme") or not hasattr(
+                balance_layer.quantization_scheme, "weights"
+            ):
+                continue
+
+            w_qscheme = balance_layer.quantization_scheme.weights
+            balance_layer.weight.data.copy_(
+                orig_layer_weights[balance_layer].to(_scalesview.device) * _scalesview
+            )
+
+            should_calculate_gparam = (
+                w_qscheme.strategy == QuantizationStrategy.TENSOR_GROUP
+            )
+            call_observer(
+                balance_layer,
+                "weight",
+                balance_layer.weight,
+                should_calculate_gparam=should_calculate_gparam,
+            )
+            balance_layer.weight.data = (
+                forward_quantize(
+                    balance_layer,
+                    balance_layer.weight,
+                    "weight",
+                    w_qscheme,
+                )
+                / _scalesview
+            ).to(balance_layer.weight.dtype)
+
+        # Apply fused global scales for TENSOR_GROUP during grid search
+        if balance_layers_to_patch and all(
+            getattr(layer.quantization_scheme.weights, "strategy", None)
+            == QuantizationStrategy.TENSOR_GROUP
+            for layer in balance_layers_to_patch
+        ):
+            update_fused_layer_weight_global_scales(mapping.parent)
+
+        # W * X
+        int_w_outputs = self._run_samples(mapping.parent)
+
+        # compute mean squared error
+        loss = self._compute_loss(fp16_outputs, int_w_outputs)
+        del int_w_outputs
+
+        return loss
+
+    def _select_best_scale(
+        self,
+        mapping: ResolvedMapping,
+        fp16_outputs: list[torch.Tensor],
+        orig_layer_weights: dict[Module, torch.Tensor],
+    ) -> AWQSearchResult:
+        """
+        Orchestrate grid search: generate candidates, evaluate each, return best.
+        """
+        device = get_execution_device(mapping.parent)
+        x_mean, w_mean = self._collect_activation_stats(mapping, device)
 
         match self.duo_scaling:
-            # if self.duo_scaling is "both", perform half the grid search with
-            # duo_scaling off and half with duo_scaling on
             case "both":
                 n_grid = int(self.n_grid / 2)
                 duo_scalings = [False, True]
@@ -673,14 +1062,20 @@ class AWQModifier(Modifier, QuantizationMixin):
                 n_grid = self.n_grid
                 duo_scalings = [self.duo_scaling]
 
-        # Where appropriate, replace observers with memoryless_minmax
-        # for duration of grid search
         balance_layers_to_patch = [
-            balance_layer
-            for balance_layer in mapping.balance_layers
-            if hasattr(balance_layer, "quantization_scheme")
-            and hasattr(balance_layer.quantization_scheme, "weights")
+            bl
+            for bl in mapping.balance_layers
+            if hasattr(bl, "quantization_scheme")
+            and hasattr(bl.quantization_scheme, "weights")
         ]
+
+        history = []
+        best_ratio = -1.0
+        best_scales = None
+        best_error = float("inf")
+        initial_error = None
+
+        # Replace observers with memoryless_minmax for duration of grid search
         with patch_attrs(
             balance_layers_to_patch,
             "weight_observer",
@@ -688,82 +1083,31 @@ class AWQModifier(Modifier, QuantizationMixin):
                 Observer.load_from_registry(
                     "memoryless_minmax",
                     base_name="weight",
-                    args=balance_layer.quantization_scheme.weights,
-                    module=balance_layer,
+                    args=bl.quantization_scheme.weights,
+                    module=bl,
                 )
-                for balance_layer in balance_layers_to_patch
+                for bl in balance_layers_to_patch
             ],
         ):
             total_iterations = n_grid * len(duo_scalings)
+            candidates = self._generate_scale_candidates(
+                x_mean, w_mean, n_grid, duo_scalings
+            )
             pbar = tqdm(
-                product(range(n_grid), duo_scalings),
+                candidates,
                 total=total_iterations,
                 desc=f"Grid search for {mapping.smooth_name}",
                 leave=False,
             )
-            for grid_idx, use_duo_scaling in pbar:
-                # create new scales
-                ratio = grid_idx / n_grid
-
-                # NOTE: s^-1 * x is fused here, according to paper
-                if use_duo_scaling:
-                    scales = (x_mean.pow(ratio) / (w_mean.pow(1 - ratio) + 1e-4)).clamp(
-                        min=1e-4
-                    )
-                else:
-                    scales = x_mean.pow(ratio).clamp(min=1e-4).view(-1)
-                scales = scales / (scales.max() * scales.min()).sqrt()
-                scales[torch.isinf(scales)] = 1
-                scales[torch.isnan(scales)] = 1
-                _scalesview = scales.view(1, -1).to(device)
-
-                # Q(W * s)
-                for balance_layer in balance_layers_to_patch:
-                    if not hasattr(balance_layer, "quantization_scheme") or not hasattr(
-                        balance_layer.quantization_scheme, "weights"
-                    ):
-                        continue
-
-                    w_qscheme = balance_layer.quantization_scheme.weights
-                    balance_layer.weight.data.copy_(
-                        orig_layer_weights[balance_layer].to(_scalesview.device)
-                        * _scalesview
-                    )
-
-                    should_calculate_gparam = (
-                        w_qscheme.strategy == QuantizationStrategy.TENSOR_GROUP
-                    )
-                    call_observer(
-                        balance_layer,
-                        "weight",
-                        balance_layer.weight,
-                        should_calculate_gparam=should_calculate_gparam,
-                    )
-                    balance_layer.weight.data = (
-                        forward_quantize(
-                            balance_layer,
-                            balance_layer.weight,
-                            "weight",
-                            w_qscheme,
-                        )
-                        / _scalesview
-                    ).to(balance_layer.weight.dtype)
-
-                # Apply fused global scales for TENSOR_GROUP during grid search
-                # to match inference behavior
-                if balance_layers_to_patch and all(
-                    getattr(layer.quantization_scheme.weights, "strategy", None)
-                    == QuantizationStrategy.TENSOR_GROUP
-                    for layer in balance_layers_to_patch
-                ):
-                    update_fused_layer_weight_global_scales(mapping.parent)
-
-                # W * X
-                int_w_outputs = self._run_samples(mapping.parent)
-
-                # compute mean squared error (L2 norm)
-                loss = self._compute_loss(fp16_outputs, int_w_outputs)
-                del int_w_outputs
+            for ratio, use_duo_scaling, scales in pbar:
+                loss = self._evaluate_candidate(
+                    mapping,
+                    scales,
+                    fp16_outputs,
+                    orig_layer_weights,
+                    balance_layers_to_patch,
+                    device,
+                )
 
                 if initial_error is None:
                     initial_error = loss
@@ -780,7 +1124,7 @@ class AWQModifier(Modifier, QuantizationMixin):
         if best_ratio == -1:
             logger.debug(history)
             raise Exception(
-                "No finite loss was found in best scalesgrid search. This typically "
+                "No finite loss was found in best scales grid search. This typically "
                 "means NaN values are appearing in the forward pass of the parent "
                 "module. If you encounter this error, raise an issue at "
                 "https://github.com/vllm-project/llm-compressor/issues"
@@ -794,7 +1138,6 @@ class AWQModifier(Modifier, QuantizationMixin):
             f"error reduction rate (best/initial) = {err_reduction * 100:.3f}%"
         )
 
-        # Store error metrics for this layer
         self._error_metrics.append(
             {
                 "layer_name": mapping.smooth_name,
@@ -805,11 +1148,69 @@ class AWQModifier(Modifier, QuantizationMixin):
             }
         )
 
-        assert (
-            torch.isnan(best_scales).sum() == 0
-        ), f"Nan found in scales: {best_scales}"
+        assert torch.isnan(best_scales).sum() == 0, (
+            f"Nan found in scales: {best_scales}"
+        )
 
-        return best_scales.detach().cpu()
+        return AWQSearchResult(
+            best_scales=best_scales.detach().cpu(),
+            best_error=best_error,
+            initial_error=initial_error,
+            best_ratio=best_ratio,
+            history=history,
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Scale application (smoothing)                                      #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    @torch.no_grad()
+    def _apply_best_scales(
+        mapping: ResolvedMapping,
+        best_scales: torch.Tensor,
+        orig_layer_weights: dict[Module, torch.Tensor],
+    ):
+        """Apply the best smoothing scales to smooth_layer and balance_layers."""
+        smooth_layer = mapping.smooth_layer
+        balance_layers = mapping.balance_layers
+
+        for layer in balance_layers:
+            if layer in orig_layer_weights:
+                scales = best_scales.to(layer.weight.device)
+                update_offload_parameter(
+                    layer,
+                    "weight",
+                    orig_layer_weights[layer].to(layer.weight.device)
+                    * scales.view(1, -1),
+                )
+
+        # Apply inverse to smooth layer
+        scales = best_scales.to(smooth_layer.weight.device)
+        if smooth_layer.weight.ndim == 1:
+            update_offload_parameter(
+                smooth_layer,
+                "weight",
+                smooth_layer.weight.div_(scales),
+            )
+        else:
+            # Edge case: smooth layer out_features != balance layer in_features
+            # e.g. fused qkv_proj smoothing o_proj — scale last output features
+            # https://github.com/casper-hansen/AutoAWQ/blob/main/awq/quantize/scale.py#L123
+            weight = smooth_layer.weight
+            weight[-scales.size(0) :].div_(scales.view(-1, 1))
+            update_offload_parameter(smooth_layer, "weight", weight)
+
+        if hasattr(smooth_layer, "bias") and smooth_layer.bias is not None:
+            update_offload_parameter(
+                smooth_layer,
+                "bias",
+                smooth_layer.bias.div_(scales),
+            )
+
+    # ------------------------------------------------------------------ #
+    #  Utility methods                                                    #
+    # ------------------------------------------------------------------ #
 
     @torch.no_grad()
     def _compute_loss(
@@ -850,11 +1251,9 @@ class AWQModifier(Modifier, QuantizationMixin):
         return (loss / num_elements).item()
 
     def _log_error_metrics(self):
-        """
-        Log the error metrics (initial error, best error, reduction).
-        """
+        if not self._error_metrics:
+            return
 
-        # Prepare data for saving
         metrics_data = {
             "quantization_config": {
                 "duo_scaling": self.duo_scaling,
@@ -864,10 +1263,8 @@ class AWQModifier(Modifier, QuantizationMixin):
             "metrics": self._error_metrics,
         }
 
-        # Save to disk
         logger.debug(f"AWQ per-mapping error metrics: {metrics_data}")
 
-        # Also print summary statistics
         reductions = [m["reduction"] for m in self._error_metrics]
         avg_reduction = sum(reductions) / len(reductions)
         min_reduction = min(reductions)
@@ -914,11 +1311,7 @@ class AWQModifier(Modifier, QuantizationMixin):
         """
         Compute per-channel/group/block/tensor mean of normalised weights
         for all passed in layers taking into account the quantization_scheme.
-
-        To minimize memory requirements, layers are reduced to a running total
-            of sums and counts when calculating mean
         """
-        # to calculate mean without having to carry full population
         weight_total_count = 0
         weight_total_sum = 0
 
@@ -941,8 +1334,6 @@ class AWQModifier(Modifier, QuantizationMixin):
                 continue
 
             match q_args.strategy:
-                # chunk size is the size of the size of the
-                # set of elements that get quantized together
                 case QuantizationStrategy.TENSOR:
                     chunk_size = weight.numel()
                 case QuantizationStrategy.CHANNEL:
@@ -951,39 +1342,31 @@ class AWQModifier(Modifier, QuantizationMixin):
                     chunk_size = q_args.group_size
                 case QuantizationStrategy.BLOCK:
                     block_height, block_width = q_args.block_structure
-                    weight = (  # (row, col) = (num_H*block_H, num_W*block_W)
+                    weight = (
                         weight.unflatten(0, (-1, block_height))
                         .unflatten(-1, (-1, block_width))
-                        .transpose(1, 2)  # ↳ (num_H, num_W, block_H, block_W)
+                        .transpose(1, 2)
                     )
                     intermediate_shape = weight.shape
                     chunk_size = block_height * block_width
 
-            # need to get to shape (num_chunks x chunk_size)
             weight = weight.reshape(-1, chunk_size)
-            # normalize
             weight.abs_()
             weight.div_(weight.amax(dim=1, keepdim=True) + 1e-6)
-            # Reshape back to original dimensions
             if q_args.strategy == QuantizationStrategy.BLOCK:
                 weight = weight.view(intermediate_shape).transpose(1, 2)
 
-            # back to (rows, cols)
             weight = weight.reshape(orig_shape)
-            # Gets the average rescaled magnitude for each output channel
             weight_total_count += weight.size(0)
             weight_sum = weight.sum(0, dtype=torch.float64)
             weight_total_sum += weight_sum
 
         return weight_total_sum / weight_total_count
 
-    @field_validator("duo_scaling")
-    @classmethod
-    def validate_duo_scaling(cls, v):
-        """Validate that duo_scaling is either True, False, or 'both' (lowercase)"""
-        if v not in (True, False, "both"):
-            raise ValueError(f"duo_scaling must be True, False, or 'both', got {v!r}")
-        return v
+
+# ------------------------------------------------------------------ #
+#  Module-level helpers (unchanged from original)                      #
+# ------------------------------------------------------------------ #
 
 
 def _check_layers_are_compatible(

--- a/tests/e2e/vLLM/recipes/NVFP4/recipe_awq_nvfp4.yaml
+++ b/tests/e2e/vLLM/recipes/NVFP4/recipe_awq_nvfp4.yaml
@@ -5,4 +5,7 @@ quant_stage:
       scheme: "NVFP4"
       duo_scaling: "both"
       targets: ["Linear"]
-      
+    QuantizationModifier:
+      ignore: ["lm_head"]
+      scheme: "NVFP4"
+      targets: ["Linear"]

--- a/tests/e2e/vLLM/recipes/NVFP4/recipe_awq_nvfp4a16.yaml
+++ b/tests/e2e/vLLM/recipes/NVFP4/recipe_awq_nvfp4a16.yaml
@@ -5,4 +5,7 @@ quant_stage:
       scheme: "NVFP4A16"
       duo_scaling: "both"
       targets: ["Linear"]
-      
+    QuantizationModifier:
+      ignore: ["lm_head"]
+      scheme: "NVFP4A16"
+      targets: ["Linear"]

--- a/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_awq_asym.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_awq_asym.yaml
@@ -6,3 +6,9 @@ quant_stage:
         group_0:
           weights: {num_bits: 4, type: int, symmetric: false, strategy: "group", group_size: 128}
           targets: [Linear]
+    QuantizationModifier:
+      ignore: [lm_head]
+      config_groups:
+        group_0:
+          weights: {num_bits: 4, type: int, symmetric: false, strategy: "group", group_size: 128}
+          targets: [Linear]

--- a/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_awq_sym.yaml
+++ b/tests/e2e/vLLM/recipes/WNA16/recipe_w4a16_awq_sym.yaml
@@ -11,3 +11,14 @@ quant_stage:
             strategy: "group"
             group_size: 128
           targets: ["Linear"]
+    QuantizationModifier:
+      ignore: ["lm_head"]
+      config_groups:
+        group_0:
+          weights:
+            num_bits: 4
+            type: "int"
+            symmetric: true
+            strategy: "group"
+            group_size: 128
+          targets: ["Linear"]

--- a/tests/llmcompressor/modifiers/awq/test_integration.py
+++ b/tests/llmcompressor/modifiers/awq/test_integration.py
@@ -1,0 +1,242 @@
+"""
+Integration test proving that when AWQModifier is stacked with
+QuantizationModifier, the downstream quantizer operates on
+post-AWQ-smoothed weights — not the original weights.
+
+This is the key correctness proof for the AWQ decoupling: AWQ applies
+smoothing first, then the downstream quantizer calibrates and produces
+scales/zero-points on the already-smoothed model.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from llmcompressor.core import State, active_session, reset_session
+from llmcompressor.modifiers.awq import AWQMapping, AWQModifier
+from llmcompressor.modifiers.quantization.quantization.base import QuantizationModifier
+from llmcompressor.recipe import Recipe
+
+
+class _TinyTransformerBlock(nn.Module):
+    """
+    Minimal model that has the structure AWQ mappings expect:
+    a LayerNorm (smooth_layer) feeding into Linear projections (balance_layers).
+    """
+
+    def __init__(self, dim: int = 128):
+        super().__init__()
+        self.input_layernorm = nn.LayerNorm(dim)
+        self.q_proj = nn.Linear(dim, dim, bias=False)
+        self.k_proj = nn.Linear(dim, dim, bias=False)
+        self.v_proj = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, x):
+        h = self.input_layernorm(x)
+        q = self.q_proj(h)
+        k = self.k_proj(h)
+        v = self.v_proj(h)
+        return q + k + v
+
+
+class _TinyModel(nn.Module):
+    """Wraps a single transformer block to look like a full model."""
+
+    def __init__(self, dim: int = 128):
+        super().__init__()
+        self.layer = _TinyTransformerBlock(dim)
+
+    def forward(self, x):
+        return self.layer(x)
+
+
+@pytest.mark.unit
+@torch.no_grad()
+def test_downstream_quantizer_sees_smoothed_weights():
+    """
+    Prove that QuantizationModifier produces quantization artifacts
+    (weight_scale, weight_zero_point) on weights that differ from the
+    original — i.e. the weights AWQ smoothed.
+
+    Flow:
+    1. Snapshot original weights.
+    2. Initialize AWQModifier (resolves mappings).
+    3. Manually apply smoothing (via _apply_smoothing with synthetic
+       activation data, inside the temp quant scheme context).
+    4. Confirm weights changed (AWQ smoothing applied).
+    5. Initialize + calibrate QuantizationModifier on the post-smoothed model.
+    6. Confirm quantization artifacts exist on the smoothed weights.
+    """
+    reset_session()
+    dim = 128
+    model = _TinyModel(dim)
+
+    # -- 1. Snapshot original weights --
+    orig_q_weight = model.layer.q_proj.weight.clone()
+    orig_k_weight = model.layer.k_proj.weight.clone()
+    orig_v_weight = model.layer.v_proj.weight.clone()
+    orig_ln_weight = model.layer.input_layernorm.weight.clone()
+
+    # -- 2. Set up AWQ with explicit mappings --
+    awq = AWQModifier(
+        mappings=[
+            AWQMapping(
+                "re:.*input_layernorm",
+                ["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"],
+            ),
+        ],
+        scheme="W4A16",
+        targets=["Linear"],
+    )
+    quant = QuantizationModifier(
+        scheme="W4A16",
+        targets=["Linear"],
+    )
+
+    # Register modifiers in the session so _validate_recipe can find them
+    session = active_session()
+    recipe = Recipe.from_modifiers([awq, quant])
+    session.lifecycle.recipe = recipe
+
+    state = State(model=model)
+
+    # Initialize AWQ (resolves mappings, validates recipe)
+    awq.on_initialize(state)
+    assert len(awq._resolved_mappings) > 0, "AWQ should resolve at least one mapping"
+
+    # -- 3. Simulate calibration: populate AWQ caches with synthetic data --
+    # AWQ needs: _parent_args_cache (for re-running forward) and
+    #            _smooth_activation_means (for scale computation)
+    awq.on_start(state, None)
+
+    # Run a few synthetic batches through the model to populate hooks
+    for _ in range(3):
+        x = torch.randn(2, dim)
+        model(x)
+
+    # -- Apply smoothing --
+    awq._apply_smoothing(model)
+
+    # -- 4. Confirm AWQ changed the weights --
+    q_changed = not torch.equal(model.layer.q_proj.weight, orig_q_weight)
+    k_changed = not torch.equal(model.layer.k_proj.weight, orig_k_weight)
+    v_changed = not torch.equal(model.layer.v_proj.weight, orig_v_weight)
+    ln_changed = not torch.equal(model.layer.input_layernorm.weight, orig_ln_weight)
+
+    assert q_changed or k_changed or v_changed or ln_changed, (
+        "AWQ smoothing should have modified at least some weights, "
+        "but all weights are identical to originals"
+    )
+
+    # Record the post-smoothed weights that the quantizer should see
+    smoothed_q_weight = model.layer.q_proj.weight.clone()
+    smoothed_k_weight = model.layer.k_proj.weight.clone()
+    smoothed_v_weight = model.layer.v_proj.weight.clone()
+
+    # Finish AWQ
+    awq.on_end(state, None)
+
+    # -- 5. Confirm AWQ left no quantization artifacts --
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Linear):
+            assert not hasattr(module, "weight_scale"), (
+                f"AWQ should not leave weight_scale on {name}"
+            )
+            assert not hasattr(module, "weight_zero_point"), (
+                f"AWQ should not leave weight_zero_point on {name}"
+            )
+
+    # -- 6. Now run QuantizationModifier on the post-smoothed model --
+    quant.on_initialize(state)
+
+    # Start calibration (attaches observers, enables quantization)
+    quant.on_start(state, None)
+
+    # End calibration (freezes quantization, removes observers)
+    quant.on_end(state, None)
+
+    # -- 7. Verify quantization artifacts exist --
+    linear_modules = [
+        (name, module)
+        for name, module in model.named_modules()
+        if isinstance(module, nn.Linear)
+    ]
+    assert len(linear_modules) > 0
+
+    for name, module in linear_modules:
+        assert hasattr(module, "quantization_scheme"), (
+            f"QuantizationModifier should have set quantization_scheme on {name}"
+        )
+
+    # -- 8. Verify the quantizer operated on smoothed weights, not originals --
+    # The weights on the model should still be the smoothed versions
+    # (quantization modifies the forward path, not the stored weights in PTQ)
+    assert torch.equal(model.layer.q_proj.weight, smoothed_q_weight), (
+        "The quantizer should have operated on the smoothed q_proj weights"
+    )
+    assert torch.equal(model.layer.k_proj.weight, smoothed_k_weight), (
+        "The quantizer should have operated on the smoothed k_proj weights"
+    )
+    assert torch.equal(model.layer.v_proj.weight, smoothed_v_weight), (
+        "The quantizer should have operated on the smoothed v_proj weights"
+    )
+
+
+@pytest.mark.unit
+@torch.no_grad()
+def test_awq_alone_produces_no_quantization_artifacts():
+    """
+    When AWQModifier runs alone (without a downstream quantizer),
+    the model should have smoothed weights but NO quantization
+    artifacts (no scales, no zero-points, no quantization_scheme).
+    """
+    reset_session()
+    dim = 128
+    model = _TinyModel(dim)
+
+    orig_q_weight = model.layer.q_proj.weight.clone()
+
+    awq = AWQModifier(
+        mappings=[
+            AWQMapping(
+                "re:.*input_layernorm",
+                ["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"],
+            ),
+        ],
+        scheme="W4A16",
+        targets=["Linear"],
+    )
+
+    session = active_session()
+    recipe = Recipe.from_modifiers([awq])
+    session.lifecycle.recipe = recipe
+
+    state = State(model=model)
+    awq.on_initialize(state)
+    awq.on_start(state, None)
+
+    # Populate caches
+    for _ in range(3):
+        model(torch.randn(2, dim))
+
+    awq._apply_smoothing(model)
+    awq.on_end(state, None)
+    awq.on_finalize(state)
+
+    # Weights should have changed (smoothing applied)
+    assert not torch.equal(model.layer.q_proj.weight, orig_q_weight), (
+        "AWQ should have smoothed the weights"
+    )
+
+    # But NO quantization artifacts should exist
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Linear):
+            assert not hasattr(module, "quantization_scheme"), (
+                f"AWQ alone should not leave quantization_scheme on {name}"
+            )
+            assert not hasattr(module, "weight_scale"), (
+                f"AWQ alone should not leave weight_scale on {name}"
+            )
+            assert not hasattr(module, "weight_zero_point"), (
+                f"AWQ alone should not leave weight_zero_point on {name}"
+            )

--- a/tests/llmcompressor/modifiers/awq/test_validation.py
+++ b/tests/llmcompressor/modifiers/awq/test_validation.py
@@ -1,0 +1,361 @@
+"""
+Tests for AWQModifier recipe validation and temporary quant scheme management.
+"""
+
+import pytest
+import torch
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationScheme,
+    QuantizationStrategy,
+)
+from torch.nn import Linear
+
+from llmcompressor.core import State, active_session
+from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.quantization.quantization.base import QuantizationModifier
+from llmcompressor.recipe import Recipe
+
+
+def _make_simple_model():
+    """Create a simple model with Linear layers for testing."""
+    return torch.nn.Sequential(
+        torch.nn.LayerNorm(8),
+        Linear(8, 8),
+        Linear(8, 8),
+    )
+
+
+def _setup_session_with_modifiers(modifiers):
+    """
+    Register modifiers on the active session's lifecycle recipe so that
+    _validate_recipe (which calls active_session().lifecycle.recipe.modifiers)
+    can find them. Returns a State with the model attached.
+    """
+    session = active_session()
+    session.lifecycle.recipe = Recipe.from_modifiers(modifiers)
+    state = State(model=_make_simple_model())
+    return state
+
+
+# ------------------------------------------------------------------ #
+#  Validation tests                                                    #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.unit
+def test_validate_warns_no_downstream_quantizer():
+    """AWQ without a downstream quantizer should log a warning."""
+    from loguru import logger
+
+    awq = AWQModifier(scheme="W4A16")
+    state = _setup_session_with_modifiers([awq])
+
+    messages = []
+    handler_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        awq._validate_recipe(state)
+    finally:
+        logger.remove(handler_id)
+
+    assert any("without a downstream quantizer" in m for m in messages)
+
+
+@pytest.mark.unit
+def test_validate_warns_reversed_order():
+    """Quantizer before AWQ should warn about reversed ordering."""
+    from loguru import logger
+
+    quant = QuantizationModifier(scheme="W4A16")
+    awq = AWQModifier(scheme="W4A16")
+    state = _setup_session_with_modifiers([quant, awq])
+
+    messages = []
+    handler_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        awq._validate_recipe(state)
+    finally:
+        logger.remove(handler_id)
+
+    assert any("before AWQModifier" in m for m in messages)
+
+
+@pytest.mark.unit
+def test_validate_passes_correct_order():
+    """AWQ followed by QuantizationModifier should pass validation."""
+    awq = AWQModifier(scheme="W4A16")
+    quant = QuantizationModifier(scheme="W4A16")
+    state = _setup_session_with_modifiers([awq, quant])
+
+    # Should not raise
+    awq._validate_recipe(state)
+
+
+@pytest.mark.unit
+def test_validate_mismatched_num_bits():
+    """Mismatched num_bits between AWQ and downstream quantizer should error."""
+    awq = AWQModifier(scheme="W4A16")
+    quant = QuantizationModifier(scheme="W8A16")
+    state = _setup_session_with_modifiers([awq, quant])
+
+    with pytest.raises(ValueError, match="num_bits"):
+        awq._validate_recipe(state)
+
+
+@pytest.mark.unit
+def test_validate_mismatched_symmetry():
+    """Mismatched symmetry should error."""
+    awq = AWQModifier(scheme="W4A16_ASYM")
+
+    # Create a symmetric quantizer via config_groups
+    quant = QuantizationModifier(
+        config_groups={
+            "group_0": QuantizationScheme(
+                targets=["Linear"],
+                weights=QuantizationArgs(
+                    num_bits=4,
+                    symmetric=True,
+                    strategy=QuantizationStrategy.GROUP,
+                    group_size=128,
+                ),
+            )
+        }
+    )
+    state = _setup_session_with_modifiers([awq, quant])
+
+    with pytest.raises(ValueError, match="symmetric"):
+        awq._validate_recipe(state)
+
+
+@pytest.mark.unit
+def test_validate_warns_mismatched_ignore():
+    """Mismatched ignore lists should warn."""
+    from loguru import logger
+
+    awq = AWQModifier(scheme="W4A16", ignore=["lm_head"])
+    quant = QuantizationModifier(scheme="W4A16", ignore=["lm_head", "extra_layer"])
+    state = _setup_session_with_modifiers([awq, quant])
+
+    messages = []
+    handler_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        awq._validate_recipe(state)
+    finally:
+        logger.remove(handler_id)
+
+    assert any("ignore list" in m for m in messages)
+
+
+# ------------------------------------------------------------------ #
+#  Temporary quant scheme context manager tests                        #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.unit
+def test_temporary_quant_schemes_applied_and_stripped():
+    """
+    Verify that _temporary_quant_schemes applies schemes inside the context
+    and fully strips them on exit.
+    """
+    model = _make_simple_model()
+    awq = AWQModifier(scheme="W4A16")
+
+    # Before: no quant schemes
+    for module in model.modules():
+        if isinstance(module, Linear):
+            assert not hasattr(module, "quantization_scheme")
+
+    with awq._temporary_quant_schemes(model):
+        # Inside: quant schemes should be present
+        for module in model.modules():
+            if isinstance(module, Linear):
+                assert hasattr(module, "quantization_scheme")
+
+    # After: quant schemes should be stripped
+    for module in model.modules():
+        if isinstance(module, Linear):
+            assert not hasattr(module, "quantization_scheme")
+
+
+@pytest.mark.unit
+def test_temporary_quant_schemes_preserves_prior_state():
+    """
+    If a downstream modifier already applied quant schemes, the context
+    manager should restore them exactly on exit.
+    """
+    model = _make_simple_model()
+    awq = AWQModifier(scheme="W4A16")
+
+    # Simulate a prior modifier having set a scheme on one layer
+    linear = list(m for m in model.modules() if isinstance(m, Linear))[0]
+    prior_scheme = QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(num_bits=8),
+    )
+    linear.quantization_scheme = prior_scheme
+
+    with awq._temporary_quant_schemes(model):
+        # AWQ's temp scheme is present (may differ from prior)
+        assert hasattr(linear, "quantization_scheme")
+
+    # After exit: prior scheme should be restored
+    assert hasattr(linear, "quantization_scheme")
+    assert linear.quantization_scheme is prior_scheme
+
+
+@pytest.mark.unit
+def test_temporary_quant_schemes_strips_on_exception():
+    """
+    If an exception occurs inside the context, schemes should still be stripped.
+    """
+    model = _make_simple_model()
+    awq = AWQModifier(scheme="W4A16")
+
+    with pytest.raises(RuntimeError):
+        with awq._temporary_quant_schemes(model):
+            # Verify schemes are present
+            for module in model.modules():
+                if isinstance(module, Linear):
+                    assert hasattr(module, "quantization_scheme")
+            raise RuntimeError("simulated failure")
+
+    # After exception: schemes should be stripped
+    for module in model.modules():
+        if isinstance(module, Linear):
+            assert not hasattr(module, "quantization_scheme")
+
+
+@pytest.mark.unit
+def test_temporary_quant_schemes_with_observers_true():
+    """
+    When with_observers=True, weight observers should be initialized on
+    modules that have a weight quantization scheme.
+    """
+    model = _make_simple_model()
+    awq = AWQModifier(scheme="W4A16")
+
+    with awq._temporary_quant_schemes(model, with_observers=True):
+        for module in model.modules():
+            if isinstance(module, Linear):
+                assert hasattr(module, "quantization_scheme")
+                if module.quantization_scheme.weights is not None:
+                    assert hasattr(module, "weight_observer"), (
+                        "weight_observer should be initialized when with_observers=True"
+                    )
+
+    # After exit: observers should be stripped along with schemes
+    for module in model.modules():
+        if isinstance(module, Linear):
+            assert not hasattr(module, "weight_observer")
+
+
+@pytest.mark.unit
+def test_temporary_quant_schemes_with_observers_false():
+    """
+    When with_observers=False (default), weight observers should NOT be
+    initialized. Only scheme metadata should be present.
+    """
+    model = _make_simple_model()
+    awq = AWQModifier(scheme="W4A16")
+
+    with awq._temporary_quant_schemes(model, with_observers=False):
+        for module in model.modules():
+            if isinstance(module, Linear):
+                assert hasattr(module, "quantization_scheme")
+                # No observer should be created
+                assert not hasattr(module, "weight_observer"), (
+                    "weight_observer should NOT be initialized when "
+                    "with_observers=False"
+                )
+
+
+@pytest.mark.unit
+def test_on_initialize_leaves_no_quant_schemes():
+    """
+    After on_initialize returns, no temporary quant schemes should remain
+    on the model. This verifies on_initialize uses the context manager
+    properly and does not leak state.
+    """
+    model = _make_simple_model()
+    awq = AWQModifier(scheme="W4A16")
+    quant = QuantizationModifier(scheme="W4A16")
+
+    session = active_session()
+    session.lifecycle.recipe = Recipe.from_modifiers([awq, quant])
+    state = State(model=model)
+
+    awq.on_initialize(state)
+
+    for module in model.modules():
+        if isinstance(module, Linear):
+            assert not hasattr(module, "quantization_scheme"), (
+                "on_initialize should not leave quantization_scheme on modules"
+            )
+            assert not hasattr(module, "quantization_status"), (
+                "on_initialize should not leave quantization_status on modules"
+            )
+            assert not hasattr(module, "weight_observer"), (
+                "on_initialize should not leave weight_observer on modules"
+            )
+
+
+@pytest.mark.unit
+def test_on_initialize_preserves_downstream_modifier_schemes():
+    """
+    If a downstream modifier has already applied quant schemes before AWQ
+    initializes, on_initialize must not destroy them.
+    """
+    model = _make_simple_model()
+    linear = list(m for m in model.modules() if isinstance(m, Linear))[0]
+
+    # Simulate a downstream modifier having already set a scheme
+    prior_scheme = QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(num_bits=4),
+    )
+    linear.quantization_scheme = prior_scheme
+
+    awq = AWQModifier(scheme="W4A16")
+    quant = QuantizationModifier(scheme="W4A16")
+
+    session = active_session()
+    session.lifecycle.recipe = Recipe.from_modifiers([awq, quant])
+    state = State(model=model)
+
+    awq.on_initialize(state)
+
+    # Prior scheme must be restored
+    assert hasattr(linear, "quantization_scheme")
+    assert linear.quantization_scheme is prior_scheme
+
+
+# ------------------------------------------------------------------ #
+#  AWQModifier no longer inherits QuantizationMixin                    #
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.unit
+def test_awq_does_not_inherit_quantization_mixin():
+    """Confirm AWQModifier no longer inherits from QuantizationMixin."""
+    from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
+
+    assert not issubclass(AWQModifier, QuantizationMixin)
+
+
+@pytest.mark.unit
+def test_awq_is_smoothing_only():
+    """
+    AWQModifier.on_end should NOT call any quantization finalization methods.
+    Verify the modifier's on_end is clean — just asserts activations consumed,
+    sets ended_ flag, and removes hooks.
+    """
+    awq = AWQModifier(scheme="W4A16")
+    # Simulate that smoothing has already run and activations consumed
+    awq._smooth_activation_means = {}
+    awq.started_ = True
+
+    state = State(model=_make_simple_model())
+
+    # on_end should not raise or try to call quantization methods
+    awq.on_end(state, None)
+    assert awq.ended_ is True


### PR DESCRIPTION
…zationMixin

Remove QuantizationMixin inheritance from AWQModifier so it becomes a pre-quantization transform (like SmoothQuant) that only applies smoothing scales. Final quantization is now handled by a downstream quantizer (QuantizationModifier, GPTQModifier) stacked after AWQ in the recipe.

Key changes:
- Drop QuantizationMixin inheritance, keep quant config locally for grid search pseudo-quantization only
- Add _temporary_quant_schemes context manager that snapshots/restores all quant-related module state (schemes, observers, scales, zero-points, forward overrides) with full exception safety
- Decompose _compute_best_scale into pure helpers: _collect_activation_stats, _generate_scale_candidates, _evaluate_candidate, _select_best_scale, _apply_best_scales
- Add recipe validation: errors on mismatched scheme config, warns on missing downstream quantizer or reversed ordering
- Remove all quantization lifecycle calls from on_end (no more update_weight_zp_scale, update_weight_global_scale, end_calibration)
- Update all examples and e2e recipes to stacked pattern [AWQModifier, QuantizationModifier]

Closes #2327

SUMMARY:
"please provide a brief summary"


TEST PLAN:
"please outline how the changes were tested"
