### PR TITLE
Add MixFP4A16 quantization recipe support

### DIFF
--- a/src/llmcompressor/observers/__init__.py
+++ b/src/llmcompressor/observers/__init__.py
@@ -15,3 +15,4 @@ from .moving_base import *
 from .min_max import *
 from .mse import *
 from .imatrix import *
+from .mixfp4 import *

--- a/src/llmcompressor/observers/__init__.py
+++ b/src/llmcompressor/observers/__init__.py
@@ -15,4 +15,4 @@ from .moving_base import *
 from .min_max import *
 from .mse import *
 from .imatrix import *
-from .mixfp4 import *
+from .codebook import *

--- a/src/llmcompressor/observers/codebook.py
+++ b/src/llmcompressor/observers/codebook.py
@@ -1,8 +1,8 @@
 """
-MixFP4 observer for choosing NVFP4 E2M1 or signed INT4 per group.
+Codebook-selection observers for quantization calibration.
 
-The selected format is stored in the unused sign bit of the FP8 per-group
-scale byte:
+MixFP4 chooses NVFP4 E2M1 or signed INT4 per group and stores the choice in
+unused bit 7 of the FP8 per-group scale byte:
   bit7 = 0 -> FP4 E2M1 group
   bit7 = 1 -> signed INT4 group
 """

