### PR TITLE
[Bugfix] Truncate using `max_seq_length` for user-defined pre-tokenized datasets

### DIFF
--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -119,12 +119,13 @@ class DatasetArguments(CustomDatasetArguments):
             "help": ("The configuration name of the dataset to use"),
         },
     )
-    max_seq_length: int = field(
-        default=384,
+    max_seq_length: int | None = field(
+        default=None,
         metadata={
             "help": "The maximum total input sequence length after tokenization. "
-            "Sequences longer  than this will be truncated, sequences shorter will "
-            "be padded."
+            "Sequences longer than this will be truncated, sequences shorter will "
+            "be padded. If None, no truncation is applied (tokenizer uses its "
+            "model_max_length)."
         },
     )
     concatenate_data: bool = field(

--- a/src/llmcompressor/datasets/utils.py
+++ b/src/llmcompressor/datasets/utils.py
@@ -225,7 +225,13 @@ def _make_collate_fn(args: DatasetArguments, processor: Processor) -> Callable:
             logger.debug("Could not find padding token. Setting PAD token to EOS token")
             tokenizer.pad_token = tokenizer.eos_token
 
-        return DataCollatorWithPadding(tokenizer, max_length=args.max_seq_length)
+        if args.max_seq_length is not None:
+            logger.warning(
+                "Cannot use `data_collator='padding'` with `max_seq_length`. Ignoring "
+                "truncation specified by `max_seq_length`"
+            )
+
+        return DataCollatorWithPadding(tokenizer)
 
     else:
         raise ValueError(f"Unknown data collator {args.data_collator}")

--- a/src/llmcompressor/datasets/utils.py
+++ b/src/llmcompressor/datasets/utils.py
@@ -208,7 +208,7 @@ def _make_collate_fn(args: DatasetArguments, processor: Processor) -> Callable:
                 "to use more uniform sequence lengths"
             )
 
-        return data_collator_with_truncation
+        return DataCollatorWithTruncation(args.max_seq_length)
 
     elif args.data_collator == "padding":
         if args.batch_size > BS_WARNING_THRESHOLD:
@@ -225,7 +225,7 @@ def _make_collate_fn(args: DatasetArguments, processor: Processor) -> Callable:
             logger.debug("Could not find padding token. Setting PAD token to EOS token")
             tokenizer.pad_token = tokenizer.eos_token
 
-        return DataCollatorWithPadding(tokenizer)
+        return DataCollatorWithPadding(tokenizer, max_length=args.max_seq_length)
 
     else:
         raise ValueError(f"Unknown data collator {args.data_collator}")
@@ -304,18 +304,24 @@ def _make_sampler(args: DatasetArguments, dataset: Dataset) -> Sampler:
         )
 
 
-def data_collator_with_truncation(
-    features: list[dict[str, Any]], return_tensors: str = "pt"
-) -> dict[str, Any]:
-    for key in ("input_ids", "labels", "attention_mask", "loss_mask"):
-        if any(key not in feature for feature in features):
-            continue
+class DataCollatorWithTruncation:
+    def __init__(self, max_seq_length: int | None = None):
+        self.max_seq_length = max_seq_length
 
-        min_len = min(len(feature[key]) for feature in features)
-        for feature in features:
-            feature[key] = feature[key][:min_len]
+    def __call__(
+        self, features: list[dict[str, Any]], return_tensors: str = "pt"
+    ) -> dict[str, Any]:
+        for key in ("input_ids", "labels", "attention_mask", "loss_mask"):
+            if any(key not in feature for feature in features):
+                continue
 
