### PR TITLE
Fix Mergify merge queue: squash method and max_parallel_checks

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,6 +1,9 @@
+merge_queue:
+  max_parallel_checks: 1
+
 queue_rules:
   - name: default
-    merge_method: merge
+    merge_method: squash
     batch_size: 1
     commit_message_template: |
       {{ title }} (#{{ number }})


### PR DESCRIPTION
## Summary
- Change `merge_method` from `merge` to `squash` to comply with the repo's linear history branch protection requirement
- Add top-level `merge_queue.max_parallel_checks: 1` to resolve incompatibility with "Require branches to be up to date before merging" branch protection

## Test plan
- [ ] Verify Mergify auto-queues and merges a PR as `mergify[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)