### PR TITLE
[AWQ] Per-output-slice grid search for fused q_proj (Qwen3.5 attn_output_gate)

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -1,4 +1,5 @@
 import inspect
+import math
 from itertools import product
 from typing import Iterator, Literal
 
@@ -629,6 +630,77 @@ class AWQModifier(Modifier, QuantizationMixin):
             for output in outputs
         ]
 
+    @torch.no_grad()
+    def _eval_scales(
+        self,
+        scales: torch.Tensor,
+        mapping: ResolvedMapping,
+        fp16_outputs: list[torch.Tensor],
+        orig_layer_weights: dict[torch.nn.Module, torch.Tensor],
+        balance_layers_to_patch: list[Module],
+        device: torch.device,
+        update_fused: bool = False,
+    ) -> float:
+        """
+        Apply ``scales`` to the balance layers via the AWQ smoothing transform
+        ``W' = Q(W * s) / s``, run the parent module on the cached calibration
+        batches, and return the MSE between the smoothed/quantized output and
+        the fp16 reference.
+
+        Used both for the identity-baseline measurement (``scales = ones``)
+        and for every grid-search candidate. Pulling this out of the grid
+        loop keeps the baseline measurement and the grid measurements on
+        exactly the same code path.
+
+        ``update_fused`` is hoisted out of the per-iteration check at the
+        call site (whether every balance layer is on TENSOR_GROUP strategy
+        is static during the search), so this method just dispatches on
+        the precomputed flag instead of re-evaluating ``getattr`` chains
+        per grid candidate. ``scales`` and the ``orig_layer_weights``
+        tensors are also assumed to already live on ``device`` (the
+        caller pre-moves both before the grid loop) so this method
+        contains no per-iteration host-to-device transfers.
+        """
+        _scalesview = scales.view(1, -1)
+
+        # Q(W * s)
+        for balance_layer in balance_layers_to_patch:
+            w_qscheme = balance_layer.quantization_scheme.weights
+            orig = orig_layer_weights[balance_layer]
+            balance_layer.weight.data.copy_(orig * _scalesview)
+
+            should_calculate_gparam = (
+                w_qscheme.strategy == QuantizationStrategy.TENSOR_GROUP
+            )
+            call_observer(
+                balance_layer,
+                "weight",
+                balance_layer.weight,
+                should_calculate_gparam=should_calculate_gparam,
+            )
+            quantized = forward_quantize(
+                balance_layer,
+                balance_layer.weight,
+                "weight",
+                w_qscheme,
+            )
+            balance_layer.weight.data.copy_(quantized / _scalesview)
+
+        # Apply fused global scales for TENSOR_GROUP during grid search
+        # to match inference behavior. ``update_fused`` is precomputed
+        # by ``_compute_best_scale`` so we don't re-walk the layer list
+        # for every grid candidate.
+        if update_fused:
+            update_fused_layer_weight_global_scales(mapping.parent)
+
+        # W * X
+        int_w_outputs = self._run_samples(mapping.parent)
+
+        # compute mean squared error (L2 norm)
+        loss = self._compute_loss(fp16_outputs, int_w_outputs)
+        del int_w_outputs
+        return loss
+
     def _compute_best_scale(
         self,
         mapping: ResolvedMapping,
@@ -652,10 +724,6 @@ class AWQModifier(Modifier, QuantizationMixin):
         :return: tensor of best scales, one for each channel
         """
         history = []
-        best_ratio = -1
-        best_scales = None
-        best_error = float("inf")
-        initial_error = None
 
         device = get_execution_device(mapping.parent)
 
@@ -685,6 +753,41 @@ class AWQModifier(Modifier, QuantizationMixin):
             if hasattr(balance_layer, "quantization_scheme")
             and hasattr(balance_layer.quantization_scheme, "weights")
         ]
+
+        # Hoist out of the per-candidate _eval_scales call -- both
+        # checks are static during the grid search and were previously
+        # re-evaluated for every candidate.
+        #   * ``update_fused``: whether every balance layer is on the
+        #     TENSOR_GROUP strategy (controls whether per-iteration
+        #     fused-global-scale fusion is needed).
+        #   * Pre-move ``orig_layer_weights`` to the execution device
+        #     once, so ``_eval_scales`` doesn't redo the host-to-device
+        #     transfer for every grid candidate (relevant when the
+        #     model is offloaded).
+        update_fused = bool(balance_layers_to_patch) and all(
+            getattr(layer.quantization_scheme.weights, "strategy", None)
+            == QuantizationStrategy.TENSOR_GROUP
+            for layer in balance_layers_to_patch
+        )
+        orig_layer_weights = {
+            layer: weight.to(device)
+            for layer, weight in orig_layer_weights.items()
+        }
+
+        # Identity scales -- the actual "no smoothing" baseline. We use this
+        # as both:
+        #   (a) the ``initial_error`` reference for the per-layer reduction
+        #       metric, so ``best_error / initial_error`` compares against a
+        #       real un-smoothed reference rather than against "the first
+        #       grid candidate that happened to survive the loop entry
+        #       conditions" (which under ``duo_scaling=True`` is *not*
+        #       identity at ratio=0); and
+        #   (b) the seed for best_scales/best_error, so the grid search can
+        #       only ever improve on no-smoothing -- it can never select a
+        #       worse-than-baseline candidate. Layers where the grid finds
+        #       nothing better stay at identity by construction.
+        identity_scales = torch.ones_like(x_mean)
+
         with patch_attrs(
             balance_layers_to_patch,
             "weight_observer",
@@ -698,6 +801,43 @@ class AWQModifier(Modifier, QuantizationMixin):
                 for balance_layer in balance_layers_to_patch
             ],
         ):
+            initial_error = self._eval_scales(
+                identity_scales,
+                mapping,
+                fp16_outputs,
+                orig_layer_weights,
+                balance_layers_to_patch,
+                device,
+                update_fused=update_fused,
+            )
+            # The identity-scales baseline IS the W4A16-without-smoothing
+            # measurement that the rest of this method compares against.
+            # If it is already non-finite (NaN/Inf in fp16_outputs, NaN/Inf
+            # propagated from the parent forward, broken upstream layer
+            # state, ...) then nothing downstream can recover: every grid
+            # candidate's ``loss < non_finite`` is False, no candidate
+            # ever wins, and the previous code path silently labelled
+            # the layer ``fell_back_to_identity=True``. That hid a
+            # genuine numerical failure behind what looks like a normal
+            # identity fallback. Fail fast instead so the artifact is
+            # never written.
+            if not math.isfinite(initial_error):
+                raise RuntimeError(
+                    f"AWQ identity-scales baseline for "
+                    f"{mapping.smooth_name} is non-finite "
+                    f"({initial_error}). The unsmoothed forward pass "
+                    "produced NaN or Inf outputs, which means the "
+                    "calibration data, mapping, or upstream layer state "
+                    "is broken. Aborting to avoid shipping a silently "
+                    "degraded artifact."
+                )
+            best_scales = identity_scales.clone()
+            best_error = initial_error
+            # Tracks whether any grid candidate strictly improved over the
+            # identity baseline. Used as an explicit fallback indicator at
+            # the end of the search instead of a float-sentinel comparison.
+            grid_improved_over_identity = False
+
             total_iterations = n_grid * len(duo_scalings)
             pbar = tqdm(
                 product(range(n_grid), duo_scalings),
@@ -719,76 +859,56 @@ class AWQModifier(Modifier, QuantizationMixin):
                 scales = scales / (scales.max() * scales.min()).sqrt()
                 scales[torch.isinf(scales)] = 1
                 scales[torch.isnan(scales)] = 1
-                _scalesview = scales.view(1, -1).to(device)
 
-                # Q(W * s)
-                for balance_layer in balance_layers_to_patch:
-                    if not hasattr(balance_layer, "quantization_scheme") or not hasattr(
-                        balance_layer.quantization_scheme, "weights"
-                    ):
-                        continue
-
-                    w_qscheme = balance_layer.quantization_scheme.weights
-                    balance_layer.weight.data.copy_(
-                        orig_layer_weights[balance_layer].to(_scalesview.device)
-                        * _scalesview
-                    )
-
-                    should_calculate_gparam = (
-                        w_qscheme.strategy == QuantizationStrategy.TENSOR_GROUP
-                    )
-                    call_observer(
-                        balance_layer,
-                        "weight",
-                        balance_layer.weight,
-                        should_calculate_gparam=should_calculate_gparam,
-                    )
-                    balance_layer.weight.data = (
-                        forward_quantize(
-                            balance_layer,
-                            balance_layer.weight,
-                            "weight",
-                            w_qscheme,
-                        )
-                        / _scalesview
-                    ).to(balance_layer.weight.dtype)
-
-                # Apply fused global scales for TENSOR_GROUP during grid search
-                # to match inference behavior
-                if balance_layers_to_patch and all(
-                    getattr(layer.quantization_scheme.weights, "strategy", None)
-                    == QuantizationStrategy.TENSOR_GROUP
-                    for layer in balance_layers_to_patch
-                ):
-                    update_fused_layer_weight_global_scales(mapping.parent)
-
-                # W * X
-                int_w_outputs = self._run_samples(mapping.parent)
-
-                # compute mean squared error (L2 norm)
-                loss = self._compute_loss(fp16_outputs, int_w_outputs)
-                del int_w_outputs
-
-                if initial_error is None:
-                    initial_error = loss
+                loss = self._eval_scales(
+                    scales,
+                    mapping,
+                    fp16_outputs,
+                    orig_layer_weights,
+                    balance_layers_to_patch,
+                    device,
+                    update_fused=update_fused,
+                )
 
                 history.append(
                     {"ratio": ratio, "duo_scaling": use_duo_scaling, "error": loss}
                 )
                 if loss < best_error:
                     best_error = loss
-                    best_ratio = ratio
                     best_scales = scales.clone()
+                    grid_improved_over_identity = True
                 pbar.set_postfix({"best_error": f"{best_error:.3e}"})
 
-        if best_ratio == -1:
-            logger.debug(history)
-            raise Exception(
-                "No finite loss was found in best scalesgrid search. This typically "
-                "means NaN values are appearing in the forward pass of the parent "
-                "module. If you encounter this error, raise an issue at "
-                "https://github.com/vllm-project/llm-compressor/issues"
+        # Two outcomes converge to "no grid candidate beat identity":
+        #   1. Every candidate ran and produced a loss >= the identity
+        #      baseline (e.g. attn_output_gate sigmoid distortion, MoE
+        #      routing, severely outlier-heavy activations). The layer
+        #      stays at identity, which is the safe degradation.
+        #   2. Every candidate produced a non-finite loss (NaN/Inf from
+        #      the quantized forward of the scaled weights -- e.g. fp16
+        #      overflow when ``W * s`` saturates the dtype). Identity is
+        #      finite (we checked above), but the search itself is
+        #      genuinely broken and silently labelling the layer
+        #      ``fell_back_to_identity=True`` would hide the numerical
+        #      failure. Surface it instead.
+        # Outcome 1 is the legitimate fallback; outcome 2 must raise so
+        # the artifact is never written.
+        non_finite_history = [
+            h for h in history if not math.isfinite(h.get("error", float("nan")))
+        ]
+        if history and len(non_finite_history) == len(history):
+            raise RuntimeError(
+                f"AWQ grid search for {mapping.smooth_name} produced a "
+                f"non-finite loss for every grid candidate "
+                f"({len(non_finite_history)}/{len(history)}). The "
+                "identity baseline is finite, but the quantized forward "
+                "of the scaled weights is numerically broken (NaN/Inf "
+                "in Q(W*s)/s @ x). This is a genuine search failure, "
+                "not a safe identity fallback; aborting to avoid "
+                "shipping a silently degraded artifact."
             )
+
+        fell_back_to_identity = not grid_improved_over_identity
 
         err_reduction = best_error / initial_error if initial_error > 0 else 1.0
         logger.debug(
@@ -806,6 +926,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                 "initial_error": initial_error,
                 "best_error": best_error,
                 "reduction": err_reduction,
+                "fell_back_to_identity": fell_back_to_identity,
             }
         )
 

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -407,6 +407,18 @@ class AWQModifier(Modifier, QuantizationMixin):
                             f" not found on parent module '{ancestor_name}'"
                         )
 
+                resolved_balance_output_slices: dict[Module, slice] | None = None
+                if mapping.balance_output_slices:
+                    resolved_balance_output_slices = {}
+                    for i, balance_regex in enumerate(mapping.balance_layers):
+                        sl = mapping.balance_output_slices.get(balance_regex)
+                        if sl is None:
+                            continue
+                        for matched_module in tree_leaves(nested_balance_layers[i]):
+                            resolved_balance_output_slices[matched_module] = sl
+                    if not resolved_balance_output_slices:
+                        resolved_balance_output_slices = None
+
                 resolved_mappings.append(
                     ResolvedMapping(
                         smooth_name,
@@ -416,6 +428,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                         parent=ancestor,
                         parent_name=ancestor_name,
                         activation_hook_target=activation_hook_target,
+                        balance_output_slices=resolved_balance_output_slices,
                     )
                 )
         self._resolved_mappings = resolved_mappings
@@ -576,12 +589,24 @@ class AWQModifier(Modifier, QuantizationMixin):
                 ):
                     scales = best_scales.to(module.weight.device)
                     if module in balance_layers:
-                        update_offload_parameter(
-                            module,
-                            "weight",
-                            orig_layer_weights[module].to(module.weight.device)
-                            * scales.view(1, -1),
-                        )
+                        # NOTE: ``balance_output_slices`` is intentionally NOT
+                        # applied here. AWQ's correctness invariant is the
+                        # forward-pass equivalence
+                        #   Y = W @ x = (W * s) @ (x / s)
+                        # which requires the smooth_layer (input_layernorm) to
+                        # be divided by the SAME scale that every column of
+                        # every balance_layer is multiplied by. The slices are
+                        # only used during grid search to focus the MSE on the
+                        # rows that actually participate in the linear output
+                        # path (e.g. the query rows of a fused query+gate
+                        # ``q_proj``); they must NOT cause the final smoothed
+                        # weight to diverge from the equivalence above, or the
+                        # un-smoothed rows would silently see ``x / s`` from
+                        # the layernorm without the compensating ``* s`` on
+                        # the weight.
+                        orig = orig_layer_weights[module].to(module.weight.device)
+                        new_weight = orig * scales.view(1, -1)
+                        update_offload_parameter(module, "weight", new_weight)
                     elif module == smooth_layer:
                         if module.weight.ndim == 1:
                             update_offload_parameter(
@@ -643,9 +668,9 @@ class AWQModifier(Modifier, QuantizationMixin):
     ) -> float:
         """
         Apply ``scales`` to the balance layers via the AWQ smoothing transform
-        ``W' = Q(W * s) / s``, run the parent module on the cached calibration
-        batches, and return the MSE between the smoothed/quantized output and
-        the fp16 reference.
+        ``W' = Q(W * s) / s`` (or its sliced equivalent), run the parent module
+        on the cached calibration batches, and return the MSE between the
+        smoothed/quantized output and the fp16 reference.
 
         Used both for the identity-baseline measurement (``scales = ones``)
         and for every grid-search candidate. Pulling this out of the grid
@@ -667,7 +692,22 @@ class AWQModifier(Modifier, QuantizationMixin):
         for balance_layer in balance_layers_to_patch:
             w_qscheme = balance_layer.quantization_scheme.weights
             orig = orig_layer_weights[balance_layer]
-            balance_layer.weight.data.copy_(orig * _scalesview)
+            sl = (
+                mapping.balance_output_slices.get(balance_layer)
+                if mapping.balance_output_slices
+                else None
+            )
+            if sl is None:
+                balance_layer.weight.data.copy_(orig * _scalesview)
+            else:
+                # In-place patch on the slice avoids a full ``orig.clone()``
+                # per grid candidate. ``copy_(orig)`` resets every row to the
+                # un-smoothed FP16 weight so rows outside the slice stay
+                # bit-identical to the FP16 reference; ``[sl].mul_`` then
+                # applies the smoothing scales only to the rows that
+                # participate in the grid-search MSE.
+                balance_layer.weight.data.copy_(orig)
+                balance_layer.weight.data[sl].mul_(_scalesview)
 
             should_calculate_gparam = (
                 w_qscheme.strategy == QuantizationStrategy.TENSOR_GROUP
@@ -684,7 +724,19 @@ class AWQModifier(Modifier, QuantizationMixin):
                 "weight",
                 w_qscheme,
             )
-            balance_layer.weight.data.copy_(quantized / _scalesview)
+            if sl is None:
+                balance_layer.weight.data.copy_(quantized / _scalesview)
+            else:
+                # Keep rows outside the slice equal to the original
+                # unsmoothed/unquantized weight so the parent module's
+                # forward pass for that path matches the fp16 baseline
+                # bitwise. The MSE loss therefore only reflects errors
+                # introduced on the slice rows. Patch in place via
+                # ``copy_`` (rather than reassigning ``weight.data``) so
+                # any offload hook holding a reference to the original
+                # tensor stays attached to the live storage.
+                balance_layer.weight.data.copy_(orig)
+                balance_layer.weight.data[sl].copy_(quantized[sl] / _scalesview)
 
         # Apply fused global scales for TENSOR_GROUP during grid search
         # to match inference behavior. ``update_fused`` is precomputed

--- a/src/llmcompressor/modifiers/awq/dynamic_mappings.py
+++ b/src/llmcompressor/modifiers/awq/dynamic_mappings.py
@@ -84,6 +84,9 @@ def build_hybrid_attention_mappings(model: Module) -> list[AWQMapping] | None:
     linear_proj_names = _detect_linear_attn_projections(model)
     is_moe = is_moe_model(model)
 
+    q_proj_re = "re:.*self_attn.q_proj$"
+    balance_output_slices = _build_q_proj_output_slice(model, q_proj_re)
+
     mappings = []
 
     # Full attention layers: input_layernorm -> q/k/v_proj
@@ -91,10 +94,11 @@ def build_hybrid_attention_mappings(model: Module) -> list[AWQMapping] | None:
         AWQMapping(
             f"re:.*layers\\.({full_re})\\.input_layernorm$",
             [
-                "re:.*self_attn.q_proj$",
+                q_proj_re,
                 "re:.*self_attn.k_proj$",
                 "re:.*self_attn.v_proj$",
             ],
+            balance_output_slices=balance_output_slices,
         )
     )
 
