### PR TITLE
[Refactor] Consolidate Intermediate Offloading

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -631,7 +631,7 @@ class AWQModifier(Modifier, QuantizationMixin):
     @torch.no_grad()
     def _run_samples(self, module: Module) -> list[torch.Tensor]:
         cache = self._parent_args_cache[module]
-        batch_iter = maybe_prefetch(iter_batches(cache))
+        batch_iter = maybe_prefetch(cache)
         outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
         return [
             # If tuple, assume that first argument is the input

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -43,7 +43,13 @@ from llmcompressor.modifiers.utils import update_fused_layer_weight_global_scale
 from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.modifiers.utils.pytorch_helpers import is_moe_model
 from llmcompressor.observers.base import Observer
-from llmcompressor.pipelines.cache import IntermediatesCache
+from llmcompressor.pipelines.cache import (
+    IntermediateBatches,
+    IntermediateCache,
+    iter_batches,
+    maybe_prefetch,
+    update_batch,
+)
 from llmcompressor.sentinel import Sentinel
 from llmcompressor.utils import wait_for_comms
 from llmcompressor.utils.helpers import calibration_forward_context
@@ -166,12 +172,12 @@ class AWQModifier(Modifier, QuantizationMixin):
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
     # Cache list of forward input args for each parent module, one dict for each batch
-    _parent_args_cache: dict[Module, IntermediatesCache] = PrivateAttr(
+    _parent_args_cache: dict[Module, IntermediateBatches] = PrivateAttr(
         default_factory=dict
     )
-    # Dict[smooth layer name, [activation sums, activation counts]]
-    _smooth_activation_stats: dict[str, list[torch.Tensor]] = PrivateAttr(
-        default_factory=dict
+    # Dict[smooth layer name, (activation sums cache, activation counts cache)]
+    _smooth_activation_stats: dict[str, tuple[IntermediateCache, IntermediateCache]] = (
+        PrivateAttr(default_factory=dict)
     )
     # List to store error metrics for each layer
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
@@ -436,7 +442,9 @@ class AWQModifier(Modifier, QuantizationMixin):
             kwargs,
         ):
             values = inspect.signature(module.forward).bind(*args, **kwargs)
-            self._parent_args_cache[module].append(values.arguments)
+            batch: dict = {}
+            update_batch(batch, values.arguments, self.offload_device)
+            self._parent_args_cache[module].append(batch)
 
         def create_cache_smooth_activations_hook_fn(smooth_name):
             def cache_smooth_activations_hook(
@@ -465,15 +473,23 @@ class AWQModifier(Modifier, QuantizationMixin):
                     masked_activations = activations.flatten(0, -2)
 
                 # accumulate activation sum&count
-                new_sum = masked_activations.float().sum(dim=0).cpu()
-                new_count = torch.tensor(masked_activations.size(0)).cpu()
+                new_sum = masked_activations.float().sum(dim=0)
+                new_count = torch.tensor(masked_activations.size(0))
                 if smooth_name not in self._smooth_activation_stats:
-                    self._smooth_activation_stats[smooth_name] = [
-                        torch.zeros_like(new_sum),
-                        torch.zeros_like(new_count),
-                    ]
-                self._smooth_activation_stats[smooth_name][0] += new_sum
-                self._smooth_activation_stats[smooth_name][1] += new_count
+                    self._smooth_activation_stats[smooth_name] = (
+                        IntermediateCache(
+                            torch.zeros_like(new_sum),
+                            offload_device=self.offload_device,
+                        ),
+                        IntermediateCache(
+                            torch.zeros_like(new_count),
+                            offload_device=self.offload_device,
+                        ),
+                    )
+                x_sum_cache, count_cache = self._smooth_activation_stats[smooth_name]
+                with x_sum_cache.onloaded() as x_sum, count_cache.onloaded() as count:
+                    x_sum += new_sum.to(x_sum.device)
+                    count += new_count.to(count.device)
 
             return cache_smooth_activations_hook
 
@@ -481,10 +497,7 @@ class AWQModifier(Modifier, QuantizationMixin):
             # parent kwargs needed for future forward passes
             # same parent may appear multiple times in resolved mappings
             if mapping.parent not in self._parent_args_cache:
-                self._parent_args_cache[mapping.parent] = IntermediatesCache(
-                    None,
-                    self.offload_device,
-                )
+                self._parent_args_cache[mapping.parent] = []
                 self.register_hook(
                     mapping.parent,
                     cache_parent_kwargs_hook,
@@ -612,14 +625,13 @@ class AWQModifier(Modifier, QuantizationMixin):
                 del orig_layer_weights
 
         for v in self._parent_args_cache.values():
-            v.batch_intermediates.clear()
+            v.clear()
         self._assert_all_activations_consumed()
 
     @torch.no_grad()
     def _run_samples(self, module: Module) -> list[torch.Tensor]:
         cache = self._parent_args_cache[module]
-        use_prefetch = active_session().state.sequential_prefetch
-        batch_iter = cache.iter_prefetch() if use_prefetch else cache
+        batch_iter = maybe_prefetch(iter_batches(cache))
         outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
         return [
             # If tuple, assume that first argument is the input
@@ -657,7 +669,9 @@ class AWQModifier(Modifier, QuantizationMixin):
 
         device = get_execution_device(mapping.parent)
 
-        x_sum, count = self._smooth_activation_stats[mapping.smooth_name]
+        x_sum_cache, count_cache = self._smooth_activation_stats[mapping.smooth_name]
+        x_sum = x_sum_cache.fetch()
+        count = count_cache.fetch()
         if is_distributed():
             x_sum, count = _allreduce_data_sum([x_sum, count])
         x_mean = x_sum.to(device) / count.to(device)

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -30,6 +30,7 @@ from llmcompressor.modifiers.gptq.gptq_quantize import (
 from llmcompressor.modifiers.quantization.calibration import update_weight_global_scale
 from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.modifiers.utils import update_fused_layer_weight_global_scales
+from llmcompressor.pipelines.cache import IntermediateCache
 from llmcompressor.sentinel import Sentinel
 from llmcompressor.utils import greedy_bin_packing, wait_for_comms
 from llmcompressor.utils.metric_logging import CompressionLogger
@@ -127,7 +128,9 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
     # private variables
     _module_names: Dict[torch.nn.Module, str] = PrivateAttr(default_factory=dict)
-    _hessians: Dict[torch.nn.Module, torch.Tensor] = PrivateAttr(default_factory=dict)
+    _hessians: Dict[torch.nn.Module, IntermediateCache] = PrivateAttr(
+        default_factory=dict
+    )
     _num_samples: Dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
         default_factory=dict
     )
@@ -253,22 +256,27 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
         # Initialize hessian if not present
         if module not in self._num_samples:
-            init_device = (
-                "cpu" if self.offload_hessians else get_execution_device(module)
+            execution_device = get_execution_device(module)
+            init_device = "cpu" if self.offload_hessians else execution_device
+            self._hessians[module] = IntermediateCache(
+                make_empty_hessian(module, device=init_device),
+                offload_device=torch.device("cpu") if self.offload_hessians else None,
+                onload_device=execution_device,
             )
-            self._hessians[module] = make_empty_hessian(module, device=init_device)
             self._num_samples[module] = torch.zeros(
                 tuple(), device=get_execution_device(module)
             )
 
         # Accumulate hessian with input with optional offloading
-        with self._maybe_onload_hessian(module):
-            self._hessians[module], self._num_samples[module] = accumulate_hessian(
+        with self._maybe_onload_hessian(module) as hessian:
+            updated_hessian, self._num_samples[module] = accumulate_hessian(
                 inp,
                 module,
-                self._hessians[module],
+                hessian,
                 self._num_samples[module],
             )
+            if updated_hessian is not hessian:
+                hessian.copy_(updated_hessian)
 
     def compress_modules(self):
         """
@@ -287,7 +295,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
             list(self._hessians.keys()),
             world_size,
-            item_weight_fn=lambda mod: self._hessians[mod].shape[0],
+            item_weight_fn=lambda mod: self._hessians[mod].value.shape[0],
         )
 
         # send hessians to assigned ranks
@@ -303,18 +311,18 @@ class GPTQModifier(Modifier, QuantizationMixin):
             name = self._module_names[module]
             num_samples = self._num_samples[module]
             quant_args = getattr_chain(module, "quantization_scheme.weights")
+            hessian = self._hessians.pop(module).fetch()
 
             logger.info(f"Quantizing {name} using {int(num_samples)} samples")
             with (
                 torch.no_grad(),
                 align_module_device(module),
-                self._maybe_onload_hessian(module),
                 CompressionLogger(module) as comp_logger,
             ):
                 loss, q_param_dict = quantize_weight(
                     module=module,
                     quant_args=quant_args,
-                    hessian=self._hessians.pop(module) / self._num_samples.pop(module),
+                    hessian=hessian / self._num_samples.pop(module),
                     blocksize=self.block_size,
                     percdamp=self.dampening_frac,
                 )
@@ -328,10 +336,10 @@ class GPTQModifier(Modifier, QuantizationMixin):
         pending_comms = []
         for module in module_list:
             target_rank = module_to_rank[module]
-            with self._maybe_onload_hessian(module):
+            with self._maybe_onload_hessian(module) as hessian:
                 pending_comms.append(
                     dist.reduce(
-                        self._hessians[module],
+                        hessian,
                         op=dist.ReduceOp.SUM,
                         dst=target_rank,
                         async_op=True,
@@ -394,12 +402,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
     @contextlib.contextmanager
     def _maybe_onload_hessian(self, module: torch.nn.Module):
-        if self.offload_hessians:
-            device = get_execution_device(module)
-            self._hessians[module] = self._hessians[module].to(device=device)
-
-        yield
-
-        if self.offload_hessians:
-            if module in self._hessians:  # may have been deleted in context
-                self._hessians[module] = self._hessians[module].to(device="cpu")
+        self._hessians[module].onload_()
+        yield self._hessians[module].value
+        if module in self._hessians:
+            self._hessians[module].offload_()

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -16,6 +16,7 @@ from llmcompressor.modifiers.pruning.sparsegpt.sgpt_sparsify import (
     make_empty_hessian,
     sparsify_weight,
 )
+from llmcompressor.pipelines.cache import IntermediateCache
 from llmcompressor.utils.metric_logging import CompressionLogger
 
 __all__ = ["SparseGPTModifier"]
@@ -82,7 +83,9 @@ class SparseGPTModifier(SparsityModifierBase):
 
     # private variables
     _num_samples: dict[torch.nn.Module, int] = PrivateAttr(default_factory=dict)
-    _hessians: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(default_factory=dict)
+    _hessians: dict[torch.nn.Module, IntermediateCache] = PrivateAttr(
+        default_factory=dict
+    )
 
     def calibrate_module(
         self,
@@ -103,18 +106,25 @@ class SparseGPTModifier(SparsityModifierBase):
 
         # Initialize hessian if not present
         if module not in self._num_samples:
-            device = get_execution_device(module)
-            self._hessians[module] = make_empty_hessian(module, device=device)
+            execution_device = get_execution_device(module)
+            init_device = "cpu" if self.offload_hessians else execution_device
+            self._hessians[module] = IntermediateCache(
+                make_empty_hessian(module, device=init_device),
+                offload_device=torch.device("cpu") if self.offload_hessians else None,
+                onload_device=execution_device,
+            )
             self._num_samples[module] = 0
 
         # Accumulate hessian with input with optional offloading
-        with self._maybe_onload_hessian(module):
-            self._hessians[module], self._num_samples[module] = accumulate_hessian(
+        with self._hessian(module) as hessian:
+            updated_hessian, self._num_samples[module] = accumulate_hessian(
                 inp,
                 module,
-                self._hessians[module],
+                hessian,
                 self._num_samples[module],
             )
+            if updated_hessian is not hessian:
+                hessian.copy_(updated_hessian)
 
     def compress_modules(self):
         """
@@ -124,6 +134,7 @@ class SparseGPTModifier(SparsityModifierBase):
             name = self._module_names[module]
             sparsity = self._module_sparsities[module]
             num_samples = self._num_samples[module]
+            hessian = self._hessians.pop(module).fetch()
 
             logger.info(f"Sparsifying {name} using {num_samples} samples")
             with (
@@ -133,7 +144,7 @@ class SparseGPTModifier(SparsityModifierBase):
             ):
                 loss, sparsified_weight = sparsify_weight(
                     module=module,
-                    hessians_dict=self._hessians,
+                    hessian=hessian,
                     sparsity=sparsity,
                     prune_n=self._prune_n,
                     prune_m=self._prune_m,
@@ -145,20 +156,12 @@ class SparseGPTModifier(SparsityModifierBase):
 
             update_offload_parameter(module, "weight", sparsified_weight)
 
-            # self._hessians[module] already deleted by sparsify_weight
             del self._num_samples[module]
 
     @contextlib.contextmanager
-    def _maybe_onload_hessian(self, module: torch.nn.Module):
-        if self.offload_hessians:
-            device = get_execution_device(module)
-            self._hessians[module] = self._hessians[module].to(device=device)
-
-        yield
-
-        if self.offload_hessians:
-            if module in self._hessians:  # may have been deleted in context
-                self._hessians[module] = self._hessians[module].to(device="cpu")
+    def _hessian(self, module: torch.nn.Module):
+        with self._hessians[module].onloaded(get_execution_device(module)) as hessian:
+            yield hessian
 
     def on_finalize(self, state: State, **kwargs) -> bool:
         # TODO: modify lifecycle to end on finalize

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 import transformers
@@ -58,7 +58,7 @@ def accumulate_hessian(
 
 def sparsify_weight(
     module: torch.nn.Module,
-    hessians_dict: Dict[torch.nn.Module, torch.Tensor],
+    hessian: torch.Tensor,
     sparsity: float,
     prune_n: int,
     prune_m: int,
@@ -70,7 +70,7 @@ def sparsify_weight(
     Run pruning on the layer up to the target sparsity value.
 
     :param module: module with weight being sparsified
-    :param hessian_dict: dictionary containing preaccumulated hessian for sparsification
+    :param hessian: preaccumulated hessian for sparsification
     :param sparsity: target sparsity to reach for layer
     :param prune_n: N for N:M pruning
     :param prune_m: M for N:M pruning
@@ -82,8 +82,7 @@ def sparsify_weight(
     final_shape = module.weight.shape
     final_dtype = module.weight.dtype
     W = module.weight.clone()
-    H = hessians_dict[module]  # unfortunately python does not have a `move` keyword
-    del hessians_dict[module]  # so we have to delete the original reference manually
+    H = hessian
 
     # standardize shape and dtype
     if isinstance(module, torch.nn.Conv2d):

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -3,47 +3,29 @@ from __future__ import annotations
 import sys
 import warnings
 from collections import defaultdict
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, fields, is_dataclass
-from typing import Any, Generator
+from contextlib import contextmanager
+from dataclasses import fields, is_dataclass
+from typing import Any, Generator, Sequence
 from weakref import WeakKeyDictionary
 
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
 from tqdm import tqdm
 
+# Top-level type alias: a list of batches, each batch is a dict string -> Any
+IntermediateBatches = list[dict[str, Any]]
 
-@dataclass
-class IntermediateValue:
+
+class IntermediateCache:
     """
-    Dataclass which recursively defines offloaded values and which device to onload to
+    Cache a single tensor and move it between an offload device and the execution
+    device on demand.
 
-    :param value: either an offloaded Tensor, an primative value, or a recursable value
-    :param device: if the value is a Tensor, then the device to onload the tensor to,
-        otherwise None
+    The stored ``value`` is always the currently cached representation — i.e. it lives
+    on ``offload_device`` when offloading is enabled.
     """
-
-    value: torch.Tensor | "IntermediateValue" | Any
-    device: torch.device | None
-
-
-IntermediateValues = dict[str, IntermediateValue]
-
-
-class IntermediatesCache:
-    """
-    Cache which stores intermediate values (activations) produced by batched, sequential
-    execution of models. Values are offloaded to the `offload_device` when stored in
-    the cache and onloaded to their original device when fetched from the cache. If
-    `offload_device` is None, values will not be offloaded at all.
-
-    Currently supports nested offloading of dataclass instances and tuples
-
-    Construct using `empty` and `from_dataloader` class methods
-    """
-
-    batch_intermediates: list[IntermediateValues]
-    offload_device: torch.device | None
 
     # map of onload value -> offload value
     # used to avoid excess memory usage when shared tensors are offloaded
@@ -51,319 +33,264 @@ class IntermediatesCache:
 
     def __init__(
         self,
-        batch_intermediates: list[IntermediateValues] | None = None,
+        value: torch.Tensor,
         offload_device: torch.device | None = "cpu",
+        onload_device: torch.device | None = None,
     ):
-        self.batch_intermediates = batch_intermediates or []
         self.offload_device = offload_device
+        self.onload_device = (
+            onload_device if onload_device is not None else value.device
+        )
+        self.value = self._offload_value(value)
 
-    @classmethod
-    def empty(cls, num_batches: int, offload_device: torch.device):
-        """
-        Construct an empty cache
+    def fetch(self) -> torch.Tensor:
+        return self._onload_value(self.value)
 
-        :param num_batches: the expected number of batches to be stored
-        :param offload_device: device to offload values to
-        """
-        batch_intermediates = [{} for _ in range(num_batches)]
-        return cls(batch_intermediates, offload_device)
+    def update(self, value: torch.Tensor):
+        self.value = self._offload_value(value)
 
-    @classmethod
-    def from_dataloader(
-        cls,
-        dataloader: torch.utils.data.DataLoader,
-        model_device: torch.device = torch.device("cpu"),
-        offload_device: torch.device | None = torch.device("cpu"),
-    ):
-        """
-        Initialize a cache with data from the provided dataloader
+    def onload_(self, device: torch.device | None = None):
+        self.value = self._onload_value(self.value, device)
 
-        This method iterates through all batches in the dataloader and offloads
-        them to the specified device. For faster cache preparation, consider:
-        - Increasing batch_size to reduce the number of iterations
-        - Using num_workers > 0 in the DataLoader for parallel loading (e.g. the
-          calibration DataLoader from format_calibration_data uses
-          dataloader_num_workers; when > 0, pin_memory and prefetch_factor are
-          also set where applicable, which speeds both cache build and calibration)
-        - Ensuring data preprocessing is done before creating the dataloader
+    def offload_(self):
+        self.value = self._offload_value(self.value)
 
-        :param dataloader: dataloader which generates values to be cached
-        :param model_device: device which values will be onloaded to when fetched
-        :param offload_device: device to offload values to
-        """
-        batch_intermediates = [
-            {
-                key: cls._offload_value(value, offload_device, model_device)
-                for key, value in batch.items()
-            }
-            for batch in tqdm(dataloader, desc="Preparing cache")
-        ]
-
-        return cls(batch_intermediates, offload_device)
-
-    def fetch(
-        self, batch_index: int, input_names: list[str] | None = None
-    ) -> dict[str, Any]:
-        """
-        Fetch values belonging to a batch
-
-        :param batch_index: index of batch whose values are being fetched
-        :param input_names: list of keys whose values are being fetched
-        :return: dictionary mapping keys to onloaded values
-        """
-        intermediates = self.batch_intermediates[batch_index]
-
-        return {
-            key: self._onload_value(subgraph_input)
-            for key, subgraph_input in intermediates.items()
-            if input_names is None or key in input_names
-        }
-
-    def update(self, batch_index: int, values: dict[str, Any]):
-        """
-        Update/put values belonging to a batch
-
-        :param batch_index: index of batch whose values will be updated
-        :param values: dictionary mapping keys to values used for update
-        """
-        device = self.offload_device
-        intermediates = {k: self._offload_value(v, device) for k, v in values.items()}
-        self.batch_intermediates[batch_index].update(intermediates)
-
-    def delete(self, batch_index: int, consumed_names: list[str] | None = None):
-        """
-        Delete values from the cache
-
-        :param batch_index: index of batch whose values will be deleted
-        :param consumed_names: list of keys whose values will be deleted, defaults to
-            removing all keys
-        """
-        intermediates = self.batch_intermediates[batch_index]
-
-        if consumed_names is None:
-            consumed_names = list(intermediates.keys())
-
-        for name in consumed_names:
-            del intermediates[name]
-
-    def append(self, values: dict[str, Any]):
-        """
-        Append new values to the cache. The new values will be assigned the next
-        available batch index
-
-        :param values: dictionary mapping keys to values used for update
-        """
-        batch_index = len(self.batch_intermediates)
-        self.batch_intermediates.append({})
-        self.update(batch_index, values)
+    @contextmanager
+    def onloaded(self, device: torch.device | None = None):
+        self.onload_(device)
+        try:
+            yield self.value
+        finally:
+            self.offload_()
 
     def size(self) -> dict[torch.device, int]:
-        """
-        Returns the memory used by cached values, keyed by device, in bytes
-
-        :return: dictionary mapping torch device to number of bytes in cache
-        """
         sizes = defaultdict(lambda: 0)
-        memo = set()
-
-        def _size_helper(intermediate: IntermediateValue) -> int:
-            value = intermediate.value
-
-            match value:
-                case torch.Tensor():
-                    if value not in memo:
-                        sizes[value.device] += value.nbytes
-                    memo.add(value)
-                case list() | tuple():
-                    for v in value:
-                        _size_helper(v)
-                case dict():
-                    for v in value.values():
-                        _size_helper(v)
-                case _ if is_dataclass(value):
-                    for field in fields(value):
-                        _size_helper(getattr(value, field.name))
-                case _:
-                    # this handles primitive values that don't match any other cases
-                    sizes[torch.device("cpu")] += sys.getsizeof(value, 0)
-
-        for intermediates in self.batch_intermediates:
-            for value in intermediates.values():
-                _size_helper(value)
-
+        if isinstance(self.value, torch.Tensor):
+            sizes[self.value.device] += self.value.nbytes
+        else:
+            sizes[torch.device("cpu")] += sys.getsizeof(self.value, 0)
         return dict(sizes)
 
-    def iter(self, input_names: list[str] | None = None) -> Generator[Any, None, None]:
-        for batch_index in range(len(self.batch_intermediates)):
-            yield self.fetch(batch_index, input_names)
+    def _onload_value(
+        self,
+        value: torch.Tensor,
+        device_override: torch.device | None = None,
+    ) -> torch.Tensor:
+        device = device_override if device_override is not None else self.onload_device
+        if device is None:
+            return value
+        non_blocking = value.is_pinned() and torch.device(device).type == "cuda"
+        return value.to(device=device, non_blocking=non_blocking)
 
-    def iter_prefetch(
-        self, input_names: list[str] | None = None
-    ) -> Generator[Any, None, None]:
+    def _offload_value(self, value: torch.Tensor) -> torch.Tensor:
         """
-        Iterate over batches with the next batch prefetched in a background thread.
-        Overlaps onload from offload_device with consumption of the current batch,
-        which can reduce wall-clock time when offloading to CPU.
+        Offload a tensor to the offload device.
 
-        When CUDA is available, uses non_blocking transfers (requires pinned CPU
-        tensors, set up by _offload_value) and synchronises via CUDA events so the
-        main stream waits for each H2D copy before running GPU kernels on the data.
-
-        Yields the same fetched batch dicts as :meth:`iter`; only the timing
-        of onloads differs.
+        If offload_device is None or same as onload_device, returns value unchanged.
         """
-        num_batches = len(self.batch_intermediates)
-        if num_batches == 0:
-            return
+        offload_device = self.offload_device
 
-        # Create a dedicated CUDA stream for H2D transfers so they run on a
-        # separate stream from the main thread's compute stream. Without this,
-        # both threads default to the null stream (stream 0) which serializes
-        # all operations and prevents any overlap.
-        h2d_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
+        # No-op if offload_device is None or same as onload_device
+        if offload_device is None or offload_device == self.onload_device:
+            return value
 
-        def _fetch_and_record(batch_index):
-            event = None
-            if h2d_stream is not None:
-                with torch.cuda.stream(h2d_stream):
-                    data = self.fetch(batch_index, input_names)
-                event = torch.cuda.Event()
-                event.record(h2d_stream)
+        with OverrideEqMode():
+            if value in self.offload_values:
+                offloaded = self.offload_values[value]
             else:
-                data = self.fetch(batch_index, input_names)
-            return data, event
+                offloaded = value.to(device=offload_device)
+                if offloaded is not value:
+                    if (
+                        offload_device is not None
+                        and torch.device(offload_device).type == "cpu"
+                        and torch.cuda.is_available()
+                        and not offloaded.is_pinned()
+                    ):
+                        offloaded = offloaded.pin_memory()
+                    self.offload_values[value] = offloaded
+        return offloaded
 
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = None
-            for batch_index in range(num_batches):
-                if future is not None:
-                    current, event = future.result()
-                else:
-                    current, event = _fetch_and_record(batch_index)
-                if batch_index + 1 < num_batches:
-                    future = executor.submit(_fetch_and_record, batch_index + 1)
-                else:
-                    future = None
-                # Make the main CUDA stream wait for the background H2D copy
-                # before any GPU kernel consumes the prefetched tensors
-                if event is not None:
-                    torch.cuda.current_stream().wait_event(event)
-                yield current
 
-    def __iter__(self) -> Generator[Any, None, None]:
-        yield from self.iter()
+def empty_batches(num_batches: int) -> IntermediateBatches:
+    return [{} for _ in range(num_batches)]
 
-    def __len__(self) -> int:
-        return len(self.batch_intermediates)
 
-    @classmethod
-    def _onload_value(cls, intermediate: IntermediateValue) -> Any:
-        """
-        Onload a value's tensors to the onload device
+def recursive_offload_to_cache(
+    value: Any,
+    offload_device: torch.device | None,
+    onload_device: torch.device | None = None,
+) -> Any:
+    """
+    Recursively offload any tensors in a nested structure of lists, tuples and dicts
 
-        :param intermediate: intermediates value representation to onload
-        :return: original value with tensors onloaded to the onload device
-        """
-        value = intermediate.value
-        device = intermediate.device
+    :param value: value to offload
+    :param offload_device: device to offload `torch.Tensor` values to
+    :return: value with all tensors offloaded
+    """
+    kwargs = {"offload_device": offload_device, "onload_device": onload_device}
+    match value:
+        case torch.Tensor():
+            return IntermediateCache(value, **kwargs)
+        case list():
+            return [recursive_offload_to_cache(v, **kwargs) for v in value]
+        case tuple():
+            return tuple(recursive_offload_to_cache(v, **kwargs) for v in value)
+        case dict():
+            return {
+                k: recursive_offload_to_cache(v, **kwargs) for k, v in value.items()
+            }
+        case _ if is_dataclass(value):
+            for field in fields(value):
+                v = getattr(value, field.name)
+                setattr(value, field.name, recursive_offload_to_cache(v, **kwargs))
+            return value
+        case _:
+            # handles primitive values and provides a warning for unsupported types.
+            # without this, values trigger a MatchError exception.
+            if not isinstance(
+                value,
+                (int, str, float, bool, torch.dtype, torch.device, type(None)),
+            ):
+                warnings.warn(f"Offloading not implemented for type {type(value)}.")
+            return value
 
-        match value:
-            case torch.Tensor():
-                # use non_blocking when source is pinned and target is CUDA so the
-                # H2D DMA can overlap with GPU compute on a separate CUDA stream
-                non_blocking = (
-                    value.is_pinned()
-                    and device is not None
-                    and torch.device(device).type == "cuda"
-                )
-                return value.to(device=device, non_blocking=non_blocking)
-            case list():
-                return [cls._onload_value(v) for v in value]
-            case tuple():
-                return tuple(cls._onload_value(v) for v in value)
-            case dict():
-                return {k: cls._onload_value(v) for k, v in value.items()}
-            case _ if is_dataclass(value):
-                for field in fields(value):
-                    v = getattr(value, field.name)
-                    setattr(value, field.name, cls._onload_value(v))
-                return value
-            case _:
-                # handles primitive values that should be returned as is.
-                # without this, a MatchError would be raised for unhandled types.
-                return value
 
-    @classmethod
-    def _offload_value(
-        cls,
-        value: Any,
-        offload_device: torch.device | None,
-        onload_device: torch.device | None = None,
-    ) -> IntermediateValue:
-        """
-        Offload a value's tensors to the offload device
+def build_batches_from_dataloader(
+    dataloader: torch.utils.data.DataLoader,
+    model_device: torch.device = torch.device("cpu"),
+    offload_device: torch.device | None = torch.device("cpu"),
+) -> IntermediateBatches:
+    """
+    Materialize a dataloader into cached batches of ``IntermediateCache`` values.
+    """
+    batch_intermediates = []
+    for batch in tqdm(dataloader, desc="Preparing cache"):
+        batch_cache = {
+            key: recursive_offload_to_cache(value, offload_device, model_device)
+            for key, value in batch.items()
+        }
+        batch_intermediates.append(batch_cache)
+    return batch_intermediates
 
-        :param value: value to offload
-        :param offload_device: device to offload `torch.Tensor` values to
-        :param onload_device: device used when onloading `torch.Tensor` values.
-            If None is provided, use the tensor's current device
-        :return: Instance of IntermediateValue representing the offloaded value
-        """
-        kwargs = {"offload_device": offload_device, "onload_device": onload_device}
-        match value:
-            case torch.Tensor():
-                with OverrideEqMode():
-                    # check for cache hit between shared tensors
-                    if value in cls.offload_values:
-                        offloaded = cls.offload_values[value]
-                    else:
-                        # move to offload if no hit
-                        offloaded = value.to(device=offload_device)
-                        if offloaded is not value:  # avoid circular ref
-                            # pin CPU tensors so onload can use non_blocking DMA
-                            if (
-                                torch.device(offload_device).type == "cpu"
-                                and torch.cuda.is_available()
-                                and not offloaded.is_pinned()
-                            ):
-                                offloaded = offloaded.pin_memory()
-                            cls.offload_values[value] = offloaded
 
-                return IntermediateValue(
-                    value=offloaded,
-                    device=(onload_device if onload_device else value.device),
-                )
-            case list():
-                return IntermediateValue(
-                    value=[cls._offload_value(v, **kwargs) for v in value],
-                    device=None,
-                )
-            case tuple():
-                return IntermediateValue(
-                    value=tuple(cls._offload_value(v, **kwargs) for v in value),
-                    device=None,
-                )
-            case dict():
-                return IntermediateValue(
-                    value={
-                        k: cls._offload_value(v, **kwargs) for k, v in value.items()
-                    },
-                    device=None,
-                )
-            case _ if is_dataclass(value):
-                for field in fields(value):
-                    v = getattr(value, field.name)
-                    setattr(value, field.name, cls._offload_value(v, **kwargs))
-                return IntermediateValue(value=value, device=None)
-            case _:
-                # handles primitive values and provides a warning for unsupported types.
-                # without this, values trigger a MatchError exception.
-                if not isinstance(
-                    value,
-                    (int, str, float, bool, torch.dtype, torch.device, type(None)),
-                ):
-                    warnings.warn(f"Offloading not implemented for type {type(value)}.")
-                return IntermediateValue(value=value, device=None)
+def recursive_fetch_from_cache(value: Any) -> Any:
+    match value:
+        case IntermediateCache():
+            return value.fetch()
+        case list():
+            return [recursive_fetch_from_cache(v) for v in value]
+        case tuple():
+            return tuple(recursive_fetch_from_cache(v) for v in value)
+        case dict():
+            return {k: recursive_fetch_from_cache(v) for k, v in value.items()}
+        case _ if is_dataclass(value):
+            for field in fields(value):
+                v = getattr(value, field.name)
+                setattr(value, field.name, recursive_fetch_from_cache(v))
+            return value
+        case _:
+            return value
+
+
+def fetch_batch(
+    batch: dict[str, Any], input_names: list[str] | None = None
+) -> dict[str, Any]:
+    return {
+        key: recursive_fetch_from_cache(cache)
+        for key, cache in batch.items()
+        if input_names is None or key in input_names
+    }
+
+
+def update_batch(
+    batch: dict[str, Any],
+    values: dict[str, Any],
+    offload_device: torch.device | None = "cpu",
+) -> None:
+    batch.update(
+        {k: recursive_offload_to_cache(v, offload_device) for k, v in values.items()}
+    )
+
+
+def delete_from_batch(
+    batch: dict[str, Any], consumed_names: list[str] | None = None
+) -> None:
+    if consumed_names is None:
+        consumed_names = list(batch.keys())
+
+    for name in consumed_names:
+        del batch[name]
+
+
+def iter_batches(
+    batches: IntermediateBatches, input_names: list[str] | None = None
+) -> Iterator[dict[str, Any]]:
+    for batch in batches:
+        yield fetch_batch(batch, input_names)
+
+
+def maybe_prefetch(batches: Sequence[Any]) -> Iterator[Any]:
+    """
+    Iterate with optional one-item background prefetch, controlled by
+    ``active_session().state.sequential_prefetch``.
+
+    When CUDA is available, records an event on the worker thread's current stream
+    so the main thread can wait for any asynchronous H2D copies before consuming
+    the prefetched item.
+    """
+
+    try:
+        from llmcompressor.core import active_session
+
+        use_prefetch = active_session().state.sequential_prefetch
+    except Exception:
+        use_prefetch = False
+
+    if use_prefetch:
+        # Single ThreadPoolExecutor for all caches
+        yield from _prefetch_all(batches)
+    else:
+        # Direct fetch - replace each cache with its fetched value
+        for batch in batches:
+            yield recursive_fetch_from_cache(batch)
+
+
+def _prefetch_all(batches: Sequence[Any]) -> Generator[Any, None, None]:
+    """Prefetch all caches in a single ThreadPoolExecutor."""
+
+    # Create a dedicated CUDA stream for H2D transfers so they run on a
+    # separate stream from the main thread's compute stream. Without this,
+    # both threads default to the null stream (stream 0) which serializes
+    # all operations and prevents any overlap.
+    h2d_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
+
+    def _fetch_and_record(batch):
+        event = None
+        if h2d_stream is not None:
+            with torch.cuda.stream(h2d_stream):
+                data = fetch_batch(batch)
+            event = torch.cuda.Event()
+            event.record(h2d_stream)
+        else:
+            data = fetch_batch(batch)
+        return data, event
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = None
+        for batch_index, batch in enumerate(batches):
+            if future is not None:
+                current, event = future.result()
+            else:
+                current, event = _fetch_and_record(batch)
+            if batch_index + 1 < len(batches):
+                future = executor.submit(_fetch_and_record, batches[batch_index + 1])
+            else:
+                future = None
+            # Make the main CUDA stream wait for the background H2D copy
+            # before any GPU kernel consumes the prefetched tensors
+            if event is not None:
+                torch.cuda.current_stream().wait_event(event)
+            yield current
 
 
 class OverrideEqMode(TorchDispatchMode):

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -63,14 +63,6 @@ class IntermediateCache:
         finally:
             self.offload_()
 
-    def size(self) -> dict[torch.device, int]:
-        sizes = defaultdict(lambda: 0)
-        if isinstance(self.value, torch.Tensor):
-            sizes[self.value.device] += self.value.nbytes
-        else:
-            sizes[torch.device("cpu")] += sys.getsizeof(self.value, 0)
-        return dict(sizes)
-
     def _onload_value(
         self,
         value: torch.Tensor,
@@ -229,7 +221,9 @@ def iter_batches(
         yield fetch_batch(batch, input_names)
 
 
-def maybe_prefetch(batches: Sequence[Any]) -> Iterator[Any]:
+def maybe_prefetch(
+    batches: Sequence[dict[str, Any]], input_names: list[str] | None = None
+) -> Iterator[dict[str, Any]]:
     """
     Iterate with optional one-item background prefetch, controlled by
     ``active_session().state.sequential_prefetch``.
@@ -248,14 +242,16 @@ def maybe_prefetch(batches: Sequence[Any]) -> Iterator[Any]:
 
     if use_prefetch:
         # Single ThreadPoolExecutor for all caches
-        yield from _prefetch_all(batches)
+        yield from _prefetch_all(batches, input_names)
     else:
         # Direct fetch - replace each cache with its fetched value
         for batch in batches:
-            yield recursive_fetch_from_cache(batch)
+            yield fetch_batch(batch, input_names)
 
 
-def _prefetch_all(batches: Sequence[Any]) -> Generator[Any, None, None]:
+def _prefetch_all(
+    batches: Sequence[dict[str, Any]], input_names: list[str] | None = None
+) -> Generator[dict[str, Any], None, None]:
     """Prefetch all caches in a single ThreadPoolExecutor."""
 
     # Create a dedicated CUDA stream for H2D transfers so they run on a
@@ -268,11 +264,11 @@ def _prefetch_all(batches: Sequence[Any]) -> Generator[Any, None, None]:
         event = None
         if h2d_stream is not None:
             with torch.cuda.stream(h2d_stream):
-                data = fetch_batch(batch)
+                data = fetch_batch(batch, input_names)
             event = torch.cuda.Event()
             event.record(h2d_stream)
         else:
-            data = fetch_batch(batch)
+            data = fetch_batch(batch, input_names)
         return data, event
 
     with ThreadPoolExecutor(max_workers=1) as executor:

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -47,7 +47,7 @@ def _get_batches(
     Yield ``(batch_idx, inputs)`` from the cached activations, optionally
     prefetching according to the active session state.
     """
-    batch_source = maybe_prefetch(iter_batches(activations, input_names))
+    batch_source = maybe_prefetch(activations, input_names)
     for batch_idx, inputs in tqdm(
         enumerate(batch_source), total=num_batches, desc=desc
     ):

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -8,7 +8,15 @@ from tqdm import tqdm
 
 from llmcompressor.core import LifecycleCallbacks, active_session
 from llmcompressor.modifiers.utils.hooks import HooksMixin
-from llmcompressor.pipelines.cache import IntermediatesCache
+from llmcompressor.pipelines.cache import (
+    IntermediateBatches,
+    build_batches_from_dataloader,
+    delete_from_batch,
+    fetch_batch,
+    iter_batches,
+    maybe_prefetch,
+    update_batch,
+)
 from llmcompressor.pipelines.registry import CalibrationPipeline
 from llmcompressor.pipelines.sequential.helpers import (
     dispatch_for_sequential,
@@ -30,23 +38,16 @@ __all__ = ["SequentialPipeline"]
 
 
 def _get_batches(
-    activations: IntermediatesCache,
+    activations: IntermediateBatches,
     num_batches: int,
     input_names: list[str],
     desc: str,
-    sequential_prefetch: bool = False,
 ) -> Iterator[tuple[int, dict]]:
     """
-    Yield (batch_idx, inputs) with the next batch optionally prefetched in a
-    background thread to overlap fetch (onload from offload device) with the
-    main-thread forward pass. Delegates to
-    :meth:`IntermediatesCache.iter_prefetch` when prefetching is enabled.
+    Yield ``(batch_idx, inputs)`` from the cached activations, optionally
+    prefetching according to the active session state.
     """
-    batch_source = (
-        activations.iter_prefetch(input_names)
-        if sequential_prefetch
-        else activations.iter(input_names)
-    )
+    batch_source = maybe_prefetch(iter_batches(activations, input_names))
     for batch_idx, inputs in tqdm(
         enumerate(batch_source), total=num_batches, desc=desc
     ):
@@ -117,7 +118,7 @@ class SequentialPipeline(CalibrationPipeline):
                 stack.enter_context(DisableQuantization(model))
 
             # prepare intermediates cache
-            activations = IntermediatesCache.from_dataloader(
+            activations = build_batches_from_dataloader(
                 dataloader, onload_device, offload_device
             )
 
@@ -125,14 +126,15 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations.fetch(batch_idx, ["loss_mask"]).get("loss_mask")
+                    fetch_batch(activations[batch_idx], ["loss_mask"]).get("loss_mask")
                     for batch_idx in range(len(dataloader))
                 ]
             else:
                 session.state.loss_masks = None
 
-            sequential_prefetch = getattr(dataset_args, "sequential_prefetch", False)
-            session.state.sequential_prefetch = sequential_prefetch
+            session.state.sequential_prefetch = getattr(
+                dataset_args, "sequential_prefetch", False
+            )
 
             for subgraph_index, subgraph in enumerate(subgraphs):
                 # prepare tqdm description texts
@@ -148,7 +150,6 @@ class SequentialPipeline(CalibrationPipeline):
                         num_batches,
                         subgraph.input_names,
                         calib_desc,
-                        sequential_prefetch,
                     ):
                         session.state.current_batch_idx = batch_idx
                         subgraph.forward(model, **inputs)
@@ -163,12 +164,15 @@ class SequentialPipeline(CalibrationPipeline):
                             num_batches,
                             subgraph.input_names,
                             prop_desc,
-                            sequential_prefetch,
                         ):
                             output = subgraph.forward(model, **inputs)
                             if subgraph_index < num_subgraphs - 1:
-                                activations.update(batch_idx, output)
-                                activations.delete(batch_idx, subgraph.consumed_names)
+                                update_batch(
+                                    activations[batch_idx], output, offload_device
+                                )
+                                delete_from_batch(
+                                    activations[batch_idx], subgraph.consumed_names
+                                )
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_epoch_end()

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -299,7 +299,7 @@ class TestMaybePrefetch:
             offload_device=torch.device("cpu"),
         )
 
-        result = list(maybe_prefetch(iter_batches(cache)))
+        result = list(maybe_prefetch(cache))
         assert len(result) == 1
         assert isinstance(result[0], dict)
         assert "input_ids" in result[0]

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -4,13 +4,31 @@ import pytest
 import torch
 from torch.utils.data import DataLoader, StackDataset
 
-from llmcompressor.pipelines.cache import IntermediatesCache, OverrideEqMode
+from llmcompressor.core import active_session
+from llmcompressor.pipelines.cache import (
+    IntermediateCache,
+    OverrideEqMode,
+    build_batches_from_dataloader,
+    delete_from_batch,
+    fetch_batch,
+    iter_batches,
+    maybe_prefetch,
+    update_batch,
+)
 
 
 @dataclass
 class SampleDataclass:
     a: torch.Tensor
     b: int
+
+
+values_to_test = [
+    torch.randn(2, 3).to("cpu"),
+    SampleDataclass(a=torch.randn(2, 3), b=42),
+    torch.float32,
+    [1, 2, 3],
+]
 
 
 @pytest.fixture
@@ -26,141 +44,266 @@ def sample_dataloader():
 
 @pytest.fixture
 def sample_cache(sample_dataloader):
-    return IntermediatesCache.from_dataloader(
+    return build_batches_from_dataloader(
         dataloader=sample_dataloader,
         model_device=torch.device("cpu"),
         offload_device=torch.device("cpu"),
     )
 
 
-values_to_test = [
-    torch.randn(2, 3).to("cpu"),
-    SampleDataclass(a=torch.randn(2, 3), b=42),
-    torch.float32,
-    [1, 2, 3],
-]
+class TestIntermediateCache:
+    """Unit tests for IntermediateCache and related cache functions."""
+
+    @pytest.mark.unit
+    def test_offload_and_onload(self):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        value = torch.randn(2, 3, device="cuda:0")
+        cache = IntermediateCache(value, torch.device("cpu"))
+        onloaded = cache.fetch()
+        assert onloaded.device == torch.device("cuda:0")
+        assert torch.equal(onloaded, value)
+
+    @pytest.mark.unit
+    def test_onload_device_defaults_to_tensor_device(self):
+        """onload_device defaults to the tensor's current device when not specified."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        value = torch.randn(2, 3, device="cuda:0")
+        cache = IntermediateCache(value, offload_device=torch.device("cpu"))
+        assert cache.onload_device == value.device
+        assert cache.value.device == torch.device("cpu")
+
+    @pytest.mark.unit
+    def test_offload_none_means_no_op(self):
+        """offload_device=None keeps the tensor on its current device."""
+        value = torch.randn(2, 3, device="cpu")
+        cache = IntermediateCache(
+            value, offload_device=None, onload_device=torch.device("cpu")
+        )
+        # Tensor should remain on its original device
+        assert cache.value.device == value.device
+        assert cache.value is value
+
+    @pytest.mark.unit
+    def test_offload_same_as_onload_no_op(self):
+        """offload_device==onload_device keeps the tensor in place."""
+        value = torch.randn(2, 3, device="cpu")
+        cache = IntermediateCache(
+            value, offload_device=torch.device("cpu"), onload_device=torch.device("cpu")
+        )
+        # Tensor should remain on its original device (no offload needed)
+        assert cache.value.device == value.device
+
+    @pytest.mark.unit
+    def test_fetch_returns_onload_device(self):
+        """fetch() returns the tensor on onload_device."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        cuda_device = torch.device("cuda:0")
+        value = torch.randn(2, 3, device=cuda_device)
+        cache = IntermediateCache(
+            value, offload_device=torch.device("cpu"), onload_device=cuda_device
+        )
+        # Fetch should return tensor on cuda
+        fetched = cache.fetch()
+        assert fetched.device.type == cuda_device.type
+        assert fetched.device.index == cuda_device.index
+
+    @pytest.mark.unit
+    def test_update_changes_value(self):
+        """update() changes the stored value and offloads it."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        value1 = torch.randn(2, 3, device="cuda:0")
+        value2 = torch.randn(2, 3, device="cuda:0")
+        cache = IntermediateCache(value1, offload_device=torch.device("cpu"))
+        cache.update(value2)
+        assert torch.equal(cache.value, value2.to("cpu"))
+        assert cache.value.device == torch.device("cpu")
+
+    @pytest.mark.unit
+    def test_onload_override_device(self):
+        """onload_(device) override moves tensor to specified device."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        cuda_device = torch.device("cuda:0")
+        cpu_device = torch.device("cpu")
+        value = torch.randn(2, 3, device=cuda_device)
+        cache = IntermediateCache(
+            value, offload_device=cpu_device, onload_device=cuda_device
+        )
+        # Override onload to cpu
+        cache.onload_(cpu_device)
+        assert cache.value.device.type == cpu_device.type
+
+    @pytest.mark.unit
+    def test_onloaded_context_manager(self):
+        """onloaded() context manager moves tensor to specified device."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        cuda_device = torch.device("cuda:0")
+        cpu_device = torch.device("cpu")
+        value = torch.randn(2, 3, device=cuda_device)
+        cache = IntermediateCache(
+            value, offload_device=cpu_device, onload_device=cuda_device
+        )
+        # Test onloaded context manager
+        with cache.onloaded(cuda_device):
+            assert cache.value.device.type == cuda_device.type
+        # After context, should return to offload_device
+        assert cache.value.device.type == cpu_device.type
 
 
-@pytest.mark.unit
-def test_initialization(sample_dataloader):
-    cache = IntermediatesCache.from_dataloader(
-        dataloader=sample_dataloader,
-        model_device=torch.device("cpu"),
-    )
+class TestBatches:
+    """Unit tests for batch-related functions."""
 
-    assert isinstance(cache, IntermediatesCache)
-    assert len(cache.batch_intermediates) > 0
-    assert isinstance(cache.batch_intermediates[0], dict)
+    @pytest.mark.unit
+    def test_from_dataloader(self, sample_dataloader):
+        cache = build_batches_from_dataloader(sample_dataloader)
+
+        onloaded = fetch_batch(cache[0], ["input_ids"])["input_ids"]
+        assert isinstance(onloaded, torch.Tensor)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("value", values_to_test)
+    def test_from_dataloader_diff_types(self, value):
+        dataset = StackDataset(value=[value])
+        dataloader = DataLoader(dataset, batch_size=1, collate_fn=lambda x: x[0])
+        cache = build_batches_from_dataloader(dataloader)
+
+        onloaded = fetch_batch(cache[0], ["value"])["value"]
+        assert deep_equal(onloaded, value)
+
+    @pytest.mark.unit
+    def test_fetch_batch(self, sample_cache):
+        fetched = fetch_batch(sample_cache[0], ["input_ids", "attention_mask"])
+
+        assert isinstance(fetched, dict)
+        assert "input_ids" in fetched
+        assert "attention_mask" in fetched
+        assert isinstance(fetched["input_ids"], torch.Tensor)
+        assert isinstance(fetched["attention_mask"], torch.Tensor)
+
+    @pytest.mark.unit
+    def test_update_batch(self, sample_cache):
+        new_outputs = {
+            "hidden_states": torch.randn(2, 4, 768),
+            "logits": torch.randn(2, 4, 1000),
+        }
+
+        update_batch(sample_cache[0], new_outputs, torch.device("cpu"))
+
+        # Verify the updates were stored
+        assert "hidden_states" in sample_cache[0]
+        assert "logits" in sample_cache[0]
+
+    @pytest.mark.unit
+    def test_delete_from_batch(self, sample_cache):
+        # First add some intermediates
+        new_outputs = {
+            "hidden_states": torch.randn(2, 4, 768),
+            "logits": torch.randn(2, 4, 1000),
+        }
+        update_batch(sample_cache[0], new_outputs, torch.device("cpu"))
+
+        # Then delete them
+        delete_from_batch(sample_cache[0], ["hidden_states"])
+
+        assert "hidden_states" not in sample_cache[0]
+        assert "logits" in sample_cache[0]
+
+    @pytest.mark.unit
+    def test_device_handling(self, sample_dataloader):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        cuda_device = torch.device("cuda:0")
+        cpu_device = torch.device("cpu")
+
+        # Create a cache with GPU as model device and CPU as offload device
+        cache = build_batches_from_dataloader(
+            dataloader=sample_dataloader,
+            model_device=cuda_device,
+            offload_device=cpu_device,
+        )
+
+        # Add some GPU tensors
+        new_outputs = {"hidden_states": torch.randn(2, 3).to(cuda_device)}
+        update_batch(cache[0], new_outputs, cpu_device)
+
+        # Verify tensors are offloaded to CPU
+        assert cache[0]["hidden_states"].value.device.type == "cpu"
+
+        # Verify tensors are loaded back to GPU when fetched
+        fetched = fetch_batch(cache[0], ["hidden_states"])
+        assert fetched["hidden_states"].device.type == "cuda"
+
+    @pytest.mark.unit
+    def test_iter_batches_basic(self, sample_cache):
+        """Test iter_batches yields correct batch structure."""
+        batches = list(iter_batches(sample_cache))
+
+        assert len(batches) == len(sample_cache)
+        for batch in batches:
+            assert isinstance(batch, dict)
+            assert "input_ids" in batch
+            assert "attention_mask" in batch
+
+    @pytest.mark.unit
+    def test_iter_batches_with_input_names(self, sample_cache):
+        """Test iter_batches with specific input_names filter."""
+        batches = list(iter_batches(sample_cache, input_names=["input_ids"]))
+
+        assert len(batches) == len(sample_cache)
+        for batch in batches:
+            assert list(batch.keys()) == ["input_ids"]
 
 
-@pytest.mark.unit
-def test_iter_prefetch_empty_cache():
-    """iter_prefetch yields nothing when cache has no batches."""
-    cache = IntermediatesCache.empty(0, torch.device("cpu"))
-    assert list(cache.iter_prefetch()) == []
+class TestMaybePrefetch:
+    """Unit tests for maybe_prefetch function."""
 
+    @pytest.mark.unit
+    def test_maybe_prefetch_matches_iter(self, sample_cache):
+        """maybe_prefetch yields the same batch contents as iter."""
+        via_iter = list(iter_batches(sample_cache))
+        via_prefetch = list(maybe_prefetch(sample_cache))
+        assert len(via_iter) == len(via_prefetch)
+        for i, (b_iter, b_prefetch) in enumerate(zip(via_iter, via_prefetch)):
+            assert deep_equal(b_iter, b_prefetch), f"batch {i} differs"
 
-@pytest.mark.unit
-def test_iter_prefetch_matches_iter(sample_cache):
-    """iter_prefetch yields the same batch contents as iter."""
+    @pytest.mark.unit
+    def test_maybe_prefetch_use_prefetch(self, sample_cache):
+        """Test maybe_prefetch actually prefetches."""
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
 
-    def batch_dicts_equal(a: dict, b: dict) -> bool:
-        if set(a.keys()) != set(b.keys()):
-            return False
-        return all(deep_equal(a[k], b[k]) for k in a)
+        session = active_session()
+        session.state.sequential_prefetch = True
 
-    via_iter = list(sample_cache.iter())
-    via_prefetch = list(sample_cache.iter_prefetch())
-    assert len(via_iter) == len(via_prefetch)
-    for i, (b_iter, b_prefetch) in enumerate(zip(via_iter, via_prefetch)):
-        assert batch_dicts_equal(b_iter, b_prefetch), f"batch {i} differs"
+        result = list(maybe_prefetch(sample_cache))
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+        assert "input_ids" in result[0]
+        assert torch.equal(
+            result[0]["input_ids"],
+            torch.tensor([[1, 2, 3, 0], [4, 5, 6, 0]], dtype=torch.long),
+        )
 
+    @pytest.mark.unit
+    def test_maybe_prefetch_no_cuda(self):
+        """Test maybe_prefetch works correctly without CUDA."""
+        cache = build_batches_from_dataloader(
+            dataloader=DataLoader(StackDataset(input_ids=torch.tensor([[1, 2]]))),
+            model_device=torch.device("cpu"),
+            offload_device=torch.device("cpu"),
+        )
 
-@pytest.mark.unit
-def test_fetch_inputs(sample_cache):
-    fetched = sample_cache.fetch(0, ["input_ids", "attention_mask"])
-
-    assert isinstance(fetched, dict)
-    assert "input_ids" in fetched
-    assert "attention_mask" in fetched
-    assert isinstance(fetched["input_ids"], torch.Tensor)
-    assert isinstance(fetched["attention_mask"], torch.Tensor)
-
-
-@pytest.mark.unit
-def test_update_intermediates(sample_cache):
-    new_outputs = {
-        "hidden_states": torch.randn(2, 4, 768),
-        "logits": torch.randn(2, 4, 1000),
-    }
-
-    sample_cache.update(0, new_outputs)
-
-    # Verify the updates were stored
-    assert "hidden_states" in sample_cache.batch_intermediates[0]
-    assert "logits" in sample_cache.batch_intermediates[0]
-
-
-@pytest.mark.unit
-def test_delete_intermediates(sample_cache):
-    # First add some intermediates
-    new_outputs = {
-        "hidden_states": torch.randn(2, 4, 768),
-        "logits": torch.randn(2, 4, 1000),
-    }
-    sample_cache.update(0, new_outputs)
-
-    # Then delete them
-    sample_cache.delete(0, ["hidden_states"])
-
-    assert "hidden_states" not in sample_cache.batch_intermediates[0]
-    assert "logits" in sample_cache.batch_intermediates[0]
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("value", values_to_test)
-def test_from_dataloader(value):
-    dataset = StackDataset(value=[value])
-    dataloader = DataLoader(dataset, batch_size=1, collate_fn=lambda x: x[0])
-    cache = IntermediatesCache.from_dataloader(dataloader)
-
-    onloaded = cache.fetch(0, ["value"])["value"]
-    assert deep_equal(onloaded, value)
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("value", values_to_test)
-def test_offload_and_onload(value):
-    offloaded = IntermediatesCache._offload_value(value, torch.device("cpu"))
-    onloaded = IntermediatesCache._onload_value(offloaded)
-    assert deep_equal(onloaded, value)
-
-
-@pytest.mark.unit
-def test_device_handling(sample_dataloader):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-
-    cuda_device = torch.device("cuda")
-    cpu_device = torch.device("cpu")
-
-    # Create a cache with GPU as model device and CPU as offload device
-    cache = IntermediatesCache.from_dataloader(
-        dataloader=sample_dataloader,
-        model_device=cuda_device,
-        offload_device=cpu_device,
-    )
-
-    # Add some GPU tensors
-    new_outputs = {"hidden_states": torch.randn(2, 3).to(cuda_device)}
-    cache.update(0, new_outputs)
-
-    # Verify tensors are offloaded to CPU
-    assert cache.batch_intermediates[0]["hidden_states"].value.device.type == "cpu"
-
-    # Verify tensors are loaded back to GPU when fetched
-    fetched = cache.fetch(0, ["hidden_states"])
-    assert fetched["hidden_states"].device.type == "cuda"
+        result = list(maybe_prefetch(iter_batches(cache)))
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+        assert "input_ids" in result[0]
+        assert torch.equal(result[0]["input_ids"], torch.tensor([[1, 2]]))
 
 
 def deep_equal(a, b) -> bool:


### PR DESCRIPTION
According to the #2490  Refactor the IntermediatesCache to IntermediateCache, and replace the adhoc offloading logic.


SUMMARY:
1. Refactor IntermediatesCache to IntermediateCache for caching a single tensor.
2. Use standalone functions for original IntermediatesCache logic, now use a IntermediateBatches alias.
3. Use a maybe_prefetch to simplify the prefetch usage.
4. Refactor the awq gptq to use IntermediateCache offload logic.

TEST PLAN:
make test
FAILED tests/llmcompressor/modifiers/quantization/test_base.py::test_serialize_actorder[False-N/A-static] - AssertionError: assert static == 'static'
================================================================== 1 failed, 297 passed, 17 skipped, 27 warnings in 425.19s (0:07:05) 

The above error seems not introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned intermediate caching and batch handling to improve memory management and device offload/onload behavior.
  * Centralized and simplified prefetch/batch-iteration logic for more consistent and efficient processing.
  * Streamlined accumulation and retrieval of activation/Hessian statistics to reduce unnecessary device transfers and improve throughput.

* **Tests**
  * Updated unit and integration tests to cover the new caching and prefetch behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->