### PR TITLE
[oneshot] clean offload_dir during post-processing

### DIFF
--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -106,6 +106,7 @@ class Oneshot:
     def __init__(
         self,
         log_dir: str | None = None,
+        clean_offload_dir: bool = True,
         **kwargs,
     ):
         """
@@ -124,6 +125,8 @@ class Oneshot:
         :param output_dir: Path to save the output model after carrying out oneshot
         :param log_dir: Path to save logs during oneshot run.
             Nothing is logged to file if None.
+        :param clean_offload_dir: Whether to clean up intermediate offload files
+            after oneshot completes. Defaults to True.
         """
         # Disable tokenizer parallelism to prevent warning when using
         # multiprocessing for dataset preprocessing. The warning occurs because
@@ -163,6 +166,7 @@ class Oneshot:
         self.dataset_args = dataset_args
         self.recipe_args = recipe_args
         self.output_dir = output_dir
+        self.clean_offload_dir = clean_offload_dir
 
         # initialize the model and processor
         pre_process(model_args, dataset_args, output_dir)
@@ -194,6 +198,7 @@ class Oneshot:
             model_args=self.model_args,
             recipe_args=self.recipe_args,
             output_dir=self.output_dir,
+            clean_offload_dir=self.clean_offload_dir,
         )
 
     def apply_recipe_modifiers(
@@ -304,6 +309,7 @@ def oneshot(
     # Miscellaneous arguments
     output_dir: str | None = None,
     log_dir: str | None = None,
+    clean_offload_dir: bool = True,
     **kwargs,
 ) -> PreTrainedModel:
     """
@@ -401,6 +407,9 @@ def oneshot(
         Nothing is saved if None.
     :param log_dir: Path to save logs during oneshot run.
         Nothing is logged to file if None.
+    :param clean_offload_dir: Whether to clean up intermediate offload files after
+        oneshot completes. These are temporary files created during disk offloading
+        (symlinks and intermediate tensors). Defaults to True.
 
     :return: The calibrated PreTrainedModel
     """

--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -147,7 +147,7 @@ def post_process(
                 logger.debug(f"Removed {files_cleaned} intermediate offload files")
         except Exception as e:
             logger.warning(
-                f"An error occured when attempting to clean offload directory: {e}"
+                f"An error occurred when attempting to clean offload directory: {e}"
             )
 
     # Reset the one-time-use session upon completion

--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -100,6 +100,7 @@ def post_process(
     model_args: ModelArguments | None = None,
     recipe_args: RecipeArguments | None = None,
     output_dir: str | None = None,
+    clean_offload_dir: bool = True,
 ):
     """
     Saves the model and tokenizer/processor to the output directory if model_args,
@@ -108,6 +109,9 @@ def post_process(
     If the `output_dir` is not the default directory, the method resets lifecycle
     actions. The model is saved in a compressed format if specified in `model_args`.
     Additionally, the tokenizer or processor, if available, is also saved.
+
+    :param clean_offload_dir: Whether to clean up intermediate offload files after
+        saving. Defaults to True.
 
     Raises:
         ValueError: If saving fails due to an invalid `output_dir` or other issues.
@@ -132,6 +136,19 @@ def post_process(
             "`output_dir` as input arg."
             "Ex. `oneshot(..., output_dir=...)`"
         )
+
+    # Clean up disk offload files if requested
+    if clean_offload_dir:
+        try:
+            from compressed_tensors.offload.cache import DiskCache
+
+            files_cleaned = DiskCache.clean_offload_dir()
+            if files_cleaned > 0:
+                logger.debug(f"Removed {files_cleaned} intermediate offload files")
+        except Exception as e:
+            logger.warning(
+                f"An error occured when attempting to clean offload directory: {e}"
+            )
 
     # Reset the one-time-use session upon completion
     if recipe_args is not None and recipe_args.clear_sparse_session:


### PR DESCRIPTION
SUMMARY:
Corequisite:
* https://github.com/vllm-project/compressed-tensors/pull/678

The DiskCache creates potentially several hundreds of intermediate files in user-provided offload_dir during normal operation with large models. These are either symlinks or intermediate tensors that are not necessary/valuable to keep around after successfully running oneshot.

PR adds an input to oneshot to allow user to clean the offload dir during post-processing.

Some open questions:
- [ ] Do we want to run this in try/catch instead?
- [ ] Do this with a context instead? `with disk_cache as DiskCache(): ...` 

- [ ] How to handle DistributedDiskCache?

TEST PLAN:
"please outline how the changes were tested"