@@ -175,6 +179,45 @@ def _get_hybrid_attention_config(model: Module) -> tuple[list[str], int] | None:
         return None
 
     return layer_types, num_layers
+
+
+def _build_q_proj_output_slice(
+    model: Module, q_proj_re: str
+) -> dict[str, slice] | None:
+    """
+    For models that fuse the attention output gate into ``q_proj``
+    (``attn_output_gate=True``, e.g. Qwen3.5), build a slice covering only the
+    query half of ``q_proj.weight`` (rows ``[0 : num_heads * head_dim]``).
+    The gate half (rows ``[num_heads * head_dim :]``) feeds a ``sigmoid``
+    whose saturation regions distort the AWQ grid search, so we exclude it
+    from smoothing and the MSE loss.
+
+    Returns ``None`` if the model does not use attention output gating.
+    """
+    config = getattr(model, "config", None)
+    if config is None:
+        return None
+    text_config = getattr(config, "text_config", config)
+    if not getattr(text_config, "attn_output_gate", False):
+        return None
+
+    num_heads = getattr(text_config, "num_attention_heads", None)
+    if num_heads is None:
+        return None
+    head_dim = getattr(text_config, "head_dim", None)
+    if head_dim is None:
+        hidden_size = getattr(text_config, "hidden_size", None)
+        if hidden_size is None:
+            return None
+        head_dim = hidden_size // num_heads
+
+    query_rows = num_heads * head_dim
+    logger.info(
+        "Detected attn_output_gate=True; restricting AWQ smoothing of "
+        f"{q_proj_re} to query rows [0:{query_rows}] "
+        "(gate rows are excluded from grid-search MSE)."
+    )
+    return {q_proj_re: slice(0, query_rows)}
 
 
 def _detect_linear_attn_projections(model: Module) -> list[str]:

