### PR TITLE
Add top-level merge_queue.max_parallel_checks: 1

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,6 @@
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
     merge_method: merge


### PR DESCRIPTION
## Summary
- Adds a top-level `merge_queue` section with `max_parallel_checks: 1`
- This is the missing piece to fully resolve the incompatibility between Mergify's merge queue and the "Require branches to be up to date before merging" branch protection setting

## Test plan
- [ ] Verify `@Mergifyio queue` no longer returns the branch protection incompatibility error
- [ ] Verify Mergify auto-merges a queued PR as `mergify[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)