### PR TITLE
Add top-level merge_queue.max_parallel_checks: 1

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,6 @@
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
     merge_method: merge


### PR DESCRIPTION
## Summary
- Adds a top-level `merge_queue` section with `max_parallel_checks: 1`
- This is the missing piece alongside `batch_size: 1` and `merge_conditions` to fully resolve the incompatibility with the "Require branches to be up to date before merging" branch protection setting
- Previously `max_parallel_checks` was incorrectly placed inside `queue_rules` (invalid) — the correct location is as a top-level `merge_queue` config

## Test plan
- [ ] Verify `@Mergifyio queue` no longer returns the branch protection incompatibility error
- [ ] Verify Mergify auto-merges a queued PR as `mergify[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)