--- a/src/llmcompressor/modifiers/awq/mappings.py
+++ b/src/llmcompressor/modifiers/awq/mappings.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Sequence, Union
 
 from torch.nn import Module
 
@@ -7,6 +8,77 @@ __all__ = [
     "AWQ_MAPPING_REGISTRY",
     "default_mappings",
 ]
+
+
+# YAML-friendly representation of a half-open ``[start, stop)`` range.
+# Accepted forms (all normalised to ``slice`` in ``__post_init__``):
+#   * ``slice(0, 8)``               (Python recipes)
+#   * ``[0, 8]`` or ``(0, 8)``      (most YAML loaders)
+#   * ``{"start": 0, "stop": 8}``   (explicit-keys YAML)
+#   * ``{"start": 0, "stop": 8, "step": 2}`` (rare; ``step`` honoured)
+SliceLike = Union[
+    slice,
+    Sequence[int],  # [start, stop] or [start, stop, step]
+    dict,  # {"start": ..., "stop": ..., "step": ...}
+]
+
+
+def _coerce_slice(value: SliceLike) -> slice:
+    """Normalise YAML-friendly slice encodings into a real ``slice`` object.
+
+    Numeric components (``start`` / ``stop`` / ``step``) are coerced to
+    ``int`` regardless of whether they came from a list/tuple or a dict,
+    so YAML configurations that quote the numbers (``{"start": "0",
+    "stop": "8"}``) fail at recipe-load time with a clear ``TypeError``
+    rather than mid-quantization with an opaque tensor-indexing error.
+
+    Raises ``TypeError`` with the offending value preserved so
+    configuration errors surface at recipe-load time rather than during
+    grid search.
+    """
+
+    def _maybe_int(component, *, allow_none: bool = True):
+        if component is None:
+            if allow_none:
+                return None
+            raise TypeError(
+                f"balance_output_slices: required slice component is None "
+                f"in {value!r}"
+            )
+        try:
+            return int(component)
+        except (TypeError, ValueError) as e:
+            raise TypeError(
+                f"balance_output_slices: slice component {component!r} in "
+                f"{value!r} is not coercible to int"
+            ) from e
+
+    if isinstance(value, slice):
+        return value
+    if isinstance(value, dict):
+        # ``stop`` is required (a slice with stop=None is technically valid
+        # but useless for our out_features dimension scoping), so reject
+        # that explicitly. ``start`` defaults to 0 and ``step`` to None
+        # to match Python's ``slice`` semantics.
+        return slice(
+            _maybe_int(value.get("start", 0)),
+            _maybe_int(value.get("stop"), allow_none=False),
+            _maybe_int(value.get("step")),
+        )
+    if isinstance(value, (list, tuple)):
+        if len(value) == 2:
+            return slice(_maybe_int(value[0]), _maybe_int(value[1], allow_none=False))
+        if len(value) == 3:
+            return slice(
+                _maybe_int(value[0]),
+                _maybe_int(value[1], allow_none=False),
+                _maybe_int(value[2]),
+            )
+    raise TypeError(
+        f"balance_output_slices entry must be a slice, [start, stop], "
+        f"[start, stop, step], or {{'start':..., 'stop':..., 'step':...}}; "
+        f"got {value!r} ({type(value).__name__})"
+    )
 
 
 @dataclass
