### PR TITLE
[CI] Add two-reviews merge protection for community PRs and significant changes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -66,6 +66,8 @@ reviews:
       instructions: "Issues or PRs related to model transforms functionality. Match case-insensitively — 'transforms', 'Transforms', 'TRANSFORMS' all qualify."
     - label: "tracing"
       instructions: "Issues or PRs related to model tracing functionality. Match case-insensitively — 'tracing', 'Tracing', 'TRACING' all qualify."
+    - label: "two-reviews"
+      instructions: "Apply when the PR makes significant or substantial changes to source code under src/ (e.g. large refactors, new core functionality, public API changes, or modifications spanning multiple components), or when it changes dependency version bounds in pyproject.toml or setup.py."
   auto_review:
     enabled: true
     ignore_title_keywords:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -87,7 +87,10 @@ pull_request_rules:
       - label != stale
       - -closed
       - -draft
-      - author != @vllm-project
+      - author != kylesayrs
+      - author != dsikka
+      - author != HDCharles
+      - author != brian-dellabetta
     actions:
       label:
         add:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -81,3 +81,29 @@ pull_request_rules:
       label:
         remove:
           - quality-failed
+
+  - name: label community PRs for two reviews
+    conditions:
+      - label != stale
+      - -closed
+      - -draft
+      - author_association != OWNER
+      - author_association != MEMBER
+      - author_association != COLLABORATOR
+    actions:
+      label:
+        add:
+          - two-reviews
+
+merge_protections:
+  - name: Require two reviews
+    description: >-
+      PRs labelled "two-reviews" must have at least two approving reviews
+      before merging.
+    if:
+      - label = two-reviews
+    success_conditions:
+      - "#approved-reviews-by >= 2"
+
+merge_protections_settings:
+  reporting_method: check-runs

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -87,9 +87,7 @@ pull_request_rules:
       - label != stale
       - -closed
       - -draft
-      - -author_association = OWNER
-      - -author_association = MEMBER
-      - -author_association = COLLABORATOR
+      - author != @vllm-project
     actions:
       label:
         add:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -87,9 +87,9 @@ pull_request_rules:
       - label != stale
       - -closed
       - -draft
-      - author_association != OWNER
-      - author_association != MEMBER
-      - author_association != COLLABORATOR
+      - -author_association = OWNER
+      - -author_association = MEMBER
+      - -author_association = COLLABORATOR
     actions:
       label:
         add:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -104,6 +104,7 @@ merge_protections:
       - label = two-reviews
     success_conditions:
       - "#approved-reviews-by >= 2"
+      - "#changes-requested-reviews-by = 0"
 
 merge_protections_settings:
   reporting_method: check-runs


### PR DESCRIPTION
## Summary

- Adds a Mergify merge protection requiring at least 2 approving reviews for any PR labelled `two-reviews`, enforced via check-runs
- Adds a Mergify rule to automatically apply the `two-reviews` label to PRs from community contributors (anyone who is not an owner, member, or collaborator)
- Adds a CodeRabbit labeling instruction to apply the `two-reviews` label for PRs with significant `src/` changes (large refactors, new core functionality, API changes) or dependency bound modifications in `pyproject.toml` / `setup.py`