### PR TITLE
[deps] bump datasets/autoround

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,9 +127,9 @@ setup(
             if BUILD_TYPE == "release"
             else "transformers>=4.56.1,<=4.57.6"
         ),
-        ("datasets>=4.0.0,<=4.6.0" if BUILD_TYPE == "release" else "datasets>=4.0.0"),
+        ("datasets>=4.8.4,<=4.8.4" if BUILD_TYPE == "release" else "datasets>=4.8.4"),
         (
-            "auto-round>=0.10.2,<=0.10.2"
+            "auto-round>=0.10.2,<=0.12.2"
             if BUILD_TYPE == "release"
             else "auto-round>=0.10.2"
         ),


### PR DESCRIPTION
SUMMARY:
The upgrade to torch 2.11 is triggering error `ImportError: cannot import name 'VideoReader' from 'torchvision.io'` in some [weekly autoround tests](https://github.com/neuralmagic/llm-compressor-testing/actions/runs/24789489585/job/72718241902#step:12:296). As posted in https://github.com/huggingface/datasets/issues/8085 bumping to latest datasets will resolve.

Also bumping autoround to allow for latest version.


TEST PLAN:
- [x] https://github.com/neuralmagic/llm-compressor-testing/actions/runs/24848256494 Test are green except for known transformers v5 tests and lm-eval regressions
