### PR TITLE
[Tests] Restore LM Eval test stability with `use_deterministic_algorithms` flag

### DIFF
--- a/tests/lmeval/test_lmeval.py
+++ b/tests/lmeval/test_lmeval.py
@@ -105,6 +105,7 @@ class TestLMEval:
         random.seed(self.seed)
         numpy.random.seed(self.seed)
         torch.manual_seed(self.seed)
+        torch.use_deterministic_algorithms(True)
 
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(self.seed)


### PR DESCRIPTION
## Background ##
After upgrading testing runners from cuda `12.9` to `13.0`, it was found that the results from `test_lmeval.py` were no longer stable, ie two runs with the same configurations produced different results with high variance, meaning that it was impossible to use these tests to determine if an algorithmic change/ regression had occurred.

## Purpose ##
* Restore stability (determinism) for lm_eval tests

## Changes ##
* Add `torch.use_deterministic_algorithms(True)` flag

## Testing ##
| Past History of Instability | Two Runs Without Flag |Two Runs With Flag |
| - | - | - |
| <img width="962" height="668" alt="Screenshot 2026-04-25 at 15 08 45" src="https://github.com/user-attachments/assets/e33927ab-8d41-485f-8f0a-2f7f37bfb546" /> | <img width="1357" height="982" alt="Screenshot 2026-04-25 at 15 12 46" src="https://github.com/user-attachments/assets/bab112b5-ee50-4cd1-aa93-f4a07a1e4c3d" /> |<img width="1359" height="972" alt="Screenshot 2026-04-25 at 15 09 48" src="https://github.com/user-attachments/assets/2b1e3396-61cc-4388-b99d-37c6fe9ebd28" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup with deterministic execution settings to improve test consistency and reliability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->