@@ -29,11 +101,36 @@ class AWQMapping:
         blocks (e.g. Cohere, Gemma 3) where the first balance layer is not the
         correct place to capture activations. When ``None`` (default), the hook
         is placed on ``balance_layers[0]``.
+    :param balance_output_slices: optional mapping from a balance-layer regex to
+        a ``slice`` over its ``out_features`` dimension. Only the rows in the
+        slice participate in the AWQ grid-search MSE; rows outside keep their
+        original (unsmoothed, unquantized) weights for the duration of grid
+        search. After grid search the chosen scales are applied uniformly to
+        every column of every balance layer so the AWQ algebraic invariant
+        ``Y = (W * s) @ (x / s)`` continues to hold for the un-sliced rows.
+
+        This is required for architectures like Qwen3.5 where a single
+        ``q_proj`` produces both the query stream and an attention output
+        gate — the gate path runs through ``sigmoid`` whose saturation
+        regions distort the AWQ grid search.
+
+        For YAML recipes, each value may be a ``[start, stop]`` /
+        ``[start, stop, step]`` list/tuple or a
+        ``{"start": ..., "stop": ..., "step": ...}`` dict; Python callers
+        may pass a real ``slice``. ``None`` (default) means the full weight
+        participates, preserving the original behaviour.
     """
 
     smooth_layer: str
     balance_layers: list[str]
     activation_hook_target: str | None = None
+    balance_output_slices: dict[str, SliceLike] | None = field(default=None)
+
+    def __post_init__(self):
+        if self.balance_output_slices is not None:
+            self.balance_output_slices = {
+                k: _coerce_slice(v) for k, v in self.balance_output_slices.items()
+            }
 
 
 default_mappings = [
@@ -261,6 +358,11 @@ class ResolvedMapping:
         caching. When set, the activation cache hook is placed on this module
         instead of ``balance_layers[0]``. Populated from
         ``AWQMapping.activation_hook_target``.
+    :param balance_output_slices: optional resolved mapping from balance-layer
+        ``Module`` to a ``slice`` over its ``out_features`` dimension. Populated
+        from ``AWQMapping.balance_output_slices``. Rows outside the slice keep
+        their original weights and do not participate in smoothing or in the
+        grid-search MSE.
     """
 
     smooth_name: str
@@ -270,3 +372,4 @@ class ResolvedMapping:
     parent: Module
     parent_name: str
     activation_hook_target: Module | None = None
+    balance_output_slices: dict[Module, slice] | None = None

