### PR TITLE
[model_free_ptq] hotfix + Minimax2.7 example

### DIFF
--- a/examples/model_free_ptq/minimax_m27_w4a16.py
+++ b/examples/model_free_ptq/minimax_m27_w4a16.py
@@ -1,0 +1,31 @@
+from llmcompressor import model_free_ptq
+from compressed_tensors.quantization import (
+    QuantizationScheme,
+)
+from compressed_tensors.quantization.quant_scheme import W4A16
+from compressed_tensors.entrypoints.convert import FP8BlockDequantizer
+
+MODEL_ID = "MiniMaxAI/MiniMax-M2.7"
+SAVE_DIR = "MiniMax-M2.7-W4A16"
+
+model_free_ptq(
+    model_stub=MODEL_ID,
+    save_directory=SAVE_DIR,
+    scheme=QuantizationScheme(
+        **W4A16,
+        targets=[
+            r"re:model.layers.\d+.self_attn.(q|k|v|o)_proj$",
+            r"re:model.layers.\d+.block_sparse_moe.experts.\d+.w[1-3]$",
+            # NOTE: required when loading in vllm
+            "re:.*(gate_up|gate|up|down)_proj$",
+        ]
+    ),
+    # Pre-process: dequantize original checkpoint's FP8_BLOCK layers
+    converter=FP8BlockDequantizer(
+        targets=[
+            r"re:model.layers.\d+.self_attn.(q|k|v|o)_proj$",
+            r"re:model.layers.\d+.block_sparse_moe.experts.\d+.w[1-3]$",
+        ]
+    ),
+    max_workers=8,
+)

--- a/examples/model_free_ptq/minimax_m27_w4a16.py
+++ b/examples/model_free_ptq/minimax_m27_w4a16.py
@@ -1,9 +1,10 @@
-from llmcompressor import model_free_ptq
+from compressed_tensors.entrypoints.convert import FP8BlockDequantizer
 from compressed_tensors.quantization import (
     QuantizationScheme,
 )
 from compressed_tensors.quantization.quant_scheme import W4A16
-from compressed_tensors.entrypoints.convert import FP8BlockDequantizer
+
+from llmcompressor import model_free_ptq
 
 MODEL_ID = "MiniMaxAI/MiniMax-M2.7"
 SAVE_DIR = "MiniMax-M2.7-W4A16"
@@ -18,7 +19,7 @@ model_free_ptq(
             r"re:model.layers.\d+.block_sparse_moe.experts.\d+.w[1-3]$",
             # NOTE: required when loading in vllm
             "re:.*(gate_up|gate|up|down)_proj$",
-        ]
+        ],
     ),
     # Pre-process: dequantize original checkpoint's FP8_BLOCK layers
     converter=FP8BlockDequantizer(

--- a/src/llmcompressor/entrypoints/model_free/__init__.py
+++ b/src/llmcompressor/entrypoints/model_free/__init__.py
@@ -14,6 +14,7 @@ from compressed_tensors.utils.safetensors_load import (
     get_checkpoint_files,
     get_weight_map,
     is_weights_file,
+    update_safetensors_index,
 )
 from loguru import logger
 
@@ -106,6 +107,7 @@ def model_free_ptq(
     # weight_map may contain tensors re-located to new shards (partner tensors
     # re-saved alongside the shard that needed them for fused scale computation)
     update_config(save_directory, scheme_name, scheme, ignore, converter)
+    update_safetensors_index(save_directory, total_size, weight_map)
 
 
 def _build_jobs(


### PR DESCRIPTION
SUMMARY:
We introduced a bug [here](https://github.com/vllm-project/llm-compressor/commit/3544a0ecbf7effdd503c2d7acc424a088d63479d#diff-e5b26ce370538934331f9baeff891c6b1afef6d09481a1d66b21c794fc99c040L106) in #2498 , dropping the call to update safetensors.index.json. This hotfixes that and adds a MiniMax M2.5 Example


TEST PLAN:
Need to make sure this is tested in a follow-up. Example runs with following output:

<details>
  <summary>Sample Model Output</summary>

The user wants a Python function that sorts a list of numbers in ascending order. I can show them a few different approaches:

1. Using Python's built-in `sorted()` function
2. Using the `list.sort()` method
3. Implementing a sorting algorithm from scratch (like bubble sort or quicksort)

I'll provide multiple approaches so they can choose what fits their needs.
</think>

# Python Function to Sort Numbers in Ascending Order

Here are several approaches to sort a list of numbers in ascending order:

## Method 1: Using Python's Built-in `sorted()` Function

```python
def sort_ascending(numbers):
    """
    Sort a list of numbers in ascending order.
    
    Args:
        numbers: A list of numbers (int or float)
    
    Returns:
        A new sorted list in ascending order
    """
    return sorted(numbers)
```

## Method 2: Using the `list.sort()` Method (In-Place Sorting)

```python
def sort_ascending_inplace(numbers):
    """
    Sort a list in-place in ascending order.
    """
    numbers.sort()
    return numbers
```

## Method 3: Manual Implementation - Bubble Sort

```python
def sort_ascending_manual(numbers):
    """
    Implement bubble sort algorithm manually.
    """
    numbers = numbers.copy()  # Create a copy to avoid modifying original
    n = len(numbers)
    
    for i in range(n):
        for j in range(0, n - i - 1):
            if numbers[j] > numbers[j + 1]:
                # Swap elements
                numbers[j], numbers[j + 1] = numbers[j + 1], numbers[j]
    
    return numbers
```

## Method 4: Custom Comparator with Reverse Parameter

```python
def sort_ascending(numbers, reverse=False):
    """
    Sort a list of numbers with optional direction.
    """
    return sorted(numbers, reverse=reverse)
```

---

## Example Usage

```python
# Test the functions
if __name__ == "__main__":
    my_list = [64, 34, 25, 12, 22, 11, 90]
    
    # Using sorted()
    result1 = sort_ascending(my_list)
    print(f"Original list: {my_list}")
    print(f"Sorted list:   {result1}")
    # Output: [11, 12, 22, 25, 34, 64, 90]
    
    # Using in-place sort
    my_list2 = [64, 34, 25, 12, 22, 11, 90]
    sort_ascending_inplace(my_list2)
    print(f"After in-place sort: {my_list2}")
    # Output: [11, 12, 22, 25, 34, 64, 90]
    
    # Handles different data types
    mixed_list = [3.14, 1, 4.5, 2, 0.5]
    print(f"Mixed int/float: {sort_ascending(mixed_list)}")
    # Output: [0.5, 1, 2, 3.14, 4.5]
```

---

## Summary

| Method | Time Complexity | Space Complexity | Modifies Original? |
|--------|-----------------|------------------|-------------------|
| `sorted()` | O(n log n) | O(n) | No |
| `.sort()` | O(n log n) | O(1) | Yes |
| Bubble Sort | O(n²) | O(1) | No |

**Recommendation:** For production code, use the built-in `sorted()` or `.sort()` method as they're optimized and well-tested. Use the manual implementation for learning purposes.


</details>