### PR TITLE
[Examples] Add Gemma 4 E4B NVFP4A16 quantization example

### DIFF
--- a/examples/quantization_w4a16_fp4/nvfp4/gemma4_example.py
+++ b/examples/quantization_w4a16_fp4/nvfp4/gemma4_example.py
@@ -38,7 +38,9 @@ dispatch_model(model)
 messages = [
     {"role": "user", "content": "Hello my name is"},
 ]
-text = processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+text = processor.apply_chat_template(
+    messages, add_generation_prompt=True, tokenize=False
+)
 inputs = processor(text=text, return_tensors="pt").to(model.device)
 output = model.generate(**inputs, max_new_tokens=100)
 print(processor.decode(output[0], skip_special_tokens=True))


### PR DESCRIPTION
## Summary
- Add NVFP4A16 weight-only quantization example for Google Gemma 4 E4B-it (multimodal)

## Details
### Key differences from other examples:
- Uses `AutoModelForImageTextToText` + `AutoProcessor` (multimodal model)
- Ignores `vision_tower`, `audio_tower`, `embed_vision`, `embed_audio` modules (Gemma 4 architecture, different from Gemma 3's `multi_modal_projector`)

### Quantized model: [2imi9/gemma-4-E4B-it-NVFP4A16](https://huggingface.co/2imi9/gemma-4-E4B-it-NVFP4A16)

## Test plan
- [x] Ran quantization end-to-end on NVIDIA GPU
- [x] Verified sample generation produces coherent output after quantization
- [x] Uploaded quantized model to HuggingFace