### PR TITLE
[bugfix][awq] fix kv_cache + awq bug

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -3,6 +3,7 @@ from itertools import product
 from typing import Iterator, Literal
 
 import torch
+from compressed_tensors.modeling.kvcache import QuantizedKVCache
 from compressed_tensors.offload.dist_utils import as_broadcastable, is_distributed
 from compressed_tensors.quantization import (
     QuantizationStrategy,
@@ -430,6 +431,12 @@ class AWQModifier(Modifier, QuantizationMixin):
             kwargs,
         ):
             values = inspect.signature(module.forward).bind(*args, **kwargs)
+
+            # replace any quantized kv cache with None
+            for k, v in values.arguments.items():
+                if isinstance(v, QuantizedKVCache):
+                    values.arguments[k] = None
+
             self._parent_args_cache[module].append(values.arguments)
 
         def create_cache_smooth_activations_hook_fn(smooth_name):

--- a/tests/llmcompressor/modifiers/awq/test_base.py
+++ b/tests/llmcompressor/modifiers/awq/test_base.py
@@ -15,6 +15,7 @@ from llmcompressor.modifiers.awq import AWQMapping, AWQModifier
 from llmcompressor.modifiers.awq.base import get_lowest_common_ancestor_with_avoid
 from llmcompressor.modifiers.factory import ModifierFactory
 from llmcompressor.utils import get_high_precision
+from tests.testing_utils import requires_gpu
 
 
 @pytest.mark.unit
@@ -674,3 +675,47 @@ def test_block_strategy_compute_layer_means(rows, cols, block_height, block_widt
     # check
     assert_close(llmc_awq_means, ref_means, atol=1e-5, rtol=1e-5)
     assert_close(llmc_awq_means, auto_awq_means, atol=1e-5, rtol=1e-5)
+
+
+@requires_gpu(1)
+@pytest.mark.smoke
+def test_awq_with_kv_cache_quantization():
+    """Test AWQModifier with kv_cache_scheme runs without errors"""
+    from compressed_tensors.quantization import (
+        QuantizationArgs,
+        QuantizationStrategy,
+        QuantizationType,
+    )
+    from datasets import Dataset
+    from transformers import AutoModelForCausalLM
+
+    from llmcompressor import oneshot
+
+    model_id = "nm-testing/tinysmokellama-3.2"
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id, torch_dtype="auto", device_map="cuda"
+    )
+    dataset = Dataset.from_dict({"text": ["Hello world " * 10]})
+
+    modifier = AWQModifier(
+        targets="Linear",
+        scheme="W8A16",
+        kv_cache_scheme=QuantizationArgs(
+            num_bits=8,
+            type=QuantizationType.FLOAT,
+            strategy=QuantizationStrategy.TENSOR,
+            symmetric=True,
+            dynamic=False,
+        ),
+    )
+
+    oneshot(
+        model=model,
+        dataset=dataset,
+        recipe=[modifier],
+        max_seq_length=16,
+        num_calibration_samples=1,
+    )
+
+    # Verify quantization was applied
+    assert hasattr(model.model.layers[0].self_attn, "kv_cache")


### PR DESCRIPTION
intermediatescache would get handed a quantizedkv_cache and misbehave.

added functionality to ignore any quantized kv cache that the hook would pick up.

partial fix for https://github.com/vllm-project/llm-compressor/issues/2584

added smoke test for AWQ + kv cache quantization

test plan:

see unit test