### PR TITLE
Modernize sparsification info type hints

### DIFF
--- a/src/llmcompressor/pytorch/utils/sparsification_info/configs.py
+++ b/src/llmcompressor/pytorch/utils/sparsification_info/configs.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
-from typing import Any, Dict, Generator, Tuple, Union
+from typing import Any, Generator
 
 import torch.nn
 from pydantic import BaseModel, ConfigDict, Field
@@ -40,7 +40,7 @@ class SparsificationInfo(BaseModel, ABC):
     def loggable_items(
         self,
         **kwargs,
-    ) -> Generator[Tuple[str, Union[Dict[str, int], float, int]], None, None]:
+    ) -> Generator[tuple[str, dict[str, int] | float | int], None, None]:
         """
         Yield the loggable items for SparsificationInfo object.
 
@@ -50,7 +50,7 @@ class SparsificationInfo(BaseModel, ABC):
 
     @staticmethod
     def filter_loggable_items_percentages_only(
-        items_to_log: Generator[Tuple[str, Any], None, None],
+        items_to_log: Generator[tuple[str, Any], None, None],
         percentage_only: bool = False,
     ):
         """
@@ -128,11 +128,11 @@ class SparsificationSummaries(SparsificationInfo):
         description="A model that contains the number of "
         "parameters/the percent of parameters that are pruned."
     )
-    parameter_counts: Dict[str, int] = Field(
+    parameter_counts: dict[str, int] = Field(
         description="A dictionary that maps the name of a parameter "
         "to the number of elements (weights) in that parameter."
     )
-    operation_counts: Dict[str, int] = Field(
+    operation_counts: dict[str, int] = Field(
         description="A dictionary that maps the name of an operation "
         "to the number of times that operation is used in the model."
     )
@@ -141,7 +141,7 @@ class SparsificationSummaries(SparsificationInfo):
     def from_module(
         cls,
         module=torch.nn.Module,
-        pruning_thresholds: Tuple[float, float] = (0.05, 1 - 1e-9),
+        pruning_thresholds: tuple[float, float] = (0.05, 1 - 1e-9),
     ) -> "SparsificationSummaries":
         """
         Factory method to create a SparsificationSummaries object from a module.
@@ -192,7 +192,7 @@ class SparsificationSummaries(SparsificationInfo):
         non_zero_only: bool = False,
         percentages_only: bool = True,
         **kwargs,
-    ) -> Generator[Tuple[str, Union[Dict[str, int], float, int]], None, None]:
+    ) -> Generator[tuple[str, dict[str, int] | float | int], None, None]:
         """
         Yield the loggable items for SparsificationSummaries object.
 
@@ -227,7 +227,7 @@ class SparsificationPruning(SparsificationInfo):
     A model that contains the pruning information for a torch module.
     """
 
-    sparse_parameters: Dict[str, CountAndPercent] = Field(
+    sparse_parameters: dict[str, CountAndPercent] = Field(
         description="A dictionary that maps the name of a parameter "
         "to the number/percent of weights that are zeroed out "
         "in that layer."
@@ -261,7 +261,7 @@ class SparsificationPruning(SparsificationInfo):
         percentages_only: bool = False,
         non_zero_only: bool = False,
         **kwargs,
-    ) -> Generator[Tuple[str, Union[Dict[str, int], float, int]], None, None]:
+    ) -> Generator[tuple[str, dict[str, int] | float | int], None, None]:
         """
         Yield the loggable items for SparsificationPruning object.
 
@@ -302,12 +302,12 @@ class SparsificationQuantization(SparsificationInfo):
     A model that contains the quantization information for a torch module.
     """
 
-    enabled: Dict[str, bool] = Field(
+    enabled: dict[str, bool] = Field(
         description="A dictionary that maps the name of an "
         "operation to a boolean flag that indicates whether "
         "the operation is quantized or not."
     )
-    precision: Dict[str, Union[BaseModel, None, int]] = Field(
+    precision: dict[str, BaseModel | None | int] = Field(
         description="A dictionary that maps the name of a layer"
         "to the precision of that layer."
     )
@@ -344,7 +344,7 @@ class SparsificationQuantization(SparsificationInfo):
         self,
         enabled_only: bool = False,
         **kwargs,
-    ) -> Generator[Tuple[str, Union[Dict[str, int], float, int]], None, None]:
+    ) -> Generator[tuple[str, dict[str, int] | float | int], None, None]:
         """
         Yield the loggable items for SparsificationQuantization object.
 

--- a/src/llmcompressor/pytorch/utils/sparsification_info/configs.py
+++ b/src/llmcompressor/pytorch/utils/sparsification_info/configs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from typing import Any, Generator
@@ -40,7 +42,7 @@ class SparsificationInfo(BaseModel, ABC):
     def loggable_items(
         self,
         **kwargs,
-    ) -> Generator[tuple[str, dict[str, int] | float | int], None, None]:
+    ) -> Generator[tuple[str, dict[str, int] | float | int | None], None, None]:
         """
         Yield the loggable items for SparsificationInfo object.
 
@@ -192,7 +194,7 @@ class SparsificationSummaries(SparsificationInfo):
         non_zero_only: bool = False,
         percentages_only: bool = True,
         **kwargs,
-    ) -> Generator[tuple[str, dict[str, int] | float | int], None, None]:
+    ) -> Generator[tuple[str, dict[str, int] | float | int | None], None, None]:
         """
         Yield the loggable items for SparsificationSummaries object.
 
@@ -261,7 +263,7 @@ class SparsificationPruning(SparsificationInfo):
         percentages_only: bool = False,
         non_zero_only: bool = False,
         **kwargs,
-    ) -> Generator[tuple[str, dict[str, int] | float | int], None, None]:
+    ) -> Generator[tuple[str, dict[str, int] | float | int | None], None, None]:
         """
         Yield the loggable items for SparsificationPruning object.
 
@@ -344,7 +346,7 @@ class SparsificationQuantization(SparsificationInfo):
         self,
         enabled_only: bool = False,
         **kwargs,
-    ) -> Generator[tuple[str, dict[str, int] | float | int], None, None]:
+    ) -> Generator[tuple[str, dict[str, int] | float | int | None], None, None]:
         """
         Yield the loggable items for SparsificationQuantization object.
 

