### PR TITLE
Fix YAML indentation of or block for transformers-tests condition

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,9 +9,9 @@ queue_rules:
       - check-success=DCO
       - check-success=quality-check
       - or:
-        - check-success=transformers-tests
-        - check-neutral=transformers-tests
-        - check-skipped=transformers-tests
+          - check-success=transformers-tests
+          - check-neutral=transformers-tests
+          - check-skipped=transformers-tests
       - check-success=base-tests (3.10)
       - check-success=base-tests (3.13)
       - check-success=pytorch-tests (3.10)
@@ -21,9 +21,9 @@ queue_rules:
       - check-success=DCO
       - check-success=quality-check
       - or:
-        - check-success=transformers-tests
-        - check-neutral=transformers-tests
-        - check-skipped=transformers-tests
+          - check-success=transformers-tests
+          - check-neutral=transformers-tests
+          - check-skipped=transformers-tests
       - check-success=base-tests (3.10)
       - check-success=base-tests (3.13)
       - check-success=pytorch-tests (3.10)
@@ -39,9 +39,9 @@ pull_request_rules:
       - check-success=DCO
       - check-success=quality-check
       - or:
-        - check-success=transformers-tests
-        - check-neutral=transformers-tests
-        - check-skipped=transformers-tests
+          - check-success=transformers-tests
+          - check-neutral=transformers-tests
+          - check-skipped=transformers-tests
       - check-success=base-tests (3.10)
       - check-success=base-tests (3.13)
       - check-success=pytorch-tests (3.10)


### PR DESCRIPTION
## Summary
- Fixes indentation of `or:` sub-items for the `transformers-tests` condition in `queue_conditions`, `merge_conditions`, and `pull_request_rules`
- Sub-items were at the same indentation level as the `or:` key, causing YAML to parse them as sibling AND conditions rather than children of the `or` block — meaning all three conclusions (success, neutral, skipped) were simultaneously required, which is impossible

## Test plan
- [ ] Verify Mergify auto-queues and merges a PR where `transformers-tests` is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)