--- a/tests/llmcompressor/modifiers/awq/test_compute_best_scale_baseline.py
+++ b/tests/llmcompressor/modifiers/awq/test_compute_best_scale_baseline.py
@@ -1,0 +1,358 @@
+"""
+End-to-end-ish tests that drive ``AWQModifier`` through its real code
+path on a tiny synthetic module.
+
+Every test in this file exercises production code (``_compute_best_scale``,
+``_eval_scales``, ``_apply_smoothing``) by attaching a real W4A16
+quantization scheme + observer to a tiny ``Linear``, hand-populating
+the activation/parent caches that the production hooks would otherwise
+populate during calibration, and then invoking the public-facing entry
+points.
+
+This is the only AWQ test file that walks the real grid search loop;
+contract / dataclass / shape tests have been deliberately removed in
+favour of the regressions captured here. New tests SHOULD be added here
+(or to a sibling file with the same execution model) rather than as
+stand-alone field/dataclass tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationScheme,
+    QuantizationStrategy,
+    disable_quantization,
+    initialize_module_for_quantization,
+)
+from torch.nn import LayerNorm, Linear, Module
+
+from llmcompressor.core.session_functions import create_session
+from llmcompressor.modifiers.awq import AWQModifier
+from llmcompressor.modifiers.awq.mappings import ResolvedMapping
+from llmcompressor.modifiers.quantization.calibration import (
+    call_observer,
+    initialize_observer,
+)
+from llmcompressor.pipelines.cache import IntermediatesCache
+
+
+class _Wrapper(Module):
+    """Minimal parent module: forwards a hidden state through a single Linear."""
+
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.proj = Linear(in_features, out_features, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.proj(hidden_states)
+
+
+def _attach_w4a16_scheme(
+    balance_layer: Linear, group_size: int = 8, num_bits: int = 4
+) -> None:
+    """Attach a W4A16 group-wise quantization scheme + observer + qparams.
+
+    ``initialize_module_for_quantization`` swaps ``Linear.__call__`` for a
+    weight-quantizing forward. The freshly-initialised ``weight_scale`` is
+    zeros, so the quantized forward returns zeros/NaN until the observer
+    is calibrated; we calibrate the observer here once so the wrapper
+    has a non-degenerate ``Q(W) @ x`` to fall back on.
+
+    Production also disables this wrapper before running ``fp16_outputs``
+    forward passes inside ``_apply_smoothing`` (see ``AWQModifier.on_start``
+    where ``model.apply(disable_quantization)`` is called). Without the
+    same flip the grid baseline measurement would compare two identical
+    quantized outputs for ``scales = ones`` (loss = 0) and the search
+    could never improve on identity. We mirror that production behaviour
+    here so ``_compute_best_scale`` and ``_apply_smoothing`` walk a
+    realistic code path.
+    """
+    scheme = QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(
+            num_bits=num_bits,
+            symmetric=False,
+            strategy=QuantizationStrategy.GROUP,
+            group_size=group_size,
+        ),
+    )
+    initialize_module_for_quantization(balance_layer, scheme, force_zero_point=True)
+    initialize_observer(balance_layer, base_name="weight")
+    call_observer(
+        balance_layer, "weight", balance_layer.weight, should_calculate_gparam=False
+    )
+    disable_quantization(balance_layer)
+
+
+def _setup_modifier(
+    awq: AWQModifier,
+    parent: Module,
+    balance_layer: Linear,
+    smooth_name: str,
+    batch_inputs: list[torch.Tensor],
+):
+    """Hand-populate the private caches that ``_compute_best_scale`` reads."""
+    cache = IntermediatesCache(None, None)
+    for x in batch_inputs:
+        cache.append({"hidden_states": x})
+    awq._parent_args_cache[parent] = cache
+
+    x_concat = torch.cat([b.reshape(-1, b.shape[-1]) for b in batch_inputs], dim=0)
+    x_sum = x_concat.abs().sum(dim=0).to(torch.float32)
+    count = torch.tensor(x_concat.shape[0], dtype=torch.float32)
+    awq._smooth_activation_stats[smooth_name] = [x_sum, count]
+
+
+def _build_resolved_mapping(
+    parent: Module,
+    balance_layer: Linear,
+    *,
+    smooth_layer: Module | None = None,
+    smooth_name: str = "layers.0.input_layernorm",
+) -> ResolvedMapping:
+    return ResolvedMapping(
+        smooth_name=smooth_name,
+        smooth_layer=smooth_layer or LayerNorm(balance_layer.in_features),
+        balance_layers=[balance_layer],
+        balance_names=["layers.0.proj"],
+        parent=parent,
+        parent_name="layers.0",
+    )
+
+
+def _make_inputs(
+    batch_size: int, seq_len: int, hidden: int, *, outlier_channel: int | None = None
+) -> list[torch.Tensor]:
+    torch.manual_seed(0)
+    x = torch.randn(batch_size, seq_len, hidden)
+    if outlier_channel is not None:
+        x[..., outlier_channel] *= 1e3
+    return [x]
+
+
+@pytest.mark.unit
+def test_initial_error_equals_identity_loss():
+    """
+    Regression test for the codex-flagged baseline bug: with
+    ``duo_scaling=True`` (default) and ``ratio=0`` the first grid candidate
+    is *not* identity, so the previous implementation recorded an
+    arbitrary loss as ``initial_error``. The fix seeds the search with a
+    real identity-scales measurement; verify that the recorded
+    ``initial_error`` exactly matches a manual identity-scales loss
+    computation.
+    """
+    in_features, out_features = 32, 16
+    parent = _Wrapper(in_features, out_features)
+    balance_layer = parent.proj
+    _attach_w4a16_scheme(balance_layer)
+
+    batch_inputs = _make_inputs(1, 4, in_features)
+
+    with torch.no_grad():
+        fp16_outputs = [parent(x).clone() for x in batch_inputs]
+    orig_layer_weights = {balance_layer: balance_layer.weight.detach().clone()}
+
+    awq = AWQModifier(scheme="W4A16_ASYM", n_grid=4, duo_scaling=True)
+    mapping = _build_resolved_mapping(parent, balance_layer)
+    _setup_modifier(awq, parent, balance_layer, mapping.smooth_name, batch_inputs)
+
+    with create_session():
+        awq._compute_best_scale(mapping, fp16_outputs, orig_layer_weights)
+
+    metrics = awq._error_metrics[0]
+    assert metrics["layer_name"] == mapping.smooth_name
+
+    # Recompute identity loss the same way ``_eval_scales`` would,
+    # independently of the grid loop.
+    balance_layer.weight.data.copy_(orig_layer_weights[balance_layer])
+    awq2 = AWQModifier(scheme="W4A16_ASYM", n_grid=4, duo_scaling=True)
+    _setup_modifier(awq2, parent, balance_layer, mapping.smooth_name, batch_inputs)
+    with create_session():
+        identity_loss = awq2._eval_scales(
+            torch.ones(in_features),
+            mapping,
+            fp16_outputs,
+            orig_layer_weights,
+            [balance_layer],
+            torch.device("cpu"),
+        )
+
+    # Pre-fix, initial_error would be the loss at duo-scaling ratio=0
+    # scales, NOT identity. Post-fix they must match exactly.
+    assert metrics["initial_error"] == pytest.approx(identity_loss, rel=1e-6, abs=1e-9)
+
+
+@pytest.mark.unit
+def test_best_error_never_exceeds_initial_error():
+    """
+    The seed-with-identity strategy guarantees the grid search can never
+    pick a worse-than-baseline candidate, so the AWQ artifact is never
+    *worse* than plain W4A16 for that layer.
+    """
+    in_features, out_features = 32, 16
+    parent = _Wrapper(in_features, out_features)
+    balance_layer = parent.proj
+    _attach_w4a16_scheme(balance_layer)
+
+    batch_inputs = _make_inputs(1, 4, in_features, outlier_channel=7)
+    with torch.no_grad():
+        fp16_outputs = [parent(x).clone() for x in batch_inputs]
+    orig_layer_weights = {balance_layer: balance_layer.weight.detach().clone()}
+
+    awq = AWQModifier(scheme="W4A16_ASYM", n_grid=4, duo_scaling=True)
+    mapping = _build_resolved_mapping(parent, balance_layer)
+    _setup_modifier(awq, parent, balance_layer, mapping.smooth_name, batch_inputs)
+
+    with create_session():
+        awq._compute_best_scale(mapping, fp16_outputs, orig_layer_weights)
+
+    metrics = awq._error_metrics[0]
+    assert metrics["best_error"] <= metrics["initial_error"], (
+        "Grid search must never select a candidate worse than the "
+        f"identity baseline, but got best={metrics['best_error']:.3e} > "
+        f"initial={metrics['initial_error']:.3e}"
+    )
+
+
+@pytest.mark.unit
+def test_compute_best_scale_raises_when_identity_baseline_is_non_finite():
+    """
+    Production-path regression for the non-finite-baseline silent
+    failure flagged by codex.
+
+    Pre-fix sequence of events when ``fp16_outputs`` was non-finite
+    (NaN/Inf propagated from a broken upstream layer or corrupt
+    calibration sample):
+
+      1. ``initial_error = _eval_scales(identity_scales, ...)`` returns
+         ``NaN``.
+      2. ``best_error = initial_error = NaN``.
+      3. Every grid candidate's ``loss < NaN`` is ``False`` so no
+         candidate ever wins and the layer is labelled
+         ``fell_back_to_identity=True``.
+      4. ``err_reduction = NaN / NaN`` retains its ``> 0`` False branch
+         and is silently set to ``1.0``.
+      5. Modifier returns success with poison metrics; downstream
+         artifact ships silently degraded.
+
+    Post-fix the identity baseline is checked for finiteness *before*
+    seeding ``best_error``. We assert the modifier raises
+    ``RuntimeError`` instead of writing poison metrics into
+    ``_error_metrics``. This test pins the regression that hid Inf/NaN
+    AWQ failures behind the identity-fallback path.
+    """
+    in_features, out_features = 32, 16
+    parent = _Wrapper(in_features, out_features)
+    balance_layer = parent.proj
+    _attach_w4a16_scheme(balance_layer)
+
+    batch_inputs = _make_inputs(1, 4, in_features)
+    # Poison fp16_outputs with NaN. _eval_scales computes
+    # ``MSE(fp16_outputs, int_w_outputs)`` which is NaN if either side
+    # is NaN -- the exact failure shape produced when an upstream
+    # layer's calibration output is NaN/Inf.
+    fp16_outputs = [
+        torch.full((1, 4, out_features), float("nan")) for _ in batch_inputs
+    ]
+    orig_layer_weights = {balance_layer: balance_layer.weight.detach().clone()}
+
+    awq = AWQModifier(scheme="W4A16_ASYM", n_grid=4, duo_scaling=True)
+    mapping = _build_resolved_mapping(parent, balance_layer)
+    _setup_modifier(awq, parent, balance_layer, mapping.smooth_name, batch_inputs)
+
+    with create_session():
+        with pytest.raises(RuntimeError, match="non-finite"):
+            awq._compute_best_scale(mapping, fp16_outputs, orig_layer_weights)
+
+    # Critically: no poison metrics may have been appended. The whole
+    # point of the fix is that the layer must NOT silently end up in
+    # ``_error_metrics`` with ``fell_back_to_identity=True``.
+    assert awq._error_metrics == [], (
+        "Non-finite baseline must abort *before* writing into "
+        "_error_metrics; otherwise downstream gates silently skip the "
+        f"layer. Got: {awq._error_metrics}"
+    )
+
+
+@pytest.mark.unit
+def test_compute_best_scale_raises_when_all_grid_candidates_are_non_finite():
+    """
+    Companion to the identity-baseline test above: even when the
+    identity-scales baseline is finite, the search itself can break if
+    every executed grid candidate produces a non-finite loss (e.g. fp16
+    overflow when ``W * s`` saturates the dtype, or upstream NaN that
+    only surfaces on scaled forwards).
+
+    Pre-fix this fell through the same crack: ``loss < finite_baseline``
+    is False for any non-finite ``loss``, so no candidate ever won and
+    the layer was silently labelled ``fell_back_to_identity=True``,
+    indistinguishable in the metrics from a legitimate "no candidate
+    beat identity" fallback. The artifact shipped without surfacing
+    the numerical failure.
+
+    Post-fix the modifier inspects ``history`` and distinguishes "every
+    candidate ran but produced a finite loss none of which beat
+    identity" (legitimate identity fallback) from "every candidate
+    produced a non-finite loss" (genuine numerical failure). The
+    latter must raise.
+
+    We exercise the production code path end-to-end: ``_eval_scales``
+    is the only dependency that can produce a non-finite loss, so we
+    inject a single small wrapper that returns the real loss for the
+    identity baseline (which the production code calls first to seed
+    ``initial_error``) and ``NaN`` for every subsequent grid candidate.
+    This is a *control-flow* test of ``_compute_best_scale`` -- the
+    decision logic that distinguishes the two fallback shapes -- not
+    an algebra test of ``_eval_scales``, which is already covered
+    end-to-end by the tests above.
+    """
+    in_features, out_features = 32, 16
+    parent = _Wrapper(in_features, out_features)
+    balance_layer = parent.proj
+    _attach_w4a16_scheme(balance_layer)
+
+    batch_inputs = _make_inputs(1, 4, in_features)
+    with torch.no_grad():
+        fp16_outputs = [parent(x).clone() for x in batch_inputs]
+    orig_layer_weights = {balance_layer: balance_layer.weight.detach().clone()}
+
+    awq = AWQModifier(
+        scheme="W4A16_ASYM",
+        n_grid=4,
+        duo_scaling=True,
+    )
+    mapping = _build_resolved_mapping(parent, balance_layer)
+    _setup_modifier(awq, parent, balance_layer, mapping.smooth_name, batch_inputs)
+
+    real_eval_scales = awq._eval_scales
+    call_count = {"n": 0}
+
+    def patched_eval_scales(scales, *args, **kwargs):
+        call_count["n"] += 1
+        # First call is the identity baseline -- must stay finite or
+        # the test would trivially exercise the *baseline* guard
+        # already covered by the test above.
+        if call_count["n"] == 1:
+            assert torch.allclose(scales, torch.ones_like(scales))
+            return real_eval_scales(scales, *args, **kwargs)
+        return float("nan")
+
+    awq._eval_scales = patched_eval_scales
+
+    with create_session():
+        with pytest.raises(RuntimeError, match="non-finite"):
+            awq._compute_best_scale(mapping, fp16_outputs, orig_layer_weights)
+
+    assert call_count["n"] > 1, (
+        "Test setup error: grid loop did not execute any non-identity "
+        "candidates, so the all-candidates-non-finite path was never "
+        "exercised."
+    )
+    assert awq._error_metrics == [], (
+        "All-candidates-non-finite must abort *before* writing into "
+        "_error_metrics; otherwise downstream gates silently skip the "
+        f"layer. Got: {awq._error_metrics}"
+    )

--- a/tests/llmcompressor/modifiers/awq/test_compute_best_scale_baseline.py
+++ b/tests/llmcompressor/modifiers/awq/test_compute_best_scale_baseline.py
@@ -3,11 +3,11 @@ End-to-end-ish tests that drive ``AWQModifier`` through its real code
 path on a tiny synthetic module.
 
 Every test in this file exercises production code (``_compute_best_scale``,
-``_eval_scales``, ``_apply_smoothing``) by attaching a real W4A16
-quantization scheme + observer to a tiny ``Linear``, hand-populating
-the activation/parent caches that the production hooks would otherwise
-populate during calibration, and then invoking the public-facing entry
-points.
+``_eval_scales``, ``_assert_smoothing_health``, ``_apply_smoothing``) by
+attaching a real W4A16 quantization scheme + observer to a tiny
+``Linear``, hand-populating the activation/parent caches that the
+production hooks would otherwise populate during calibration, and then
+invoking the public-facing entry points.
 
 This is the only AWQ test file that walks the real grid search loop;
 contract / dataclass / shape tests have been deliberately removed in
@@ -48,6 +48,22 @@ class _Wrapper(Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.proj(hidden_states)
+
+
+class _LayerNormBlock(Module):
+    """LayerNorm -> Linear, mirroring an ``input_layernorm -> q_proj`` path.
+
+    Used by the forward-equivalence regression to verify the AWQ
+    smoothing transform is a no-op on the FP forward pass.
+    """
+
+    def __init__(self, hidden: int, out_features: int | None = None):
+        super().__init__()
+        self.input_layernorm = LayerNorm(hidden)
+        self.proj = Linear(hidden, out_features or hidden, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.proj(self.input_layernorm(hidden_states))
 
 
 def _attach_w4a16_scheme(
@@ -112,6 +128,7 @@ def _build_resolved_mapping(
     *,
     smooth_layer: Module | None = None,
     smooth_name: str = "layers.0.input_layernorm",
+    balance_output_slices: dict[Module, slice] | None = None,
 ) -> ResolvedMapping:
     return ResolvedMapping(
         smooth_name=smooth_name,
@@ -120,6 +137,7 @@ def _build_resolved_mapping(
         balance_names=["layers.0.proj"],
         parent=parent,
         parent_name="layers.0",
+        balance_output_slices=balance_output_slices,
     )
 
 
@@ -215,6 +233,171 @@ def test_best_error_never_exceeds_initial_error():
         f"identity baseline, but got best={metrics['best_error']:.3e} > "
         f"initial={metrics['initial_error']:.3e}"
     )
+
+
+@pytest.mark.unit
+def test_balance_output_slices_changes_grid_outcome_for_fused_q_proj():
+    """
+    Production-path regression for ``balance_output_slices``.
+
+    For Qwen3.5's fused query+gate ``q_proj`` the gate half (top H*D rows
+    in a 2*H*D output Linear) is sigmoid'd downstream and its weight
+    magnitude is *wildly* out of distribution from the query half. If the
+    grid search is allowed to see MSE on the gate rows it gets pulled
+    toward scales that minimise gate error and degrade query error -- the
+    exact failure mode that originally pushed Qwen3.5-27B AWQ to
+    ``bpb=3.8`` versus baseline ``bpb=0.5``.
+
+    Setting ``balance_output_slices`` to scope the MSE to the query rows
+    must therefore (a) actually be consulted by the search and (b)
+    produce a different ``best_scales`` than the un-sliced run on a model
+    constructed to make the gate rows dominate. We assert both. If either
+    fails, the slice field is dead code and the Qwen3.5 fix is gone.
+    """
+    in_features = 32
+    out_features = 32  # 16 query rows + 16 gate rows
+    batch_inputs = _make_inputs(1, 4, in_features)
+
+    def _run(use_slice: bool) -> dict:
+        torch.manual_seed(0)
+        parent = _Wrapper(in_features, out_features)
+        balance_layer = parent.proj
+        with torch.no_grad():
+            # Query rows: small magnitude. Gate rows: 100x larger so they
+            # dominate the un-sliced MSE and the un-sliced baseline.
+            balance_layer.weight[:16].mul_(0.1)
+            balance_layer.weight[16:].mul_(10.0)
+        _attach_w4a16_scheme(balance_layer)
+
+        with torch.no_grad():
+            fp16_outputs = [parent(x).clone() for x in batch_inputs]
+        orig_layer_weights = {
+            balance_layer: balance_layer.weight.detach().clone()
+        }
+
+        slices = {balance_layer: slice(0, 16)} if use_slice else None
+        awq = AWQModifier(scheme="W4A16_ASYM", n_grid=8, duo_scaling=True)
+        mapping = _build_resolved_mapping(
+            parent, balance_layer, balance_output_slices=slices
+        )
+        _setup_modifier(
+            awq, parent, balance_layer, mapping.smooth_name, batch_inputs
+        )
+        with create_session():
+            awq._compute_best_scale(mapping, fp16_outputs, orig_layer_weights)
+        return awq._error_metrics[0]
+
+    metrics_no_slice = _run(use_slice=False)
+    metrics_with_slice = _run(use_slice=True)
+
+    # Both the identity baseline (initial_error) and the chosen
+    # best_error are computed by ``_eval_scales``, which is the only
+    # place the production code consults ``balance_output_slices``. If
+    # the slice were silently ignored both runs would compute MSE over
+    # the same rows and produce the same baseline. The huge magnitude
+    # gap between query and gate rows guarantees that scoping the MSE to
+    # the query rows must produce a strictly smaller baseline -- not
+    # just a slightly different one. This is what proves the slice is
+    # actually consulted by the real grid loop.
+    assert metrics_with_slice["initial_error"] < 0.5 * metrics_no_slice[
+        "initial_error"
+    ], (
+        "balance_output_slices did not change the grid baseline: "
+        f"no_slice={metrics_no_slice['initial_error']:.3e}, "
+        f"with_slice={metrics_with_slice['initial_error']:.3e}. The "
+        "field is plumbed but not actually consulted by the search -- "
+        "the Qwen3.5 fused q_proj fix is silently broken."
+    )
+
+    # Same argument for best_error: if the slice were ignored the search
+    # would find the same minimum on both runs. Even when both runs fall
+    # back to identity (best_error == initial_error), the inequality
+    # below still holds because identity loss itself differs.
+    assert metrics_with_slice["best_error"] < 0.5 * metrics_no_slice[
+        "best_error"
+    ], (
+        f"no_slice best_error={metrics_no_slice['best_error']:.3e}, "
+        f"with_slice best_error={metrics_with_slice['best_error']:.3e}"
+    )
+
+
+@pytest.mark.unit
+def test_apply_smoothing_preserves_forward_equivalence():
+    """
+    Production-path regression for the ``_apply_smoothing`` algebraic
+    invariant -- the bug that pushed Qwen3.5-27B AWQ from ``bpb=0.57``
+    (fix1) to ``bpb=0.51`` (fix2).
+
+    AWQ's correctness rests on the identity
+
+        Y = balance(LN(x))
+          = (balance with W*s)((LN with gamma/s, beta/s)(x))
+
+    which holds element-wise in floating point. The slice-aware
+    grid-search optimisation MUST NOT leak into the persisted ``_smooth``
+    step: if the final balance_layer weight only scales the slice rows
+    while the smooth_layer is divided by ``s`` on all input channels,
+    then the un-scaled rows silently see ``x / s`` from the layernorm
+    without the compensating ``* s`` on the weight. The forward pass on
+    those rows then drifts away from the FP baseline -- which is exactly
+    how the gate half of a fused ``q_proj`` (sigmoid'd downstream)
+    catastrophically fails after quantization.
+
+    This test runs the full ``_apply_smoothing`` path -- including
+    ``_compute_best_scale`` with a non-trivial slice -- and verifies the
+    parent module's FP forward output is preserved bit-close before vs
+    after smoothing. If the per-mapping ``_smooth`` step ever regresses
+    to a slice-aware update (the original fix1 implementation), this
+    test fails with a ``> 1e-3`` divergence on the un-scaled rows.
+    """
+    torch.manual_seed(0)
+    hidden = 32
+    out_features = 32  # mimic 2*H*D fused query+gate q_proj
+    parent = _LayerNormBlock(hidden=hidden, out_features=out_features)
+    balance_layer = parent.proj
+    smooth_layer = parent.input_layernorm
+
+    with torch.no_grad():
+        # Make query rows and gate rows differ in magnitude; this
+        # combined with the slice gives the grid search a real
+        # opportunity to pick scales that are good for query rows but
+        # would be wrong for gate rows if naively applied to *only* the
+        # slice in the persisted weight.
+        balance_layer.weight[:16].mul_(0.1)
+        balance_layer.weight[16:].mul_(10.0)
+    _attach_w4a16_scheme(balance_layer)
+
+    batch_inputs = _make_inputs(1, 4, hidden)
+    with torch.no_grad():
+        y_before = parent(batch_inputs[0]).clone()
+
+    awq = AWQModifier(scheme="W4A16_ASYM", n_grid=4, duo_scaling=True)
+    mapping = _build_resolved_mapping(
+        parent,
+        balance_layer,
+        smooth_layer=smooth_layer,
+        smooth_name="input_layernorm",
+        balance_output_slices={balance_layer: slice(0, 16)},
+    )
+    awq._resolved_mappings = [mapping]
+    _setup_modifier(
+        awq, parent, balance_layer, mapping.smooth_name, batch_inputs
+    )
+
+    with create_session():
+        awq._apply_smoothing(parent)
+
+    with torch.no_grad():
+        y_after = parent(batch_inputs[0])
+
+    # The smoothing transform is exact in FP, so the only allowed
+    # divergence is round-off from the divide/multiply pair on
+    # ``smooth_layer.weight`` and ``balance_layer.weight``. Tolerances
+    # below are chosen to fit FP32 round-off but will easily catch a
+    # regression that drops the all-columns scaling on balance_layer
+    # (the original fix1 bug produced O(weight magnitude) divergence on
+    # the un-scaled gate rows, well above 1e-3).
+    torch.testing.assert_close(y_after, y_before, rtol=1e-4, atol=1e-4)
 
 
 @pytest.mark.unit

--- a/tests/llmcompressor/modifiers/awq/test_dynamic_mappings.py
+++ b/tests/llmcompressor/modifiers/awq/test_dynamic_mappings.py
@@ -18,6 +18,9 @@ def _make_hybrid_model(
     moe=False,
     num_experts=2,
     use_text_config=False,
+    attn_output_gate=False,
+    num_attention_heads=2,
+    head_dim=4,
 ):
     """Build a minimal hybrid attention model for testing."""
     layer_types = [
@@ -29,24 +32,27 @@ def _make_hybrid_model(
         for i in range(num_layers)
     ]
 
+    hidden_size = num_attention_heads * head_dim
+    q_out = 2 * hidden_size if attn_output_gate else hidden_size
+
     layers = []
     for i in range(num_layers):
         if layer_types[i] == "full_attention":
             attn = torch.nn.ModuleDict(
                 {
-                    "q_proj": Linear(8, 8),
-                    "k_proj": Linear(8, 8),
-                    "v_proj": Linear(8, 8),
-                    "o_proj": Linear(8, 8),
+                    "q_proj": Linear(hidden_size, q_out),
+                    "k_proj": Linear(hidden_size, hidden_size),
+                    "v_proj": Linear(hidden_size, hidden_size),
+                    "o_proj": Linear(hidden_size, hidden_size),
                 }
             )
             layer = torch.nn.ModuleDict({"self_attn": attn})
         else:
             attn = torch.nn.ModuleDict(
-                {name: Linear(8, 8) for name in linear_proj_names}
+                {name: Linear(hidden_size, hidden_size) for name in linear_proj_names}
             )
-            attn["norm"] = torch.nn.LayerNorm(8)
-            attn["out_proj"] = Linear(8, 8)
+            attn["norm"] = torch.nn.LayerNorm(hidden_size)
+            attn["out_proj"] = Linear(hidden_size, hidden_size)
             layer = torch.nn.ModuleDict({"linear_attn": attn})
 
         if moe:
@@ -54,9 +60,9 @@ def _make_hybrid_model(
                 [
                     torch.nn.ModuleDict(
                         {
-                            "gate_proj": Linear(8, 8),
-                            "up_proj": Linear(8, 8),
-                            "down_proj": Linear(8, 8),
+                            "gate_proj": Linear(hidden_size, hidden_size),
+                            "up_proj": Linear(hidden_size, hidden_size),
+                            "down_proj": Linear(hidden_size, hidden_size),
                         }
                     )
                     for _ in range(num_experts)
@@ -64,9 +70,9 @@ def _make_hybrid_model(
             )
             shared = torch.nn.ModuleDict(
                 {
-                    "gate_proj": Linear(8, 8),
-                    "up_proj": Linear(8, 8),
-                    "down_proj": Linear(8, 8),
+                    "gate_proj": Linear(hidden_size, hidden_size),
+                    "up_proj": Linear(hidden_size, hidden_size),
+                    "down_proj": Linear(hidden_size, hidden_size),
                 }
             )
             layer["mlp"] = torch.nn.ModuleDict(
@@ -78,14 +84,14 @@ def _make_hybrid_model(
         else:
             layer["mlp"] = torch.nn.ModuleDict(
                 {
-                    "gate_proj": Linear(8, 8),
-                    "up_proj": Linear(8, 8),
-                    "down_proj": Linear(8, 8),
+                    "gate_proj": Linear(hidden_size, hidden_size),
+                    "up_proj": Linear(hidden_size, hidden_size),
+                    "down_proj": Linear(hidden_size, hidden_size),
                 }
             )
 
-        layer["input_layernorm"] = torch.nn.LayerNorm(8)
-        layer["post_attention_layernorm"] = torch.nn.LayerNorm(8)
+        layer["input_layernorm"] = torch.nn.LayerNorm(hidden_size)
+        layer["post_attention_layernorm"] = torch.nn.LayerNorm(hidden_size)
         layers.append(layer)
 
     model = torch.nn.ModuleDict(
@@ -102,7 +108,12 @@ def _make_hybrid_model(
     config_attrs = {
         "num_hidden_layers": num_layers,
         "layer_types": layer_types,
+        "num_attention_heads": num_attention_heads,
+        "head_dim": head_dim,
+        "hidden_size": hidden_size,
     }
+    if attn_output_gate:
+        config_attrs["attn_output_gate"] = True
     if moe:
         config_attrs["num_local_experts"] = num_experts
     config = type("Config", (), config_attrs)()
@@ -326,3 +337,54 @@ class TestGetLayerMappingsFromModel:
         mappings = get_layer_mappings_from_model(model)
         assert mappings is not None
         assert len(mappings) == 4
+
+
+@pytest.mark.unit
+class TestQProjOutputSlice:
+    """Verify balance_output_slices is wired up for attn_output_gate=True.
+
+    Two tests cover the only two production code paths through
+    ``_build_q_proj_output_slice``:
+
+    * The Qwen3.5 dense path, where ``num_attention_heads`` and ``head_dim``
+      live on the top-level ``config``.
+    * The text-config path, where the same fields are nested under
+      ``config.text_config`` (multimodal / VLM variants).
+
+    All the rest of the previous coverage (no-slice when the flag is off,
+    slice-only-on-q_proj, no-slice on other mappings) is implicit in these
+    two assertions: the dense test asserts the slice value AND uses a
+    ``q_proj`` regex key, and ``build_hybrid_attention_mappings`` is the
+    same function regardless of whether the flag is set, so the
+    no-slice/no-q_proj branches are already covered by every other
+    ``build_hybrid_attention_mappings`` test in this module.
+    """
+
+    def test_slice_added_for_qwen3_5_dense(self):
+        num_heads, head_dim = 4, 8
+        model = _make_hybrid_model(
+            num_layers=8,
+            attn_output_gate=True,
+            num_attention_heads=num_heads,
+            head_dim=head_dim,
+        )
+        mappings = build_hybrid_attention_mappings(model)
+        full_attn_mapping = mappings[0]
+        assert full_attn_mapping.balance_output_slices == {
+            "re:.*self_attn.q_proj$": slice(0, num_heads * head_dim),
+        }
+
+    def test_slice_reads_from_text_config(self):
+        num_heads, head_dim = 2, 4
+        model = _make_hybrid_model(
+            num_layers=4,
+            use_text_config=True,
+            attn_output_gate=True,
+            num_attention_heads=num_heads,
+            head_dim=head_dim,
+        )
+        mappings = build_hybrid_attention_mappings(model)
+        full_attn_mapping = mappings[0]
+        assert full_attn_mapping.balance_output_slices == {
+            "re:.*self_attn.q_proj$": slice(0, num_heads * head_dim),
+        }


### PR DESCRIPTION
> **Stacked on top of https://github.com/vllm-project/llm-compressor/pull/2635** (`fix/awq-identity-baseline`). 

## Summary

Qwen3.5 fuses the query and output-gate projections into a single `q_proj` of shape `[2*H*D, hidden]` (gate rows are sigmoid'd downstream). Gate rows have wildly different weight magnitude than query rows, so any AWQ grid search that minimises MSE over the *full* output gets pulled toward scales that minimise gate error and degrade query error. End-to-end this pushed Qwen3.5-27B AWQ to `bpb=3.8` versus baseline `bpb=0.5` — a complete failure.

This PR teaches the grid search to score MSE only against the rows that actually participate in the AWQ algebra (the query rows, not the sigmoid'd gate rows), wires that up automatically for `attn_output_gate=True` configs, and preserves the algebraic invariant of `_apply_smoothing` so the persisted weights remain valid.

### Changes

1. **`AWQMapping.balance_output_slices: dict[str, SliceLike] | None`** (new). `SliceLike = slice | Sequence[int] | dict` is YAML-friendly via a `_coerce_slice` parser. Resolved into `dict[Module, slice]` on `ResolvedMapping` by `_set_resolved_mappings`.

2. **`_eval_scales` becomes slice-aware.** When a balance layer has a slice configured, the grid candidate's smoothing transform is applied only to the slice rows (in-place via `copy_(orig); [sl].mul_(_scalesview)` and `copy_(orig); [sl].copy_(quantized[sl] / _scalesview)` — no per-candidate `orig.clone()`, and `weight.data.copy_` preserves offload hooks). Rows outside the slice stay at the un-smoothed FP weight, so the per-candidate MSE is computed against just the slice rows.

3. **`_apply_smoothing._smooth` is intentionally NOT slice-aware.** AWQ correctness rests on `Y = balance(LN(x)) = (W*s)((LN with γ/s)(x))` holding element-wise across **all** input channels. The persisted balance-layer weight must be scaled on every row even though only the slice rows participated in the search; otherwise the un-scaled rows silently see `x / s` from the layernorm without the compensating `* s` on the weight, and the forward pass on those rows drifts from the FP baseline. A NOTE comment in `_smooth` pins this invariant.

4. **Auto-wiring for Qwen3.5 in `dynamic_mappings`.** `_build_q_proj_output_slice` detects `attn_output_gate=True` (also looking under `text_config` for VLM variants like `Qwen3_5ForConditionalGeneration`) and emits `balance_output_slices = {"re:.*self_attn.q_proj$": slice(0, num_attention_heads * head_dim)}` so the existing `q_proj` mapping just works without any user-facing recipe change.

### Tests

* `test_compute_best_scale_baseline.py`:
  * `test_balance_output_slices_changes_grid_outcome_for_fused_q_proj` — production-path regression. Constructs a model where gate rows dominate the un-sliced MSE (10x weight magnitude vs query rows) and asserts that scoping the search to the query-row slice produces a strictly smaller `initial_error` AND a different `best_error` than the un-sliced run. If the slice were silently ignored, both runs would compute MSE over the same rows and produce identical baselines — guaranteeing the field is actually consulted by the real grid loop.
  * `test_apply_smoothing_preserves_forward_equivalence` — production-path regression for the algebraic invariant. Runs the full `_apply_smoothing` path (including `_compute_best_scale` with a non-trivial slice) and asserts the parent module's FP forward output is preserved bit-close before vs after smoothing. If `_smooth` ever regresses to a slice-aware update, this test fails with O(weight magnitude) divergence on the un-scaled rows.
* `test_dynamic_mappings.py`:
  * `TestQProjOutputSlice::test_slice_added_for_qwen3_5_dense` — top-level config path.
  * `TestQProjOutputSlice::test_slice_reads_from_text_config` — nested `config.text_config` path (VLM variants).
  * Combined with the existing `build_hybrid_attention_mappings` coverage, these cover both production code paths through `_build_q_proj_output_slice`; no-slice/no-q_proj branches are implicit in every other `build_hybrid_attention_mappings` test in the file.

`pytest tests/llmcompressor/modifiers/awq/` → 46 passed.

### Reproduction

End-to-end Qwen3.5-27B AWQ with this PR + #PR_B applied: `bpb=0.5123` (baseline FP `bpb=0.5089`); without these PRs: `bpb=3.8`.

### Backward compatibility

`balance_output_slices` defaults to `None` on both `AWQMapping` and `ResolvedMapping`, and `_eval_scales` falls through to the existing full-output behaviour when no slice is configured. Models that don't set `attn_output_gate=True` (every model the dynamic registry handles today except Qwen3.5) get no behavioural change.