### PR TITLE
[CLOSED] Add actorder support for GPTQ block quantization

### DIFF
--- a/examples/quantization_w8a8_fp8/qwen2vl_example.py
+++ b/examples/quantization_w8a8_fp8/qwen2vl_example.py
@@ -17,7 +17,7 @@ processor = AutoProcessor.from_pretrained(MODEL_ID)
 recipe = QuantizationModifier(
     targets="Linear",
     scheme="FP8_DYNAMIC",
-    ignore=["re:.*lm_head", "re:visual.*"],
+    ignore=["re:.*lm_head", "re:.*visual.*"],
 )
 
 # Apply quantization and save to disk in compressed-tensors format.

--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -241,6 +241,13 @@ class DatasetArguments(CustomDatasetArguments):
             "than one gpu. Default is cpu."
         },
     )
+    sequential_targets_per_subgraph: int = field(
+        default=1,
+        metadata={
+            "help": "Number of sequential targets to include per subgraph. "
+            "Higher values use more VRAM but are faster to calibrate. Default is 1."
+        },
+    )
     quantization_aware_calibration: bool = field(
         default=True,
         metadata={

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -111,11 +111,16 @@ def quantize_weight(
 
     scale, zero_point = observer(W)
     # handle g_idx and activation ordering
-    if strategy in (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP):
+    if strategy in (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP, QuantizationStrategy.BLOCK):
         # mapping from column index to group index
+        divisor = (
+            quant_args.group_size
+            if strategy != QuantizationStrategy.BLOCK
+            else quant_args.block_structure[1]
+        )
         g_idx = (
             torch.arange(num_columns, device=W.device, dtype=torch.int)
-            // quant_args.group_size
+            // divisor
         )
 
         if actorder == ActivationOrdering.GROUP:
@@ -217,8 +222,8 @@ def quantize_weight(
                     global_scale=global_scale,
                 )
             elif strategy == QuantizationStrategy.BLOCK:
-                block_width = quant_args.block_structure[1]
-                block_column_idx = (i1 + i) // block_width
+                column_idx = i1 + i
+                block_column_idx = g_idx[column_idx]
                 q = fake_quantize(
                     q.unsqueeze(1),
                     scale[:, block_column_idx : block_column_idx + 1],

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -111,17 +111,19 @@ def quantize_weight(
 
     scale, zero_point = observer(W)
     # handle g_idx and activation ordering
-    if strategy in (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP, QuantizationStrategy.BLOCK):
+    g_idx_to_save = None
+    if strategy in (
+        QuantizationStrategy.GROUP,
+        QuantizationStrategy.TENSOR_GROUP,
+        QuantizationStrategy.BLOCK,
+    ):
         # mapping from column index to group index
         divisor = (
             quant_args.group_size
             if strategy != QuantizationStrategy.BLOCK
             else quant_args.block_structure[1]
         )
-        g_idx = (
-            torch.arange(num_columns, device=W.device, dtype=torch.int)
-            // divisor
-        )
+        g_idx = torch.arange(num_columns, device=W.device, dtype=torch.int) // divisor
 
         if actorder == ActivationOrdering.GROUP:
             W, H, perm = _apply_activation_ordering(W, H)
@@ -258,24 +260,18 @@ def quantize_weight(
         else:
             W[:, i2:] -= w_err
 
-    has_gidx = False
-    if strategy in (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP):
-        if actorder == ActivationOrdering.WEIGHT:
+    if strategy in (
+        QuantizationStrategy.GROUP,
+        QuantizationStrategy.TENSOR_GROUP,
+        QuantizationStrategy.BLOCK,
+    ):
+        if actorder in (ActivationOrdering.WEIGHT, ActivationOrdering.GROUP):
             # restore original permutation
             invperm = torch.argsort(perm)
             W = W[:, invperm]
 
-        elif actorder == ActivationOrdering.GROUP:
-            # restore original permutation
-            invperm = torch.argsort(perm)
-            W = W[:, invperm]
-            g_idx = g_idx[invperm]
-
-            # only save g_idx if mapping is not identity
-            has_gidx = True
-
-    if not has_gidx:
-        g_idx = None
+            if actorder == ActivationOrdering.GROUP:
+                g_idx_to_save = g_idx[invperm]
 
     if isinstance(module, transformers.Conv1D):
         W.transpose_(0, 1)
@@ -287,8 +283,8 @@ def quantize_weight(
         "weight_scale": scale.to(dtype=final_dtype),
         "weight_zero_point": zero_point.to(dtype=quant_args.zp_dtype),
     }
-    if g_idx is not None:
-        q_param_dict["weight_g_idx"] = g_idx
+    if g_idx_to_save is not None:
+        q_param_dict["weight_g_idx"] = g_idx_to_save
     return (loss, q_param_dict)
 
 

--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -84,6 +84,7 @@ def trace_subgraphs(
     sample_input: dict[str, Any],
     sequential_targets: list[str],
     ignore: list[str],
+    targets_per_subgraph: int = 1,
 ) -> list[Subgraph]:
     """
     Trace a model to produce subgraphs, where each sequential target belongs to exactly
@@ -95,6 +96,7 @@ def trace_subgraphs(
         __len__, __bool__, and __contains__ values are assumed constant across batches
     :param sequential_targets: list of patterns matching sequential targets
     :param ignore: function and method names to skip during tracing
+    :param targets_per_subgraph: number of targets to include per subgraph
     :return: a list of Subgraphs in order of execution
     """
     # find modules
@@ -149,7 +151,7 @@ def trace_subgraphs(
     graph.device = model.device
 
     # perform subgraph partition
-    partitions = topological_partition(graph, targets)
+    partitions = topological_partition(graph, targets, targets_per_subgraph)
     subgraphs = partition_graph(model, partitions)
     trace_consumed_names(subgraphs)
 
@@ -257,7 +259,9 @@ def find_target_nodes(graph: GraphModule, targets: set[Module]) -> set[Node]:
     )
 
 
-def topological_partition(graph: GraphModule, targets: set[Module]) -> list[list[Node]]:
+def topological_partition(
+    graph: GraphModule, targets: set[Module], targets_per_subgraph: int = 1
+) -> list[list[Node]]:
     """
     Partition the graph into partitions such that each `target` belongs to exactly one
     partition and executing each partition depends only on intermediate values produced
@@ -265,11 +269,17 @@ def topological_partition(graph: GraphModule, targets: set[Module]) -> list[list
 
     :param graph: graph being partitioned
     :param targets: target modules which will be assigned to disjoint partitions
+    :param targets_per_subgraph: number of targets to include per subgraph
     :return: list of partitions, where each partition is a list of nodes belonging to
         that partition
     """
     assert graph_is_well_formed(graph.graph)
     target_nodes = find_target_nodes(graph, targets)
+
+    if targets_per_subgraph <= 0:
+        raise ValueError(
+            "targets_per_subgraph is required to be greater than or equal to one"
+        )
 
     partitions: list[list[Node]] = [[]]
     remaining_indegrees = {
@@ -277,6 +287,7 @@ def topological_partition(graph: GraphModule, targets: set[Module]) -> list[list
         for node in graph.graph.nodes
     }
     partition_index = 0  # global counter
+    targets_seen = 0  # number of targets encountered so far
 
     # start with graph input nodes,
     # but delay the `get_attr` nodes as long as possible
@@ -293,8 +304,12 @@ def topological_partition(graph: GraphModule, targets: set[Module]) -> list[list
 
         # guarantee targets are assigned to disjoint partitions
         if node in target_nodes:
-            partition_index += 1
-            partitions.append([])
+            targets_seen += 1
+
+            if targets_seen >= targets_per_subgraph:
+                partition_index += 1
+                partitions.append([])
+                targets_seen = 0
 
         # recurse on last indegree only in order to guarantee that
         # the node is assigned to maximal partition

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -99,7 +99,13 @@ class SequentialPipeline(CalibrationPipeline):
 
         # trace subgraphs
         sample_input = next(iter(dataloader))
-        subgraphs = trace_subgraphs(model, sample_input, sequential_targets, ignore)
+        subgraphs = trace_subgraphs(
+            model,
+            sample_input,
+            sequential_targets,
+            ignore,
+            dataset_args.sequential_targets_per_subgraph,
+        )
         num_subgraphs = len(subgraphs)
 
         LifecycleCallbacks.calibration_epoch_start()

--- a/src/llmcompressor/transformers/tracing/debug.py
+++ b/src/llmcompressor/transformers/tracing/debug.py
@@ -27,6 +27,7 @@ def parse_args():
     parser.add_argument("--trust_remote_code", type=bool, default=False, help="Whether to trust model remote code")  # noqa: E501
     parser.add_argument("--skip_weights", type=bool, default=True, help="Whether to load the model with dummy weights")  # noqa: E501
     parser.add_argument("--device_map", type=str, default="cpu", help="Device to load model and inputs onto")  # noqa: E501
+    parser.add_argument("--targets_per_subgraph", type=int, default=1, help="Number of sequential targets to include per subgraph")  # noqa: E501
     return parser.parse_args()
 
 
@@ -39,6 +40,7 @@ def trace(
     trust_remote_code: bool = True,
     skip_weights: bool = True,
     device_map: str | dict = "cpu",
+    targets_per_subgraph: int = 1
 ) -> Tuple[PreTrainedModel, list[Subgraph], dict[str, torch.Tensor]]:
     """
     Debug traceability by tracing a pre-trained model into subgraphs
@@ -51,6 +53,7 @@ def trace(
     :param ignore: patterns to ignore during tracing
     :param modality: data modality for dummy tracing data, defaults to 'text'
     :param trust_remote_code: trust remote model code
+    :param targets_per_subgraph: number of targets to include per subgraph
 
     Example usage from CLI
     llmcompressor.trace \
@@ -103,7 +106,11 @@ def trace(
         f"    ignore={dataset_args.tracing_ignore}\n"
     )
     subgraphs = trace_subgraphs(
-        model, sample, sequential_targets, dataset_args.tracing_ignore
+        model,
+        sample,
+        sequential_targets,
+        dataset_args.tracing_ignore,
+        targets_per_subgraph
     )
     print(f"Successfully traced model into {len(subgraphs)} subgraphs!\n")
 
@@ -165,6 +172,7 @@ def main():
         trust_remote_code=args.trust_remote_code,
         skip_weights=args.skip_weights,
         device_map=args.device_map,
+        targets_per_subgraph=args.targets_per_subgraph
     )
 
 

--- a/tests/llmcompressor/pipelines/sequential/test_helpers.py
+++ b/tests/llmcompressor/pipelines/sequential/test_helpers.py
@@ -1,6 +1,15 @@
+import pytest
 import torch
+import torch.fx
+from transformers import AutoModelForCausalLM
 
-from llmcompressor.pipelines.sequential.helpers import get_sequential_ancestors
+from llmcompressor.args.dataset_arguments import DatasetArguments
+from llmcompressor.pipelines.sequential.helpers import (
+    get_sequential_ancestors,
+    topological_partition,
+    trace_subgraphs,
+)
+from llmcompressor.utils.dev import skip_weights_download, skip_weights_initialize
 
 
 class DummyModel(torch.nn.Module):
@@ -14,11 +23,111 @@ class DummyModel(torch.nn.Module):
         return self.fc(x)
 
 
+class DummyModelMultipleSequentialLayers(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer1 = torch.nn.Linear(10, 10)
+        self.layer2 = torch.nn.Linear(10, 10)
+        self.layer3 = torch.nn.Linear(10, 10)
+        self.layer4 = torch.nn.Linear(10, 10)
+        self.layer5 = torch.nn.Linear(10, 10)
+        self.layer6 = torch.nn.Linear(10, 10)
+
+    def forward(self, x):
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+        x = self.layer5(x)
+        x = self.layer6(x)
+        return x
+
+
 def test_get_sequential_ancestors():
-    model = DummyModel()
+    with skip_weights_initialize():
+        model = DummyModel()
 
     assert get_sequential_ancestors(model, set()) == set()
     assert get_sequential_ancestors(model, {model}) == set()
     assert get_sequential_ancestors(model, {model.fc}) == {model}
     assert get_sequential_ancestors(model, {model.seq[0]}) == {model, model.seq}
     assert get_sequential_ancestors(model, {model.seq[1]}) == {model, model.seq}
+
+
+def test_topological_partition_default():
+    with skip_weights_initialize():
+        model = DummyModelMultipleSequentialLayers()
+
+    targets = {
+        model.layer1,
+        model.layer2,
+        model.layer3,
+        model.layer4,
+        model.layer5,
+        model.layer6,
+    }
+    gm = torch.fx.symbolic_trace(model)
+
+    assert len(topological_partition(gm, targets)) == 7
+
+
+def test_topological_partition_multiple_targets():
+    with skip_weights_initialize():
+        model = DummyModelMultipleSequentialLayers()
+
+    gm = torch.fx.symbolic_trace(model)
+    targets = {
+        model.layer1,
+        model.layer2,
+        model.layer3,
+        model.layer4,
+        model.layer5,
+        model.layer6,
+    }
+
+    assert len(topological_partition(gm, targets, 2)) == 4
+
+
+def test_topological_partition_invalid():
+    with skip_weights_initialize():
+        model = DummyModelMultipleSequentialLayers()
+
+    gm = torch.fx.symbolic_trace(model)
+    targets = {
+        model.layer1,
+        model.layer2,
+        model.layer3,
+        model.layer4,
+        model.layer5,
+        model.layer6,
+    }
+
+    with pytest.raises(ValueError):
+        topological_partition(gm, targets, 0)
+
+
+@pytest.mark.parametrize("targets_per_subgraph", [1, 2, 3, 4, 5])
+def test_trace_subgraphs(targets_per_subgraph):
+    target = "Qwen3DecoderLayer"
+
+    with skip_weights_download(AutoModelForCausalLM):
+        model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-0.6B", dtype="auto")
+
+    subgraphs = trace_subgraphs(
+        model,
+        model.dummy_inputs,
+        sequential_targets=[target],
+        ignore=DatasetArguments().tracing_ignore,
+        targets_per_subgraph=targets_per_subgraph,
+    )
+
+    for subgraph in subgraphs[:-1]:
+        subgraph_modules = subgraph.submodules(model)
+        num_targets_present = len(
+            [
+                module
+                for module in subgraph_modules
+                if module.__class__.__name__ == target
+            ]
+        )
+        assert num_targets_present == targets_per_subgraph

--- a/tests/llmcompressor/transformers/gptq/test_gptq_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_gptq_oneshot.py
@@ -117,7 +117,7 @@ recipe_modifier_block_actorder_weight = GPTQModifier(
         "group_0": QuantizationScheme(
             targets=["re:.*model.layers.2.self_attn.q_proj$"],
             weights=QuantizationArgs(
-                num_bits=4,
+                num_bits=8,
                 strategy="block",
                 block_structure=[2, 8],
                 actorder=ActivationOrdering.WEIGHT,

--- a/tests/llmcompressor/transformers/gptq/test_gptq_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_gptq_oneshot.py
@@ -111,6 +111,21 @@ recipe_modifier_full_block = GPTQModifier(
     },
 )
 
+recipe_modifier_block_actorder_weight = GPTQModifier(
+    ignore=["lm_head"],
+    config_groups={
+        "group_0": QuantizationScheme(
+            targets=["re:.*model.layers.2.self_attn.q_proj$"],
+            weights=QuantizationArgs(
+                num_bits=4,
+                strategy="block",
+                block_structure=[2, 8],
+                actorder=ActivationOrdering.WEIGHT,
+            ),
+        )
+    },
+)
+
 @pytest.mark.parametrize(
     "recipe",
     [
@@ -122,6 +137,7 @@ recipe_modifier_full_block = GPTQModifier(
         recipe_modifier_group_actorder_weight,
         recipe_modifier_group_actorder_group,
         recipe_modifier_full_block,
+        recipe_modifier_block_actorder_weight,
     ],
 )
 def test_oneshot_application(recipe, tmp_path):

--- a/tests/llmcompressor/transformers/gptq/test_gptq_oneshot.py
+++ b/tests/llmcompressor/transformers/gptq/test_gptq_oneshot.py
@@ -96,6 +96,20 @@ recipe_modifier_group_actorder_group = GPTQModifier(
     },
 )
 
+# Test block quantization variant
+recipe_modifier_full_block = GPTQModifier(
+    ignore=["lm_head"],
+    config_groups={
+        "group_0": QuantizationScheme(
+            targets=["re:.*model.layers.2.self_attn.q_proj$"],
+            weights=QuantizationArgs(
+                num_bits=8,
+                strategy="block",
+                block_structure=[2, 8],
+            ),
+        )
+    },
+)
 
 @pytest.mark.parametrize(
     "recipe",
@@ -107,6 +121,7 @@ recipe_modifier_group_actorder_group = GPTQModifier(
         recipe_modifier_shorthand_b,
         recipe_modifier_group_actorder_weight,
         recipe_modifier_group_actorder_group,
+        recipe_modifier_full_block,
     ],
 )
 def test_oneshot_application(recipe, tmp_path):
@@ -154,7 +169,7 @@ def test_oneshot_application(recipe, tmp_path):
     assert quant_scheme.targets == ["re:.*model.layers.2.self_attn.q_proj$"]
     weight_args = quantization_config.config_groups["group_0"].weights
     assert isinstance(weight_args, QuantizationArgs)
-    assert weight_args.num_bits == 4
+    assert weight_args.num_bits == 4 or weight_args.num_bits == 8
 
     # Check a specific layer is quantized
     targetted_linear_layer = model_loaded.model.layers[2].self_attn.q_proj


### PR DESCRIPTION
SUMMARY:

- Closes:  #2587 

- Replaced the separate `block_column_idx` calculation in block quantization by reusing `g_idx`, first getting the divisor from either the group size value or the block width value. This should automatically ensure the use of actorder.

- Remove `has_gidx` from and simplified the logic to save g_idx if `ActivationOrdering.GROUP` is opted for.

TEST PLAN:

- Added an additional block quantization recipe in `tests/llmcompressor/transformers/gptq/test_gptq_oneshot.py`.
- Ran the relevant tests to ensure that the changes do not introduce inconsistencies or errors.

CHANGES PENDING:

- Address errors.
- Add more relevant recipes in the tests and ensure that all tests pass.