-    return default_data_collator(features, return_tensors)
+            min_len = min(len(feature[key]) for feature in features)
+            if self.max_seq_length is not None:
+                min_len = min(min_len, self.max_seq_length)
+            for feature in features:
+                feature[key] = feature[key][:min_len]
+
+        return default_data_collator(features, return_tensors)
 
 
 class LengthAwareSampler(Sampler[int]):

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -273,7 +273,7 @@ def oneshot(
     data_collator: str | Callable = "truncation",
     num_calibration_samples: int = 512,
     shuffle_calibration_samples: bool = True,
-    max_seq_length: int = 384,
+    max_seq_length: int | None = None,
     pad_to_max_length: bool = True,
     text_column: str = "text",
     concatenate_data: bool = False,

--- a/src/llmcompressor/transformers/data/base.py
+++ b/src/llmcompressor/transformers/data/base.py
@@ -66,15 +66,19 @@ class TextGenerationDataset(RegistryMixin):
 
             # configure sequence length
             max_seq_length = dataset_args.max_seq_length
-            if dataset_args.max_seq_length > self.tokenizer.model_max_length:
-                logger.warning(
-                    f"The max_seq_length passed ({max_seq_length}) is larger than "
-                    f"maximum length for model ({self.tokenizer.model_max_length}). "
-                    f"Using max_seq_length={self.tokenizer.model_max_length}."
+            if max_seq_length is not None:
+                if max_seq_length > self.tokenizer.model_max_length:
+                    logger.warning(
+                        f"The max_seq_length passed ({max_seq_length}) is larger "
+                        f"than maximum length for model "
+                        f"({self.tokenizer.model_max_length}). "
+                        f"Using max_seq_length={self.tokenizer.model_max_length}."
+                    )
+                self.max_seq_length = min(
+                    max_seq_length, self.tokenizer.model_max_length
                 )
-            self.max_seq_length = min(
-                dataset_args.max_seq_length, self.tokenizer.model_max_length
-            )
+            else:
+                self.max_seq_length = self.tokenizer.model_max_length
 
             # configure padding
             self.padding = (

--- a/tests/llmcompressor/datasets/test_max_seq_length.py
+++ b/tests/llmcompressor/datasets/test_max_seq_length.py
@@ -1,0 +1,45 @@
+import pytest
+
+from llmcompressor.args import DatasetArguments
+from llmcompressor.datasets.utils import DataCollatorWithTruncation
+
+
+def _make_features(lengths: list[int]) -> list[dict[str, list[int]]]:
+    return [
+        {"input_ids": [1] * length, "attention_mask": [1] * length}
+        for length in lengths
+    ]
+
+
+class TestMaxSeqLengthDefault:
+    @pytest.mark.unit
+    def test_default_is_none(self):
+        args = DatasetArguments()
+        assert args.max_seq_length is None
+
+
+class TestDataCollatorWithTruncation:
+    @pytest.mark.unit
+    def test_truncates_to_min_in_batch_when_no_max(self):
+        collator = DataCollatorWithTruncation(max_seq_length=None)
+        result = collator(_make_features([10, 20]))
+        assert result["input_ids"].shape[1] == 10
+
+    @pytest.mark.unit
+    def test_truncates_to_max_seq_length_when_shorter_than_batch(self):
+        collator = DataCollatorWithTruncation(max_seq_length=5)
+        result = collator(_make_features([10, 20]))
+        assert result["input_ids"].shape[1] == 5
+
+    @pytest.mark.unit
+    def test_truncates_to_min_when_shorter_than_max_seq_length(self):
+        collator = DataCollatorWithTruncation(max_seq_length=15)
+        result = collator(_make_features([10, 20]))
+        assert result["input_ids"].shape[1] == 10
+
+    @pytest.mark.unit
+    def test_uniform_lengths_with_max_seq_length(self):
+        collator = DataCollatorWithTruncation(max_seq_length=5)
+        result = collator(_make_features([10, 10]))
+        assert result["input_ids"].shape[1] == 5
+        assert result["attention_mask"].shape[1] == 5

--- a/tests/llmcompressor/transformers/data/test_registry.py
+++ b/tests/llmcompressor/transformers/data/test_registry.py
@@ -11,7 +11,9 @@ from llmcompressor.transformers.data import (
 
 @pytest.mark.usefixtures("tiny_llama_tokenizer")
 def test_c4_initializes(tiny_llama_tokenizer):
-    dataset_args = DatasetArguments(dataset="c4", concatenate_data=True)
+    dataset_args = DatasetArguments(
+        dataset="c4", concatenate_data=True, max_seq_length=128
+    )
     c4_manager = TextGenerationDataset.load_from_registry(
         dataset_args.dataset,
         dataset_args=dataset_args,
@@ -28,7 +30,7 @@ def test_c4_initializes(tiny_llama_tokenizer):
 @pytest.mark.usefixtures("tiny_llama_tokenizer")
 def test_wikitext_initializes(tiny_llama_tokenizer):
     dataset_args = DatasetArguments(
-        dataset="wikitext", dataset_config_name="wikitext-2-raw-v1"
+        dataset="wikitext", dataset_config_name="wikitext-2-raw-v1", max_seq_length=128
     )
     wiki_manager = TextGenerationDataset.load_from_registry(
         dataset_args.dataset,
@@ -45,7 +47,9 @@ def test_wikitext_initializes(tiny_llama_tokenizer):
 
 @pytest.mark.usefixtures("tiny_llama_tokenizer")
 def test_open_platypus_initializes(tiny_llama_tokenizer):
-    dataset_args = DatasetArguments(dataset="open_platypus", pad_to_max_length=False)
+    dataset_args = DatasetArguments(
+        dataset="open_platypus", pad_to_max_length=False, max_seq_length=128
+    )
     op_manager = TextGenerationDataset.load_from_registry(
         dataset_args.dataset,
         dataset_args=dataset_args,


### PR DESCRIPTION
## Purpose ##
* Fix #2648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made maximum sequence length configurable and optional; when unspecified, the tokenizer’s default governs sequence length.
  * Truncation now respects the batch’s effective length and is capped by an explicit max when provided.
  * When using a padding-only path with an explicit max, a warning is emitted and the max is ignored.

* **Tests**
  * Added tests covering optional max length and truncation semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->