### PR TITLE
fix(examples): prevent visual modules from being quantized in Qwen2VL w8a8_fp8 example

### DIFF
--- a/examples/quantization_w8a8_fp8/qwen2vl_example.py
+++ b/examples/quantization_w8a8_fp8/qwen2vl_example.py
@@ -17,7 +17,7 @@ processor = AutoProcessor.from_pretrained(MODEL_ID)
 recipe = QuantizationModifier(
     targets="Linear",
     scheme="FP8_DYNAMIC",
-    ignore=["re:.*lm_head", "re:visual.*", "re:model.visual.*"],
+    ignore=["re:.*lm_head", "re:.*visual.*"],
 )
 
 # Apply quantization and save to disk in compressed-tensors format.

--- a/examples/quantization_w8a8_fp8/qwen2vl_example.py
+++ b/examples/quantization_w8a8_fp8/qwen2vl_example.py
@@ -17,7 +17,7 @@ processor = AutoProcessor.from_pretrained(MODEL_ID)
 recipe = QuantizationModifier(
     targets="Linear",
     scheme="FP8_DYNAMIC",
-    ignore=["re:.*lm_head", "re:visual.*"],
+    ignore=["re:.*lm_head", "re:visual.*", "re:model.visual.*"],
 )
 
 # Apply quantization and save to disk in compressed-tensors format.


### PR DESCRIPTION

SUMMARY:
In the w8a8_fp8 example for Qwen2VL, the regex used to ignore visual quantization did not match the actual module naming from Transformers loading, which caused visual components to be quantized as well. This change aligns the visual ignore pattern with the other QwenVL examples.


TEST PLAN:
before：
```bash
'model.visual.merger.mlp.0.bias', 'model.visual.merger.mlp.0.weight', 'model.visual.merger.mlp.0.weight_scale', 'model.visual.merger.mlp.2.bias', 'model.visual.merger.mlp.2.weight', 'model.visual.merger.mlp.2.weight_scale'
```
after
```bash
'model.visual.merger.mlp.0.bias', 'model.visual.merger.mlp.0.weight', 'model.visual.merger.mlp.2.bias', 'model.visual.merger.mlp.2.weight'
```