--- a/src/llmcompressor/observers/mixfp4.py
+++ b/src/llmcompressor/observers/mixfp4.py
@@ -1,0 +1,138 @@
+"""
+MixFP4 observer for choosing NVFP4 E2M1 or signed INT4 per group.
+
+The selected format is stored in the unused sign bit of the FP8 per-group
+scale byte:
+  bit7 = 0 -> FP4 E2M1 group
+  bit7 = 1 -> signed INT4 group
+"""
+
+import torch
+from compressed_tensors.quantization import (
+    FP8_E4M3_DATA,
+    QuantizationArgs,
+    QuantizationStrategy,
+    QuantizationType,
+)
+from llmcompressor.observers.base import MinMaxTuple, Observer, ScaleZpTuple
+from llmcompressor.observers.helpers import flatten_for_calibration
+
+__all__ = ["MixFP4Observer"]
+
+_FP4_MAX = 6.0
+_INT4_MAX = 7.0
+_FP8_MAX = FP8_E4M3_DATA.max
+_E2M1_CODEBOOK = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32
+)
+
+
+@Observer.register("mixfp4", alias="mixed_fp4_int4")
+class MixFP4Observer(Observer):
+    """
+    Observer that chooses FP4 E2M1 or signed INT4 per tensor-group by MSE.
+
+    MixFP4 uses the same 4-bit packed weights and FP8 per-group scale storage
+    as NVFP4. The INT4/FP4 selector is packed into the FP8 scale sign bit, so
+    no extra metadata is produced.
+    """
+
+    def __init__(
+        self,
+        base_name: str,
+        args: QuantizationArgs,
+        module: torch.nn.Module | None = None,
+        **observer_kwargs,
+    ):
+        super().__init__(
+            base_name=base_name, args=args, module=module, **observer_kwargs
+        )
+        self._validate_args()
+
+    def get_min_max(self, observed: torch.Tensor) -> MinMaxTuple:
+        return _get_min_max(observed)
+
+    def get_global_min_max(self, observed: torch.Tensor) -> MinMaxTuple:
+        return _get_min_max(observed)
+
+    @torch.no_grad()
+    def forward(self, observed: torch.Tensor) -> ScaleZpTuple:
+        g_idx = self._get_module_param("g_idx")
+        global_scale = self._get_module_param("global_scale")
+        self._check_has_global_scale(global_scale)
+
+        observed = flatten_for_calibration(observed, self.base_name, self.args, g_idx)
+        scales = self._calculate_mixfp4_scales(observed, global_scale)
+        zero_points = torch.zeros_like(scales)
+        return scales, zero_points
+
+    def _calculate_mixfp4_scales(
+        self, observed: torch.Tensor, global_scale: torch.Tensor
+    ) -> torch.Tensor:
+        global_scale = global_scale.to(torch.float32).reshape(-1)[0].to(observed.device)
+        max_abs_group = observed.abs().amax(dim=(0, -1))
+
+        mag_fp4 = _quantize_fp8_magnitude(global_scale * max_abs_group / _FP4_MAX)
+        mag_int4 = _quantize_fp8_magnitude(global_scale * max_abs_group / _INT4_MAX)
+
+        min_scale = torch.finfo(torch.float32).tiny
+        eff_fp4 = (mag_fp4 / global_scale).clamp(min=min_scale)
+        eff_int4 = (mag_int4 / global_scale).clamp(min=min_scale)
+
+        err_fp4 = _fake_quant_error_fp4(observed, eff_fp4)
+        err_int4 = _fake_quant_error_int4(observed, eff_int4)
+        is_int4 = err_int4 < err_fp4
+        magnitudes = torch.where(is_int4, mag_int4, mag_fp4)
+
+        return _pack_scale_flag(magnitudes, is_int4)
+
+    def _validate_args(self) -> None:
+        if self.base_name != "weight":
+            raise ValueError("MixFP4Observer only supports weight quantization")
+        if self.args.strategy != QuantizationStrategy.TENSOR_GROUP:
+            raise ValueError("MixFP4Observer requires tensor_group strategy")
+        if self.args.group_size != 16:
+            raise ValueError("MixFP4Observer requires group_size=16")
+        if self.args.num_bits != 4:
+            raise ValueError("MixFP4Observer requires num_bits=4")
+        if self.args.type != QuantizationType.FLOAT:
+            raise ValueError("MixFP4Observer requires floating-point 4-bit weights")
+        if not self.args.symmetric:
+            raise ValueError("MixFP4Observer requires symmetric quantization")
+        if self.args.scale_dtype != torch.float8_e4m3fn:
+            raise ValueError("MixFP4Observer requires float8_e4m3fn scales")
+
+
+def _get_min_max(observed: torch.Tensor) -> MinMaxTuple:
+    return torch.amin(observed, dim=(0, -1)), torch.amax(observed, dim=(0, -1))
+
+
+def _quantize_fp8_magnitude(x: torch.Tensor) -> torch.Tensor:
+    return x.clamp(min=0, max=_FP8_MAX).to(torch.float8_e4m3fn).to(torch.float32)
+
+
+def _fake_quant_error_fp4(observed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    codebook = _E2M1_CODEBOOK.to(device=observed.device)
+    scale = scale.unsqueeze(0).unsqueeze(-1)
+    scaled = observed / scale
+    sign = torch.sign(scaled)
+    magnitude = scaled.abs().clamp(max=_FP4_MAX)
+    indices = (magnitude.unsqueeze(-1) - codebook).abs().argmin(dim=-1)
+    dequantized = sign * codebook[indices] * scale
+    return ((dequantized - observed) ** 2).sum(dim=(0, -1))
+
+
+def _fake_quant_error_int4(observed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    scale = scale.unsqueeze(0).unsqueeze(-1)
+    quantized = (observed / scale).round().clamp(-_INT4_MAX, _INT4_MAX)
+    dequantized = quantized * scale
+    return ((dequantized - observed) ** 2).sum(dim=(0, -1))
+
+
+def _pack_scale_flag(magnitude: torch.Tensor, is_int4: torch.Tensor) -> torch.Tensor:
+    magnitude_fp8 = magnitude.clamp(min=0, max=_FP8_MAX).to(torch.float8_e4m3fn)
+    raw = magnitude_fp8.contiguous().view(torch.uint8)
+    nonzero_magnitude = (raw & 0x7F) != 0
+    sign_mask = ((is_int4 & nonzero_magnitude).to(torch.uint8) & 1) << 7
+    packed = (raw & 0x7F) | sign_mask
+    return packed.view(torch.float8_e4m3fn)

--- a/tests/llmcompressor/modifiers/quantization/test_mixfp4_scheme.py
+++ b/tests/llmcompressor/modifiers/quantization/test_mixfp4_scheme.py
@@ -1,0 +1,28 @@
+import torch
+
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+
+def test_mixfp4a16_recipe_resolves_to_canonical_scheme():
+    recipe = QuantizationModifier(
+        targets="Linear",
+        scheme="MixFP4A16",
+        ignore=["lm_head"],
+    )
+
+    config = recipe.resolve_quantization_config()
+    assert len(config.config_groups) == 1
+    scheme = next(iter(config.config_groups.values()))
+
+    assert scheme.targets == ["Linear"]
+    assert scheme.format == "mixfp4-pack-quantized"
+    assert scheme.weights.num_bits == 4
+    assert scheme.weights.type == "float"
+    assert scheme.weights.strategy == "tensor_group"
+    assert scheme.weights.group_size == 16
+    assert scheme.weights.symmetric is True
+    assert scheme.weights.dynamic is False
+    assert scheme.weights.observer == "mixfp4"
+    assert scheme.weights.scale_dtype == torch.float8_e4m3fn
+    assert scheme.weights.zp_dtype == torch.float8_e4m3fn
+    assert config.ignore == ["lm_head"]

--- a/tests/llmcompressor/observers/test_mixfp4.py
+++ b/tests/llmcompressor/observers/test_mixfp4.py
@@ -1,0 +1,144 @@
+import pytest
+import torch
+from compressed_tensors.quantization import QuantizationArgs
+
+from llmcompressor.observers import MixFP4Observer, Observer
+
+
+def _mixfp4_args(**overrides):
+    kwargs = dict(
+        num_bits=4,
+        type="float",
+        strategy="tensor_group",
+        symmetric=True,
+        dynamic=False,
+        group_size=16,
+        observer="mixfp4",
+        scale_dtype=torch.float8_e4m3fn,
+        zp_dtype=torch.float8_e4m3fn,
+    )
+    kwargs.update(overrides)
+    return QuantizationArgs(**kwargs)
+
+
+def test_mixfp4_observer_registry_alias():
+    args = _mixfp4_args()
+    observer = Observer.load_from_registry("mixfp4", base_name="weight", args=args)
+    legacy = Observer.load_from_registry(
+        "mixed_fp4_int4", base_name="weight", args=args
+    )
+
+    assert isinstance(observer, MixFP4Observer)
+    assert isinstance(legacy, MixFP4Observer)
+
+
+def test_mixfp4_requires_global_scale():
+    args = _mixfp4_args()
+    module = torch.nn.Linear(16, 1, bias=False)
+    observer = Observer.load_from_registry(
+        "mixfp4", base_name="weight", args=args, module=module
+    )
+
+    with pytest.raises(ValueError, match="global scale"):
+        observer(module.weight)
+
+
+def test_mixfp4_packs_int4_flag_in_scale_sign_bit():
+    int4_group = torch.tensor(
+        [-7, -6, -5, -4, -3, -2, -1, 0, 0, 1, 2, 3, 4, 5, 6, 7],
+        dtype=torch.float32,
+    )
+    fp4_group = torch.tensor(
+        [-6, -4, -3, -2, -1.5, -1, -0.5, 0, 0, 0.5, 1, 1.5, 2, 3, 4, 6],
+        dtype=torch.float32,
+    )
+    weight = torch.stack([int4_group, fp4_group])
+
+    args = _mixfp4_args()
+    module = torch.nn.Linear(16, 2, bias=False)
+    module.weight.data.copy_(weight)
+    observer = Observer.load_from_registry(
+        "mixfp4", base_name="weight", args=args, module=module
+    )
+
+    module.weight_global_scale = observer.get_global_scale(module.weight)
+    scale, zero_point = observer(module.weight)
+    raw_scale = scale.view(torch.uint8)
+
+    assert scale.dtype == torch.float8_e4m3fn
+    assert zero_point.dtype == torch.float8_e4m3fn
+    assert scale.shape == (2, 1)
+    assert (raw_scale[0, 0] & 0x80) != 0
+    assert (raw_scale[1, 0] & 0x80) == 0
+
+
+def test_mixfp4_zero_group_does_not_encode_negative_zero():
+    args = _mixfp4_args()
+    module = torch.nn.Linear(16, 1, bias=False)
+    module.weight.data.zero_()
+    observer = Observer.load_from_registry(
+        "mixfp4", base_name="weight", args=args, module=module
+    )
+
+    module.weight_global_scale = observer.get_global_scale(module.weight)
+    scale, _ = observer(module.weight)
+
+    assert scale.view(torch.uint8).item() == 0
+
+
+@pytest.mark.parametrize(
+    "overrides,error",
+    [
+        ({"strategy": "group"}, "tensor_group"),
+        ({"group_size": 8}, "group_size=16"),
+        ({"num_bits": 8}, "num_bits=4"),
+        ({"type": "int"}, "floating-point"),
+        ({"symmetric": False}, "symmetric"),
+        ({"scale_dtype": torch.bfloat16}, "float8_e4m3fn"),
+    ],
+)
+def test_mixfp4_rejects_noncanonical_args(overrides, error):
+    args = _mixfp4_args(**overrides)
+
+    with pytest.raises(ValueError, match=error):
+        Observer.load_from_registry("mixfp4", base_name="weight", args=args)
+
+
+def test_mixfp4_rejects_activation_observer():
+    args = _mixfp4_args()
+
+    with pytest.raises(ValueError, match="weight"):
+        Observer.load_from_registry("mixfp4", base_name="input", args=args)
+
+
+def test_mixfp4_observer_scales_are_safe_for_fake_quantize():
+    from compressed_tensors.quantization import fake_quantize
+
+    int4_group = torch.tensor(
+        [-7, -6, -5, -4, -3, -2, -1, 0, 0, 1, 2, 3, 4, 5, 6, 7],
+        dtype=torch.float32,
+    )
+    fp4_group = torch.tensor(
+        [-6, -4, -3, -2, -1.5, -1, -0.5, 0, 0, 0.5, 1, 1.5, 2, 3, 4, 6],
+        dtype=torch.float32,
+    )
+    weight = torch.stack([int4_group, fp4_group])
+
+    args = _mixfp4_args()
+    module = torch.nn.Linear(16, 2, bias=False)
+    module.weight.data.copy_(weight)
+    observer = Observer.load_from_registry(
+        "mixfp4", base_name="weight", args=args, module=module
+    )
+
+    module.weight_global_scale = observer.get_global_scale(module.weight)
+    scale, zero_point = observer(module.weight)
+    quantized = fake_quantize(
+        module.weight,
+        scale,
+        zero_point,
+        args,
+        global_scale=module.weight_global_scale,
+    )
+
+    assert torch.allclose(quantized, weight)


### PR DESCRIPTION
# Add MixFP4A16 quantization recipe support

SUMMARY:

Add llm-compressor support for generating MixFP4A16 checkpoints with the same recipe style as NVFP4A16. MixFP4 is an extension of NVFP4: for each 16-weight group, it compares the reconstruction MSE and chooses whether the elements in that group use the NVFP4 FP4 codebook or the INT4 (E1M2) codebook.

The user-facing recipe remains:

```python
recipe = QuantizationModifier(targets="Linear", scheme="MixFP4A16", ignore=["lm_head"])
```

## Usage

Python recipe usage mirrors the existing NVFP4A16 flow, with only the scheme name changed to `MixFP4A16`:

```python
from transformers import AutoModelForCausalLM

from llmcompressor import oneshot
from llmcompressor.modifiers.quantization import QuantizationModifier

model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype="auto")
recipe = QuantizationModifier(
    targets="Linear",
    scheme="MixFP4A16",
    ignore=["lm_head"],
)

oneshot(model=model, recipe=recipe, output_dir=OUTPUT_DIR)
```

YAML form:

```yaml
quant_stage:
  quant_modifiers:
    QuantizationModifier:
      targets: ["Linear"]
      scheme: "MixFP4A16"
      ignore: ["lm_head"]
```

The emitted compressed-tensors config uses `format: mixfp4-pack-quantized` and `observer: mixfp4`. Quantized weights are saved as `weight_packed`, `weight_scale`, and `weight_global_scale`; no separate selector metadata is saved.

## Implementation

- Add `MixFP4A16` scheme registration for `QuantizationModifier`.
- Reuse the NVFP4-style W4A16 quantization path except for the MixFP4 observer/format marker.
- Keep the selector inside the FP8 scale sign bit; no side tensor or extra metadata is introduced.
- Preserve `lm_head` ignore behavior from the user recipe.

## Cross-project workflow

MixFP4 is intended to be used across the compressed-tensors -> llm-compressor -> vLLM stack:

1. `compressed-tensors` defines the canonical `mixfp4-pack-quantized` format, the `MIXFP4A16` preset, and pack/unpack/fake-quant behavior.
2. `llm-compressor` exposes the user-facing quantization recipe: `QuantizationModifier(targets="Linear", scheme="MixFP4A16", ignore=["lm_head"])`.
3. `vLLM` loads the resulting compressed-tensors checkpoint and routes `mixfp4-pack-quantized` W4A16 layers to the MixFP4 Marlin path.

Related PRs:

- compressed-tensors: https://github.com/vllm-project/compressed-tensors/pull/687
- llm-compressor: https://github.com/vllm-project/llm-compressor/pull/2657
- vLLM: https://github.com/vllm-project/vllm/pull/41004

## Shared validation summary

Storage contract:

- Persisted tensors: `weight_packed`, `weight_scale`, `weight_global_scale`.
- `weight_packed` stores 4 bits/element.
- `weight_scale` remains `torch.float8_e4m3fn`, one scale byte per 16 weights; bit 7 stores the FP4/INT4 selector.
- No extra selector tensor or side metadata is emitted.

Accuracy / quality uses lm-eval + vLLM. Math/reasoning uses Qwen math prompts with chat template and math system instruction. MMLU uses lm-eval default `mmlu`, 5-shot, no chat template. WikiText uses lm-eval default `wikitext`; lower PPL is better.

| Model | Quant | GSM8K | MATH500 strict | AIME25 | MMLU | WikiText word PPL |
|---|---|---:|---:|---:|---:|---:|
| Qwen3-8B | BF16 | 93.71% | 76.20% | 70.00% | 74.93% | 13.4838 |
| Qwen3-8B | NVFP4 | 91.58% | 72.00% | 56.67% | 73.55% | 13.7782 |
| Qwen3-8B | MixFP4 | 93.40% | 76.20% | 56.67% | 73.88% | 13.5464 |
| Qwen3-14B | BF16 | 95.07% | 78.80% | 66.67% | 78.82% | 11.6597 |
| Qwen3-14B | NVFP4 | 95.38% | 79.20% | 70.00% | 78.08% | 11.9641 |
| Qwen3-14B | MixFP4 | 94.77% | 76.20% | 66.67% | 78.14% | 11.8100 |

Quality claim: MixFP4 is close to BF16 and improves over NVFP4 on Qwen3-8B for GSM8K, MATH500, MMLU, and WikiText PPL, while tying NVFP4 on AIME25 in the post-fix rerun. On Qwen3-14B, MixFP4 improves WikiText PPL over NVFP4 and is effectively tied on MMLU, while math/reasoning is mixed. AIME25 has only 30 examples, so small-sample deltas should not be overinterpreted.

Latest-vLLM E2E performance on Qwen3-8B with H100 80GB, CUDA 12.8, Torch 2.11, and FA3 enabled:

| Shape | Quant | Wall median ms | Total tok/s median | Decode tok/s median |
|---|---|---:|---:|---:|
| prefill-heavy in=1024 out=32 bs=1 | BF16 | 233.48 | 4522.9 | 148.4 |
| prefill-heavy in=1024 out=32 bs=1 | NVFP4 | 176.25 | 5991.5 | 244.4 |
| prefill-heavy in=1024 out=32 bs=1 | MixFP4 | 187.25 | 5639.6 | 230.1 |
| decode-heavy in=32 out=512 bs=1 | BF16 | 3402.27 | 159.9 | 150.6 |
| decode-heavy in=32 out=512 bs=1 | NVFP4 | 2073.25 | 262.4 | 247.4 |
| decode-heavy in=32 out=512 bs=1 | MixFP4 | 2182.98 | 249.2 | 235.0 |
| batched in=512 out=128 bs=8 | BF16 | 982.90 | 5209.1 | 1141.7 |
| batched in=512 out=128 bs=8 | NVFP4 | 736.97 | 6947.3 | 1837.8 |
| batched in=512 out=128 bs=8 | MixFP4 | 782.96 | 6539.3 | 1751.0 |

MixFP4 is about 5-6% slower than the existing NVFP4 Marlin path in these Qwen3-8B shapes, while remaining substantially faster than BF16 in decode-heavy and batched cases.

TEST PLAN:

- Run focused MixFP4A16 recipe tests.
- Quantize Qwen3-8B and Qwen3-14B with `QuantizationModifier(targets="Linear", scheme="MixFP4A16", ignore=["lm_head"])`.
- Verify emitted checkpoint metadata: `format: mixfp4-pack-quantized`, `observer: mixfp4`, and `quantization_status: compressed`.
- Verify stored tensors use `weight_packed`, `weight_scale`, and `weight_global_scale` with no extra selector metadata.
- Run downstream lm-eval accuracy/PPL and vLLM E2E performance validation.

TEST RESULT:

- Qwen3-8B and Qwen3-14B MixFP4A16 quantization jobs completed successfully.
- Both generated checkpoints have `format: mixfp4-pack-quantized` and `quantization_status: compressed`.
- Downstream accuracy/PPL and E2E performance results are listed above.

## Dependency / follow-up

This PR depends on compressed-tensors containing the `MIXFP4A16` preset and `mixfp4-pack-quantized` format. The compressed-tensors PR should merge/release first, or llm-compressor should bump to a compressed-tensors version containing those definitions.

