### PR TITLE
[MoE] Add calibration support for Trinity Large Thinking

### DIFF
--- a/examples/quantization_w4a4_fp4/trinity_large_nvfp4.py
+++ b/examples/quantization_w4a4_fp4/trinity_large_nvfp4.py
@@ -1,0 +1,94 @@
+from compressed_tensors.offload import dispatch_model
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+MODEL_ID = "arcee-ai/Trinity-Large-Thinking"
+
+# Load model with trust_remote_code since afmoe is not in transformers 4.x
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_ID, dtype="auto", trust_remote_code=True
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
+
+# MoE calibration is now handled automatically by the pipeline.
+# The `CalibrationAfmoeMoE` module (from `llmcompressor.modeling.afmoe`)
+# will be applied during calibration to enable proper expert calibration.
+# This replaces the original `AfmoeMoE` class during calibration.
+
+DATASET_ID = "HuggingFaceH4/ultrachat_200k"
+DATASET_SPLIT = "train_sft"
+
+NUM_CALIBRATION_SAMPLES = 100
+MAX_SEQUENCE_LENGTH = 2048
+
+# Load dataset and preprocess.
+ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {
+        "text": tokenizer.apply_chat_template(
+            example["messages"],
+            tokenize=False,
+        )
+    }
+
+
+ds = ds.map(preprocess)
+
+
+# Tokenize inputs.
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+# Configure the quantization algorithm and scheme.
+# In this case, we:
+#   * quantize all expert layers (routed + shared) to nvfp4 with per group 16 via ptq
+#   * calibrate a global_scale for activations, which will be used to
+#       quantize activations to fp4 on the fly
+#   * skip attention layers and lm_head
+
+recipe = QuantizationModifier(
+    targets="Linear",
+    scheme="NVFP4",
+    ignore=["lm_head", "re:.*self_attn.*", "re:.*mlp.router.*"],
+)
+
+# Apply quantization.
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    tokenizer=tokenizer,
+)
+
+print("\n\n")
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(
+    model.device
+)
+output = model.generate(input_ids, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================\n\n")
+
+
+# Save to disk in compressed-tensors format.
+SAVE_DIR = "/raid/engine/dsikka/" + MODEL_ID.rstrip("/").split("/")[-1] + "-NVFP4"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/src/llmcompressor/modeling/__init__.py
+++ b/src/llmcompressor/modeling/__init__.py
@@ -10,6 +10,7 @@ needed for efficient compression.
 """
 
 # trigger registration
+from .afmoe import CalibrationAfmoeMoE  # noqa: F401
 from .deepseek_v3 import CalibrationDeepseekV3MoE  # noqa: F401
 from .glm4_moe import CalibrationGlm4MoeMoE  # noqa: F401
 from .glm_moe_dsa import CalibrationGlmMoeDsaMoE  # noqa: F401

--- a/src/llmcompressor/modeling/afmoe.py
+++ b/src/llmcompressor/modeling/afmoe.py
@@ -1,0 +1,108 @@
+import torch
+
+from llmcompressor.modeling.moe_context import MoECalibrationModule
+
+
+@MoECalibrationModule.register("AfmoeMoE")
+class CalibrationAfmoeMoE(MoECalibrationModule):
+    """
+    Calibration version of AfmoeMoE that sends all tokens to all experts.
+
+    During calibration, when calibrate_all_experts=True, all tokens are sent to
+    all experts to ensure proper quantization statistics are collected for every
+    expert, not just those activated by the calibration data routing.
+
+    The Afmoe architecture uses:
+    - Token-choice top-K routing with sigmoid/softmax scoring
+    - Optional shared experts processed on all tokens
+    - Learnable expert bias for routing control
+
+    Note: AfmoeMoE is loaded dynamically from the model hub via trust_remote_code=True.
+    The original module is passed as a parameter.
+    """
+
+    is_permanent = False
+
+    def __init__(
+        self,
+        original: torch.nn.Module,
+        config,
+        calibrate_all_experts: bool = True,
+    ):
+        super().__init__()
+        self.config = config
+        self.router = original.router
+        self.experts = original.experts
+        self.shared_experts = original.shared_experts
+        self.expert_bias = original.expert_bias
+        self.calibrate_all_experts = calibrate_all_experts
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass with optional calibration mode.
+
+        When calibrate_all_experts=True:
+            - All tokens are sent to all experts for calibration
+            - Routing weights are still used for final output combination
+            - This ensures all experts see calibration data
+        When calibrate_all_experts=False:
+            - Normal MoE routing behavior (only routed tokens go to each expert)
+        """
+        batch_size, seq_len, hidden_dim = hidden_states.shape
+        hidden_states_flat = hidden_states.view(-1, hidden_dim)
+
+        # Step 1: Get routing decisions
+        top_scores, selected_experts = self.router(hidden_states, self.expert_bias)
+
+        # Step 2: Process through shared experts
+        if self.shared_experts is not None:
+            shared_output = self.shared_experts(hidden_states_flat)
+        else:
+            shared_output = torch.zeros_like(hidden_states_flat)
+
+        # Step 3: Create expert mask for routing - which tokens
+        # were selected
+        expert_mask = torch.nn.functional.one_hot(
+            selected_experts, num_classes=self.config.num_experts
+        ).permute(2, 1, 0)  # (num_experts, top_k, batch_size * seq_len)
+
+        # Step 4: Process routed experts
+        routed_output = torch.zeros_like(
+            hidden_states_flat, dtype=hidden_states.dtype, device=hidden_states.device
+        )
+
+        for expert_idx, expert in enumerate(self.experts):
+            # Get the indices of tokens routed to this expert
+            idx, token_idx = torch.where(expert_mask[expert_idx])
+
+            if self.calibrate_all_experts:
+                # Pass all tokens through the expert but only outputs
+                # for the selected tokens are extracted (i.e if this
+                # expert was selected)
+                expert_output = expert(hidden_states_flat)[token_idx]
+            else:
+                # Only pass routed tokens through the expert
+                expert_output = expert(hidden_states_flat[token_idx])
+
+            # If any tokens were routed to this expert, add their contribution
+            if len(token_idx) > 0:
+                weighted_output = expert_output * top_scores[token_idx, idx, None]
+                # add weighted output to the final output for the routed tokens
+                routed_output.index_add_(
+                    0, token_idx, weighted_output.to(hidden_states.dtype)
+                )
+
+        # Step 5: Combine shared and routed expert output
+        output = shared_output.to(hidden_states.dtype) + routed_output.to(
+            hidden_states.dtype
+        )
+        return output.view(batch_size, seq_len, hidden_dim)
+
+    def restore(self, original: torch.nn.Module) -> torch.nn.Module:
+        """
+        Restore the original module structure.
+
+        Since is_permanent=False, this method is called when exiting
+        the calibration context to restore the original MoE module.
+        """
+        return original

--- a/tests/llmcompressor/modeling/test_calib_afmoe.py
+++ b/tests/llmcompressor/modeling/test_calib_afmoe.py
@@ -1,0 +1,101 @@
+import contextlib
+from functools import partial
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+
+from llmcompressor.modeling.afmoe import CalibrationAfmoeMoE
+from llmcompressor.modeling.moe_context import moe_calibration_context
+from llmcompressor.utils.dev import skip_weights_download
+from llmcompressor.utils.helpers import calibration_forward_context
+from tests.testing_utils import requires_cadence, requires_gpu
+
+
+@requires_cadence("weekly")
+@pytest.mark.parametrize("model_stub", ["arcee-ai/Trinity-Large-Thinking"])
+def test_calib_replace_afmoe_all_experts(model_stub):
+    with skip_weights_download():
+        model = AutoModelForCausalLM.from_pretrained(model_stub, trust_remote_code=True)
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(calibration_forward_context(model))
+        stack.enter_context(moe_calibration_context(model, calibrate_all_experts=True))
+
+        # Find an AfmoeMoE layer
+        moe_layer = None
+        for _, module in model.named_modules():
+            if isinstance(module, CalibrationAfmoeMoE):
+                moe_layer = module
+                break
+
+        assert moe_layer is not None
+
+        num_experts = len(moe_layer.experts)
+        expert_triggered = [False for _ in range(num_experts)]
+
+        # Define the hook function
+        def hook_fn(i, module, input, output):
+            expert_triggered[i] = True
+
+        # Attach hooks using functools.partial to bind each index
+        for i, expert in enumerate(moe_layer.experts):
+            expert.register_forward_hook(partial(hook_fn, i))
+
+        # Create dummy input tensor that simulates hidden_states
+        hidden_dim = model.config.hidden_size
+        batch, seq_len = 4, 32
+        sample = torch.randn(batch, seq_len, hidden_dim, dtype=torch.float32)
+
+        # Forward through the MoE layer directly
+        with torch.no_grad():
+            _ = moe_layer(sample)
+
+        # Assert all experts are used
+        assert all(
+            expert_triggered
+        ), f"Not all experts were triggered: {expert_triggered}"
+
+
+@requires_gpu
+def test_calib_afmoe_module():
+    # Load a small model to get the AfmoeMoE class (loaded via trust_remote_code)
+    with skip_weights_download():
+        model = AutoModelForCausalLM.from_pretrained(
+            "arcee-ai/Trinity-Large-Thinking", trust_remote_code=True
+        )
+
+    # Extract the original AfmoeMoE class and config from the model
+    original = None
+    for module in model.modules():
+        if type(module).__name__ == "AfmoeMoE":
+            original = module
+            break
+
+    assert original is not None, "Could not find AfmoeMoE module in model"
+
+    config = model.config
+
+    # Move to GPU and initialize
+    original = original.to("cuda")
+    for param in original.parameters():
+        param.data.normal_(mean=0.0, std=0.02)
+
+    # Create dummy input tensor that simulates hidden_states
+    hidden_dim = config.hidden_size
+    batch, seq_len = 4, 32
+
+    sample = torch.randn(batch, seq_len, hidden_dim, device="cuda")
+
+    with calibration_forward_context(original):
+        true_output = original(sample)
+
+    module = CalibrationAfmoeMoE(original, config, calibrate_all_experts=True)
+    with calibration_forward_context(module):
+        output = module(sample)
+        assert torch.nn.functional.mse_loss(true_output, output) < 0.1
+
+    module = CalibrationAfmoeMoE(original, config, calibrate_all_experts=False)
+    with calibration_forward_context(module):
+        output = module(sample)
+        assert torch.nn.functional.mse_loss(true_output, output) < 0.1


### PR DESCRIPTION
# SUMMARY:
- Adds calibration support for: https://huggingface.co/arcee-ai/Trinity-Large-Thinking/tree/main
- Adds tests to validate calibration
- Add NVFP4 example

The model includes modeling code on the HF and was generated through transformers v0.4.57

# Testing
- All unit tests pass
- Still need to validate recovery with vLLM