### PR TITLE
[save_pretrained] UX improvement for `save_compressed=False`

### DIFF
--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -7,6 +7,7 @@ import torch.distributed as dist
 from compressed_tensors import ModelCompressor, SparsityCompressionConfig
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.offload import from_accelerate, is_rank0, to_accelerate
+from compressed_tensors.quantization import QuantizationMetadata
 from compressed_tensors.utils import deprecated
 from loguru import logger
 from transformers import PreTrainedModel
@@ -52,14 +53,16 @@ def modify_save_pretrained(model: PreTrainedModel):
             """
             Wrapper around PreTrainedModel.save_pretrained(), adds functionality for
             saving models in a compressed format on disk. The compression format is
-            saved to the model's config file
+            saved to the model's config file.
 
             :param save_directory: output directory to save model to
             :param quantization_format: optional compression format override. If none
                 is provided, the compression format will be inferred from the model
-            :param save_compressed: whether or not to compress the model. If true,
-                weights will be compressed. Otherwise, weights will remain in full
-                precision in the "FROZEN" state.
+            :param save_compressed: whether to save the model in compressed format.
+                If true, weights will be compressed.
+                If false, weights will be compressed and decompressed (i.e.
+                "fake-quantized"), so that they remain in full precision, and no
+                associated qparams are saved.
             :param kwargs: additional kwargs to pass on to model.save_pretrained
             """
 
@@ -67,8 +70,12 @@ def modify_save_pretrained(model: PreTrainedModel):
             compressor = ModelCompressor.from_pretrained_model(
                 model, quantization_format=quantization_format
             )
-            if save_compressed:
-                compressor.compress_model(model)
+            compressor.compress_model(model)
+            if not save_compressed:
+                # Decompress back to full precision, so that weights are fake-quantized
+                compressor.decompress_model(model)
+                # Clear quantization entirely, to avoid warnings on load
+                model.apply(QuantizationMetadata.clear_quantization)
 
             # convert to accelerate offloaded for optimal saving with transformers
             to_accelerate(model)


### PR DESCRIPTION
SUMMARY:
Previously on main, applying QuantizationModifier to a model in oneshot, followed by `model.save_pretrained(..., save_compressed=False)`, results in the exact same model. A better user flow would be to fake-quantize the target weights in the model, so they are set to their quantized value but in the original dtype. 

This PR updates by calling compress and decompress, followed by removing all associated qparams and quantization attributes from targeted modules

Corequisite:
- [ ] https://github.com/vllm-project/compressed-tensors/pull/669

TEST PLAN:
The snippet at bottom will result in the exact same model weights on main. On this branch, they are pinned to the quantized value but in same dtype:
```
In [4]: orig_model.model.layers[0].self_attn.q_proj.weight
Out[4]: 
Parameter containing:
tensor([[-0.0029, -0.0288, -0.0032,  ...,  0.0080, -0.0469, -0.0214],
        [-0.0126, -0.0693, -0.0034,  ..., -0.0119, -0.0498,  0.0203],
        [-0.0188, -0.0459, -0.0046,  ...,  0.0116, -0.0137,  0.0107],
        ...,
        [-0.0043, -0.0396,  0.0708,  ...,  0.0049, -0.0022,  0.0020],
        [-0.0049, -0.0143,  0.0413,  ...,  0.0050, -0.0030, -0.0002],
        [-0.0038, -0.0165,  0.0302,  ...,  0.0082,  0.0010,  0.0026]],
       requires_grad=True)

In [5]: fake_quantized_model.model.layers[0].self_attn.q_proj.weight
Out[5]: 
Parameter containing:
tensor([[-0.0054, -0.0270, -0.0054,  ...,  0.0064, -0.0452, -0.0193],
        [-0.0145, -0.0728,  0.0000,  ..., -0.0140, -0.0559,  0.0140],
        [-0.0188, -0.0469,  0.0000,  ...,  0.0082, -0.0165,  0.0082],
        ...,
        [ 0.0000, -0.0374,  0.0747,  ...,  0.0000,  0.0000,  0.0000],
        [ 0.0000, -0.0111,  0.0444,  ...,  0.0000,  0.0000,  0.0000],
        [ 0.0000, -0.0121,  0.0243,  ...,  0.0144,  0.0000,  0.0000]],
       requires_grad=True)
```

```python
from transformers import AutoModelForCausalLM, AutoTokenizer

from llmcompressor import oneshot
from llmcompressor.modifiers.quantization import QuantizationModifier

# Select model and load it.
model_id = "meta-llama/Meta-Llama-3-8B-Instruct"
model = AutoModelForCausalLM.from_pretrained(model_id, dtype="auto")
tokenizer = AutoTokenizer.from_pretrained(model_id)


# Apply algorithms.
oneshot(
    model=model,
    recipe=QuantizationModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"]),
)

# Save to disk compressed.
SAVE_DIR = model_id.rstrip("/").split("/")[-1] + "-W4A16-G128"
model.save_pretrained(SAVE_DIR, save_compressed=True)
tokenizer.save_pretrained(SAVE_DIR)
```