--- a/src/llmcompressor/pytorch/utils/sparsification_info/helpers.py
+++ b/src/llmcompressor/pytorch/utils/sparsification_info/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import torch
 from torch.nn.modules.linear import Identity
 from torch.quantization import QuantWrapper
@@ -38,16 +36,13 @@ def get_leaf_operations(
     children = list(model.children())
 
     if children == []:
-        return model
+        return [model]
     else:
         for child in children:
             if isinstance(child, tuple(operations_to_unwrap)):
                 leaf_operations.append(child.module)
                 continue
-            try:
-                leaf_operations.extend(get_leaf_operations(child))
-            except TypeError:
-                leaf_operations.append(get_leaf_operations(child))
+            leaf_operations.extend(get_leaf_operations(child))
     leaf_operations = [
         op for op in leaf_operations if not isinstance(op, tuple(operations_to_skip))
     ]

--- a/src/llmcompressor/pytorch/utils/sparsification_info/helpers.py
+++ b/src/llmcompressor/pytorch/utils/sparsification_info/helpers.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from __future__ import annotations
 
 import torch
 from torch.nn.modules.linear import Identity
@@ -9,9 +9,9 @@ __all__ = ["get_leaf_operations", "is_quantized", "get_precision_information"]
 
 def get_leaf_operations(
     model: torch.nn.Module,
-    operations_to_skip: Optional[List[torch.nn.Module]] = None,
-    operations_to_unwrap: Optional[List[torch.nn.Module]] = None,
-) -> List[torch.nn.Module]:
+    operations_to_skip: list[torch.nn.Module] | None = None,
+    operations_to_unwrap: list[torch.nn.Module] | None = None,
+) -> list[torch.nn.Module]:
     """
     Get the leaf operations in the model
     (those that do not have operations as children)
@@ -64,7 +64,7 @@ def is_quantized(operation: torch.nn.Module) -> bool:
 
 def get_precision_information(
     operation: torch.nn.Module,
-) -> Union[None, int, "QuantizationScheme"]:  # noqa F821
+) -> None | int | "QuantizationScheme":  # noqa F821
     """
     Get the information about the precision of the operation.
 

--- a/src/llmcompressor/pytorch/utils/sparsification_info/module_sparsification_info.py
+++ b/src/llmcompressor/pytorch/utils/sparsification_info/module_sparsification_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Generator
 
 import torch

--- a/src/llmcompressor/pytorch/utils/sparsification_info/module_sparsification_info.py
+++ b/src/llmcompressor/pytorch/utils/sparsification_info/module_sparsification_info.py
@@ -1,4 +1,4 @@
-from typing import Any, Generator, Tuple
+from typing import Any, Generator
 
 import torch
 from pydantic import Field
@@ -45,7 +45,7 @@ class ModuleSparsificationInfo(SparsificationInfo):
             quantization_info=SparsificationQuantization.from_module(module),
         )
 
-    def loggable_items(self, **kwargs) -> Generator[Tuple[str, Any], None, None]:
+    def loggable_items(self, **kwargs) -> Generator[tuple[str, Any], None, None]:
         """
         A generator that yields the loggable items of
         the ModuleSparsificationInfo object.


### PR DESCRIPTION
## Summary

- Modernize type annotations in `pytorch/utils/sparsification_info` for Python 3.10+
- Replace legacy `typing` aliases like `Dict`, `Tuple`, `Union`, `Optional`, and `List`
- Keep the change type-only with no runtime behavior changes

Part of https://github.com/vllm-project/llm-compressor/issues/1927

## Tests

- `PATH="$PWD/.venv/bin:$PATH" make quality`
- `python -m py_compile src/llmcompressor/pytorch/utils/sparsification_info/helpers.py src/llmcompressor/pytorch/utils/sparsification_info/configs.py src/llmcompressor/pytorch/utils/sparsification_info/module_sparsification_info.py`