### PR TITLE
[Refactor] Consolidate Intermediate Offloading

### DIFF
--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -432,7 +432,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                 if isinstance(v, QuantizedKVCache):
                     values.arguments[k] = None
 
-            self._parent_args_cache.append((module, None), values.arguments)
+            self._parent_args_cache.append(module, values.arguments)
 
         def create_cache_smooth_activations_hook_fn(smooth_name):
             def cache_smooth_activations_hook(
@@ -461,14 +461,14 @@ class AWQModifier(Modifier, QuantizationMixin):
                     masked_activations = activations.flatten(0, -2)
 
                 # accumulate activation sum&count
-                new_sum = masked_activations.float().sum(dim=0).cpu()
-                new_count = torch.tensor(masked_activations.size(0)).cpu()
+                new_sum = masked_activations.float().sum(dim=0)
+                new_count = torch.tensor(masked_activations.size(0))
                 if smooth_name not in self._smooth_activation_stats:
                     self._smooth_activation_stats.update(
                         smooth_name,
                         [torch.zeros_like(new_sum), torch.zeros_like(new_count)],
                     )
-                x_sum, count = self._smooth_activation_stats.fetch(smooth_name)
+                x_sum, count = self._smooth_activation_stats[smooth_name]
                 x_sum += new_sum
                 count += new_count
                 self._smooth_activation_stats.update(smooth_name, [x_sum, count])
@@ -614,9 +614,9 @@ class AWQModifier(Modifier, QuantizationMixin):
         use_prefetch = active_session().state.sequential_prefetch
 
         if use_prefetch:
-            batch_iter = cache.iter_prefetch([(module, None)])
+            batch_iter = cache.iter_prefetch([(module)])
         else:
-            batch_iter = cache.iter([(module, None)])
+            batch_iter = cache.iter([(module)])
 
         outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
         return [
@@ -655,10 +655,10 @@ class AWQModifier(Modifier, QuantizationMixin):
 
         device = get_execution_device(mapping.parent)
 
-        x_sum, count = self._smooth_activation_stats.fetch(mapping.smooth_name)
+        x_sum, count = self._smooth_activation_stats[mapping.smooth_name]
         if is_distributed():
             x_sum, count = _allreduce_data_sum([x_sum, count])
-        x_mean = x_sum.to(device) / count.to(device)
+        x_mean = x_sum / count
 
         if self.duo_scaling:
             w_mean = self._compute_layer_means(mapping.balance_layers).to(device)
@@ -1041,13 +1041,6 @@ def get_lowest_common_ancestor_with_avoid(
 
 
 def _allreduce_data_sum(data: list[torch.Tensor]) -> list[torch.Tensor]:
-    # needs to be on device to broadcast
-    device = torch.device(
-        torch.accelerator.current_accelerator().type,
-        torch.accelerator.current_device_index(),
-    )
-    data = [datum.to(device) for datum in data]
-
     pending_comms = []
     for datum in data:
         pending_comms.append(

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -162,15 +162,11 @@ class AWQModifier(Modifier, QuantizationMixin):
 
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
-    # Cache list of forward input args for each parent module, one dict for each batch
-    _parent_args_cache: dict[Module, IntermediatesCache] = PrivateAttr(
-        default_factory=dict
-    )
-    # Dict[smooth layer name, [activation sums, activation counts]]
+    _parent_args_cache: IntermediatesCache = PrivateAttr(default=None)
+    _parent_args_batch_idx: dict[Module, int] = PrivateAttr(default_factory=dict)
     _smooth_activation_stats: dict[str, list[torch.Tensor]] = PrivateAttr(
         default_factory=dict
     )
-    # List to store error metrics for each layer
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -314,7 +310,9 @@ class AWQModifier(Modifier, QuantizationMixin):
 
         self._log_error_metrics()
 
-        self._parent_args_cache.clear()
+        if self._parent_args_cache is not None:
+            self._parent_args_cache.clear()
+        self._parent_args_batch_idx.clear()
         self._smooth_activation_stats.clear()
         self._resolved_mappings.clear()
         self._error_metrics.clear()
@@ -438,7 +436,12 @@ class AWQModifier(Modifier, QuantizationMixin):
                 if isinstance(v, QuantizedKVCache):
                     values.arguments[k] = None
 
-            self._parent_args_cache[module].append(values.arguments)
+            batch_idx = self._parent_args_batch_idx.get(module, 0)
+            for arg_name, arg_value in values.arguments.items():
+                self._parent_args_cache.update(
+                    (module, batch_idx, arg_name), arg_value
+                )
+            self._parent_args_batch_idx[module] = batch_idx + 1
 
         def create_cache_smooth_activations_hook_fn(smooth_name):
             def cache_smooth_activations_hook(
@@ -480,13 +483,10 @@ class AWQModifier(Modifier, QuantizationMixin):
             return cache_smooth_activations_hook
 
         for mapping in self._resolved_mappings:
-            # parent kwargs needed for future forward passes
-            # same parent may appear multiple times in resolved mappings
-            if mapping.parent not in self._parent_args_cache:
-                self._parent_args_cache[mapping.parent] = IntermediatesCache(
-                    None,
-                    self.offload_device,
-                )
+            if self._parent_args_cache is None:
+                self._parent_args_cache = IntermediatesCache(self.offload_device)
+            if mapping.parent not in self._parent_args_batch_idx:
+                self._parent_args_batch_idx[mapping.parent] = 0
                 self.register_hook(
                     mapping.parent,
                     cache_parent_kwargs_hook,
@@ -613,21 +613,33 @@ class AWQModifier(Modifier, QuantizationMixin):
                 del self._smooth_activation_stats[mapping.smooth_name]
                 del orig_layer_weights
 
-        for v in self._parent_args_cache.values():
-            v.batch_intermediates.clear()
+        self._parent_args_cache.clear()
         self._assert_all_activations_consumed()
 
     @torch.no_grad()
     def _run_samples(self, module: Module) -> list[torch.Tensor]:
-        cache = self._parent_args_cache[module]
+        cache = self._parent_args_cache
         use_prefetch = active_session().state.sequential_prefetch
-        batch_iter = cache.iter_prefetch() if use_prefetch else cache
-        outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
-        return [
-            # If tuple, assume that first argument is the input
-            output[0] if isinstance(output, tuple) else output
-            for output in outputs
-        ]
+
+        module_keys = [k for k in cache._store.keys() if k[0] == module]
+        if not module_keys:
+            return []
+
+        def group_by_fn(k):
+            return (k[0], k[1])
+
+        if use_prefetch:
+            batch_iter = cache.iter_prefetch_grouped(module_keys, group_by=group_by_fn)
+        else:
+            batch_iter = cache.iter_prefetch_grouped(module_keys, group_by=group_by_fn)
+
+        outputs = []
+        for group_dict in batch_iter:
+            batch_kwargs = {k[2]: v for k, v in group_dict.items()}
+            output = module(**batch_kwargs)
+            outputs.append(output[0] if isinstance(output, tuple) else output)
+
+        return outputs
 
     def _compute_best_scale(
         self,

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -163,9 +163,7 @@ class AWQModifier(Modifier, QuantizationMixin):
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
     _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(default=None)
-    _smooth_activation_stats: dict[str, list[torch.Tensor]] = PrivateAttr(
-        default_factory=dict
-    )
+    _smooth_activation_stats: IntermediatesCache[str] = PrivateAttr(default=None)
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -466,18 +464,21 @@ class AWQModifier(Modifier, QuantizationMixin):
                 new_sum = masked_activations.float().sum(dim=0).cpu()
                 new_count = torch.tensor(masked_activations.size(0)).cpu()
                 if smooth_name not in self._smooth_activation_stats:
-                    self._smooth_activation_stats[smooth_name] = [
-                        torch.zeros_like(new_sum),
-                        torch.zeros_like(new_count),
-                    ]
-                self._smooth_activation_stats[smooth_name][0] += new_sum
-                self._smooth_activation_stats[smooth_name][1] += new_count
+                    self._smooth_activation_stats.update(
+                        smooth_name,
+                        [torch.zeros_like(new_sum), torch.zeros_like(new_count)],
+                    )
+                x_sum, count = self._smooth_activation_stats.fetch(smooth_name)
+                x_sum += new_sum
+                count += new_count
+                self._smooth_activation_stats.update(smooth_name, [x_sum, count])
 
             return cache_smooth_activations_hook
 
         for mapping in self._resolved_mappings:
             if self._parent_args_cache is None:
                 self._parent_args_cache = IntermediatesCache(self.offload_device)
+                self._smooth_activation_stats = IntermediatesCache(self.offload_device)
 
                 self.register_hook(
                     mapping.parent,
@@ -535,7 +536,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                         "found to scale. This can occasionally occur in MoE models "
                         "when certain experts are not activated by calibration samples."
                     )
-                    del self._smooth_activation_stats[mapping.smooth_name]
+                    self._smooth_activation_stats.delete(mapping.smooth_name)
                     continue
                 if not all(
                     [fp16_output.isfinite().all() for fp16_output in fp16_outputs]
@@ -549,7 +550,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                         "ways. If you encounter this consistently, raise an issue at "
                         "https://github.com/vllm-project/llm-compressor/issues"
                     )
-                    del self._smooth_activation_stats[mapping.smooth_name]
+                    self._smooth_activation_stats.delete(mapping.smooth_name)
                     continue
 
                 orig_layer_weights = {
@@ -601,8 +602,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                     _smooth(layer, orig_layer_weights)
                 _smooth(smooth_layer, orig_layer_weights)
 
-                # remove caches needed to smooth this mapping
-                del self._smooth_activation_stats[mapping.smooth_name]
+                self._smooth_activation_stats.delete(mapping.smooth_name)
                 del orig_layer_weights
 
         self._parent_args_cache.clear()
@@ -655,7 +655,7 @@ class AWQModifier(Modifier, QuantizationMixin):
 
         device = get_execution_device(mapping.parent)
 
-        x_sum, count = self._smooth_activation_stats[mapping.smooth_name]
+        x_sum, count = self._smooth_activation_stats.fetch(mapping.smooth_name)
         if is_distributed():
             x_sum, count = _allreduce_data_sum([x_sum, count])
         x_mean = x_sum.to(device) / count.to(device)

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -162,8 +162,7 @@ class AWQModifier(Modifier, QuantizationMixin):
 
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
-    _parent_args_cache: IntermediatesCache = PrivateAttr(default=None)
-    _parent_args_batch_idx: dict[Module, int] = PrivateAttr(default_factory=dict)
+    _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(default=None)
     _smooth_activation_stats: dict[str, list[torch.Tensor]] = PrivateAttr(
         default_factory=dict
     )
@@ -312,7 +311,6 @@ class AWQModifier(Modifier, QuantizationMixin):
 
         if self._parent_args_cache is not None:
             self._parent_args_cache.clear()
-        self._parent_args_batch_idx.clear()
         self._smooth_activation_stats.clear()
         self._resolved_mappings.clear()
         self._error_metrics.clear()
@@ -436,12 +434,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                 if isinstance(v, QuantizedKVCache):
                     values.arguments[k] = None
 
-            batch_idx = self._parent_args_batch_idx.get(module, 0)
-            for arg_name, arg_value in values.arguments.items():
-                self._parent_args_cache.update(
-                    (module, batch_idx, arg_name), arg_value
-                )
-            self._parent_args_batch_idx[module] = batch_idx + 1
+            self._parent_args_cache.append((module, None), values.arguments)
 
         def create_cache_smooth_activations_hook_fn(smooth_name):
             def cache_smooth_activations_hook(
@@ -485,8 +478,7 @@ class AWQModifier(Modifier, QuantizationMixin):
         for mapping in self._resolved_mappings:
             if self._parent_args_cache is None:
                 self._parent_args_cache = IntermediatesCache(self.offload_device)
-            if mapping.parent not in self._parent_args_batch_idx:
-                self._parent_args_batch_idx[mapping.parent] = 0
+
                 self.register_hook(
                     mapping.parent,
                     cache_parent_kwargs_hook,
@@ -621,25 +613,17 @@ class AWQModifier(Modifier, QuantizationMixin):
         cache = self._parent_args_cache
         use_prefetch = active_session().state.sequential_prefetch
 
-        module_keys = [k for k in cache._store.keys() if k[0] == module]
-        if not module_keys:
-            return []
-
-        def group_by_fn(k):
-            return (k[0], k[1])
-
         if use_prefetch:
-            batch_iter = cache.iter_prefetch_grouped(module_keys, group_by=group_by_fn)
+            batch_iter = cache.iter_prefetch([(module, None)])
         else:
-            batch_iter = cache.iter_prefetch_grouped(module_keys, group_by=group_by_fn)
+            batch_iter = cache.iter([(module, None)])
 
-        outputs = []
-        for group_dict in batch_iter:
-            batch_kwargs = {k[2]: v for k, v in group_dict.items()}
-            output = module(**batch_kwargs)
-            outputs.append(output[0] if isinstance(output, tuple) else output)
-
-        return outputs
+        outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
+        return [
+            # If tuple, assume that first argument is the input
+            output[0] if isinstance(output, tuple) else output
+            for output in outputs
+        ]
 
     def _compute_best_scale(
         self,

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -162,8 +162,11 @@ class AWQModifier(Modifier, QuantizationMixin):
 
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
+    # Cache of forward input args for each parent module, one dict for each batch
     _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(default=None)
+    # Cache dict[smooth layer name, [activation sums, activation counts]]
     _smooth_activation_stats: IntermediatesCache[str] = PrivateAttr(default=None)
+    # List to store error metrics for each layer
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -476,6 +479,8 @@ class AWQModifier(Modifier, QuantizationMixin):
             return cache_smooth_activations_hook
 
         for mapping in self._resolved_mappings:
+            # parent kwargs needed for future forward passes
+            # same parent may appear multiple times in resolved mappings
             if self._parent_args_cache is None:
                 self._parent_args_cache = IntermediatesCache(self.offload_device)
                 self._smooth_activation_stats = IntermediatesCache(self.offload_device)
@@ -602,6 +607,7 @@ class AWQModifier(Modifier, QuantizationMixin):
                     _smooth(layer, orig_layer_weights)
                 _smooth(smooth_layer, orig_layer_weights)
 
+                # remove caches needed to smooth this mapping
                 self._smooth_activation_stats.delete(mapping.smooth_name)
                 del orig_layer_weights
 

--- a/src/llmcompressor/modifiers/awq/base.py
+++ b/src/llmcompressor/modifiers/awq/base.py
@@ -163,7 +163,9 @@ class AWQModifier(Modifier, QuantizationMixin):
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
     # Cache of forward input args for each parent module, one dict for each batch
-    _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(default=None)
+    _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(
+        default=None
+    )
     # Cache dict[smooth layer name, [activation sums, activation counts]]
     _smooth_activation_stats: IntermediatesCache[str] = PrivateAttr(default=None)
     # List to store error metrics for each layer

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -261,7 +261,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 tuple(), device=get_execution_device(module)
             )
 
-        # Fetch hessian (onloads to original device automatically), accumulate, then update
+        # Fetch hessian (onloads to original device automatically)
         hessian = self._hessians_cache[module]
         hessian, self._num_samples[module] = accumulate_hessian(
             inp, module, hessian, self._num_samples[module]

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -282,7 +282,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         world_size = dist.get_world_size()
 
         # Get module list from cache
-        module_list = list(self._hessians_cache._store.keys())
+        module_list = list(self._hessians_cache.iter_keys())
 
         # Assign modules to ranks
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -262,7 +262,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
             )
 
         # Fetch hessian (onloads to original device automatically), accumulate, then update
-        hessian = self._hessians_cache.fetch(module)
+        hessian = self._hessians_cache[module]
         hessian, self._num_samples[module] = accumulate_hessian(
             inp, module, hessian, self._num_samples[module]
         )
@@ -288,7 +288,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
             module_list,
             world_size,
-            item_weight_fn=lambda mod: self._hessians_cache.fetch(mod).shape[0],
+            item_weight_fn=lambda mod: self._hessians_cache[mod].shape[0],
         )
 
         # send hessians to assigned ranks
@@ -311,7 +311,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 align_module_device(module),
                 CompressionLogger(module) as comp_logger,
             ):
-                hessian = self._hessians_cache.fetch(module) / num_samples
+                hessian = self._hessians_cache[module] / num_samples
                 self._hessians_cache.delete(module)
                 self._num_samples.pop(module)
 
@@ -332,7 +332,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         pending_comms = []
         for module in module_list:
             target_rank = module_to_rank[module]
-            hessian = self._hessians_cache.fetch(module)
+            hessian = self._hessians_cache[module]
 
             pending_comms.append(
                 dist.reduce(

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -1,4 +1,3 @@
-import contextlib
 from typing import Dict, Optional, Tuple, Union
 
 import torch
@@ -31,6 +30,7 @@ from llmcompressor.modifiers.gptq.gptq_quantize import (
 from llmcompressor.modifiers.quantization.calibration import update_weight_global_scale
 from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.modifiers.utils import update_fused_layer_weight_global_scales
+from llmcompressor.pipelines.cache import IntermediatesCache
 from llmcompressor.sentinel import Sentinel
 from llmcompressor.utils.metric_logging import CompressionLogger
 
@@ -124,7 +124,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
     # private variables
     _module_names: Dict[torch.nn.Module, str] = PrivateAttr(default_factory=dict)
-    _hessians: Dict[torch.nn.Module, torch.Tensor] = PrivateAttr(default_factory=dict)
+    _hessians_cache: IntermediatesCache[torch.nn.Module] = PrivateAttr(default=None)
     _num_samples: Dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
         default_factory=dict
     )
@@ -185,6 +185,10 @@ class GPTQModifier(Modifier, QuantizationMixin):
         # register quantization calibration hooks
         # assume quantization has been initialized by this modifier or one before it
         QuantizationMixin.start_calibration(self, state.model)
+
+        # Initialize hessians cache with optional offloading
+        offload_device = torch.device("cpu") if self.offload_hessians else None
+        self._hessians_cache = IntermediatesCache(offload_device=offload_device)
 
         # register gptq hooks
         added_hook = False
@@ -250,22 +254,19 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
         # Initialize hessian if not present
         if module not in self._num_samples:
-            init_device = (
-                "cpu" if self.offload_hessians else get_execution_device(module)
+            self._hessians_cache.update(
+                module, make_empty_hessian(module, device=get_execution_device(module))
             )
-            self._hessians[module] = make_empty_hessian(module, device=init_device)
             self._num_samples[module] = torch.zeros(
                 tuple(), device=get_execution_device(module)
             )
 
-        # Accumulate hessian with input with optional offloading
-        with self._maybe_onload_hessian(module):
-            self._hessians[module], self._num_samples[module] = accumulate_hessian(
-                inp,
-                module,
-                self._hessians[module],
-                self._num_samples[module],
-            )
+        # Fetch hessian (onloads to original device automatically), accumulate, then update
+        hessian = self._hessians_cache.fetch(module)
+        hessian, self._num_samples[module] = accumulate_hessian(
+            inp, module, hessian, self._num_samples[module]
+        )
+        self._hessians_cache.update(module, hessian)
 
     def compress_modules(self):
         """
@@ -280,11 +281,14 @@ class GPTQModifier(Modifier, QuantizationMixin):
         rank = dist.get_rank()
         world_size = dist.get_world_size()
 
+        # Get module list from cache
+        module_list = list(self._hessians_cache._store.keys())
+
         # Assign modules to ranks
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
-            list(self._hessians.keys()),
+            module_list,
             world_size,
-            item_weight_fn=lambda mod: self._hessians[mod].shape[0],
+            item_weight_fn=lambda mod: self._hessians_cache.fetch(mod).shape[0],
         )
 
         # send hessians to assigned ranks
@@ -305,13 +309,16 @@ class GPTQModifier(Modifier, QuantizationMixin):
             with (
                 torch.no_grad(),
                 align_module_device(module),
-                self._maybe_onload_hessian(module),
                 CompressionLogger(module) as comp_logger,
             ):
+                hessian = self._hessians_cache.fetch(module) / num_samples
+                self._hessians_cache.delete(module)
+                self._num_samples.pop(module)
+
                 loss, q_param_dict = quantize_weight(
                     module=module,
                     quant_args=quant_args,
-                    hessian=self._hessians.pop(module) / self._num_samples.pop(module),
+                    hessian=hessian,
                     blocksize=self.block_size,
                     percdamp=self.dampening_frac,
                 )
@@ -325,26 +332,27 @@ class GPTQModifier(Modifier, QuantizationMixin):
         pending_comms = []
         for module in module_list:
             target_rank = module_to_rank[module]
-            with self._maybe_onload_hessian(module):
-                pending_comms.append(
-                    dist.reduce(
-                        self._hessians[module],
-                        op=dist.ReduceOp.SUM,
-                        dst=target_rank,
-                        async_op=True,
-                    )
+            hessian = self._hessians_cache.fetch(module)
+
+            pending_comms.append(
+                dist.reduce(
+                    hessian,
+                    op=dist.ReduceOp.SUM,
+                    dst=target_rank,
+                    async_op=True,
                 )
-                pending_comms.append(
-                    dist.reduce(
-                        self._num_samples[module],
-                        op=dist.ReduceOp.SUM,
-                        dst=target_rank,
-                        async_op=True,
-                    )
+            )
+            pending_comms.append(
+                dist.reduce(
+                    self._num_samples[module],
+                    op=dist.ReduceOp.SUM,
+                    dst=target_rank,
+                    async_op=True,
                 )
-                if rank != target_rank:
-                    self._hessians.pop(module, None)
-                    self._num_samples.pop(module, None)
+            )
+            if rank != target_rank:
+                self._hessians_cache.delete(module)
+                self._num_samples.pop(module, None)
         wait_for_comms(pending_comms)
 
     def _broadcast_quantized_params(self, module_list, module_to_rank):
@@ -384,19 +392,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")
 
-        self._hessians = dict()
+        self._hessians_cache.clear()
         self._num_samples = dict()
 
         return True
-
-    @contextlib.contextmanager
-    def _maybe_onload_hessian(self, module: torch.nn.Module):
-        if self.offload_hessians:
-            device = get_execution_device(module)
-            self._hessians[module] = self._hessians[module].to(device=device)
-
-        yield
-
-        if self.offload_hessians:
-            if module in self._hessians:  # may have been deleted in context
-                self._hessians[module] = self._hessians[module].to(device="cpu")

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -24,7 +24,7 @@ from torch import distributed as dist
 from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers import Modifier
 from llmcompressor.modifiers.gptq.gptq_quantize import (
-    accumulate_hessian,
+    calculate_hessian,
     make_empty_hessian,
     quantize_weight,
 )
@@ -129,11 +129,9 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
     # private variables
     _module_names: dict[torch.nn.Module, str] = PrivateAttr(default_factory=dict)
-    _hessians_cache: IntermediatesCache[torch.nn.Module, torch.Tensor] = PrivateAttr(
-        default=None
-    )
-    _num_samples: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
-        default_factory=dict
+    # cache for Module: [hessian, count]
+    _hessians_cache: IntermediatesCache[torch.nn.Module, list[torch.Tensor]] = (
+        PrivateAttr(default=None)
     )
 
     def resolve_quantization_config(self) -> QuantizationConfig:
@@ -276,21 +274,23 @@ class GPTQModifier(Modifier, QuantizationMixin):
         # Assume that first argument is the input
         inp = args[0]
 
+        device = get_execution_device(module)
         # Initialize hessian if not present
-        if module not in self._num_samples:
+        if module not in self._hessians_cache:
             self._hessians_cache.update(
-                module, make_empty_hessian(module, device=get_execution_device(module))
-            )
-            self._num_samples[module] = torch.zeros(
-                tuple(), device=get_execution_device(module)
+                module,
+                [
+                    make_empty_hessian(module, device=device),
+                    torch.zeros(tuple(), device=device),
+                ],
             )
 
         # Fetch hessian (onloads to original device automatically)
-        hessian = self._hessians_cache[module]
-        hessian, self._num_samples[module] = accumulate_hessian(
-            inp, module, hessian, self._num_samples[module]
-        )
-        self._hessians_cache.update(module, hessian)
+        hessian, count = self._hessians_cache.fetch_no_onload(module)
+        new_hessian, new_count = calculate_hessian(inp, module)
+        hessian += new_hessian.to(hessian.device)
+        count += new_count
+        self._hessians_cache.update(module, [hessian, count], device)
 
     def compress_modules(self):
         """
@@ -298,7 +298,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         """
         ### Not Distributed
         if not is_distributed():
-            self.compress_module_list(list(self._num_samples.keys()))
+            self.compress_module_list(self._hessians_cache.iter_keys())
             return
 
         ### Distributed
@@ -326,18 +326,17 @@ class GPTQModifier(Modifier, QuantizationMixin):
     def compress_module_list(self, module_list):
         for module in module_list:
             name = self._module_names[module]
-            num_samples = self._num_samples[module]
+            hessian, count = self._hessians_cache[module]
             quant_args = getattr_chain(module, "quantization_scheme.weights")
 
-            logger.info(f"Quantizing {name} using {int(num_samples)} samples")
+            logger.info(f"Quantizing {name} using {int(count)} samples")
             with (
                 torch.no_grad(),
                 align_module_device(module),
                 CompressionLogger(module) as comp_logger,
             ):
-                hessian = self._hessians_cache[module] / num_samples
+                hessian = hessian / count
                 self._hessians_cache.delete(module)
-                self._num_samples.pop(module)
 
                 loss, q_param_dict = quantize_weight(
                     module=module,
@@ -356,7 +355,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         pending_comms = []
         for module in module_list:
             target_rank = module_to_rank[module]
-            hessian = self._hessians_cache[module]
+            hessian, count = self._hessians_cache[module]
 
             pending_comms.append(
                 dist.reduce(
@@ -368,7 +367,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
             )
             pending_comms.append(
                 dist.reduce(
-                    self._num_samples[module],
+                    count,
                     op=dist.ReduceOp.SUM,
                     dst=target_rank,
                     async_op=True,
@@ -376,7 +375,6 @@ class GPTQModifier(Modifier, QuantizationMixin):
             )
             if rank != target_rank:
                 self._hessians_cache.delete(module)
-                self._num_samples.pop(module, None)
         wait_for_comms(pending_comms)
 
     def _broadcast_quantized_params(self, module_list, module_to_rank):
@@ -413,11 +411,9 @@ class GPTQModifier(Modifier, QuantizationMixin):
         if not self.ended_:
             self.on_end(state, None)
 
-        if len(self._num_samples) > 0:
-            raise ValueError(f"Failed to compress {len(self._num_samples)} modules")
+        if len(self._hessians_cache) > 0:
+            raise ValueError(f"Failed to compress {len(self._hessians_cache)} modules")
 
-        if self._hessians_cache is not None:
-            self._hessians_cache.clear()
-        self._num_samples = dict()
+        self._hessians_cache.clear() if self._hessians_cache else None
 
         return True

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -305,12 +305,9 @@ class GPTQModifier(Modifier, QuantizationMixin):
         rank = dist.get_rank()
         world_size = dist.get_world_size()
 
-        # Get module list from cache
-        module_list = list(self._hessians_cache.iter_keys())
-
         # Assign modules to ranks
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
-            module_list,
+            list(self._hessians_cache.iter_keys()),
             world_size,
             item_weight_fn=lambda mod: self._hessians_cache[mod].shape[0],
         )

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -1,5 +1,3 @@
-from typing import Dict, Optional, Tuple, Union
-
 import torch
 from compressed_tensors.distributed import greedy_bin_packing, wait_for_comms
 from compressed_tensors.offload.dist_utils import as_broadcastable, is_distributed

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -287,8 +287,8 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
         # Fetch hessian (onloads to original device automatically)
         hessian, count = self._hessians_cache.fetch_no_onload(module)
-        new_hessian, new_count = calculate_hessian(inp, module)
-        hessian += new_hessian.to(hessian.device)
+        new_hessian, new_count = calculate_hessian(inp, hessian.device)
+        hessian += new_hessian
         count += new_count
         self._hessians_cache.update(module, [hessian, count], device)
 

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -283,7 +283,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 tuple(), device=get_execution_device(module)
             )
 
-        # Fetch hessian (onloads to original device automatically), accumulate, then update
+        # Fetch hessian (onloads to original device automatically)
         hessian = self._hessians_cache[module]
         hessian, self._num_samples[module] = accumulate_hessian(
             inp, module, hessian, self._num_samples[module]

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -130,7 +130,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
     # private variables
     _module_names: dict[torch.nn.Module, str] = PrivateAttr(default_factory=dict)
     _hessians_cache: IntermediatesCache[torch.nn.Module, torch.Tensor] = PrivateAttr(
-        default_factory=lambda: IntermediatesCache(offload_device=None)
+        default=None
     )
     _num_samples: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
         default_factory=dict
@@ -216,10 +216,9 @@ class GPTQModifier(Modifier, QuantizationMixin):
         # assume quantization has been initialized by this modifier or one before it
         QuantizationMixin.start_calibration(self, state.model)
 
-        # Configure hessians cache offload device
-        self._hessians_cache.offload_device = (
-            torch.device("cpu") if self.offload_hessians else None
-        )
+        # Initialize hessians cache with optional offloading
+        offload_device = torch.device("cpu") if self.offload_hessians else None
+        self._hessians_cache = IntermediatesCache(offload_device=offload_device)
 
         # register gptq hooks
         added_hook = False
@@ -417,7 +416,8 @@ class GPTQModifier(Modifier, QuantizationMixin):
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")
 
-        self._hessians_cache.clear()
+        if self._hessians_cache is not None:
+            self._hessians_cache.clear()
         self._num_samples = dict()
 
         return True

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -304,7 +304,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         world_size = dist.get_world_size()
 
         # Get module list from cache
-        module_list = list(self._hessians_cache._store.keys())
+        module_list = list(self._hessians_cache.iter_keys())
 
         # Assign modules to ranks
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -1,4 +1,4 @@
-import contextlib
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 from compressed_tensors.distributed import greedy_bin_packing, wait_for_comms
@@ -35,6 +35,7 @@ from llmcompressor.modifiers.quantization.calibration import (
 )
 from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.observers import ACTIVATION_OBS
+from llmcompressor.pipelines.cache import IntermediatesCache
 from llmcompressor.sentinel import Sentinel
 from llmcompressor.utils.metric_logging import CompressionLogger
 
@@ -128,7 +129,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
     # private variables
     _module_names: dict[torch.nn.Module, str] = PrivateAttr(default_factory=dict)
-    _hessians: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(default_factory=dict)
+    _hessians_cache: IntermediatesCache[torch.nn.Module] = PrivateAttr(default=None)
     _num_samples: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
         default_factory=dict
     )
@@ -213,6 +214,10 @@ class GPTQModifier(Modifier, QuantizationMixin):
         # assume quantization has been initialized by this modifier or one before it
         QuantizationMixin.start_calibration(self, state.model)
 
+        # Initialize hessians cache with optional offloading
+        offload_device = torch.device("cpu") if self.offload_hessians else None
+        self._hessians_cache = IntermediatesCache(offload_device=offload_device)
+
         # register gptq hooks
         added_hook = False
 
@@ -271,22 +276,19 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
         # Initialize hessian if not present
         if module not in self._num_samples:
-            init_device = (
-                "cpu" if self.offload_hessians else get_execution_device(module)
+            self._hessians_cache.update(
+                module, make_empty_hessian(module, device=get_execution_device(module))
             )
-            self._hessians[module] = make_empty_hessian(module, device=init_device)
             self._num_samples[module] = torch.zeros(
                 tuple(), device=get_execution_device(module)
             )
 
-        # Accumulate hessian with input with optional offloading
-        with self._maybe_onload_hessian(module):
-            self._hessians[module], self._num_samples[module] = accumulate_hessian(
-                inp,
-                module,
-                self._hessians[module],
-                self._num_samples[module],
-            )
+        # Fetch hessian (onloads to original device automatically), accumulate, then update
+        hessian = self._hessians_cache.fetch(module)
+        hessian, self._num_samples[module] = accumulate_hessian(
+            inp, module, hessian, self._num_samples[module]
+        )
+        self._hessians_cache.update(module, hessian)
 
     def compress_modules(self):
         """
@@ -301,11 +303,14 @@ class GPTQModifier(Modifier, QuantizationMixin):
         rank = dist.get_rank()
         world_size = dist.get_world_size()
 
+        # Get module list from cache
+        module_list = list(self._hessians_cache._store.keys())
+
         # Assign modules to ranks
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
-            list(self._hessians.keys()),
+            module_list,
             world_size,
-            item_weight_fn=lambda mod: self._hessians[mod].shape[0],
+            item_weight_fn=lambda mod: self._hessians_cache.fetch(mod).shape[0],
         )
 
         # send hessians to assigned ranks
@@ -326,13 +331,16 @@ class GPTQModifier(Modifier, QuantizationMixin):
             with (
                 torch.no_grad(),
                 align_module_device(module),
-                self._maybe_onload_hessian(module),
                 CompressionLogger(module) as comp_logger,
             ):
+                hessian = self._hessians_cache.fetch(module) / num_samples
+                self._hessians_cache.delete(module)
+                self._num_samples.pop(module)
+
                 loss, q_param_dict = quantize_weight(
                     module=module,
                     quant_args=quant_args,
-                    hessian=self._hessians.pop(module) / self._num_samples.pop(module),
+                    hessian=hessian,
                     blocksize=self.block_size,
                     percdamp=self.dampening_frac,
                 )
@@ -346,26 +354,27 @@ class GPTQModifier(Modifier, QuantizationMixin):
         pending_comms = []
         for module in module_list:
             target_rank = module_to_rank[module]
-            with self._maybe_onload_hessian(module):
-                pending_comms.append(
-                    dist.reduce(
-                        self._hessians[module],
-                        op=dist.ReduceOp.SUM,
-                        dst=target_rank,
-                        async_op=True,
-                    )
+            hessian = self._hessians_cache.fetch(module)
+
+            pending_comms.append(
+                dist.reduce(
+                    hessian,
+                    op=dist.ReduceOp.SUM,
+                    dst=target_rank,
+                    async_op=True,
                 )
-                pending_comms.append(
-                    dist.reduce(
-                        self._num_samples[module],
-                        op=dist.ReduceOp.SUM,
-                        dst=target_rank,
-                        async_op=True,
-                    )
+            )
+            pending_comms.append(
+                dist.reduce(
+                    self._num_samples[module],
+                    op=dist.ReduceOp.SUM,
+                    dst=target_rank,
+                    async_op=True,
                 )
-                if rank != target_rank:
-                    self._hessians.pop(module, None)
-                    self._num_samples.pop(module, None)
+            )
+            if rank != target_rank:
+                self._hessians_cache.delete(module)
+                self._num_samples.pop(module, None)
         wait_for_comms(pending_comms)
 
     def _broadcast_quantized_params(self, module_list, module_to_rank):
@@ -405,19 +414,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")
 
-        self._hessians = dict()
+        self._hessians_cache.clear()
         self._num_samples = dict()
 
         return True
-
-    @contextlib.contextmanager
-    def _maybe_onload_hessian(self, module: torch.nn.Module):
-        if self.offload_hessians:
-            device = get_execution_device(module)
-            self._hessians[module] = self._hessians[module].to(device=device)
-
-        yield
-
-        if self.offload_hessians:
-            if module in self._hessians:  # may have been deleted in context
-                self._hessians[module] = self._hessians[module].to(device="cpu")

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -284,7 +284,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
             )
 
         # Fetch hessian (onloads to original device automatically), accumulate, then update
-        hessian = self._hessians_cache.fetch(module)
+        hessian = self._hessians_cache[module]
         hessian, self._num_samples[module] = accumulate_hessian(
             inp, module, hessian, self._num_samples[module]
         )
@@ -310,7 +310,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
             module_list,
             world_size,
-            item_weight_fn=lambda mod: self._hessians_cache.fetch(mod).shape[0],
+            item_weight_fn=lambda mod: self._hessians_cache[mod].shape[0],
         )
 
         # send hessians to assigned ranks
@@ -333,7 +333,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 align_module_device(module),
                 CompressionLogger(module) as comp_logger,
             ):
-                hessian = self._hessians_cache.fetch(module) / num_samples
+                hessian = self._hessians_cache[module] / num_samples
                 self._hessians_cache.delete(module)
                 self._num_samples.pop(module)
 
@@ -354,7 +354,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         pending_comms = []
         for module in module_list:
             target_rank = module_to_rank[module]
-            hessian = self._hessians_cache.fetch(module)
+            hessian = self._hessians_cache[module]
 
             pending_comms.append(
                 dist.reduce(

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -129,7 +129,9 @@ class GPTQModifier(Modifier, QuantizationMixin):
 
     # private variables
     _module_names: dict[torch.nn.Module, str] = PrivateAttr(default_factory=dict)
-    _hessians_cache: IntermediatesCache[torch.nn.Module] = PrivateAttr(default=None)
+    _hessians_cache: IntermediatesCache[torch.nn.Module, torch.Tensor] = PrivateAttr(
+        default_factory=lambda: IntermediatesCache(offload_device=None)
+    )
     _num_samples: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
         default_factory=dict
     )
@@ -214,9 +216,10 @@ class GPTQModifier(Modifier, QuantizationMixin):
         # assume quantization has been initialized by this modifier or one before it
         QuantizationMixin.start_calibration(self, state.model)
 
-        # Initialize hessians cache with optional offloading
-        offload_device = torch.device("cpu") if self.offload_hessians else None
-        self._hessians_cache = IntermediatesCache(offload_device=offload_device)
+        # Configure hessians cache offload device
+        self._hessians_cache.offload_device = (
+            torch.device("cpu") if self.offload_hessians else None
+        )
 
         # register gptq hooks
         added_hook = False

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -16,7 +16,7 @@ from llmcompressor.pytorch.utils.helpers import tensor_sparsity
 
 GPTQ_PRECISION = torch.float32
 
-__all__ = ["make_empty_hessian", "accumulate_hessian", "quantize_weight"]
+__all__ = ["make_empty_hessian", "calculate_hessian", "quantize_weight"]
 
 
 def make_empty_hessian(
@@ -28,13 +28,10 @@ def make_empty_hessian(
     return torch.zeros((num_columns, num_columns), device=device, dtype=GPTQ_PRECISION)
 
 
-def accumulate_hessian(
+def calculate_hessian(
     inp: torch.Tensor,
     module: torch.nn.Module,
-    H: torch.Tensor | None,
-    num_samples: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    inp = inp.to(device=H.device)
     if len(inp.shape) == 2:
         inp = inp.unsqueeze(0)
 
@@ -56,11 +53,11 @@ def accumulate_hessian(
             inp = inp.permute([1, 0, 2])
             inp = inp.flatten(1)
 
-    num_samples += num_added
+    num_samples = num_added
 
     inp = inp.to(dtype=GPTQ_PRECISION)
     inp = math.sqrt(2) * inp
-    H += inp.matmul(inp.t())
+    H = inp.matmul(inp.t())
 
     return H, num_samples
 

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -2,7 +2,6 @@ import math
 from copy import copy
 
 import torch
-import transformers
 from compressed_tensors.quantization import (
     ActivationOrdering,
     QuantizationArgs,
@@ -30,36 +29,27 @@ def make_empty_hessian(
 
 def calculate_hessian(
     inp: torch.Tensor,
-    module: torch.nn.Module,
+    device: torch.device,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    # Move input to target device before any computation to avoid device mismatch
+    inp = inp.to(device=device)
+
     if len(inp.shape) == 2:
         inp = inp.unsqueeze(0)
 
     num_added = inp.shape[0]
 
-    match module:
-        case torch.nn.Linear() | transformers.Conv1D():
-            if len(inp.shape) == 3:
-                inp = inp.reshape((-1, inp.shape[-1]))
-            inp = inp.t()
-        case torch.nn.Conv2d():
-            unfold = torch.nn.Unfold(
-                module.kernel_size,
-                dilation=module.dilation,
-                padding=module.padding,
-                stride=module.stride,
-            )
-            inp = unfold(inp)
-            inp = inp.permute([1, 0, 2])
-            inp = inp.flatten(1)
+    if len(inp.shape) == 3:
+        inp = inp.reshape((-1, inp.shape[-1]))
+    inp = inp.t()
 
-    num_samples = num_added
+    count = num_added
 
     inp = inp.to(dtype=GPTQ_PRECISION)
     inp = math.sqrt(2) * inp
     H = inp.matmul(inp.t())
 
-    return H, num_samples
+    return H, torch.tensor(count, device=device)
 
 
 def quantize_weight(

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -150,7 +150,7 @@ class SparseGPTModifier(SparsityModifierBase):
     def on_finalize(self, state: State, **kwargs) -> bool:
         # TODO: modify lifecycle to end on finalize
         if not self.ended_:
-            self.on_end(state, None)
+            self.on_end(state, None) # remove hooks
 
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -108,7 +108,7 @@ class SparseGPTModifier(SparsityModifierBase):
             )
             self._num_samples[module] = 0
 
-        hessian = self._hessians_cache.fetch(module)
+        hessian = self._hessians_cache[module]
         hessian, self._num_samples[module] = accumulate_hessian(
             inp, module, hessian, self._num_samples[module]
         )
@@ -129,7 +129,7 @@ class SparseGPTModifier(SparsityModifierBase):
                 align_module_device(module),
                 CompressionLogger(module) as comp_logger,
             ):
-                hessian = self._hessians_cache.fetch(module)
+                hessian = self._hessians_cache[module]
                 self._hessians_cache.delete(module)
                 loss, sparsified_weight = sparsify_weight(
                     module=module,

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -1,5 +1,3 @@
-import contextlib
-
 import torch
 from compressed_tensors.utils import (
     align_module_device,
@@ -9,13 +7,14 @@ from compressed_tensors.utils import (
 from loguru import logger
 from pydantic import PrivateAttr
 
-from llmcompressor.core import State
+from llmcompressor.core import Event, State
 from llmcompressor.modifiers.pruning.sparsegpt.sgpt_base import SparsityModifierBase
 from llmcompressor.modifiers.pruning.sparsegpt.sgpt_sparsify import (
     accumulate_hessian,
     make_empty_hessian,
     sparsify_weight,
 )
+from llmcompressor.pipelines.cache import IntermediatesCache
 from llmcompressor.utils.metric_logging import CompressionLogger
 
 __all__ = ["SparseGPTModifier"]
@@ -79,7 +78,12 @@ class SparseGPTModifier(SparsityModifierBase):
 
     # private variables
     _num_samples: dict[torch.nn.Module, int] = PrivateAttr(default_factory=dict)
-    _hessians: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(default_factory=dict)
+    _hessians_cache: IntermediatesCache[torch.nn.Module] = PrivateAttr(default=None)
+
+    def on_start(self, state: State, event: Event, **kwargs):
+        super().on_start(state, event, **kwargs)
+        offload_device = torch.device("cpu") if self.offload_hessians else None
+        self._hessians_cache = IntermediatesCache(offload_device=offload_device)
 
     def calibrate_module(
         self,
@@ -95,23 +99,20 @@ class SparseGPTModifier(SparsityModifierBase):
             canonical input
         :param _output: uncompressed module output, unused
         """
-        # Assume that the first argument is the input
         inp = args[0]
 
-        # Initialize hessian if not present
         if module not in self._num_samples:
             device = get_execution_device(module)
-            self._hessians[module] = make_empty_hessian(module, device=device)
+            self._hessians_cache.update(
+                module, make_empty_hessian(module, device=device)
+            )
             self._num_samples[module] = 0
 
-        # Accumulate hessian with input with optional offloading
-        with self._maybe_onload_hessian(module):
-            self._hessians[module], self._num_samples[module] = accumulate_hessian(
-                inp,
-                module,
-                self._hessians[module],
-                self._num_samples[module],
-            )
+        hessian = self._hessians_cache.fetch(module)
+        hessian, self._num_samples[module] = accumulate_hessian(
+            inp, module, hessian, self._num_samples[module]
+        )
+        self._hessians_cache.update(module, hessian)
 
     def compress_modules(self):
         """
@@ -128,9 +129,11 @@ class SparseGPTModifier(SparsityModifierBase):
                 align_module_device(module),
                 CompressionLogger(module) as comp_logger,
             ):
+                hessian = self._hessians_cache.fetch(module)
+                self._hessians_cache.delete(module)
                 loss, sparsified_weight = sparsify_weight(
                     module=module,
-                    hessians_dict=self._hessians,
+                    hessian=hessian,
                     sparsity=sparsity,
                     prune_n=self._prune_n,
                     prune_m=self._prune_m,
@@ -142,30 +145,17 @@ class SparseGPTModifier(SparsityModifierBase):
 
             update_offload_parameter(module, "weight", sparsified_weight)
 
-            # self._hessians[module] already deleted by sparsify_weight
             del self._num_samples[module]
-
-    @contextlib.contextmanager
-    def _maybe_onload_hessian(self, module: torch.nn.Module):
-        if self.offload_hessians:
-            device = get_execution_device(module)
-            self._hessians[module] = self._hessians[module].to(device=device)
-
-        yield
-
-        if self.offload_hessians:
-            if module in self._hessians:  # may have been deleted in context
-                self._hessians[module] = self._hessians[module].to(device="cpu")
 
     def on_finalize(self, state: State, **kwargs) -> bool:
         # TODO: modify lifecycle to end on finalize
         if not self.ended_:
-            self.on_end(state, None)  # remove hooks
+            self.on_end(state, None)
 
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")
 
-        self._hessians = dict()
+        self._hessians_cache.clear()
         self._num_samples = dict()
         self._module_names = dict()
         self._module_sparsities = dict()

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -150,7 +150,7 @@ class SparseGPTModifier(SparsityModifierBase):
     def on_finalize(self, state: State, **kwargs) -> bool:
         # TODO: modify lifecycle to end on finalize
         if not self.ended_:
-            self.on_end(state, None) # remove hooks
+            self.on_end(state, None)  # remove hooks
 
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -79,14 +79,13 @@ class SparseGPTModifier(SparsityModifierBase):
     # private variables
     _num_samples: dict[torch.nn.Module, int] = PrivateAttr(default_factory=dict)
     _hessians_cache: IntermediatesCache[torch.nn.Module, torch.Tensor] = PrivateAttr(
-        default_factory=lambda: IntermediatesCache(offload_device=None)
+        default=None
     )
 
     def on_start(self, state: State, event: Event, **kwargs):
         super().on_start(state, event, **kwargs)
-        self._hessians_cache.offload_device = (
-            torch.device("cpu") if self.offload_hessians else None
-        )
+        offload_device = torch.device("cpu") if self.offload_hessians else None
+        self._hessians_cache = IntermediatesCache(offload_device=offload_device)
 
     def calibrate_module(
         self,
@@ -158,7 +157,8 @@ class SparseGPTModifier(SparsityModifierBase):
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")
 
-        self._hessians_cache.clear()
+        if self._hessians_cache is not None:
+            self._hessians_cache.clear()
         self._num_samples = dict()
         self._module_names = dict()
         self._module_sparsities = dict()

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -157,8 +157,7 @@ class SparseGPTModifier(SparsityModifierBase):
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")
 
-        if self._hessians_cache is not None:
-            self._hessians_cache.clear()
+        self._hessians_cache.clear() if self._hessians_cache else None
         self._num_samples = dict()
         self._module_names = dict()
         self._module_sparsities = dict()

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/base.py
@@ -78,12 +78,15 @@ class SparseGPTModifier(SparsityModifierBase):
 
     # private variables
     _num_samples: dict[torch.nn.Module, int] = PrivateAttr(default_factory=dict)
-    _hessians_cache: IntermediatesCache[torch.nn.Module] = PrivateAttr(default=None)
+    _hessians_cache: IntermediatesCache[torch.nn.Module, torch.Tensor] = PrivateAttr(
+        default_factory=lambda: IntermediatesCache(offload_device=None)
+    )
 
     def on_start(self, state: State, event: Event, **kwargs):
         super().on_start(state, event, **kwargs)
-        offload_device = torch.device("cpu") if self.offload_hessians else None
-        self._hessians_cache = IntermediatesCache(offload_device=offload_device)
+        self._hessians_cache.offload_device = (
+            torch.device("cpu") if self.offload_hessians else None
+        )
 
     def calibrate_module(
         self,

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
@@ -1,5 +1,5 @@
 import math
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 import transformers
@@ -58,19 +58,19 @@ def accumulate_hessian(
 
 def sparsify_weight(
     module: torch.nn.Module,
-    hessians_dict: Dict[torch.nn.Module, torch.Tensor],
+    hessian: torch.Tensor,
     sparsity: float,
     prune_n: int,
     prune_m: int,
     block_size: int,
     dampening_frac: float,
     preserve_sparsity_mask: bool,
-) -> torch.Tensor:
+) -> Tuple[float, torch.Tensor]:
     """
     Run pruning on the layer up to the target sparsity value.
 
     :param module: module with weight being sparsified
-    :param hessian_dict: dictionary containing preaccumulated hessian for sparsification
+    :param hessian: preaccumulated hessian for sparsification
     :param sparsity: target sparsity to reach for layer
     :param prune_n: N for N:M pruning
     :param prune_m: M for N:M pruning
@@ -82,8 +82,7 @@ def sparsify_weight(
     final_shape = module.weight.shape
     final_dtype = module.weight.dtype
     W = module.weight.clone()
-    H = hessians_dict[module]  # unfortunately python does not have a `move` keyword
-    del hessians_dict[module]  # so we have to delete the original reference manually
+    H = hessian
 
     # standardize shape and dtype
     if isinstance(module, torch.nn.Conv2d):

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
@@ -1,4 +1,5 @@
 import math
+from typing import Optional, Tuple
 
 import torch
 import transformers
@@ -57,19 +58,19 @@ def accumulate_hessian(
 
 def sparsify_weight(
     module: torch.nn.Module,
-    hessians_dict: dict[torch.nn.Module, torch.Tensor],
+    hessian: torch.Tensor,
     sparsity: float,
     prune_n: int,
     prune_m: int,
     block_size: int,
     dampening_frac: float,
     preserve_sparsity_mask: bool,
-) -> torch.Tensor:
+) -> Tuple[float, torch.Tensor]:
     """
     Run pruning on the layer up to the target sparsity value.
 
     :param module: module with weight being sparsified
-    :param hessian_dict: dictionary containing preaccumulated hessian for sparsification
+    :param hessian: preaccumulated hessian for sparsification
     :param sparsity: target sparsity to reach for layer
     :param prune_n: N for N:M pruning
     :param prune_m: M for N:M pruning
@@ -81,8 +82,7 @@ def sparsify_weight(
     final_shape = module.weight.shape
     final_dtype = module.weight.dtype
     W = module.weight.clone()
-    H = hessians_dict[module]  # unfortunately python does not have a `move` keyword
-    del hessians_dict[module]  # so we have to delete the original reference manually
+    H = hessian
 
     # standardize shape and dtype
     match module:

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
@@ -1,5 +1,4 @@
 import math
-from typing import Optional, Tuple
 
 import torch
 import transformers
@@ -53,7 +52,7 @@ def sparsify_weight(
     block_size: int,
     dampening_frac: float,
     preserve_sparsity_mask: bool,
-) -> Tuple[float, torch.Tensor]:
+) -> tuple[float, torch.Tensor]:
     """
     Run pruning on the layer up to the target sparsity value.
 

--- a/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
+++ b/src/llmcompressor/modifiers/pruning/sparsegpt/sgpt_sparsify.py
@@ -30,21 +30,9 @@ def accumulate_hessian(
     num_added = inp.shape[0]  # note this is the number of dataset samples, not
     # multiplied by the sequence length
 
-    match module:
-        case torch.nn.Linear() | transformers.Conv1D():
-            if len(inp.shape) == 3:
-                inp = inp.reshape((-1, inp.shape[-1]))
-            inp = inp.t()
-        case torch.nn.Conv2d():
-            unfold = torch.nn.Unfold(
-                module.kernel_size,
-                dilation=module.dilation,
-                padding=module.padding,
-                stride=module.stride,
-            )
-            inp = unfold(inp)
-            inp = inp.permute([1, 0, 2])
-            inp = inp.flatten(1)
+    if len(inp.shape) == 3:
+        inp = inp.reshape((-1, inp.shape[-1]))
+    inp = inp.t()
 
     H *= num_samples / (num_samples + num_added)
     num_samples += num_added

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -150,8 +150,11 @@ class AWQModifier(Modifier):
 
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
+    # Cache of forward input args for each parent module, one dict for each batch
     _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(default=None)
+    # Cache dict[smooth layer name, [activation sums, activation counts]]
     _smooth_activation_stats: IntermediatesCache[str] = PrivateAttr(default=None)
+    # List to store error metrics for each layer
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -452,6 +455,8 @@ class AWQModifier(Modifier):
             return cache_smooth_activations_hook
 
         for mapping in self._resolved_mappings:
+            # parent kwargs needed for future forward passes
+            # same parent may appear multiple times in resolved mappings
             if self._parent_args_cache is None:
                 self._parent_args_cache = IntermediatesCache(self.offload_device)
                 self._smooth_activation_stats = IntermediatesCache(self.offload_device)
@@ -578,6 +583,7 @@ class AWQModifier(Modifier):
                     _smooth(layer, orig_layer_weights)
                 _smooth(smooth_layer, orig_layer_weights)
 
+                # remove caches needed to smooth this mapping
                 self._smooth_activation_stats.delete(mapping.smooth_name)
                 del orig_layer_weights
 

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -449,17 +449,17 @@ class AWQModifier(Modifier):
                     masked_activations = activations.flatten(0, -2)
 
                 # accumulate activation sum&count
-                new_sum = masked_activations.float().sum(dim=0)
-                new_count = torch.tensor(masked_activations.size(0))
+                new_sum = masked_activations.float().sum(dim=0).cpu()
+                new_count = torch.tensor(masked_activations.size(0)).cpu()
                 if smooth_name not in self._smooth_activation_stats:
                     self._smooth_activation_stats.update(
                         smooth_name,
                         [torch.zeros_like(new_sum), torch.zeros_like(new_count)],
                     )
-                x_sum, count = self._smooth_activation_stats[smooth_name]
+                x_sum, count = self._smooth_activation_stats.fetch_no_onload(smooth_name)
                 x_sum += new_sum
                 count += new_count
-                self._smooth_activation_stats.update(smooth_name, [x_sum, count])
+                self._smooth_activation_stats.update(smooth_name, [x_sum, count], get_execution_device(_module))
 
             return cache_smooth_activations_hook
 

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -152,11 +152,11 @@ class AWQModifier(Modifier):
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
     # Cache of forward input args for each parent module, one dict for each batch
     _parent_args_cache: IntermediatesCache[tuple[Module, int], dict[str, torch.Tensor]] = PrivateAttr(
-        default_factory=lambda: IntermediatesCache(offload_device=None)
+        default=None
     )
     # Cache dict[smooth layer name, [activation sums, activation counts]]
     _smooth_activation_stats: IntermediatesCache[str, list[torch.Tensor]] = PrivateAttr(
-        default_factory=lambda: IntermediatesCache(offload_device=None)
+        default=None
     )
     # List to store error metrics for each layer
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
@@ -191,9 +191,9 @@ class AWQModifier(Modifier):
                 # (no offloading by default)
                 self.offload_device = None
 
-        # Set offload_device for caches
-        self._parent_args_cache.offload_device = self.offload_device
-        self._smooth_activation_stats.offload_device = self.offload_device
+        # Initialize caches
+        self._parent_args_cache = IntermediatesCache(offload_device=self.offload_device)
+        self._smooth_activation_stats = IntermediatesCache(offload_device=self.offload_device)
 
         return True
 
@@ -285,8 +285,10 @@ class AWQModifier(Modifier):
 
         self._log_error_metrics()
 
-        self._parent_args_cache.clear()
-        self._smooth_activation_stats.clear()
+        if self._parent_args_cache is not None:
+            self._parent_args_cache.clear()
+        if self._smooth_activation_stats is not None:
+            self._smooth_activation_stats.clear()
         self._resolved_mappings.clear()
         self._error_metrics.clear()
 

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -408,7 +408,7 @@ class AWQModifier(Modifier):
                 if isinstance(v, QuantizedKVCache):
                     values.arguments[k] = None
 
-            self._parent_args_cache.append((module, None), values.arguments)
+            self._parent_args_cache.append(module, values.arguments)
 
         def create_cache_smooth_activations_hook_fn(smooth_name):
             def cache_smooth_activations_hook(
@@ -437,14 +437,14 @@ class AWQModifier(Modifier):
                     masked_activations = activations.flatten(0, -2)
 
                 # accumulate activation sum&count
-                new_sum = masked_activations.float().sum(dim=0).cpu()
-                new_count = torch.tensor(masked_activations.size(0)).cpu()
+                new_sum = masked_activations.float().sum(dim=0)
+                new_count = torch.tensor(masked_activations.size(0))
                 if smooth_name not in self._smooth_activation_stats:
                     self._smooth_activation_stats.update(
                         smooth_name,
                         [torch.zeros_like(new_sum), torch.zeros_like(new_count)],
                     )
-                x_sum, count = self._smooth_activation_stats.fetch(smooth_name)
+                x_sum, count = self._smooth_activation_stats[smooth_name]
                 x_sum += new_sum
                 count += new_count
                 self._smooth_activation_stats.update(smooth_name, [x_sum, count])
@@ -590,9 +590,9 @@ class AWQModifier(Modifier):
         use_prefetch = active_session().state.sequential_prefetch
 
         if use_prefetch:
-            batch_iter = cache.iter_prefetch([(module, None)])
+            batch_iter = cache.iter_prefetch([(module)])
         else:
-            batch_iter = cache.iter([(module, None)])
+            batch_iter = cache.iter([(module)])
 
         outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
         return [
@@ -631,10 +631,10 @@ class AWQModifier(Modifier):
 
         device = get_execution_device(mapping.parent)
 
-        x_sum, count = self._smooth_activation_stats.fetch(mapping.smooth_name)
+        x_sum, count = self._smooth_activation_stats[mapping.smooth_name]
         if is_distributed():
             x_sum, count = _allreduce_data_sum([x_sum, count])
-        x_mean = x_sum.to(device) / count.to(device)
+        x_mean = x_sum / count
 
         if self.duo_scaling:
             w_mean = self._compute_layer_means(mapping.balance_layers).to(device)
@@ -1026,13 +1026,6 @@ def get_lowest_common_ancestor_with_avoid(
 
 
 def _allreduce_data_sum(data: list[torch.Tensor]) -> list[torch.Tensor]:
-    # needs to be on device to broadcast
-    device = torch.device(
-        torch.accelerator.current_accelerator().type,
-        torch.accelerator.current_device_index(),
-    )
-    data = [datum.to(device) for datum in data]
-
     pending_comms = []
     for datum in data:
         pending_comms.append(

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -151,11 +151,13 @@ class AWQModifier(Modifier):
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
     # Cache of forward input args for each parent module, one dict for each batch
-    _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(
-        default=None
+    _parent_args_cache: IntermediatesCache[tuple[Module, int], dict[str, torch.Tensor]] = PrivateAttr(
+        default_factory=lambda: IntermediatesCache(offload_device=None)
     )
     # Cache dict[smooth layer name, [activation sums, activation counts]]
-    _smooth_activation_stats: IntermediatesCache[str] = PrivateAttr(default=None)
+    _smooth_activation_stats: IntermediatesCache[str, list[torch.Tensor]] = PrivateAttr(
+        default_factory=lambda: IntermediatesCache(offload_device=None)
+    )
     # List to store error metrics for each layer
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
 
@@ -188,6 +190,10 @@ class AWQModifier(Modifier):
                 # For non-MoE models, convert sentinel to None
                 # (no offloading by default)
                 self.offload_device = None
+
+        # Set offload_device for caches
+        self._parent_args_cache.offload_device = self.offload_device
+        self._smooth_activation_stats.offload_device = self.offload_device
 
         return True
 
@@ -279,8 +285,7 @@ class AWQModifier(Modifier):
 
         self._log_error_metrics()
 
-        if self._parent_args_cache is not None:
-            self._parent_args_cache.clear()
+        self._parent_args_cache.clear()
         self._smooth_activation_stats.clear()
         self._resolved_mappings.clear()
         self._error_metrics.clear()
@@ -459,10 +464,7 @@ class AWQModifier(Modifier):
         for mapping in self._resolved_mappings:
             # parent kwargs needed for future forward passes
             # same parent may appear multiple times in resolved mappings
-            if self._parent_args_cache is None:
-                self._parent_args_cache = IntermediatesCache(self.offload_device)
-                self._smooth_activation_stats = IntermediatesCache(self.offload_device)
-
+            if len(self._parent_args_cache) == 0:
                 self.register_hook(
                     mapping.parent,
                     cache_parent_kwargs_hook,

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -150,15 +150,11 @@ class AWQModifier(Modifier):
 
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
-    # Cache list of forward input args for each parent module, one dict for each batch
-    _parent_args_cache: dict[Module, IntermediatesCache] = PrivateAttr(
-        default_factory=dict
-    )
-    # dict[smooth layer name, [activation sums, activation counts]]
+    _parent_args_cache: IntermediatesCache = PrivateAttr(default=None)
+    _parent_args_batch_idx: dict[Module, int] = PrivateAttr(default_factory=dict)
     _smooth_activation_stats: dict[str, list[torch.Tensor]] = PrivateAttr(
         default_factory=dict
     )
-    # List to store error metrics for each layer
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -281,7 +277,9 @@ class AWQModifier(Modifier):
 
         self._log_error_metrics()
 
-        self._parent_args_cache.clear()
+        if self._parent_args_cache is not None:
+            self._parent_args_cache.clear()
+        self._parent_args_batch_idx.clear()
         self._smooth_activation_stats.clear()
         self._resolved_mappings.clear()
         self._error_metrics.clear()
@@ -414,7 +412,12 @@ class AWQModifier(Modifier):
                 if isinstance(v, QuantizedKVCache):
                     values.arguments[k] = None
 
-            self._parent_args_cache[module].append(values.arguments)
+            batch_idx = self._parent_args_batch_idx.get(module, 0)
+            for arg_name, arg_value in values.arguments.items():
+                self._parent_args_cache.update(
+                    (module, batch_idx, arg_name), arg_value
+                )
+            self._parent_args_batch_idx[module] = batch_idx + 1
 
         def create_cache_smooth_activations_hook_fn(smooth_name):
             def cache_smooth_activations_hook(
@@ -456,13 +459,10 @@ class AWQModifier(Modifier):
             return cache_smooth_activations_hook
 
         for mapping in self._resolved_mappings:
-            # parent kwargs needed for future forward passes
-            # same parent may appear multiple times in resolved mappings
-            if mapping.parent not in self._parent_args_cache:
-                self._parent_args_cache[mapping.parent] = IntermediatesCache(
-                    None,
-                    self.offload_device,
-                )
+            if self._parent_args_cache is None:
+                self._parent_args_cache = IntermediatesCache(self.offload_device)
+            if mapping.parent not in self._parent_args_batch_idx:
+                self._parent_args_batch_idx[mapping.parent] = 0
                 self.register_hook(
                     mapping.parent,
                     cache_parent_kwargs_hook,
@@ -589,21 +589,33 @@ class AWQModifier(Modifier):
                 del self._smooth_activation_stats[mapping.smooth_name]
                 del orig_layer_weights
 
-        for v in self._parent_args_cache.values():
-            v.batch_intermediates.clear()
+        self._parent_args_cache.clear()
         self._assert_all_activations_consumed()
 
     @torch.no_grad()
     def _run_samples(self, module: Module) -> list[torch.Tensor]:
-        cache = self._parent_args_cache[module]
+        cache = self._parent_args_cache
         use_prefetch = active_session().state.sequential_prefetch
-        batch_iter = cache.iter_prefetch() if use_prefetch else cache
-        outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
-        return [
-            # If tuple, assume that first argument is the input
-            output[0] if isinstance(output, tuple) else output
-            for output in outputs
-        ]
+
+        module_keys = [k for k in cache._store.keys() if k[0] == module]
+        if not module_keys:
+            return []
+
+        def group_by_fn(k):
+            return (k[0], k[1])
+
+        if use_prefetch:
+            batch_iter = cache.iter_prefetch_grouped(module_keys, group_by=group_by_fn)
+        else:
+            batch_iter = cache.iter_prefetch_grouped(module_keys, group_by=group_by_fn)
+
+        outputs = []
+        for group_dict in batch_iter:
+            batch_kwargs = {k[2]: v for k, v in group_dict.items()}
+            output = module(**batch_kwargs)
+            outputs.append(output[0] if isinstance(output, tuple) else output)
+
+        return outputs
 
     def _compute_best_scale(
         self,

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -150,8 +150,7 @@ class AWQModifier(Modifier):
 
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
-    _parent_args_cache: IntermediatesCache = PrivateAttr(default=None)
-    _parent_args_batch_idx: dict[Module, int] = PrivateAttr(default_factory=dict)
+    _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(default=None)
     _smooth_activation_stats: dict[str, list[torch.Tensor]] = PrivateAttr(
         default_factory=dict
     )
@@ -279,7 +278,6 @@ class AWQModifier(Modifier):
 
         if self._parent_args_cache is not None:
             self._parent_args_cache.clear()
-        self._parent_args_batch_idx.clear()
         self._smooth_activation_stats.clear()
         self._resolved_mappings.clear()
         self._error_metrics.clear()
@@ -412,12 +410,7 @@ class AWQModifier(Modifier):
                 if isinstance(v, QuantizedKVCache):
                     values.arguments[k] = None
 
-            batch_idx = self._parent_args_batch_idx.get(module, 0)
-            for arg_name, arg_value in values.arguments.items():
-                self._parent_args_cache.update(
-                    (module, batch_idx, arg_name), arg_value
-                )
-            self._parent_args_batch_idx[module] = batch_idx + 1
+            self._parent_args_cache.append((module, None), values.arguments)
 
         def create_cache_smooth_activations_hook_fn(smooth_name):
             def cache_smooth_activations_hook(
@@ -461,8 +454,7 @@ class AWQModifier(Modifier):
         for mapping in self._resolved_mappings:
             if self._parent_args_cache is None:
                 self._parent_args_cache = IntermediatesCache(self.offload_device)
-            if mapping.parent not in self._parent_args_batch_idx:
-                self._parent_args_batch_idx[mapping.parent] = 0
+
                 self.register_hook(
                     mapping.parent,
                     cache_parent_kwargs_hook,
@@ -597,25 +589,17 @@ class AWQModifier(Modifier):
         cache = self._parent_args_cache
         use_prefetch = active_session().state.sequential_prefetch
 
-        module_keys = [k for k in cache._store.keys() if k[0] == module]
-        if not module_keys:
-            return []
-
-        def group_by_fn(k):
-            return (k[0], k[1])
-
         if use_prefetch:
-            batch_iter = cache.iter_prefetch_grouped(module_keys, group_by=group_by_fn)
+            batch_iter = cache.iter_prefetch([(module, None)])
         else:
-            batch_iter = cache.iter_prefetch_grouped(module_keys, group_by=group_by_fn)
+            batch_iter = cache.iter([(module, None)])
 
-        outputs = []
-        for group_dict in batch_iter:
-            batch_kwargs = {k[2]: v for k, v in group_dict.items()}
-            output = module(**batch_kwargs)
-            outputs.append(output[0] if isinstance(output, tuple) else output)
-
-        return outputs
+        outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
+        return [
+            # If tuple, assume that first argument is the input
+            output[0] if isinstance(output, tuple) else output
+            for output in outputs
+        ]
 
     def _compute_best_scale(
         self,

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -151,7 +151,9 @@ class AWQModifier(Modifier):
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
     # Cache of forward input args for each parent module, one dict for each batch
-    _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(default=None)
+    _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(
+        default=None
+    )
     # Cache dict[smooth layer name, [activation sums, activation counts]]
     _smooth_activation_stats: IntermediatesCache[str] = PrivateAttr(default=None)
     # List to store error metrics for each layer

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -151,9 +151,9 @@ class AWQModifier(Modifier):
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
     # Cache of forward input args for each parent module, one dict for each batch
-    _parent_args_cache: IntermediatesCache[tuple[Module, int], dict[str, torch.Tensor]] = PrivateAttr(
-        default=None
-    )
+    _parent_args_cache: IntermediatesCache[
+        tuple[Module, int], dict[str, torch.Tensor]
+    ] = PrivateAttr(default=None)
     # Cache dict[smooth layer name, [activation sums, activation counts]]
     _smooth_activation_stats: IntermediatesCache[str, list[torch.Tensor]] = PrivateAttr(
         default=None
@@ -193,7 +193,9 @@ class AWQModifier(Modifier):
 
         # Initialize caches
         self._parent_args_cache = IntermediatesCache(offload_device=self.offload_device)
-        self._smooth_activation_stats = IntermediatesCache(offload_device=self.offload_device)
+        self._smooth_activation_stats = IntermediatesCache(
+            offload_device=self.offload_device
+        )
 
         return True
 
@@ -285,10 +287,8 @@ class AWQModifier(Modifier):
 
         self._log_error_metrics()
 
-        if self._parent_args_cache is not None:
-            self._parent_args_cache.clear()
-        if self._smooth_activation_stats is not None:
-            self._smooth_activation_stats.clear()
+        self._parent_args_cache.clear() if self._parent_args_cache else None
+        self._smooth_activation_stats.clear() if self._smooth_activation_stats else None
         self._resolved_mappings.clear()
         self._error_metrics.clear()
 
@@ -449,17 +449,17 @@ class AWQModifier(Modifier):
                     masked_activations = activations.flatten(0, -2)
 
                 # accumulate activation sum&count
-                new_sum = masked_activations.float().sum(dim=0).cpu()
-                new_count = torch.tensor(masked_activations.size(0)).cpu()
+                new_sum = masked_activations.float().sum(dim=0).to(self.offload_device)
+                new_count = torch.tensor(masked_activations.size(0)).to(self.offload_device)
+
+                device = get_execution_device(_module)
                 if smooth_name not in self._smooth_activation_stats:
-                    self._smooth_activation_stats.update(
-                        smooth_name,
-                        [torch.zeros_like(new_sum), torch.zeros_like(new_count)],
-                    )
+                    new = [torch.zeros_like(new_sum), torch.zeros_like(new_count)]
+                    self._smooth_activation_stats.update(smooth_name, new)
                 x_sum, count = self._smooth_activation_stats.fetch_no_onload(smooth_name)
                 x_sum += new_sum
                 count += new_count
-                self._smooth_activation_stats.update(smooth_name, [x_sum, count], get_execution_device(_module))
+                self._smooth_activation_stats.update(smooth_name, [x_sum, count], device)
 
             return cache_smooth_activations_hook
 
@@ -601,12 +601,8 @@ class AWQModifier(Modifier):
         cache = self._parent_args_cache
         use_prefetch = active_session().state.sequential_prefetch
 
-        if use_prefetch:
-            batch_iter = cache.iter_prefetch([(module)])
-        else:
-            batch_iter = cache.iter([(module)])
-
-        outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
+        iter_fn = cache.iter_prefetch if use_prefetch else cache.iter
+        outputs = [module(**batch_kwargs) for batch_kwargs in iter_fn([(module)])]
         return [
             # If tuple, assume that first argument is the input
             output[0] if isinstance(output, tuple) else output

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -151,9 +151,7 @@ class AWQModifier(Modifier):
     # Private vars set during initialization, cleared during finalization
     _resolved_mappings: list[ResolvedMapping] = PrivateAttr(default_factory=list)
     _parent_args_cache: IntermediatesCache[tuple[Module, int]] = PrivateAttr(default=None)
-    _smooth_activation_stats: dict[str, list[torch.Tensor]] = PrivateAttr(
-        default_factory=dict
-    )
+    _smooth_activation_stats: IntermediatesCache[str] = PrivateAttr(default=None)
     _error_metrics: list[dict] = PrivateAttr(default_factory=list)
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -442,18 +440,21 @@ class AWQModifier(Modifier):
                 new_sum = masked_activations.float().sum(dim=0).cpu()
                 new_count = torch.tensor(masked_activations.size(0)).cpu()
                 if smooth_name not in self._smooth_activation_stats:
-                    self._smooth_activation_stats[smooth_name] = [
-                        torch.zeros_like(new_sum),
-                        torch.zeros_like(new_count),
-                    ]
-                self._smooth_activation_stats[smooth_name][0] += new_sum
-                self._smooth_activation_stats[smooth_name][1] += new_count
+                    self._smooth_activation_stats.update(
+                        smooth_name,
+                        [torch.zeros_like(new_sum), torch.zeros_like(new_count)],
+                    )
+                x_sum, count = self._smooth_activation_stats.fetch(smooth_name)
+                x_sum += new_sum
+                count += new_count
+                self._smooth_activation_stats.update(smooth_name, [x_sum, count])
 
             return cache_smooth_activations_hook
 
         for mapping in self._resolved_mappings:
             if self._parent_args_cache is None:
                 self._parent_args_cache = IntermediatesCache(self.offload_device)
+                self._smooth_activation_stats = IntermediatesCache(self.offload_device)
 
                 self.register_hook(
                     mapping.parent,
@@ -511,7 +512,7 @@ class AWQModifier(Modifier):
                         "found to scale. This can occasionally occur in MoE models "
                         "when certain experts are not activated by calibration samples."
                     )
-                    del self._smooth_activation_stats[mapping.smooth_name]
+                    self._smooth_activation_stats.delete(mapping.smooth_name)
                     continue
                 if not all(
                     [fp16_output.isfinite().all() for fp16_output in fp16_outputs]
@@ -525,7 +526,7 @@ class AWQModifier(Modifier):
                         "ways. If you encounter this consistently, raise an issue at "
                         "https://github.com/vllm-project/llm-compressor/issues"
                     )
-                    del self._smooth_activation_stats[mapping.smooth_name]
+                    self._smooth_activation_stats.delete(mapping.smooth_name)
                     continue
 
                 orig_layer_weights = {
@@ -577,8 +578,7 @@ class AWQModifier(Modifier):
                     _smooth(layer, orig_layer_weights)
                 _smooth(smooth_layer, orig_layer_weights)
 
-                # remove caches needed to smooth this mapping
-                del self._smooth_activation_stats[mapping.smooth_name]
+                self._smooth_activation_stats.delete(mapping.smooth_name)
                 del orig_layer_weights
 
         self._parent_args_cache.clear()
@@ -631,7 +631,7 @@ class AWQModifier(Modifier):
 
         device = get_execution_device(mapping.parent)
 
-        x_sum, count = self._smooth_activation_stats[mapping.smooth_name]
+        x_sum, count = self._smooth_activation_stats.fetch(mapping.smooth_name)
         if is_distributed():
             x_sum, count = _allreduce_data_sum([x_sum, count])
         x_mean = x_sum.to(device) / count.to(device)

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -450,16 +450,25 @@ class AWQModifier(Modifier):
 
                 # accumulate activation sum&count
                 new_sum = masked_activations.float().sum(dim=0).to(self.offload_device)
-                new_count = torch.tensor(masked_activations.size(0)).to(self.offload_device)
+                new_count = torch.tensor(masked_activations.size(0)).to(
+                    self.offload_device
+                )
 
                 device = get_execution_device(_module)
                 if smooth_name not in self._smooth_activation_stats:
-                    new = [torch.zeros_like(new_sum), torch.zeros_like(new_count)]
+                    new = [
+                        torch.zeros_like(new_sum),
+                        torch.zeros_like(new_count),
+                    ]
                     self._smooth_activation_stats.update(smooth_name, new)
-                x_sum, count = self._smooth_activation_stats.fetch_no_onload(smooth_name)
+                x_sum, count = self._smooth_activation_stats.fetch_no_onload(
+                    smooth_name
+                )
                 x_sum += new_sum
                 count += new_count
-                self._smooth_activation_stats.update(smooth_name, [x_sum, count], device)
+                self._smooth_activation_stats.update(
+                    smooth_name, [x_sum, count], device
+                )
 
             return cache_smooth_activations_hook
 

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -43,6 +43,8 @@ class IntermediatesCache(Generic[TKey]):
     _store: dict[TKey, Any]
     offload_device: torch.device | None
 
+    # map of onload value -> offload value
+    # used to avoid excess memory usage when shared tensors are offloaded
     offload_values: WeakKeyDictionary[torch.Tensor, torch.Tensor] = WeakKeyDictionary()
 
     def __init__(self, offload_device: torch.device | None = None):
@@ -324,11 +326,14 @@ class IntermediatesCache(Generic[TKey]):
         for leaf in leaves:
             if isinstance(leaf, torch.Tensor):
                 with OverrideEqMode():
+                    # check for cache hit between shared tensors
                     if leaf in cls.offload_values:
                         offloaded_tensor = cls.offload_values[leaf]
                     else:
+                        # move to offload if no hit
                         offloaded_tensor = leaf.to(device=offload_device)
-                        if offloaded_tensor is not leaf:
+                        if offloaded_tensor is not leaf: # avoid circular ref
+                            # pin CPU tensors so onload can use non_blocking DMA
                             if (
                                 torch.device(offload_device).type == "cpu"
                                 and torch.accelerator.is_available()

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -5,12 +5,15 @@ import warnings
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, fields, is_dataclass
-from typing import Any, Generator
+from typing import Any, Callable, Generator, Generic, TypeVar
 from weakref import WeakKeyDictionary
 
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
 from tqdm import tqdm
+
+
+TKey = TypeVar("TKey", bound=Any)
 
 
 @dataclass
@@ -27,10 +30,7 @@ class IntermediateValue:
     device: torch.device | None
 
 
-IntermediateValues = dict[str, IntermediateValue]
-
-
-class IntermediatesCache:
+class IntermediatesCache(Generic[TKey]):
     """
     Cache which stores intermediate values (activations) produced by batched, sequential
     execution of models. Values are offloaded to the `offload_device` when stored in
@@ -39,34 +39,19 @@ class IntermediatesCache:
 
     Currently supports nested offloading of dataclass instances and tuples
 
-    Construct using `empty` and `from_dataloader` class methods
+    Construct using `from_dataloader` class method or directly with offload_device
     """
 
-    batch_intermediates: list[IntermediateValues]
+    _store: dict[TKey, IntermediateValue]
     offload_device: torch.device | None
 
     # map of onload value -> offload value
     # used to avoid excess memory usage when shared tensors are offloaded
     offload_values: WeakKeyDictionary[torch.Tensor, torch.Tensor] = WeakKeyDictionary()
 
-    def __init__(
-        self,
-        batch_intermediates: list[IntermediateValues] | None = None,
-        offload_device: torch.device | None = "cpu",
-    ):
-        self.batch_intermediates = batch_intermediates or []
+    def __init__(self, offload_device: torch.device | None = None):
+        self._store = {}
         self.offload_device = offload_device
-
-    @classmethod
-    def empty(cls, num_batches: int, offload_device: torch.device):
-        """
-        Construct an empty cache
-
-        :param num_batches: the expected number of batches to be stored
-        :param offload_device: device to offload values to
-        """
-        batch_intermediates = [{} for _ in range(num_batches)]
-        return cls(batch_intermediates, offload_device)
 
     @classmethod
     def from_dataloader(
@@ -91,71 +76,189 @@ class IntermediatesCache:
         :param model_device: device which values will be onloaded to when fetched
         :param offload_device: device to offload values to
         """
-        batch_intermediates = [
-            {
-                key: cls._offload_value(value, offload_device, model_device)
-                for key, value in batch.items()
-            }
-            for batch in tqdm(dataloader, desc="Preparing cache")
-        ]
+        cache = cls(offload_device)
+        for batch_idx, batch in enumerate(tqdm(dataloader, desc="Preparing cache")):
+            for key, value in batch.items():
+                cache._store[(batch_idx, key)] = cls._offload_value(
+                    value, offload_device, model_device
+                )
+        return cache
 
-        return cls(batch_intermediates, offload_device)
-
-    def fetch(
-        self, batch_index: int, input_names: list[str] | None = None
-    ) -> dict[str, Any]:
+    def fetch(self, key: TKey) -> Any:
         """
-        Fetch values belonging to a batch
+        Fetch a value by key, onloading it to the original device
 
-        :param batch_index: index of batch whose values are being fetched
-        :param input_names: list of keys whose values are being fetched
-        :return: dictionary mapping keys to onloaded values
+        :param key: key to fetch
+        :return: onloaded value
+        :raises KeyError: if key is not found in cache
         """
-        intermediates = self.batch_intermediates[batch_index]
+        if key not in self._store:
+            raise KeyError(f"Key {key} not found in cache")
+        return self._onload_value(self._store[key])
 
-        return {
-            key: self._onload_value(subgraph_input)
-            for key, subgraph_input in intermediates.items()
-            if input_names is None or key in input_names
-        }
-
-    def update(self, batch_index: int, values: dict[str, Any]):
+    def update(self, key: TKey, value: Any) -> None:
         """
-        Update/put values belonging to a batch
+        Update/put a value for a key, offloading any tensors
 
-        :param batch_index: index of batch whose values will be updated
-        :param values: dictionary mapping keys to values used for update
+        :param key: key to store value under
+        :param value: value to store (tensors will be offloaded)
         """
-        device = self.offload_device
-        intermediates = {k: self._offload_value(v, device) for k, v in values.items()}
-        self.batch_intermediates[batch_index].update(intermediates)
+        self._store[key] = self._offload_value(value, self.offload_device)
 
-    def delete(self, batch_index: int, consumed_names: list[str] | None = None):
+    def delete(self, key: TKey) -> None:
         """
-        Delete values from the cache
+        Delete a value from the cache
 
-        :param batch_index: index of batch whose values will be deleted
-        :param consumed_names: list of keys whose values will be deleted, defaults to
-            removing all keys
+        :param key: key to delete
         """
-        intermediates = self.batch_intermediates[batch_index]
+        del self._store[key]
 
-        if consumed_names is None:
-            consumed_names = list(intermediates.keys())
-
-        for name in consumed_names:
-            del intermediates[name]
-
-    def append(self, values: dict[str, Any]):
+    def __contains__(self, key: TKey) -> bool:
         """
-        Append new values to the cache. The new values will be assigned the next
-        available batch index
+        Check if a key is in the cache
 
-        :param values: dictionary mapping keys to values used for update
+        :param key: key to check
+        :return: True if key is in cache, False otherwise
         """
-        batch_index = len(self.batch_intermediates)
-        self.batch_intermediates.append({})
-        self.update(batch_index, values)
+        return key in self._store
+
+    def iter_prefetch(
+        self, keys: list[TKey] | None = None
+    ) -> Generator[torch.Tensor, None, None]:
+        """
+        Iterate over keys with values prefetched in a background thread.
+        Overlaps onload from offload_device with consumption of the current value,
+        which can reduce wall-clock time when offloading to CPU.
+
+        When CUDA is available, uses non_blocking transfers (requires pinned CPU
+        tensors, set up by _offload_value) and synchronises via CUDA events so the
+        main stream waits for each H2D copy before running GPU kernels on the data.
+
+        :param keys: list of keys to iterate over. If None, iterates over all keys.
+        """
+        if keys is None:
+            keys = list(self._store.keys())
+
+        num_keys = len(keys)
+        if num_keys == 0:
+            return
+
+        # Create a dedicated CUDA stream for H2D transfers so they run on a
+        # separate stream from the main thread's compute stream. Without this,
+        # both threads default to the null stream (stream 0) which serializes
+        # all operations and prevents any overlap.
+        h2d_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
+
+        def _fetch_and_record(key):
+            event = None
+            if h2d_stream is not None:
+                with torch.cuda.stream(h2d_stream):
+                    data = self._onload_value(self._store[key])
+                event = torch.cuda.Event()
+                event.record(h2d_stream)
+            else:
+                data = self._onload_value(self._store[key])
+            return data, event
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = None
+            for idx, key in enumerate(keys):
+                if future is not None:
+                    current, event = future.result()
+                else:
+                    current, event = _fetch_and_record(key)
+                if idx + 1 < num_keys:
+                    future = executor.submit(_fetch_and_record, keys[idx + 1])
+                else:
+                    future = None
+                # Make the main CUDA stream wait for the background H2D copy
+                # before any GPU kernel consumes the prefetched tensors
+                if event is not None:
+                    torch.cuda.current_stream().wait_event(event)
+                yield current
+
+    def iter_prefetch_grouped(
+        self,
+        keys: list[TKey],
+        group_by: Callable[[TKey], Any],
+    ) -> Generator[dict[TKey, Any], None, None]:
+        """
+        Prefetch values for given keys, grouped by group_by function.
+
+        Keys are grouped in the order they appear in the input list. Each group
+        is yielded as a dict mapping TKey to value. The next group is prefetched
+        in a background thread while consuming current.
+
+        Uses CUDA stream optimization when available for overlapping H2D transfers.
+
+        :param keys: list of keys to fetch (caller should filter for existence).
+            Keys should be ordered such that all keys in a group appear consecutively.
+        :param group_by: function that returns the group identifier for a key
+        :yield: dict mapping original TKey to onloaded value, one per group
+        """
+        if not keys:
+            return
+
+        grouped_keys = []
+        current_group = []
+        current_group_id = None
+
+        for key in keys:
+            group_id = group_by(key)
+            if group_id != current_group_id:
+                if current_group:
+                    grouped_keys.append(current_group)
+                current_group = [key]
+                current_group_id = group_id
+            else:
+                current_group.append(key)
+
+        if current_group:
+            grouped_keys.append(current_group)
+
+        num_groups = len(grouped_keys)
+
+        h2d_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
+
+        def _fetch_group(key_list: list[TKey]) -> tuple[dict[TKey, Any], Any]:
+            event = None
+            group_dict = {}
+            for key in key_list:
+                if h2d_stream is not None:
+                    with torch.cuda.stream(h2d_stream):
+                        group_dict[key] = self._onload_value(self._store[key])
+                    event = torch.cuda.Event()
+                    event.record(h2d_stream)
+                else:
+                    group_dict[key] = self._onload_value(self._store[key])
+            return group_dict, event
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = None
+            for idx in range(num_groups):
+                if future is not None:
+                    group_dict, event = future.result()
+                else:
+                    group_dict, event = _fetch_group(grouped_keys[idx])
+
+                if event is not None:
+                    torch.cuda.current_stream().wait_event(event)
+
+                yield group_dict
+
+                if idx + 1 < num_groups:
+                    future = executor.submit(_fetch_group, grouped_keys[idx + 1])
+                else:
+                    future = None
+
+    def __iter__(self) -> Generator[torch.Tensor, None, None]:
+        """
+        Iterate over all tensors in the cache
+
+        :return: generator yielding onloaded tensors
+        """
+        for key in self._store:
+            yield self._onload_value(self._store[key])
 
     def size(self) -> dict[torch.device, int]:
         """
@@ -187,74 +290,18 @@ class IntermediatesCache:
                     # this handles primitive values that don't match any other cases
                     sizes[torch.device("cpu")] += sys.getsizeof(value, 0)
 
-        for intermediates in self.batch_intermediates:
-            for value in intermediates.values():
-                _size_helper(value)
+        for value in self._store.values():
+            _size_helper(value)
 
         return dict(sizes)
 
-    def iter(self, input_names: list[str] | None = None) -> Generator[Any, None, None]:
-        for batch_index in range(len(self.batch_intermediates)):
-            yield self.fetch(batch_index, input_names)
-
-    def iter_prefetch(
-        self, input_names: list[str] | None = None
-    ) -> Generator[Any, None, None]:
-        """
-        Iterate over batches with the next batch prefetched in a background thread.
-        Overlaps onload from offload_device with consumption of the current batch,
-        which can reduce wall-clock time when offloading to CPU.
-
-        When CUDA is available, uses non_blocking transfers (requires pinned CPU
-        tensors, set up by _offload_value) and synchronises via CUDA events so the
-        main stream waits for each H2D copy before running GPU kernels on the data.
-
-        Yields the same fetched batch dicts as :meth:`iter`; only the timing
-        of onloads differs.
-        """
-        num_batches = len(self.batch_intermediates)
-        if num_batches == 0:
-            return
-
-        # Create a dedicated CUDA stream for H2D transfers so they run on a
-        # separate stream from the main thread's compute stream. Without this,
-        # both threads default to the null stream (stream 0) which serializes
-        # all operations and prevents any overlap.
-        h2d_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
-
-        def _fetch_and_record(batch_index):
-            event = None
-            if h2d_stream is not None:
-                with torch.cuda.stream(h2d_stream):
-                    data = self.fetch(batch_index, input_names)
-                event = torch.cuda.Event()
-                event.record(h2d_stream)
-            else:
-                data = self.fetch(batch_index, input_names)
-            return data, event
-
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = None
-            for batch_index in range(num_batches):
-                if future is not None:
-                    current, event = future.result()
-                else:
-                    current, event = _fetch_and_record(batch_index)
-                if batch_index + 1 < num_batches:
-                    future = executor.submit(_fetch_and_record, batch_index + 1)
-                else:
-                    future = None
-                # Make the main CUDA stream wait for the background H2D copy
-                # before any GPU kernel consumes the prefetched tensors
-                if event is not None:
-                    torch.cuda.current_stream().wait_event(event)
-                yield current
-
-    def __iter__(self) -> Generator[Any, None, None]:
-        yield from self.iter()
+    def clear(self) -> None:
+        """Clear all entries from the cache."""
+        self._store.clear()
 
     def __len__(self) -> int:
-        return len(self.batch_intermediates)
+        """Return the number of entries in the cache."""
+        return len(self._store)
 
     @classmethod
     def _onload_value(cls, intermediate: IntermediateValue) -> Any:

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -58,7 +58,7 @@ class IntermediatesCache(Generic[TKey]):
     ):
         """
         Initialize a cache with data from the provided dataloader.
-        Stores each batch as a dict under key (batch_idx,).
+        Stores each batch as a dict under key batch_idx.
 
         :param dataloader: dataloader which generates values to be cached
         :param model_device: device which values will be onloaded to when fetched
@@ -66,12 +66,12 @@ class IntermediatesCache(Generic[TKey]):
         """
         cache = cls(offload_device)
         for batch_idx, batch in enumerate(tqdm(dataloader, desc="Preparing cache")):
-            cache._store[(batch_idx,)] = cls._offload_value(
+            cache._store[batch_idx] = cls._offload_value(
                 batch, offload_device, model_device
             )
         return cache
 
-    def fetch(self, key: TKey) -> Any:
+    def __getitem__(self, key: TKey) -> Any:
         """
         Fetch a value by key, onloading it to the original device
 
@@ -92,41 +92,35 @@ class IntermediatesCache(Generic[TKey]):
         """
         self._store[key] = self._offload_value(value, self.offload_device)
 
-    def append(self, key: TKey, value: Any) -> int:
+    def append(self, key_prefix: TKey, value: Any) -> tuple[TKey, int]:
         """
         Append a value with an auto-generated index.
 
-        The key must contain None as a placeholder for the index position.
+        The key_prefix is used as a prefix, and an integer index is appended
+        to create the full key: (key_prefix, index) or (key_prefix[0], ..., key_prefix[n], index).
 
-        :param key: key with None as placeholder for index position
+        :param key_prefix: key prefix for storing the value
         :param value: value to store
-        :return: the index that was used
+        :return: tuple of (full_key, index) where full_key is the complete key used
         """
-        if not isinstance(key, tuple):
-            raise ValueError("Key must be a tuple with None as placeholder for index")
-
-        try:
-            none_idx = key.index(None)
-        except ValueError:
-            raise ValueError("Key must contain None as placeholder for index")
-
-        prefix = key[:none_idx]
-        suffix = key[none_idx + 1:]
+        if isinstance(key_prefix, tuple):
+            prefix = key_prefix
+        else:
+            prefix = (key_prefix,)
 
         matching_keys = [
             k for k in self._store.keys()
             if isinstance(k, tuple)
-            and len(k) > none_idx
-            and k[:none_idx] == prefix
-            and isinstance(k[none_idx], int)
-            and k[none_idx + 1:] == suffix
+            and len(k) == len(prefix) + 1
+            and k[:-1] == prefix
+            and isinstance(k[-1], int)
         ]
 
-        next_idx = max((k[none_idx] for k in matching_keys), default=-1) + 1
-        full_key = prefix + (next_idx,) + suffix
+        next_idx = max((k[-1] for k in matching_keys), default=-1) + 1
+        full_key = prefix + (next_idx,)
         self._store[full_key] = self._offload_value(value, self.offload_device)
 
-        return next_idx
+        return full_key, next_idx
 
     def delete(self, key: TKey) -> None:
         """
@@ -147,61 +141,49 @@ class IntermediatesCache(Generic[TKey]):
 
     def iter_keys(self, prefix: TKey | None = None) -> list[TKey]:
         """
-        Get keys matching a prefix pattern.
+        Get keys matching a prefix.
 
-        For keys like (module, None), returns all keys with that module.
+        For prefix like (module,), returns all keys (module, 0), (module, 1), etc.
+        Non-tuple prefixes are treated as single-element tuples.
 
-        :param prefix: prefix to match, with None matching any integer index
-        :return: list of matching keys sorted by index
+        :param prefix: prefix to match keys starting with this prefix
+        :return: list of matching keys sorted by final integer index
         """
         if prefix is None:
             return list(self._store.keys())
 
-        if not isinstance(prefix, tuple):
-            return [k for k in self._store.keys() if k == prefix]
+        if isinstance(prefix, tuple):
+            p = prefix
+        else:
+            p = (prefix,)
 
         keys = []
         for k in self._store.keys():
-            if not isinstance(k, tuple) or len(k) < len(prefix):
+            if not isinstance(k, tuple):
                 continue
-            match = True
-            for i, p in enumerate(prefix):
-                if p is None:
-                    if not isinstance(k[i], int):
-                        match = False
-                        break
-                elif k[i] != p:
-                    match = False
-                    break
-            if match:
+            if len(k) == len(p) + 1 and k[:-1] == p and isinstance(k[-1], int):
                 keys.append(k)
 
-        def get_index(k):
-            for i, p in enumerate(prefix):
-                if p is None:
-                    return k[i]
-            return 0
-
-        return sorted(keys, key=get_index)
+        return sorted(keys, key=lambda k: k[-1])
 
     def iter(self, keys: list[TKey] | None = None) -> Generator[Any, None, None]:
         """
         Iterate over keys with values onloaded in the current thread.
 
-        Keys can contain None placeholders which match any integer index.
-        For example, [(module, None)] matches all (module, 0), (module, 1), etc.
+        Keys that are not exact matches are treated as prefixes.
+        For example, [module] matches (module, 0), (module, 1), etc.
 
-        :param keys: list of keys or patterns to iterate over. If None, iterates over all keys.
+        :param keys: list of keys or prefixes to iterate over. If None, iterates over all keys.
         """
         if keys is None:
             keys = list(self._store.keys())
         else:
             resolved_keys = []
             for key in keys:
-                if isinstance(key, tuple) and None in key:
-                    resolved_keys.extend(self.iter_keys(key))
-                elif key in self._store:
+                if key in self._store:
                     resolved_keys.append(key)
+                else:
+                    resolved_keys.extend(self.iter_keys(key))
             keys = resolved_keys
 
         for key in keys:
@@ -214,20 +196,20 @@ class IntermediatesCache(Generic[TKey]):
         Iterate over keys with values prefetched in a background thread.
         Overlaps onload from offload_device with consumption of the current value.
 
-        Keys can contain None placeholders which match any integer index.
-        For example, [(module, None)] matches all (module, 0), (module, 1), etc.
+        Keys that are not exact matches are treated as prefixes.
+        For example, [module] matches (module, 0), (module, 1), etc.
 
-        :param keys: list of keys or patterns to iterate over. If None, iterates over all keys.
+        :param keys: list of keys or prefixes to iterate over. If None, iterates over all keys.
         """
         if keys is None:
             keys = list(self._store.keys())
         else:
             resolved_keys = []
             for key in keys:
-                if isinstance(key, tuple) and None in key:
-                    resolved_keys.extend(self.iter_keys(key))
-                elif key in self._store:
+                if key in self._store:
                     resolved_keys.append(key)
+                else:
+                    resolved_keys.extend(self.iter_keys(key))
             keys = resolved_keys
 
         num_keys = len(keys)

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -92,34 +92,39 @@ class IntermediatesCache(Generic[TKey]):
         """
         self._store[key] = self._offload_value(value, self.offload_device)
 
-    def append(self, key_prefix: TKey, value: Any) -> tuple[TKey, int]:
+    def append(self, key_prefix: TKey | None, value: Any) -> tuple[TKey, int]:
         """
         Append a value with an auto-generated index.
 
-        The key_prefix is used as a prefix, and an integer index is appended
-        to create the full key: (key_prefix, index) or (key_prefix[0], ..., key_prefix[n], index).
+        If key_prefix is None, uses integer keys directly (0, 1, 2, ...).
+        Otherwise, creates keys as (key_prefix, index).
 
-        :param key_prefix: key prefix for storing the value
+        :param key_prefix: key prefix for storing the value, or None for pure integer keys
         :param value: value to store
         :return: tuple of (full_key, index) where full_key is the complete key used
         """
-        if isinstance(key_prefix, tuple):
-            prefix = key_prefix
+        if key_prefix is None:
+            matching_keys = [k for k in self._store.keys() if isinstance(k, int)]
+            next_idx = max(matching_keys, default=-1) + 1
+            full_key = next_idx
         else:
-            prefix = (key_prefix,)
+            if isinstance(key_prefix, tuple):
+                prefix = key_prefix
+            else:
+                prefix = (key_prefix,)
 
-        matching_keys = [
-            k for k in self._store.keys()
-            if isinstance(k, tuple)
-            and len(k) == len(prefix) + 1
-            and k[:-1] == prefix
-            and isinstance(k[-1], int)
-        ]
+            matching_keys = [
+                k for k in self._store.keys()
+                if isinstance(k, tuple)
+                and len(k) == len(prefix) + 1
+                and k[:-1] == prefix
+                and isinstance(k[-1], int)
+            ]
 
-        next_idx = max((k[-1] for k in matching_keys), default=-1) + 1
-        full_key = prefix + (next_idx,)
+            next_idx = max((k[-1] for k in matching_keys), default=-1) + 1
+            full_key = prefix + (next_idx,)
+
         self._store[full_key] = self._offload_value(value, self.offload_device)
-
         return full_key, next_idx
 
     def delete(self, key: TKey) -> None:

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import sys
 import warnings
-from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, fields, is_dataclass
-from typing import Any, Callable, Generator, Generic, TypeVar
+from dataclasses import dataclass
+from typing import Any, Generator, Generic, TypeVar
 from weakref import WeakKeyDictionary
 
 import torch
+from torch.utils._pytree import tree_flatten, tree_unflatten
 from torch.utils._python_dispatch import TorchDispatchMode
 from tqdm import tqdm
 
@@ -19,14 +18,12 @@ TKey = TypeVar("TKey", bound=Any)
 @dataclass
 class IntermediateValue:
     """
-    Dataclass which recursively defines offloaded values and which device to onload to
+    Wrapper for offloaded tensors, tracking the device to onload to.
 
-    :param value: either an offloaded Tensor, an primative value, or a recursable value
-    :param device: if the value is a Tensor, then the device to onload the tensor to,
-        otherwise None
+    Only used at leaf tensor positions in pytrees stored in the cache.
     """
 
-    value: torch.Tensor | "IntermediateValue" | Any
+    value: torch.Tensor
     device: torch.device | None
 
 
@@ -37,16 +34,15 @@ class IntermediatesCache(Generic[TKey]):
     the cache and onloaded to their original device when fetched from the cache. If
     `offload_device` is None, values will not be offloaded at all.
 
-    Currently supports nested offloading of dataclass instances and tuples
+    Uses pytree internally to handle nested containers (dicts, tuples, lists, dataclasses).
+    IntermediateValue wrappers are placed at tensor leaf positions only.
 
     Construct using `from_dataloader` class method or directly with offload_device
     """
 
-    _store: dict[TKey, IntermediateValue]
+    _store: dict[TKey, Any]
     offload_device: torch.device | None
 
-    # map of onload value -> offload value
-    # used to avoid excess memory usage when shared tensors are offloaded
     offload_values: WeakKeyDictionary[torch.Tensor, torch.Tensor] = WeakKeyDictionary()
 
     def __init__(self, offload_device: torch.device | None = None):
@@ -61,16 +57,8 @@ class IntermediatesCache(Generic[TKey]):
         offload_device: torch.device | None = torch.device("cpu"),
     ):
         """
-        Initialize a cache with data from the provided dataloader
-
-        This method iterates through all batches in the dataloader and offloads
-        them to the specified device. For faster cache preparation, consider:
-        - Increasing batch_size to reduce the number of iterations
-        - Using num_workers > 0 in the DataLoader for parallel loading (e.g. the
-          calibration DataLoader from format_calibration_data uses
-          dataloader_num_workers; when > 0, pin_memory and prefetch_factor are
-          also set where applicable, which speeds both cache build and calibration)
-        - Ensuring data preprocessing is done before creating the dataloader
+        Initialize a cache with data from the provided dataloader.
+        Stores each batch as a dict under key (batch_idx,).
 
         :param dataloader: dataloader which generates values to be cached
         :param model_device: device which values will be onloaded to when fetched
@@ -78,10 +66,9 @@ class IntermediatesCache(Generic[TKey]):
         """
         cache = cls(offload_device)
         for batch_idx, batch in enumerate(tqdm(dataloader, desc="Preparing cache")):
-            for key, value in batch.items():
-                cache._store[(batch_idx, key)] = cls._offload_value(
-                    value, offload_device, model_device
-                )
+            cache._store[(batch_idx,)] = cls._offload_value(
+                batch, offload_device, model_device
+            )
         return cache
 
     def fetch(self, key: TKey) -> Any:
@@ -105,6 +92,42 @@ class IntermediatesCache(Generic[TKey]):
         """
         self._store[key] = self._offload_value(value, self.offload_device)
 
+    def append(self, key: TKey, value: Any) -> int:
+        """
+        Append a value with an auto-generated index.
+
+        The key must contain None as a placeholder for the index position.
+
+        :param key: key with None as placeholder for index position
+        :param value: value to store
+        :return: the index that was used
+        """
+        if not isinstance(key, tuple):
+            raise ValueError("Key must be a tuple with None as placeholder for index")
+
+        try:
+            none_idx = key.index(None)
+        except ValueError:
+            raise ValueError("Key must contain None as placeholder for index")
+
+        prefix = key[:none_idx]
+        suffix = key[none_idx + 1:]
+
+        matching_keys = [
+            k for k in self._store.keys()
+            if isinstance(k, tuple)
+            and len(k) > none_idx
+            and k[:none_idx] == prefix
+            and isinstance(k[none_idx], int)
+            and k[none_idx + 1:] == suffix
+        ]
+
+        next_idx = max((k[none_idx] for k in matching_keys), default=-1) + 1
+        full_key = prefix + (next_idx,) + suffix
+        self._store[full_key] = self._offload_value(value, self.offload_device)
+
+        return next_idx
+
     def delete(self, key: TKey) -> None:
         """
         Delete a value from the cache
@@ -122,22 +145,90 @@ class IntermediatesCache(Generic[TKey]):
         """
         return key in self._store
 
-    def iter_prefetch(
-        self, keys: list[TKey] | None = None
-    ) -> Generator[torch.Tensor, None, None]:
+    def iter_keys(self, prefix: TKey | None = None) -> list[TKey]:
         """
-        Iterate over keys with values prefetched in a background thread.
-        Overlaps onload from offload_device with consumption of the current value,
-        which can reduce wall-clock time when offloading to CPU.
+        Get keys matching a prefix pattern.
 
-        When CUDA is available, uses non_blocking transfers (requires pinned CPU
-        tensors, set up by _offload_value) and synchronises via CUDA events so the
-        main stream waits for each H2D copy before running GPU kernels on the data.
+        For keys like (module, None), returns all keys with that module.
 
-        :param keys: list of keys to iterate over. If None, iterates over all keys.
+        :param prefix: prefix to match, with None matching any integer index
+        :return: list of matching keys sorted by index
+        """
+        if prefix is None:
+            return list(self._store.keys())
+
+        if not isinstance(prefix, tuple):
+            return [k for k in self._store.keys() if k == prefix]
+
+        keys = []
+        for k in self._store.keys():
+            if not isinstance(k, tuple) or len(k) < len(prefix):
+                continue
+            match = True
+            for i, p in enumerate(prefix):
+                if p is None:
+                    if not isinstance(k[i], int):
+                        match = False
+                        break
+                elif k[i] != p:
+                    match = False
+                    break
+            if match:
+                keys.append(k)
+
+        def get_index(k):
+            for i, p in enumerate(prefix):
+                if p is None:
+                    return k[i]
+            return 0
+
+        return sorted(keys, key=get_index)
+
+    def iter(self, keys: list[TKey] | None = None) -> Generator[Any, None, None]:
+        """
+        Iterate over keys with values onloaded in the current thread.
+
+        Keys can contain None placeholders which match any integer index.
+        For example, [(module, None)] matches all (module, 0), (module, 1), etc.
+
+        :param keys: list of keys or patterns to iterate over. If None, iterates over all keys.
         """
         if keys is None:
             keys = list(self._store.keys())
+        else:
+            resolved_keys = []
+            for key in keys:
+                if isinstance(key, tuple) and None in key:
+                    resolved_keys.extend(self.iter_keys(key))
+                elif key in self._store:
+                    resolved_keys.append(key)
+            keys = resolved_keys
+
+        for key in keys:
+            yield self._onload_value(self._store[key])
+
+    def iter_prefetch(
+        self, keys: list[TKey] | None = None
+    ) -> Generator[Any, None, None]:
+        """
+        Iterate over keys with values prefetched in a background thread.
+        Overlaps onload from offload_device with consumption of the current value.
+
+        Keys can contain None placeholders which match any integer index.
+        For example, [(module, None)] matches all (module, 0), (module, 1), etc.
+
+        :param keys: list of keys or patterns to iterate over. If None, iterates over all keys.
+        """
+        if keys is None:
+            keys = list(self._store.keys())
+        else:
+            resolved_keys = []
+            for key in keys:
+                if isinstance(key, tuple) and None in key:
+                    resolved_keys.extend(self.iter_keys(key))
+                elif key in self._store:
+                    resolved_keys.append(key)
+            keys = resolved_keys
 
         num_keys = len(keys)
         if num_keys == 0:
@@ -177,123 +268,12 @@ class IntermediatesCache(Generic[TKey]):
                     torch.cuda.current_stream().wait_event(event)
                 yield current
 
-    def iter_prefetch_grouped(
-        self,
-        keys: list[TKey],
-        group_by: Callable[[TKey], Any],
-    ) -> Generator[dict[TKey, Any], None, None]:
+    def __iter__(self) -> Generator[Any, None, None]:
         """
-        Prefetch values for given keys, grouped by group_by function.
-
-        Keys are grouped in the order they appear in the input list. Each group
-        is yielded as a dict mapping TKey to value. The next group is prefetched
-        in a background thread while consuming current.
-
-        Uses CUDA stream optimization when available for overlapping H2D transfers.
-
-        :param keys: list of keys to fetch (caller should filter for existence).
-            Keys should be ordered such that all keys in a group appear consecutively.
-        :param group_by: function that returns the group identifier for a key
-        :yield: dict mapping original TKey to onloaded value, one per group
-        """
-        if not keys:
-            return
-
-        grouped_keys = []
-        current_group = []
-        current_group_id = None
-
-        for key in keys:
-            group_id = group_by(key)
-            if group_id != current_group_id:
-                if current_group:
-                    grouped_keys.append(current_group)
-                current_group = [key]
-                current_group_id = group_id
-            else:
-                current_group.append(key)
-
-        if current_group:
-            grouped_keys.append(current_group)
-
-        num_groups = len(grouped_keys)
-
-        h2d_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
-
-        def _fetch_group(key_list: list[TKey]) -> tuple[dict[TKey, Any], Any]:
-            event = None
-            group_dict = {}
-            for key in key_list:
-                if h2d_stream is not None:
-                    with torch.cuda.stream(h2d_stream):
-                        group_dict[key] = self._onload_value(self._store[key])
-                    event = torch.cuda.Event()
-                    event.record(h2d_stream)
-                else:
-                    group_dict[key] = self._onload_value(self._store[key])
-            return group_dict, event
-
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = None
-            for idx in range(num_groups):
-                if future is not None:
-                    group_dict, event = future.result()
-                else:
-                    group_dict, event = _fetch_group(grouped_keys[idx])
-
-                if event is not None:
-                    torch.cuda.current_stream().wait_event(event)
-
-                yield group_dict
-
-                if idx + 1 < num_groups:
-                    future = executor.submit(_fetch_group, grouped_keys[idx + 1])
-                else:
-                    future = None
-
-    def __iter__(self) -> Generator[torch.Tensor, None, None]:
-        """
-        Iterate over all tensors in the cache
-
-        :return: generator yielding onloaded tensors
+        Iterate over all values in the cache
         """
         for key in self._store:
             yield self._onload_value(self._store[key])
-
-    def size(self) -> dict[torch.device, int]:
-        """
-        Returns the memory used by cached values, keyed by device, in bytes
-
-        :return: dictionary mapping torch device to number of bytes in cache
-        """
-        sizes = defaultdict(lambda: 0)
-        memo = set()
-
-        def _size_helper(intermediate: IntermediateValue) -> int:
-            value = intermediate.value
-
-            match value:
-                case torch.Tensor():
-                    if value not in memo:
-                        sizes[value.device] += value.nbytes
-                    memo.add(value)
-                case list() | tuple():
-                    for v in value:
-                        _size_helper(v)
-                case dict():
-                    for v in value.values():
-                        _size_helper(v)
-                case _ if is_dataclass(value):
-                    for field in fields(value):
-                        _size_helper(getattr(value, field.name))
-                case _:
-                    # this handles primitive values that don't match any other cases
-                    sizes[torch.device("cpu")] += sys.getsizeof(value, 0)
-
-        for value in self._store.values():
-            _size_helper(value)
-
-        return dict(sizes)
 
     def clear(self) -> None:
         """Clear all entries from the cache."""
@@ -304,43 +284,35 @@ class IntermediatesCache(Generic[TKey]):
         return len(self._store)
 
     @classmethod
-    def _onload_value(cls, intermediate: IntermediateValue) -> Any:
+    def _onload_value(cls, value: Any) -> Any:
         """
-        Onload a value's tensors to the onload device
+        Onload a value's tensors to their original devices.
 
-        :param intermediate: intermediates value representation to onload
-        :return: original value with tensors onloaded to the onload device
+        Uses pytree to flatten, onload tensor leaves wrapped in IntermediateValue,
+        then unflatten back to original structure.
+
+        :param value: pytree with IntermediateValue at tensor leaf positions
+        :return: original value with tensors onloaded
         """
-        value = intermediate.value
-        device = intermediate.device
-
-        match value:
-            case torch.Tensor():
-                # use non_blocking when source is pinned and target is an accelerator
-                # so the H2D DMA can overlap with compute on a separate stream
-                non_blocking = (
-                    value.is_pinned()
-                    and device is not None
-                    and torch.accelerator.is_available()
-                    and torch.device(device).type
-                    == torch.accelerator.current_accelerator().type
-                )
-                return value.to(device=device, non_blocking=non_blocking)
-            case list():
-                return [cls._onload_value(v) for v in value]
-            case tuple():
-                return tuple(cls._onload_value(v) for v in value)
-            case dict():
-                return {k: cls._onload_value(v) for k, v in value.items()}
-            case _ if is_dataclass(value):
-                for field in fields(value):
-                    v = getattr(value, field.name)
-                    setattr(value, field.name, cls._onload_value(v))
-                return value
-            case _:
-                # handles primitive values that should be returned as is.
-                # without this, a MatchError would be raised for unhandled types.
-                return value
+        leaves, spec = tree_flatten(value)
+        onloaded_leaves = []
+        for leaf in leaves:
+            if isinstance(leaf, IntermediateValue):
+                tensor = leaf.value
+                device = leaf.device
+                if device is not None:
+                    non_blocking = (
+                        tensor.is_pinned()
+                        and torch.accelerator.is_available()
+                        and torch.device(device).type
+                        == torch.accelerator.current_accelerator().type
+                    )
+                    onloaded_leaves.append(tensor.to(device=device, non_blocking=non_blocking))
+                else:
+                    onloaded_leaves.append(tensor)
+            else:
+                onloaded_leaves.append(leaf)
+        return tree_unflatten(onloaded_leaves, spec)
 
     @classmethod
     def _offload_value(
@@ -348,71 +320,59 @@ class IntermediatesCache(Generic[TKey]):
         value: Any,
         offload_device: torch.device | None,
         onload_device: torch.device | None = None,
-    ) -> IntermediateValue:
+    ) -> Any:
         """
-        Offload a value's tensors to the offload device
+        Offload a value's tensors to the offload device.
+
+        Uses pytree to flatten, wrap tensor leaves in IntermediateValue,
+        then unflatten back to original structure.
 
         :param value: value to offload
-        :param offload_device: device to offload `torch.Tensor` values to
-        :param onload_device: device used when onloading `torch.Tensor` values.
-            If None is provided, use the tensor's current device
-        :return: Instance of IntermediateValue representing the offloaded value
+        :param offload_device: device to offload tensors to
+        :param onload_device: device to onload tensors to. If None, use tensor's current device
+        :return: pytree with IntermediateValue at tensor leaf positions
         """
-        kwargs = {"offload_device": offload_device, "onload_device": onload_device}
-        match value:
-            case torch.Tensor():
+        leaves, spec = tree_flatten(value)
+        offloaded_leaves = []
+        for leaf in leaves:
+            if isinstance(leaf, torch.Tensor):
                 with OverrideEqMode():
-                    # check for cache hit between shared tensors
-                    if value in cls.offload_values:
-                        offloaded = cls.offload_values[value]
+                    if leaf in cls.offload_values:
+                        offloaded_tensor = cls.offload_values[leaf]
                     else:
-                        # move to offload if no hit
-                        offloaded = value.to(device=offload_device)
-                        if offloaded is not value:  # avoid circular ref
-                            # pin CPU tensors so onload can use non_blocking DMA
+                        offloaded_tensor = leaf.to(device=offload_device)
+                        if offloaded_tensor is not leaf:
                             if (
                                 torch.device(offload_device).type == "cpu"
                                 and torch.accelerator.is_available()
-                                and not offloaded.is_pinned()
+                                and not offloaded_tensor.is_pinned()
                             ):
-                                offloaded = offloaded.pin_memory()
-                            cls.offload_values[value] = offloaded
+                                offloaded_tensor = offloaded_tensor.pin_memory()
+                            cls.offload_values[leaf] = offloaded_tensor
 
-                return IntermediateValue(
-                    value=offloaded,
-                    device=(onload_device if onload_device else value.device),
+                offloaded_leaves.append(
+                    IntermediateValue(
+                        value=offloaded_tensor,
+                        device=(onload_device if onload_device else leaf.device),
+                    )
                 )
-            case list():
-                return IntermediateValue(
-                    value=[cls._offload_value(v, **kwargs) for v in value],
-                    device=None,
+            elif isinstance(leaf, IntermediateValue):
+                warnings.warn(
+                    f"Unexpected IntermediateValue in input to _offload_value; "
+                    f"passing through unchanged"
                 )
-            case tuple():
-                return IntermediateValue(
-                    value=tuple(cls._offload_value(v, **kwargs) for v in value),
-                    device=None,
-                )
-            case dict():
-                return IntermediateValue(
-                    value={
-                        k: cls._offload_value(v, **kwargs) for k, v in value.items()
-                    },
-                    device=None,
-                )
-            case _ if is_dataclass(value):
-                for field in fields(value):
-                    v = getattr(value, field.name)
-                    setattr(value, field.name, cls._offload_value(v, **kwargs))
-                return IntermediateValue(value=value, device=None)
-            case _:
-                # handles primitive values and provides a warning for unsupported types.
-                # without this, values trigger a MatchError exception.
+                offloaded_leaves.append(leaf)
+            else:
                 if not isinstance(
-                    value,
+                    leaf,
                     (int, str, float, bool, torch.dtype, torch.device, type(None)),
                 ):
-                    warnings.warn(f"Offloading not implemented for type {type(value)}.")
-                return IntermediateValue(value=value, device=None)
+                    warnings.warn(
+                        f"Leaf type {type(leaf)} may not be handled correctly; "
+                        f"storing as-is"
+                    )
+                offloaded_leaves.append(leaf)
+        return tree_unflatten(offloaded_leaves, spec)
 
 
 class OverrideEqMode(TorchDispatchMode):

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -7,10 +7,9 @@ from typing import Any, Generator, Generic, TypeVar
 from weakref import WeakKeyDictionary
 
 import torch
-from torch.utils._pytree import tree_flatten, tree_unflatten
 from torch.utils._python_dispatch import TorchDispatchMode
+from torch.utils._pytree import tree_flatten, tree_unflatten
 from tqdm import tqdm
-
 
 TKey = TypeVar("TKey", bound=Any)
 
@@ -34,7 +33,7 @@ class IntermediatesCache(Generic[TKey]):
     the cache and onloaded to their original device when fetched from the cache. If
     `offload_device` is None, values will not be offloaded at all.
 
-    Uses pytree internally to handle nested containers (dicts, tuples, lists, dataclasses).
+    Uses pytree internally to handle nested containers (dicts, tuples, lists).
     IntermediateValue wrappers are placed at tensor leaf positions only.
 
     Construct using `from_dataloader` class method or directly with offload_device
@@ -101,7 +100,7 @@ class IntermediatesCache(Generic[TKey]):
         If key_prefix is None, uses integer keys directly (0, 1, 2, ...).
         Otherwise, creates keys as (key_prefix, index).
 
-        :param key_prefix: key prefix for storing the value, or None for pure integer keys
+        :param key_prefix: key prefix for storing the value, or None for integer keys
         :param value: value to store
         :return: tuple of (full_key, index) where full_key is the complete key used
         """
@@ -116,7 +115,8 @@ class IntermediatesCache(Generic[TKey]):
                 prefix = (key_prefix,)
 
             matching_keys = [
-                k for k in self._store.keys()
+                k
+                for k in self._store.keys()
                 if isinstance(k, tuple)
                 and len(k) == len(prefix) + 1
                 and k[:-1] == prefix
@@ -180,7 +180,8 @@ class IntermediatesCache(Generic[TKey]):
         Keys that are not exact matches are treated as prefixes.
         For example, [module] matches (module, 0), (module, 1), etc.
 
-        :param keys: list of keys or prefixes to iterate over. If None, iterates over all keys.
+        :param keys: list of keys or prefixes to iterate over. If None, iterates over
+            all keys.
         """
         if keys is None:
             keys = list(self._store.keys())
@@ -206,7 +207,8 @@ class IntermediatesCache(Generic[TKey]):
         Keys that are not exact matches are treated as prefixes.
         For example, [module] matches (module, 0), (module, 1), etc.
 
-        :param keys: list of keys or prefixes to iterate over. If None, iterates over all keys.
+        :param keys: list of keys or prefixes to iterate over. If None, iterates over
+            all keys.
         """
         if keys is None:
             keys = list(self._store.keys())
@@ -296,7 +298,9 @@ class IntermediatesCache(Generic[TKey]):
                         and torch.device(device).type
                         == torch.accelerator.current_accelerator().type
                     )
-                    onloaded_leaves.append(tensor.to(device=device, non_blocking=non_blocking))
+                    onloaded_leaves.append(
+                        tensor.to(device=device, non_blocking=non_blocking)
+                    )
                 else:
                     onloaded_leaves.append(tensor)
             else:
@@ -318,7 +322,8 @@ class IntermediatesCache(Generic[TKey]):
 
         :param value: value to offload
         :param offload_device: device to offload tensors to
-        :param onload_device: device to onload tensors to. If None, use tensor's current device
+        :param onload_device: device to onload tensors to. If None, use tensor's
+            current device
         :return: pytree with IntermediateValue at tensor leaf positions
         """
         leaves, spec = tree_flatten(value)
@@ -332,7 +337,7 @@ class IntermediatesCache(Generic[TKey]):
                     else:
                         # move to offload if no hit
                         offloaded_tensor = leaf.to(device=offload_device)
-                        if offloaded_tensor is not leaf: # avoid circular ref
+                        if offloaded_tensor is not leaf:  # avoid circular ref
                             # pin CPU tensors so onload can use non_blocking DMA
                             if (
                                 torch.device(offload_device).type == "cpu"
@@ -350,8 +355,8 @@ class IntermediatesCache(Generic[TKey]):
                 )
             elif isinstance(leaf, IntermediateValue):
                 warnings.warn(
-                    f"Unexpected IntermediateValue in input to _offload_value; "
-                    f"passing through unchanged"
+                    "Unexpected IntermediateValue in input to _offload_value; "
+                    "passing through unchanged"
                 )
                 offloaded_leaves.append(leaf)
             else:

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Generator, Generic, TypeVar
@@ -213,7 +212,8 @@ class IntermediatesCache(Generic[TKey, TValue]):
         Non-tuple prefixes are treated as single-element tuples.
 
         :param prefix: prefix to match keys starting with this prefix
-        :return: list of matching keys (sorted by final index if integer, otherwise unsorted)
+        :return: list of matching keys (sorted by final index if integer,
+            otherwise unsorted)
         """
         if prefix is None:
             return list(self._store.keys())
@@ -407,7 +407,11 @@ class IntermediatesCache(Generic[TKey, TValue]):
                     # move to offload if no hit
                     offloaded_tensor = leaf.to(device=offload_device)
                     if offloaded_tensor is not leaf:
-                        cls.offload_values[leaf] = offloaded_tensor.pin_memory() if do_pin else offloaded_tensor
+                        cls.offload_values[leaf] = (
+                            offloaded_tensor.pin_memory()
+                            if do_pin
+                            else offloaded_tensor
+                        )
 
             offloaded_leaves.append(
                 IntermediateValue(

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -40,7 +40,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
     Construct using `from_dataloader` class method or directly with offload_device
     """
 
-    _store: dict[TKey, Any]
+    _store: dict[TKey, TValue] # Notice the tensor inside TValue is wrapped in IntermediateValue
     offload_device: torch.device | None
 
     # map of onload value -> offload value
@@ -89,9 +89,9 @@ class IntermediatesCache(Generic[TKey, TValue]):
             raise KeyError(f"Key {key} not found in cache")
         return self._onload_value(self._store[key])
 
-    def fetch_no_onload(self, key: TKey) -> Any:
+    def fetch_no_onload(self, key: TKey) -> TValue:
         """
-        Fetch a value by key WITHOUT onloading (returns IntermediateValue wrapped data)
+        Fetch a value by key WITHOUT onloading
 
         :param key: key to fetch
         :return: raw offloaded value (IntermediateValue wrappers at tensor positions)
@@ -99,16 +99,18 @@ class IntermediatesCache(Generic[TKey, TValue]):
         """
         if key not in self._store:
             raise KeyError(f"Key {key} not found in cache")
-        return self._store[key]
+        leaves, spec = tree_flatten(self._store[key])
+        cleaned_leaves = [x.value if isinstance(x, IntermediateValue) else x for x in leaves]
+        return tree_unflatten(cleaned_leaves, spec)
 
-    def update(self, key: TKey, value: TValue) -> None:
+    def update(self, key: TKey, value: TValue, onload_device=None) -> None:
         """
         Update/put a value for a key, offloading any tensors
 
         :param key: key to store value under
         :param value: value to store (tensors will be offloaded)
         """
-        self._store[key] = self._offload_value(value, self.offload_device)
+        self._store[key] = self._offload_value(value, self.offload_device, onload_device)
 
         # Update prefix counter and indices to ensure append doesn't overwrite
         if isinstance(key, int):
@@ -128,7 +130,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
         if idx not in indices:
             indices.append(idx)
 
-    def append(self, key_prefix: TKey | None, value: TValue) -> tuple[TKey, int]:
+    def append(self, key_prefix: TKey | None, value: TValue, onload_device=None) -> tuple[TKey, int]:
         """
         Append a value with an auto-generated index.
 
@@ -154,7 +156,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
         else:
             full_key = prefix + (next_idx,)
 
-        self._store[full_key] = self._offload_value(value, self.offload_device)
+        self._store[full_key] = self._offload_value(value, self.offload_device, onload_device)
         self._prefix_indices.setdefault(prefix, []).append(next_idx)
         return full_key, next_idx
 
@@ -164,6 +166,9 @@ class IntermediatesCache(Generic[TKey, TValue]):
 
         :param key: key to delete
         """
+        # Avoid raising KeyError if key doesn't exist
+        if key not in self._store:
+            return
         del self._store[key]
 
         # Remove from prefix indices
@@ -181,6 +186,10 @@ class IntermediatesCache(Generic[TKey, TValue]):
                 self._prefix_indices[prefix].remove(idx)
             except ValueError:
                 pass
+
+        # Decrement counter if deleted index was the max
+        if prefix in self._prefix_counters and self._prefix_counters[prefix] == idx + 1:
+            self._prefix_counters[prefix] = idx
 
     def __contains__(self, key: TKey) -> bool:
         """
@@ -330,7 +339,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
         return len(self._store)
 
     @classmethod
-    def _onload_value(cls, value: Any) -> Any:
+    def _onload_value(cls, value: TValue) -> TValue:
         """
         Onload a value's tensors to their original devices.
 
@@ -365,10 +374,10 @@ class IntermediatesCache(Generic[TKey, TValue]):
     @classmethod
     def _offload_value(
         cls,
-        value: Any,
+        value: TValue,
         offload_device: torch.device | None,
         onload_device: torch.device | None = None,
-    ) -> Any:
+    ) -> TValue:
         """
         Offload a value's tensors to the offload device.
 

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -62,7 +62,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
     ):
         """
         Initialize a cache with data from the provided dataloader.
-        Stores each batch item with key (batch_idx, dict_key) for granular access.
+        Stores each batch as a dict under key batch_idx.
 
         :param dataloader: dataloader which generates values to be cached
         :param model_device: device which values will be onloaded to when fetched
@@ -70,11 +70,9 @@ class IntermediatesCache(Generic[TKey, TValue]):
         """
         cache = cls(offload_device)
         for batch_idx, batch in enumerate(tqdm(dataloader, desc="Preparing cache")):
-            for key, value in batch.items():
-                full_key = (batch_idx, key)
-                cache._store[full_key] = cls._offload_value(
-                    value, offload_device, model_device
-                )
+            cache._store[batch_idx] = cls._offload_value(
+                batch, offload_device, model_device
+            )
         cache._prefix_counters[()] = len(dataloader)
         cache._prefix_indices[()] = list(range(len(dataloader)))
         return cache
@@ -90,6 +88,18 @@ class IntermediatesCache(Generic[TKey, TValue]):
         if key not in self._store:
             raise KeyError(f"Key {key} not found in cache")
         return self._onload_value(self._store[key])
+
+    def fetch_no_onload(self, key: TKey) -> Any:
+        """
+        Fetch a value by key WITHOUT onloading (returns IntermediateValue wrapped data)
+
+        :param key: key to fetch
+        :return: raw offloaded value (IntermediateValue wrappers at tensor positions)
+        :raises KeyError: if key is not found in cache
+        """
+        if key not in self._store:
+            raise KeyError(f"Key {key} not found in cache")
+        return self._store[key]
 
     def update(self, key: TKey, value: TValue) -> None:
         """
@@ -399,10 +409,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
                     )
                 )
             elif isinstance(leaf, IntermediateValue):
-                warnings.warn(
-                    "Unexpected IntermediateValue in input to _offload_value; "
-                    "passing through unchanged"
-                )
+                # Pass through existing IntermediateValue (expected when merging batch dicts)
                 offloaded_leaves.append(leaf)
             else:
                 if not isinstance(

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -12,6 +12,7 @@ from torch.utils._pytree import tree_flatten, tree_unflatten
 from tqdm import tqdm
 
 TKey = TypeVar("TKey", bound=Any)
+TValue = TypeVar("TValue", bound=Any)
 
 
 @dataclass
@@ -26,7 +27,7 @@ class IntermediateValue:
     device: torch.device | None
 
 
-class IntermediatesCache(Generic[TKey]):
+class IntermediatesCache(Generic[TKey, TValue]):
     """
     Cache which stores intermediate values (activations) produced by batched, sequential
     execution of models. Values are offloaded to the `offload_device` when stored in
@@ -48,6 +49,8 @@ class IntermediatesCache(Generic[TKey]):
 
     def __init__(self, offload_device: torch.device | None = None):
         self._store = {}
+        self._prefix_counters: dict[tuple, int] = {}
+        self._prefix_indices: dict[tuple, list[int]] = {}
         self.offload_device = offload_device
 
     @classmethod
@@ -59,7 +62,7 @@ class IntermediatesCache(Generic[TKey]):
     ):
         """
         Initialize a cache with data from the provided dataloader.
-        Stores each batch as a dict under key batch_idx.
+        Stores each batch item with key (batch_idx, dict_key) for granular access.
 
         :param dataloader: dataloader which generates values to be cached
         :param model_device: device which values will be onloaded to when fetched
@@ -67,12 +70,16 @@ class IntermediatesCache(Generic[TKey]):
         """
         cache = cls(offload_device)
         for batch_idx, batch in enumerate(tqdm(dataloader, desc="Preparing cache")):
-            cache._store[batch_idx] = cls._offload_value(
-                batch, offload_device, model_device
-            )
+            for key, value in batch.items():
+                full_key = (batch_idx, key)
+                cache._store[full_key] = cls._offload_value(
+                    value, offload_device, model_device
+                )
+        cache._prefix_counters[()] = len(dataloader)
+        cache._prefix_indices[()] = list(range(len(dataloader)))
         return cache
 
-    def __getitem__(self, key: TKey) -> Any:
+    def __getitem__(self, key: TKey) -> TValue:
         """
         Fetch a value by key, onloading it to the original device
 
@@ -84,7 +91,7 @@ class IntermediatesCache(Generic[TKey]):
             raise KeyError(f"Key {key} not found in cache")
         return self._onload_value(self._store[key])
 
-    def update(self, key: TKey, value: Any) -> None:
+    def update(self, key: TKey, value: TValue) -> None:
         """
         Update/put a value for a key, offloading any tensors
 
@@ -93,7 +100,25 @@ class IntermediatesCache(Generic[TKey]):
         """
         self._store[key] = self._offload_value(value, self.offload_device)
 
-    def append(self, key_prefix: TKey | None, value: Any) -> tuple[TKey, int]:
+        # Update prefix counter and indices to ensure append doesn't overwrite
+        if isinstance(key, int):
+            prefix = ()
+            idx = key
+        elif isinstance(key, tuple) and len(key) > 0 and isinstance(key[-1], int):
+            prefix = key[:-1]
+            idx = key[-1]
+        else:
+            return
+
+        current_max = self._prefix_counters.get(prefix, 0)
+        if idx >= current_max:
+            self._prefix_counters[prefix] = idx + 1
+
+        indices = self._prefix_indices.setdefault(prefix, [])
+        if idx not in indices:
+            indices.append(idx)
+
+    def append(self, key_prefix: TKey | None, value: TValue) -> tuple[TKey, int]:
         """
         Append a value with an auto-generated index.
 
@@ -105,28 +130,22 @@ class IntermediatesCache(Generic[TKey]):
         :return: tuple of (full_key, index) where full_key is the complete key used
         """
         if key_prefix is None:
-            matching_keys = [k for k in self._store.keys() if isinstance(k, int)]
-            next_idx = max(matching_keys, default=-1) + 1
+            prefix = ()
+        elif isinstance(key_prefix, tuple):
+            prefix = key_prefix
+        else:
+            prefix = (key_prefix,)
+
+        next_idx = self._prefix_counters.get(prefix, 0)
+        self._prefix_counters[prefix] = next_idx + 1
+
+        if prefix == ():
             full_key = next_idx
         else:
-            if isinstance(key_prefix, tuple):
-                prefix = key_prefix
-            else:
-                prefix = (key_prefix,)
-
-            matching_keys = [
-                k
-                for k in self._store.keys()
-                if isinstance(k, tuple)
-                and len(k) == len(prefix) + 1
-                and k[:-1] == prefix
-                and isinstance(k[-1], int)
-            ]
-
-            next_idx = max((k[-1] for k in matching_keys), default=-1) + 1
             full_key = prefix + (next_idx,)
 
         self._store[full_key] = self._offload_value(value, self.offload_device)
+        self._prefix_indices.setdefault(prefix, []).append(next_idx)
         return full_key, next_idx
 
     def delete(self, key: TKey) -> None:
@@ -136,6 +155,22 @@ class IntermediatesCache(Generic[TKey]):
         :param key: key to delete
         """
         del self._store[key]
+
+        # Remove from prefix indices
+        if isinstance(key, int):
+            prefix = ()
+            idx = key
+        elif isinstance(key, tuple) and len(key) > 0 and isinstance(key[-1], int):
+            prefix = key[:-1]
+            idx = key[-1]
+        else:
+            return
+
+        if prefix in self._prefix_indices:
+            try:
+                self._prefix_indices[prefix].remove(idx)
+            except ValueError:
+                pass
 
     def __contains__(self, key: TKey) -> bool:
         """
@@ -154,7 +189,7 @@ class IntermediatesCache(Generic[TKey]):
         Non-tuple prefixes are treated as single-element tuples.
 
         :param prefix: prefix to match keys starting with this prefix
-        :return: list of matching keys sorted by final integer index
+        :return: list of matching keys (sorted by final index if integer, otherwise unsorted)
         """
         if prefix is None:
             return list(self._store.keys())
@@ -164,16 +199,24 @@ class IntermediatesCache(Generic[TKey]):
         else:
             p = (prefix,)
 
+        # Use prefix indices for O(K) lookup if available
+        if p in self._prefix_indices:
+            indices = sorted(self._prefix_indices[p])
+            return [p + (idx,) for idx in indices]
+
+        # Fallback: scan store for keys matching prefix (handles non-integer suffixes)
         keys = []
         for k in self._store.keys():
-            if not isinstance(k, tuple):
-                continue
-            if len(k) == len(p) + 1 and k[:-1] == p and isinstance(k[-1], int):
+            if isinstance(k, tuple) and len(k) == len(p) + 1 and k[:-1] == p:
                 keys.append(k)
 
-        return sorted(keys, key=lambda k: k[-1])
+        # Sort by final element if it's an integer
+        if keys and isinstance(keys[0][-1], int):
+            keys = sorted(keys, key=lambda k: k[-1])
 
-    def iter(self, keys: list[TKey] | None = None) -> Generator[Any, None, None]:
+        return keys
+
+    def iter(self, keys: list[TKey] | None = None) -> Generator[TValue, None, None]:
         """
         Iterate over keys with values onloaded in the current thread.
 
@@ -199,7 +242,7 @@ class IntermediatesCache(Generic[TKey]):
 
     def iter_prefetch(
         self, keys: list[TKey] | None = None
-    ) -> Generator[Any, None, None]:
+    ) -> Generator[TValue, None, None]:
         """
         Iterate over keys with values prefetched in a background thread.
         Overlaps onload from offload_device with consumption of the current value.
@@ -259,7 +302,7 @@ class IntermediatesCache(Generic[TKey]):
                     torch.cuda.current_stream().wait_event(event)
                 yield current
 
-    def __iter__(self) -> Generator[Any, None, None]:
+    def __iter__(self) -> Generator[TValue, None, None]:
         """
         Iterate over all values in the cache
         """
@@ -269,6 +312,8 @@ class IntermediatesCache(Generic[TKey]):
     def clear(self) -> None:
         """Clear all entries from the cache."""
         self._store.clear()
+        self._prefix_counters.clear()
+        self._prefix_indices.clear()
 
     def __len__(self) -> int:
         """Return the number of entries in the cache."""

--- a/src/llmcompressor/pipelines/cache.py
+++ b/src/llmcompressor/pipelines/cache.py
@@ -40,7 +40,9 @@ class IntermediatesCache(Generic[TKey, TValue]):
     Construct using `from_dataloader` class method or directly with offload_device
     """
 
-    _store: dict[TKey, TValue] # Notice the tensor inside TValue is wrapped in IntermediateValue
+    _store: dict[
+        TKey, TValue
+    ]  # Notice the tensor inside TValue is wrapped in IntermediateValue
     offload_device: torch.device | None
 
     # map of onload value -> offload value
@@ -50,7 +52,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
     def __init__(self, offload_device: torch.device | None = None):
         self._store = {}
         self._prefix_counters: dict[tuple, int] = {}
-        self._prefix_indices: dict[tuple, list[int]] = {}
+        self._prefix_indices: dict[tuple, set[int]] = {}
         self.offload_device = offload_device
 
     @classmethod
@@ -74,7 +76,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
                 batch, offload_device, model_device
             )
         cache._prefix_counters[()] = len(dataloader)
-        cache._prefix_indices[()] = list(range(len(dataloader)))
+        cache._prefix_indices[()] = set(range(len(dataloader)))
         return cache
 
     def __getitem__(self, key: TKey) -> TValue:
@@ -100,7 +102,9 @@ class IntermediatesCache(Generic[TKey, TValue]):
         if key not in self._store:
             raise KeyError(f"Key {key} not found in cache")
         leaves, spec = tree_flatten(self._store[key])
-        cleaned_leaves = [x.value if isinstance(x, IntermediateValue) else x for x in leaves]
+        cleaned_leaves = [
+            x.value if isinstance(x, IntermediateValue) else x for x in leaves
+        ]
         return tree_unflatten(cleaned_leaves, spec)
 
     def update(self, key: TKey, value: TValue, onload_device=None) -> None:
@@ -110,7 +114,9 @@ class IntermediatesCache(Generic[TKey, TValue]):
         :param key: key to store value under
         :param value: value to store (tensors will be offloaded)
         """
-        self._store[key] = self._offload_value(value, self.offload_device, onload_device)
+        self._store[key] = self._offload_value(
+            value, self.offload_device, onload_device
+        )
 
         # Update prefix counter and indices to ensure append doesn't overwrite
         if isinstance(key, int):
@@ -126,11 +132,11 @@ class IntermediatesCache(Generic[TKey, TValue]):
         if idx >= current_max:
             self._prefix_counters[prefix] = idx + 1
 
-        indices = self._prefix_indices.setdefault(prefix, [])
-        if idx not in indices:
-            indices.append(idx)
+        self._prefix_indices.setdefault(prefix, set()).add(idx)
 
-    def append(self, key_prefix: TKey | None, value: TValue, onload_device=None) -> tuple[TKey, int]:
+    def append(
+        self, key_prefix: TKey | None, value: TValue, onload_device=None
+    ) -> tuple[TKey, int]:
         """
         Append a value with an auto-generated index.
 
@@ -156,8 +162,10 @@ class IntermediatesCache(Generic[TKey, TValue]):
         else:
             full_key = prefix + (next_idx,)
 
-        self._store[full_key] = self._offload_value(value, self.offload_device, onload_device)
-        self._prefix_indices.setdefault(prefix, []).append(next_idx)
+        self._store[full_key] = self._offload_value(
+            value, self.offload_device, onload_device
+        )
+        self._prefix_indices.setdefault(prefix, set()).add(next_idx)
         return full_key, next_idx
 
     def delete(self, key: TKey) -> None:
@@ -182,10 +190,7 @@ class IntermediatesCache(Generic[TKey, TValue]):
             return
 
         if prefix in self._prefix_indices:
-            try:
-                self._prefix_indices[prefix].remove(idx)
-            except ValueError:
-                pass
+            self._prefix_indices[prefix].discard(idx)
 
         # Decrement counter if deleted index was the max
         if prefix in self._prefix_counters and self._prefix_counters[prefix] == idx + 1:
@@ -352,23 +357,19 @@ class IntermediatesCache(Generic[TKey, TValue]):
         leaves, spec = tree_flatten(value)
         onloaded_leaves = []
         for leaf in leaves:
-            if isinstance(leaf, IntermediateValue):
-                tensor = leaf.value
-                device = leaf.device
-                if device is not None:
-                    non_blocking = (
-                        tensor.is_pinned()
-                        and torch.accelerator.is_available()
-                        and torch.device(device).type
-                        == torch.accelerator.current_accelerator().type
-                    )
-                    onloaded_leaves.append(
-                        tensor.to(device=device, non_blocking=non_blocking)
-                    )
-                else:
-                    onloaded_leaves.append(tensor)
-            else:
+            if not isinstance(leaf, IntermediateValue):
                 onloaded_leaves.append(leaf)
+                continue
+            tensor = leaf.value
+            device = leaf.device
+            non_blocking = (
+                tensor.is_pinned()
+                and torch.accelerator.is_available()
+                and torch.device(device).type
+                == torch.accelerator.current_accelerator().type
+            )
+            tensor = tensor.to(device=device, non_blocking=non_blocking)
+            onloaded_leaves.append(tensor)
         return tree_unflatten(onloaded_leaves, spec)
 
     @classmethod
@@ -392,44 +393,28 @@ class IntermediatesCache(Generic[TKey, TValue]):
         """
         leaves, spec = tree_flatten(value)
         offloaded_leaves = []
+        do_pin = str(offload_device) == "cpu" and torch.accelerator.is_available()
         for leaf in leaves:
-            if isinstance(leaf, torch.Tensor):
-                with OverrideEqMode():
-                    # check for cache hit between shared tensors
-                    if leaf in cls.offload_values:
-                        offloaded_tensor = cls.offload_values[leaf]
-                    else:
-                        # move to offload if no hit
-                        offloaded_tensor = leaf.to(device=offload_device)
-                        if offloaded_tensor is not leaf:  # avoid circular ref
-                            # pin CPU tensors so onload can use non_blocking DMA
-                            if (
-                                torch.device(offload_device).type == "cpu"
-                                and torch.accelerator.is_available()
-                                and not offloaded_tensor.is_pinned()
-                            ):
-                                offloaded_tensor = offloaded_tensor.pin_memory()
-                            cls.offload_values[leaf] = offloaded_tensor
+            if not isinstance(leaf, torch.Tensor):
+                offloaded_leaves.append(leaf)
+                continue
 
-                offloaded_leaves.append(
-                    IntermediateValue(
-                        value=offloaded_tensor,
-                        device=(onload_device if onload_device else leaf.device),
-                    )
+            with OverrideEqMode():
+                # check for cache hit between shared tensors
+                if leaf in cls.offload_values:
+                    offloaded_tensor = cls.offload_values[leaf]
+                else:
+                    # move to offload if no hit
+                    offloaded_tensor = leaf.to(device=offload_device)
+                    if offloaded_tensor is not leaf:
+                        cls.offload_values[leaf] = offloaded_tensor.pin_memory() if do_pin else offloaded_tensor
+
+            offloaded_leaves.append(
+                IntermediateValue(
+                    value=offloaded_tensor,
+                    device=(onload_device if onload_device else leaf.device),
                 )
-            elif isinstance(leaf, IntermediateValue):
-                # Pass through existing IntermediateValue (expected when merging batch dicts)
-                offloaded_leaves.append(leaf)
-            else:
-                if not isinstance(
-                    leaf,
-                    (int, str, float, bool, torch.dtype, torch.device, type(None)),
-                ):
-                    warnings.warn(
-                        f"Leaf type {type(leaf)} may not be handled correctly; "
-                        f"storing as-is"
-                    )
-                offloaded_leaves.append(leaf)
+            )
         return tree_unflatten(offloaded_leaves, spec)
 
 

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -29,6 +29,38 @@ if TYPE_CHECKING:
 __all__ = ["SequentialPipeline"]
 
 
+def _iter_batches(
+    activations: IntermediatesCache,
+    input_names: list[str],
+) -> Iterator[dict]:
+    """
+    Iterate over batches without prefetching.
+    """
+    batch_idx = 0
+    while True:
+        inputs = {}
+        for name in input_names:
+            key = (batch_idx, name)
+            if key in activations:
+                inputs[name] = activations.fetch(key)
+        if not inputs:
+            return
+        yield inputs
+        batch_idx += 1
+
+
+def _iter_batches_prefetch(
+    activations: IntermediatesCache,
+    input_names: list[str],
+) -> Iterator[dict]:
+    """
+    Iterate over batches with prefetching using iter_prefetch_grouped.
+    """
+    keys = [k for k in activations._store.keys() if k[1] in input_names]
+    for group_dict in activations.iter_prefetch_grouped(keys, group_by=lambda k: k[0]):
+        yield {k[1]: v for k, v in group_dict.items()}
+
+
 def _get_batches(
     activations: IntermediatesCache,
     num_batches: int,
@@ -39,13 +71,12 @@ def _get_batches(
     """
     Yield (batch_idx, inputs) with the next batch optionally prefetched in a
     background thread to overlap fetch (onload from offload device) with the
-    main-thread forward pass. Delegates to
-    :meth:`IntermediatesCache.iter_prefetch` when prefetching is enabled.
+    main-thread forward pass.
     """
     batch_source = (
-        activations.iter_prefetch(input_names)
+        _iter_batches_prefetch(activations, input_names)
         if sequential_prefetch
-        else activations.iter(input_names)
+        else _iter_batches(activations, input_names)
     )
     for batch_idx, inputs in tqdm(
         enumerate(batch_source), total=num_batches, desc=desc
@@ -132,7 +163,7 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations.fetch(batch_idx, ["loss_mask"]).get("loss_mask")
+                    activations.fetch((batch_idx, "loss_mask"))
                     for batch_idx in range(len(dataloader))
                 ]
             else:
@@ -174,8 +205,14 @@ class SequentialPipeline(CalibrationPipeline):
                         ):
                             output = subgraph.forward(model, **inputs)
                             if subgraph_index < num_subgraphs - 1:
-                                activations.update(batch_idx, output)
-                                activations.delete(batch_idx, subgraph.consumed_names)
+                                if isinstance(output, tuple) and len(output) == 1:
+                                    output = output[0]
+                                if output is not None:
+                                    for name, value in output.items():
+                                        activations.update((batch_idx, name), value)
+                                if subgraph.consumed_names:
+                                    for name in subgraph.consumed_names:
+                                        activations.delete((batch_idx, name))
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_epoch_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -38,7 +38,7 @@ def _get_batches(
 ) -> Iterator[tuple[int, dict]]:
     """
     Yield (batch_idx, inputs) with the next batch optionally prefetched.
-    
+
     Uses wildcard pattern (None,) to match all (batch_idx,) keys.
     """
     iter_fn = activations.iter_prefetch if sequential_prefetch else activations.iter

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -29,38 +29,6 @@ if TYPE_CHECKING:
 __all__ = ["SequentialPipeline"]
 
 
-def _iter_batches(
-    activations: IntermediatesCache,
-    input_names: list[str],
-) -> Iterator[dict]:
-    """
-    Iterate over batches without prefetching.
-    """
-    batch_idx = 0
-    while True:
-        inputs = {}
-        for name in input_names:
-            key = (batch_idx, name)
-            if key in activations:
-                inputs[name] = activations.fetch(key)
-        if not inputs:
-            return
-        yield inputs
-        batch_idx += 1
-
-
-def _iter_batches_prefetch(
-    activations: IntermediatesCache,
-    input_names: list[str],
-) -> Iterator[dict]:
-    """
-    Iterate over batches with prefetching using iter_prefetch_grouped.
-    """
-    keys = [k for k in activations._store.keys() if k[1] in input_names]
-    for group_dict in activations.iter_prefetch_grouped(keys, group_by=lambda k: k[0]):
-        yield {k[1]: v for k, v in group_dict.items()}
-
-
 def _get_batches(
     activations: IntermediatesCache,
     num_batches: int,
@@ -69,18 +37,16 @@ def _get_batches(
     sequential_prefetch: bool = False,
 ) -> Iterator[tuple[int, dict]]:
     """
-    Yield (batch_idx, inputs) with the next batch optionally prefetched in a
-    background thread to overlap fetch (onload from offload device) with the
-    main-thread forward pass.
+    Yield (batch_idx, inputs) with the next batch optionally prefetched.
+    
+    Uses wildcard pattern (None,) to match all (batch_idx,) keys.
     """
-    batch_source = (
-        _iter_batches_prefetch(activations, input_names)
-        if sequential_prefetch
-        else _iter_batches(activations, input_names)
-    )
-    for batch_idx, inputs in tqdm(
-        enumerate(batch_source), total=num_batches, desc=desc
+    iter_fn = activations.iter_prefetch if sequential_prefetch else activations.iter
+    batch_iter = iter_fn([(None,)])
+    for batch_idx, batch_dict in tqdm(
+        enumerate(batch_iter), total=num_batches, desc=desc
     ):
+        inputs = {name: batch_dict[name] for name in input_names if name in batch_dict}
         yield batch_idx, inputs
 
 
@@ -104,7 +70,7 @@ class SequentialPipeline(CalibrationPipeline):
             to the cpu between each batch in order to save memory
 
         This pipeline requires that the model be traceable with respect to data from the
-        data loader. This may be an issue for vision models with vision datasets, due
+        data loader. This may be an issue for vision models with vision datasets, due to
         to specialized input processing in the model.
 
         In the event that tracing fails, a torch.fx.proxy.TraceError will be raised. A
@@ -154,7 +120,7 @@ class SequentialPipeline(CalibrationPipeline):
             if not dataset_args.quantization_aware_calibration or disable_qac:
                 stack.enter_context(DisableQuantization(model))
 
-            # prepare intermediates cache
+            # prepare intermediates cache - stores (batch_idx,) -> batch_dict
             activations = IntermediatesCache.from_dataloader(
                 dataloader, onload_device, offload_device
             )
@@ -163,7 +129,7 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations.fetch((batch_idx, "loss_mask"))
+                    activations.fetch((batch_idx,))["loss_mask"]
                     for batch_idx in range(len(dataloader))
                 ]
             else:
@@ -208,11 +174,16 @@ class SequentialPipeline(CalibrationPipeline):
                                 if isinstance(output, tuple) and len(output) == 1:
                                     output = output[0]
                                 if output is not None:
-                                    for name, value in output.items():
-                                        activations.update((batch_idx, name), value)
+                                    # Merge output into existing batch dict
+                                    existing_batch = activations.fetch((batch_idx,))
+                                    merged = {**existing_batch, **output}
+                                    activations.update((batch_idx,), merged)
                                 if subgraph.consumed_names:
+                                    # Remove consumed names from batch dict
+                                    existing_batch = activations.fetch((batch_idx,))
                                     for name in subgraph.consumed_names:
-                                        activations.delete((batch_idx, name))
+                                        existing_batch.pop(name, None)
+                                    activations.update((batch_idx,), existing_batch)
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_epoch_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -42,7 +42,7 @@ def _get_batches(
     Uses wildcard pattern (None,) to match all (batch_idx,) keys.
     """
     iter_fn = activations.iter_prefetch if sequential_prefetch else activations.iter
-    batch_iter = iter_fn([(None,)])
+    batch_iter = iter_fn()
     for batch_idx, batch_dict in tqdm(
         enumerate(batch_iter), total=num_batches, desc=desc
     ):
@@ -129,7 +129,7 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations.fetch((batch_idx,))["loss_mask"]
+                    activations[batch_idx]["loss_mask"]
                     for batch_idx in range(len(dataloader))
                 ]
             else:
@@ -175,15 +175,15 @@ class SequentialPipeline(CalibrationPipeline):
                                     output = output[0]
                                 if output is not None:
                                     # Merge output into existing batch dict
-                                    existing_batch = activations.fetch((batch_idx,))
+                                    existing_batch = activations[batch_idx]
                                     merged = {**existing_batch, **output}
-                                    activations.update((batch_idx,), merged)
+                                    activations.update(batch_idx, merged)
                                 if subgraph.consumed_names:
                                     # Remove consumed names from batch dict
-                                    existing_batch = activations.fetch((batch_idx,))
+                                    existing_batch = activations[batch_idx]
                                     for name in subgraph.consumed_names:
                                         existing_batch.pop(name, None)
-                                    activations.update((batch_idx,), existing_batch)
+                                    activations.update(batch_idx, existing_batch)
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_epoch_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -182,7 +182,9 @@ class SequentialPipeline(CalibrationPipeline):
                                     for key in subgraph.consumed_names:
                                         raw_batch.pop(key, None)
 
-                                    activations.update(batch_idx, raw_batch, onload_device)
+                                    activations.update(
+                                        batch_idx, raw_batch, onload_device
+                                    )
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_epoch_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -33,7 +33,7 @@ def _get_batches(
 ) -> Iterator[tuple[int, dict]]:
     """
     Yield (batch_idx, inputs) with the next batch optionally prefetched.
-    
+
     Uses wildcard pattern (None,) to match all (batch_idx,) keys.
     """
     iter_fn = activations.iter_prefetch if sequential_prefetch else activations.iter

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -153,19 +153,11 @@ class SequentialPipeline(CalibrationPipeline):
                                 # Get raw batch dict (no onload of existing tensors)
                                 raw_batch = activations.fetch_no_onload(batch_idx)
 
-                                # Delete consumed keys (no transfer)
+                                raw_batch.update(outputs)
                                 for key in subgraph.consumed_names:
                                     raw_batch.pop(key, None)
 
-                                # Add new outputs - only offload new values
-                                for key, value in outputs.items():
-                                    # Offload new tensors, existing ones stay offloaded
-                                    raw_batch[key] = IntermediatesCache._offload_value(
-                                        value, activations.offload_device, onload_device
-                                    )
-
-                                # Store back - existing tensors stay offloaded
-                                activations.update(batch_idx, raw_batch)
+                                activations.update(batch_idx, raw_batch, onload_device)
 
                     modules = list(subgraph.submodules(model))
                     LifecycleCallbacks.sequential_epoch_end(modules)
@@ -186,19 +178,11 @@ class SequentialPipeline(CalibrationPipeline):
                                     # Get raw batch dict (no onload of existing tensors)
                                     raw_batch = activations.fetch_no_onload(batch_idx)
 
-                                    # Delete consumed keys (no transfer)
+                                    raw_batch.update(output)
                                     for key in subgraph.consumed_names:
                                         raw_batch.pop(key, None)
 
-                                    # Add new outputs - only offload new values
-                                    for key, value in output.items():
-                                        # Offload new tensors, existing ones stay offloaded
-                                        raw_batch[key] = IntermediatesCache._offload_value(
-                                            value, activations.offload_device, onload_device
-                                        )
-
-                                    # Store back - existing tensors stay offloaded
-                                    activations.update(batch_idx, raw_batch)
+                                    activations.update(batch_idx, raw_batch, onload_device)
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_epoch_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -33,27 +33,15 @@ def _get_batches(
 ) -> Iterator[tuple[int, dict]]:
     """
     Yield (batch_idx, inputs) with the next batch optionally prefetched.
-
-    Reconstructs batch dicts from granular keys (batch_idx, name).
-    Only fetches keys matching input_names to minimize data transfer.
     """
-    all_keys = []
-    for batch_idx in range(num_batches):
-        for name in input_names:
-            full_key = (batch_idx, name)
-            if full_key in activations:
-                all_keys.append(full_key)
-
     iter_fn = activations.iter_prefetch if sequential_prefetch else activations.iter
-    value_iter = iter_fn(keys=all_keys)
+    batch_iter = iter_fn(keys=list(range(num_batches)))
 
-    for batch_idx in tqdm(range(num_batches), desc=desc):
-        batch_dict = {}
-        for name in input_names:
-            full_key = (batch_idx, name)
-            if full_key in all_keys:
-                batch_dict[name] = next(value_iter)
-        yield batch_idx, batch_dict
+    for batch_idx, batch_dict in tqdm(
+        enumerate(batch_iter), total=num_batches, desc=desc
+    ):
+        inputs = {name: batch_dict[name] for name in input_names if name in batch_dict}
+        yield batch_idx, inputs
 
 
 @CalibrationPipeline.register("sequential")
@@ -76,7 +64,7 @@ class SequentialPipeline(CalibrationPipeline):
             to the cpu between each batch in order to save memory
 
         This pipeline requires that the model be traceable with respect to data from the
-        data loader. This may be an issue for vision models with vision datasets, due to
+        data loader. This may be an issue for vision models with vision datasets, due
         to specialized input processing in the model.
 
         In the event that tracing fails, a torch.fx.proxy.TraceError will be raised. A
@@ -132,7 +120,7 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations[(batch_idx, "loss_mask")]
+                    activations[batch_idx]["loss_mask"]
                     for batch_idx in range(len(dataloader))
                 ]
             else:
@@ -162,17 +150,25 @@ class SequentialPipeline(CalibrationPipeline):
 
                         if not dataset_args.propagate_error:
                             if subgraph_index < num_subgraphs - 1:
-                                # Update outputs with granular keys
+                                # Get raw batch dict (no onload of existing tensors)
+                                raw_batch = activations.fetch_no_onload(batch_idx)
+
+                                # Delete consumed keys (no transfer)
+                                for key in subgraph.consumed_names:
+                                    raw_batch.pop(key, None)
+
+                                # Add new outputs - only offload new values
                                 if outputs is not None:
                                     if isinstance(outputs, tuple) and len(outputs) == 1:
                                         outputs = outputs[0]
                                     for key, value in outputs.items():
-                                        activations.update((batch_idx, key), value)
-                                # Delete consumed names with granular keys
-                                for key in subgraph.consumed_names:
-                                    full_key = (batch_idx, key)
-                                    if full_key in activations:
-                                        activations.delete(full_key)
+                                        # Offload new tensors, existing ones stay offloaded
+                                        raw_batch[key] = IntermediatesCache._offload_value(
+                                            value, activations.offload_device, onload_device
+                                        )
+
+                                # Store back - existing tensors stay offloaded
+                                activations.update(batch_idx, raw_batch)
 
                     modules = list(subgraph.submodules(model))
                     LifecycleCallbacks.sequential_epoch_end(modules)
@@ -190,17 +186,25 @@ class SequentialPipeline(CalibrationPipeline):
                             ):
                                 output = subgraph.forward(model, **inputs)
                                 if subgraph_index < num_subgraphs - 1:
-                                    # Update outputs with granular keys
+                                    # Get raw batch dict (no onload of existing tensors)
+                                    raw_batch = activations.fetch_no_onload(batch_idx)
+
+                                    # Delete consumed keys (no transfer)
+                                    for key in subgraph.consumed_names:
+                                        raw_batch.pop(key, None)
+
+                                    # Add new outputs - only offload new values
                                     if output is not None:
                                         if isinstance(output, tuple) and len(output) == 1:
                                             output = output[0]
                                         for key, value in output.items():
-                                            activations.update((batch_idx, key), value)
-                                    # Delete consumed names with granular keys
-                                    for key in subgraph.consumed_names:
-                                        full_key = (batch_idx, key)
-                                        if full_key in activations:
-                                            activations.delete(full_key)
+                                            # Offload new tensors, existing ones stay offloaded
+                                            raw_batch[key] = IntermediatesCache._offload_value(
+                                                value, activations.offload_device, onload_device
+                                            )
+
+                                    # Store back - existing tensors stay offloaded
+                                    activations.update(batch_idx, raw_batch)
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_epoch_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -24,38 +24,6 @@ if TYPE_CHECKING:
 __all__ = ["SequentialPipeline"]
 
 
-def _iter_batches(
-    activations: IntermediatesCache,
-    input_names: list[str],
-) -> Iterator[dict]:
-    """
-    Iterate over batches without prefetching.
-    """
-    batch_idx = 0
-    while True:
-        inputs = {}
-        for name in input_names:
-            key = (batch_idx, name)
-            if key in activations:
-                inputs[name] = activations.fetch(key)
-        if not inputs:
-            return
-        yield inputs
-        batch_idx += 1
-
-
-def _iter_batches_prefetch(
-    activations: IntermediatesCache,
-    input_names: list[str],
-) -> Iterator[dict]:
-    """
-    Iterate over batches with prefetching using iter_prefetch_grouped.
-    """
-    keys = [k for k in activations._store.keys() if k[1] in input_names]
-    for group_dict in activations.iter_prefetch_grouped(keys, group_by=lambda k: k[0]):
-        yield {k[1]: v for k, v in group_dict.items()}
-
-
 def _get_batches(
     activations: IntermediatesCache,
     num_batches: int,
@@ -64,18 +32,16 @@ def _get_batches(
     sequential_prefetch: bool = False,
 ) -> Iterator[tuple[int, dict]]:
     """
-    Yield (batch_idx, inputs) with the next batch optionally prefetched in a
-    background thread to overlap fetch (onload from offload device) with the
-    main-thread forward pass.
+    Yield (batch_idx, inputs) with the next batch optionally prefetched.
+    
+    Uses wildcard pattern (None,) to match all (batch_idx,) keys.
     """
-    batch_source = (
-        _iter_batches_prefetch(activations, input_names)
-        if sequential_prefetch
-        else _iter_batches(activations, input_names)
-    )
-    for batch_idx, inputs in tqdm(
-        enumerate(batch_source), total=num_batches, desc=desc
+    iter_fn = activations.iter_prefetch if sequential_prefetch else activations.iter
+    batch_iter = iter_fn([(None,)])
+    for batch_idx, batch_dict in tqdm(
+        enumerate(batch_iter), total=num_batches, desc=desc
     ):
+        inputs = {name: batch_dict[name] for name in input_names if name in batch_dict}
         yield batch_idx, inputs
 
 
@@ -99,7 +65,7 @@ class SequentialPipeline(CalibrationPipeline):
             to the cpu between each batch in order to save memory
 
         This pipeline requires that the model be traceable with respect to data from the
-        data loader. This may be an issue for vision models with vision datasets, due
+        data loader. This may be an issue for vision models with vision datasets, due to
         to specialized input processing in the model.
 
         In the event that tracing fails, a torch.fx.proxy.TraceError will be raised. A
@@ -145,8 +111,16 @@ class SequentialPipeline(CalibrationPipeline):
 
         with contextlib.ExitStack() as stack:
             stack.enter_context(calibration_forward_context(model))
+<<<<<<< HEAD
             stack.enter_context(DisableQuantization(model))
             # prepare intermediates cache
+=======
+            # Optionally disable quantization
+            if not dataset_args.quantization_aware_calibration or disable_qac:
+                stack.enter_context(DisableQuantization(model))
+
+            # prepare intermediates cache - stores (batch_idx,) -> batch_dict
+>>>>>>> 1349bbb3 (Address the review comments.)
             activations = IntermediatesCache.from_dataloader(
                 dataloader, onload_device, offload_device
             )
@@ -155,7 +129,7 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations.fetch((batch_idx, "loss_mask"))
+                    activations.fetch((batch_idx,))["loss_mask"]
                     for batch_idx in range(len(dataloader))
                 ]
             else:

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -24,6 +24,38 @@ if TYPE_CHECKING:
 __all__ = ["SequentialPipeline"]
 
 
+def _iter_batches(
+    activations: IntermediatesCache,
+    input_names: list[str],
+) -> Iterator[dict]:
+    """
+    Iterate over batches without prefetching.
+    """
+    batch_idx = 0
+    while True:
+        inputs = {}
+        for name in input_names:
+            key = (batch_idx, name)
+            if key in activations:
+                inputs[name] = activations.fetch(key)
+        if not inputs:
+            return
+        yield inputs
+        batch_idx += 1
+
+
+def _iter_batches_prefetch(
+    activations: IntermediatesCache,
+    input_names: list[str],
+) -> Iterator[dict]:
+    """
+    Iterate over batches with prefetching using iter_prefetch_grouped.
+    """
+    keys = [k for k in activations._store.keys() if k[1] in input_names]
+    for group_dict in activations.iter_prefetch_grouped(keys, group_by=lambda k: k[0]):
+        yield {k[1]: v for k, v in group_dict.items()}
+
+
 def _get_batches(
     activations: IntermediatesCache,
     num_batches: int,
@@ -34,13 +66,12 @@ def _get_batches(
     """
     Yield (batch_idx, inputs) with the next batch optionally prefetched in a
     background thread to overlap fetch (onload from offload device) with the
-    main-thread forward pass. Delegates to
-    :meth:`IntermediatesCache.iter_prefetch` when prefetching is enabled.
+    main-thread forward pass.
     """
     batch_source = (
-        activations.iter_prefetch(input_names)
+        _iter_batches_prefetch(activations, input_names)
         if sequential_prefetch
-        else activations.iter(input_names)
+        else _iter_batches(activations, input_names)
     )
     for batch_idx, inputs in tqdm(
         enumerate(batch_source), total=num_batches, desc=desc
@@ -124,7 +155,7 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations.fetch(batch_idx, ["loss_mask"]).get("loss_mask")
+                    activations.fetch((batch_idx, "loss_mask"))
                     for batch_idx in range(len(dataloader))
                 ]
             else:

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -37,7 +37,7 @@ def _get_batches(
     Uses wildcard pattern (None,) to match all (batch_idx,) keys.
     """
     iter_fn = activations.iter_prefetch if sequential_prefetch else activations.iter
-    batch_iter = iter_fn([(None,)])
+    batch_iter = iter_fn()
     for batch_idx, batch_dict in tqdm(
         enumerate(batch_iter), total=num_batches, desc=desc
     ):
@@ -111,16 +111,8 @@ class SequentialPipeline(CalibrationPipeline):
 
         with contextlib.ExitStack() as stack:
             stack.enter_context(calibration_forward_context(model))
-<<<<<<< HEAD
             stack.enter_context(DisableQuantization(model))
             # prepare intermediates cache
-=======
-            # Optionally disable quantization
-            if not dataset_args.quantization_aware_calibration or disable_qac:
-                stack.enter_context(DisableQuantization(model))
-
-            # prepare intermediates cache - stores (batch_idx,) -> batch_dict
->>>>>>> 1349bbb3 (Address the review comments.)
             activations = IntermediatesCache.from_dataloader(
                 dataloader, onload_device, offload_device
             )
@@ -129,7 +121,7 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations.fetch((batch_idx,))["loss_mask"]
+                    activations[batch_idx]["loss_mask"]
                     for batch_idx in range(len(dataloader))
                 ]
             else:

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -158,14 +158,11 @@ class SequentialPipeline(CalibrationPipeline):
                                     raw_batch.pop(key, None)
 
                                 # Add new outputs - only offload new values
-                                if outputs is not None:
-                                    if isinstance(outputs, tuple) and len(outputs) == 1:
-                                        outputs = outputs[0]
-                                    for key, value in outputs.items():
-                                        # Offload new tensors, existing ones stay offloaded
-                                        raw_batch[key] = IntermediatesCache._offload_value(
-                                            value, activations.offload_device, onload_device
-                                        )
+                                for key, value in outputs.items():
+                                    # Offload new tensors, existing ones stay offloaded
+                                    raw_batch[key] = IntermediatesCache._offload_value(
+                                        value, activations.offload_device, onload_device
+                                    )
 
                                 # Store back - existing tensors stay offloaded
                                 activations.update(batch_idx, raw_batch)
@@ -194,14 +191,11 @@ class SequentialPipeline(CalibrationPipeline):
                                         raw_batch.pop(key, None)
 
                                     # Add new outputs - only offload new values
-                                    if output is not None:
-                                        if isinstance(output, tuple) and len(output) == 1:
-                                            output = output[0]
-                                        for key, value in output.items():
-                                            # Offload new tensors, existing ones stay offloaded
-                                            raw_batch[key] = IntermediatesCache._offload_value(
-                                                value, activations.offload_device, onload_device
-                                            )
+                                    for key, value in output.items():
+                                        # Offload new tensors, existing ones stay offloaded
+                                        raw_batch[key] = IntermediatesCache._offload_value(
+                                            value, activations.offload_device, onload_device
+                                        )
 
                                     # Store back - existing tensors stay offloaded
                                     activations.update(batch_idx, raw_batch)

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -34,15 +34,26 @@ def _get_batches(
     """
     Yield (batch_idx, inputs) with the next batch optionally prefetched.
 
-    Uses wildcard pattern (None,) to match all (batch_idx,) keys.
+    Reconstructs batch dicts from granular keys (batch_idx, name).
+    Only fetches keys matching input_names to minimize data transfer.
     """
+    all_keys = []
+    for batch_idx in range(num_batches):
+        for name in input_names:
+            full_key = (batch_idx, name)
+            if full_key in activations:
+                all_keys.append(full_key)
+
     iter_fn = activations.iter_prefetch if sequential_prefetch else activations.iter
-    batch_iter = iter_fn()
-    for batch_idx, batch_dict in tqdm(
-        enumerate(batch_iter), total=num_batches, desc=desc
-    ):
-        inputs = {name: batch_dict[name] for name in input_names if name in batch_dict}
-        yield batch_idx, inputs
+    value_iter = iter_fn(keys=all_keys)
+
+    for batch_idx in tqdm(range(num_batches), desc=desc):
+        batch_dict = {}
+        for name in input_names:
+            full_key = (batch_idx, name)
+            if full_key in all_keys:
+                batch_dict[name] = next(value_iter)
+        yield batch_idx, batch_dict
 
 
 @CalibrationPipeline.register("sequential")
@@ -121,7 +132,7 @@ class SequentialPipeline(CalibrationPipeline):
             use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
             if use_loss_mask:
                 session.state.loss_masks = [
-                    activations[batch_idx]["loss_mask"]
+                    activations[(batch_idx, "loss_mask")]
                     for batch_idx in range(len(dataloader))
                 ]
             else:
@@ -151,8 +162,17 @@ class SequentialPipeline(CalibrationPipeline):
 
                         if not dataset_args.propagate_error:
                             if subgraph_index < num_subgraphs - 1:
-                                activations.update(batch_idx, outputs)
-                                activations.delete(batch_idx, subgraph.consumed_names)
+                                # Update outputs with granular keys
+                                if outputs is not None:
+                                    if isinstance(outputs, tuple) and len(outputs) == 1:
+                                        outputs = outputs[0]
+                                    for key, value in outputs.items():
+                                        activations.update((batch_idx, key), value)
+                                # Delete consumed names with granular keys
+                                for key in subgraph.consumed_names:
+                                    full_key = (batch_idx, key)
+                                    if full_key in activations:
+                                        activations.delete(full_key)
 
                     modules = list(subgraph.submodules(model))
                     LifecycleCallbacks.sequential_epoch_end(modules)
@@ -170,10 +190,17 @@ class SequentialPipeline(CalibrationPipeline):
                             ):
                                 output = subgraph.forward(model, **inputs)
                                 if subgraph_index < num_subgraphs - 1:
-                                    activations.update(batch_idx, output)
-                                    activations.delete(
-                                        batch_idx, subgraph.consumed_names
-                                    )
+                                    # Update outputs with granular keys
+                                    if output is not None:
+                                        if isinstance(output, tuple) and len(output) == 1:
+                                            output = output[0]
+                                        for key, value in output.items():
+                                            activations.update((batch_idx, key), value)
+                                    # Delete consumed names with granular keys
+                                    for key in subgraph.consumed_names:
+                                        full_key = (batch_idx, key)
+                                        if full_key in activations:
+                                            activations.delete(full_key)
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_epoch_end()

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -2,165 +2,154 @@ from dataclasses import dataclass, fields, is_dataclass
 
 import pytest
 import torch
-from torch.utils.data import DataLoader, StackDataset
 
 from llmcompressor.pipelines.cache import IntermediatesCache, OverrideEqMode
 
 
-@dataclass
-class SampleDataclass:
-    a: torch.Tensor
-    b: int
+@pytest.mark.unit
+def test_new_fetch_update_roundtrip():
+    """Test basic fetch/update roundtrip with flat key-value."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    tensor = torch.randn(2, 3)
+    key = "test_key"
 
-
-@pytest.fixture
-def sample_dataloader():
-    # Create sample input tensors
-    input_ids = torch.tensor([[1, 2, 3, 0], [4, 5, 6, 0]], dtype=torch.long)
-    attention_mask = torch.tensor([[1, 1, 1, 0], [1, 1, 1, 0]], dtype=torch.bool)
-
-    # Create dataset and dataloader
-    dataset = StackDataset(input_ids=input_ids, attention_mask=attention_mask)
-    return DataLoader(dataset, batch_size=2)
-
-
-@pytest.fixture
-def sample_cache(sample_dataloader):
-    return IntermediatesCache.from_dataloader(
-        dataloader=sample_dataloader,
-        model_device=torch.device("cpu"),
-        offload_device=torch.device("cpu"),
-    )
-
-
-values_to_test = [
-    torch.randn(2, 3).to("cpu"),
-    SampleDataclass(a=torch.randn(2, 3), b=42),
-    torch.float32,
-    [1, 2, 3],
-]
+    cache.update(key, tensor)
+    fetched = cache.fetch(key)
+    assert torch.equal(fetched, tensor)
 
 
 @pytest.mark.unit
-def test_initialization(sample_dataloader):
-    cache = IntermediatesCache.from_dataloader(
-        dataloader=sample_dataloader,
-        model_device=torch.device("cpu"),
-    )
-
-    assert isinstance(cache, IntermediatesCache)
-    assert len(cache.batch_intermediates) > 0
-    assert isinstance(cache.batch_intermediates[0], dict)
+def test_new_fetch_key_not_found():
+    """Test KeyError raised when key not found."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    with pytest.raises(KeyError):
+        cache.fetch("nonexistent")
 
 
 @pytest.mark.unit
-def test_iter_prefetch_empty_cache():
-    """iter_prefetch yields nothing when cache has no batches."""
-    cache = IntermediatesCache.empty(0, torch.device("cpu"))
-    assert list(cache.iter_prefetch()) == []
+def test_new_update_accepts_any_value():
+    """Test update accepts non-tensor values."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    cache.update("key", "not a tensor")  # Should not raise
+    assert cache.fetch("key") == "not a tensor"
 
 
 @pytest.mark.unit
-def test_iter_prefetch_matches_iter(sample_cache):
-    """iter_prefetch yields the same batch contents as iter."""
-
-    def batch_dicts_equal(a: dict, b: dict) -> bool:
-        if set(a.keys()) != set(b.keys()):
-            return False
-        return all(deep_equal(a[k], b[k]) for k in a)
-
-    via_iter = list(sample_cache.iter())
-    via_prefetch = list(sample_cache.iter_prefetch())
-    assert len(via_iter) == len(via_prefetch)
-    for i, (b_iter, b_prefetch) in enumerate(zip(via_iter, via_prefetch)):
-        assert batch_dicts_equal(b_iter, b_prefetch), f"batch {i} differs"
+def test_new_delete():
+    """Test delete removes entry."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    cache.update("key", torch.randn(2, 3))
+    assert "key" in cache
+    cache.delete("key")
+    assert "key" not in cache
 
 
 @pytest.mark.unit
-def test_fetch_inputs(sample_cache):
-    fetched = sample_cache.fetch(0, ["input_ids", "attention_mask"])
-
-    assert isinstance(fetched, dict)
-    assert "input_ids" in fetched
-    assert "attention_mask" in fetched
-    assert isinstance(fetched["input_ids"], torch.Tensor)
-    assert isinstance(fetched["attention_mask"], torch.Tensor)
-
-
-@pytest.mark.unit
-def test_update_intermediates(sample_cache):
-    new_outputs = {
-        "hidden_states": torch.randn(2, 4, 768),
-        "logits": torch.randn(2, 4, 1000),
-    }
-
-    sample_cache.update(0, new_outputs)
-
-    # Verify the updates were stored
-    assert "hidden_states" in sample_cache.batch_intermediates[0]
-    assert "logits" in sample_cache.batch_intermediates[0]
+def test_new_contains():
+    """Test __contains__ works correctly."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    tensor = torch.randn(2, 3)
+    key = "test_key"
+    assert key not in cache
+    cache.update(key, tensor)
+    assert key in cache
 
 
 @pytest.mark.unit
-def test_delete_intermediates(sample_cache):
-    # First add some intermediates
-    new_outputs = {
-        "hidden_states": torch.randn(2, 4, 768),
-        "logits": torch.randn(2, 4, 1000),
-    }
-    sample_cache.update(0, new_outputs)
+def test_new_iter_prefetch():
+    """Test iter_prefetch with explicit key list."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    keys = ["a", "b", "c"]
+    tensors = [torch.randn(2, 3) for _ in keys]
 
-    # Then delete them
-    sample_cache.delete(0, ["hidden_states"])
+    for k, t in zip(keys, tensors):
+        cache.update(k, t)
 
-    assert "hidden_states" not in sample_cache.batch_intermediates[0]
-    assert "logits" in sample_cache.batch_intermediates[0]
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize("value", values_to_test)
-def test_from_dataloader(value):
-    dataset = StackDataset(value=[value])
-    dataloader = DataLoader(dataset, batch_size=1, collate_fn=lambda x: x[0])
-    cache = IntermediatesCache.from_dataloader(dataloader)
-
-    onloaded = cache.fetch(0, ["value"])["value"]
-    assert deep_equal(onloaded, value)
+    prefetched = list(cache.iter_prefetch(keys))
+    assert len(prefetched) == 3
+    for original, prefetched_tensor in zip(tensors, prefetched):
+        assert torch.equal(original, prefetched_tensor)
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("value", values_to_test)
-def test_offload_and_onload(value):
+def test_iter_prefetch_grouped():
+    """Test iter_prefetch_grouped with (batch_idx, name) keys."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+
+    for batch_idx in range(3):
+        cache.update((batch_idx, "input_ids"), torch.tensor([batch_idx]))
+        cache.update((batch_idx, "attention_mask"), torch.tensor([1]))
+
+    keys = list(cache._store.keys())
+    groups = list(cache.iter_prefetch_grouped(keys, group_by=lambda k: k[0]))
+
+    assert len(groups) == 3
+    for i, group_dict in enumerate(groups):
+        assert (i, "input_ids") in group_dict
+        assert (i, "attention_mask") in group_dict
+        assert group_dict[(i, "input_ids")].item() == i
+
+
+@pytest.mark.unit
+def test_iter_prefetch_grouped_awq_keys():
+    """Test iter_prefetch_grouped with AWQ (module, batch_idx, arg_name) keys."""
+    from torch.nn import Linear
+
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    module1 = Linear(10, 10)
+    module2 = Linear(10, 10)
+
+    for batch_idx in range(2):
+        cache.update((module1, batch_idx, "hidden"), torch.tensor([batch_idx]))
+        cache.update((module2, batch_idx, "hidden"), torch.tensor([batch_idx + 10]))
+
+    keys = list(cache._store.keys())
+    groups = list(cache.iter_prefetch_grouped(keys, group_by=lambda k: (k[0], k[1])))
+
+    assert len(groups) == 4  # 2 modules x 2 batches
+    for group_dict in groups:
+        assert len(group_dict) == 1
+        key = next(iter(group_dict.keys()))
+        assert key[2] == "hidden"
+
+
+@pytest.mark.unit
+def test_iter_prefetch_grouped_empty():
+    """Test iter_prefetch_grouped with empty keys."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    groups = list(cache.iter_prefetch_grouped([], group_by=lambda k: k))
+    assert len(groups) == 0
+
+
+@pytest.mark.unit
+def test_new_iter():
+    """Test __iter__ yields all tensors."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    keys = ["a", "b", "c"]
+    for k in keys:
+        cache.update(k, torch.randn(2, 3))
+
+    iterated = list(cache)
+    assert len(iterated) == 3
+
+
+@pytest.mark.unit
+def test_new_clear():
+    """Test clear empties cache."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    cache.update("key", torch.randn(2, 3))
+    cache.clear()
+    assert len(cache) == 0
+    assert "key" not in cache
+
+
+@pytest.mark.unit
+def test_offload_and_onload():
+    """Test _offload_value and _onload_value preserve tensor values."""
+    value = torch.randn(2, 3)
     offloaded = IntermediatesCache._offload_value(value, torch.device("cpu"))
     onloaded = IntermediatesCache._onload_value(offloaded)
-    assert deep_equal(onloaded, value)
-
-
-@pytest.mark.unit
-def test_device_handling(sample_dataloader):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-
-    cuda_device = torch.device("cuda")
-    cpu_device = torch.device("cpu")
-
-    # Create a cache with GPU as model device and CPU as offload device
-    cache = IntermediatesCache.from_dataloader(
-        dataloader=sample_dataloader,
-        model_device=cuda_device,
-        offload_device=cpu_device,
-    )
-
-    # Add some GPU tensors
-    new_outputs = {"hidden_states": torch.randn(2, 3).to(cuda_device)}
-    cache.update(0, new_outputs)
-
-    # Verify tensors are offloaded to CPU
-    assert cache.batch_intermediates[0]["hidden_states"].value.device.type == "cpu"
-
-    # Verify tensors are loaded back to GPU when fetched
-    fetched = cache.fetch(0, ["hidden_states"])
-    assert fetched["hidden_states"].device.type == "cuda"
+    assert torch.equal(onloaded, value)
 
 
 def deep_equal(a, b) -> bool:
@@ -200,3 +189,32 @@ def test_override_eq_mode():
     with OverrideEqMode():
         assert a == b
         assert not (a == c)
+
+
+@pytest.mark.integration
+def test_awq_cache_flow():
+    """Test IntermediatesCache works for AWQ parent args flow."""
+    from torch.nn import Module, Linear
+    import torch
+
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+
+    # Simulate AWQ parent args cache behavior
+    module = Linear(10, 10)
+    batch_idx = 0
+
+    # Store args
+    hidden_states = torch.randn(2, 10)
+    attention_mask = torch.randn(2, 10)
+
+    cache.update((module, batch_idx, "hidden_states"), hidden_states)
+    cache.update((module, batch_idx, "attention_mask"), attention_mask)
+
+    # Fetch args for forward pass
+    fetched_kwargs = {
+        "hidden_states": cache.fetch((module, batch_idx, "hidden_states")),
+        "attention_mask": cache.fetch((module, batch_idx, "attention_mask")),
+    }
+
+    assert torch.equal(hidden_states, fetched_kwargs["hidden_states"])
+    assert torch.equal(attention_mask, fetched_kwargs["attention_mask"])

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass, fields, is_dataclass
 import threading
 import time
+from dataclasses import fields, is_dataclass
 from unittest.mock import patch
 
 import pytest
@@ -121,112 +121,115 @@ def test_iter_prefetch_with_prefix():
 def test_iter_prefetch_runs_in_separate_thread():
     """Test that iter_prefetch runs onload in a background thread."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
-    
+
     # Store several items
     for i in range(5):
         cache.update(i, torch.randn(10, 10))
-    
+
     main_thread_id = threading.current_thread().ident
     onload_thread_ids = []
-    
+
     original_onload = IntermediatesCache._onload_value
-    
+
     def tracking_onload(cls, value):
         onload_thread_ids.append(threading.current_thread().ident)
         return original_onload(value)
-    
-    with patch.object(IntermediatesCache, '_onload_value', tracking_onload):
+
+    with patch.object(IntermediatesCache, "_onload_value", tracking_onload):
         keys = list(range(5))
         results = list(cache.iter_prefetch(keys))
-        
+
         # Verify all values fetched correctly
         assert len(results) == 5
-        
+
         # Verify that onload happened in different threads (ThreadPoolExecutor)
         unique_threads = set(onload_thread_ids)
         assert len(unique_threads) == 2, (
-            f"Expected onload to run in main and background threads, but all ran in thread {unique_threads}"
+            f"Expected onload to run in main and background threads, "
+            f"but all ran in thread {unique_threads}"
         )
-        
-        # The first onload may be in main thread, but subsequent ones should be prefetched
-        # in background thread
-        assert main_thread_id in onload_thread_ids, "First item should load in main thread"
-        assert any(tid != main_thread_id for tid in onload_thread_ids), (
-            "Some items should be prefetched in background thread"
-        )
+
+        # The first onload may be in main thread, but subsequent ones should be
+        # prefetched in background thread
+        assert (
+            main_thread_id in onload_thread_ids
+        ), "First item should load in main thread"
+        assert any(
+            tid != main_thread_id for tid in onload_thread_ids
+        ), "Some items should be prefetched in background thread"
 
 
 @pytest.mark.unit
 def test_iter_prefetch_overlaps_onload_operations():
     """Test that iter_prefetch overlaps onload with processing, reducing total time.
-    
+
     Simulates realistic scenario:
     - onload: time to transfer data (e.g., H2D transfer)
     - processing: time to use data in main thread (e.g., forward pass)
-    
+
     With prefetch: while main thread processes item N, background thread loads item N+1.
-    
+
     Using large delays (50ms) to make threading overhead negligible, so we can
     measure actual speedup from overlap.
     """
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
-    
+
     num_items = 10
     onload_delay = 0.05  # 50ms - simulate data transfer
     processing_delay = 0.05  # 50ms - simulate forward pass
-    
+
     # Store items
     for i in range(num_items):
         cache.update(i, torch.randn(10, 10))
-    
+
     onload_thread_ids = []
-    
+
     original_onload = IntermediatesCache._onload_value
-    
+
     def delayed_onload(cls, value):
         onload_thread_ids.append(threading.current_thread().ident)
         time.sleep(onload_delay)  # Simulate H2D transfer time
         return original_onload(value)
-    
+
     def simulate_processing(data):
         time.sleep(processing_delay)  # Simulate forward pass time
         return data
-    
+
     # Test 1: Sequential (no prefetch)
-    with patch.object(IntermediatesCache, '_onload_value', delayed_onload):
+    with patch.object(IntermediatesCache, "_onload_value", delayed_onload):
         onload_thread_ids.clear()
         start_sequential = time.time()
         for item in cache.iter(list(range(num_items))):
-            processed = simulate_processing(item)
+            simulate_processing(item)
         sequential_time = time.time() - start_sequential
-    
+
     # Test 2: Prefetch (overlap)
-    with patch.object(IntermediatesCache, '_onload_value', delayed_onload):
+    with patch.object(IntermediatesCache, "_onload_value", delayed_onload):
         onload_thread_ids.clear()
         start_prefetch = time.time()
         for item in cache.iter_prefetch(list(range(num_items))):
-            processed = simulate_processing(item)
+            simulate_processing(item)
         prefetch_time = time.time() - start_prefetch
         prefetch_threads = set(onload_thread_ids)
-    
+
     # Verify: onload calls happened in multiple threads (background prefetch works)
-    assert len(prefetch_threads) > 1, (
-        f"Expected multiple threads for prefetch, got threads: {prefetch_threads}"
-    )
-    
+    assert (
+        len(prefetch_threads) > 1
+    ), f"Expected multiple threads for prefetch, got threads: {prefetch_threads}"
+
     # Verify timing:
     # Sequential: num_items * (onload + processing) = 10 * (0.05 + 0.05) = 1.0s
     expected_sequential = num_items * (onload_delay + processing_delay)
-    assert sequential_time >= expected_sequential * 0.85, (
-        f"Sequential time {sequential_time:.3f}s should be ~{expected_sequential:.3f}s"
-    )
-    
+    assert (
+        sequential_time >= expected_sequential * 0.85
+    ), f"Sequential time {sequential_time:.3f}s should be ~{expected_sequential:.3f}s"
+
     # Prefetch with perfect overlap:
     # - First onload (0.05s) + first processing starts
     # - While processing N, onload N+1 happens in background
     # - Total ≈ onload_delay + num_items * max(onload, processing) + small overhead
     # When onload == processing: ≈ (num_items + 1) * delay = 0.55s (vs 1.0s sequential)
-    # Expected speedup: ~1.8x    
+    # Expected speedup: ~1.8x
     # Prefetch should be at least 70% faster than sequential (speedup >= 1.7x)
     # With large delays, threading overhead becomes negligible
     speedup = sequential_time / prefetch_time

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -36,6 +36,7 @@ def test_update_accepts_any_value():
     cache.update("key", "not a tensor")  # Should not raise
     assert cache["key"] == "not a tensor"
 
+
 @pytest.mark.unit
 def test_append():
     """Test append adds to existing list."""
@@ -44,6 +45,19 @@ def test_append():
     cache.append("key", [3, 4])
     assert cache[("key", 0)] == [1, 2]
     assert cache[("key", 1)] == [3, 4]
+
+
+@pytest.mark.unit
+def test_append_no_prefix():
+    """Test append with no key_prefix uses pure integer keys."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    key0, idx0 = cache.append(None, "aaa")
+    key1, idx1 = cache.append(None, "bbb")
+    assert key0 == 0 and idx0 == 0
+    assert key1 == 1 and idx1 == 1
+    assert cache[0] == "aaa"
+    assert cache[1] == "bbb"
+
 
 @pytest.mark.unit
 def test_delete():

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -17,7 +17,7 @@ def test_fetch_update_roundtrip():
     key = "test_key"
 
     cache.update(key, tensor)
-    fetched = cache.fetch(key)
+    fetched = cache[key]
     assert torch.equal(fetched, tensor)
 
 
@@ -26,7 +26,7 @@ def test_fetch_key_not_found():
     """Test KeyError raised when key not found."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     with pytest.raises(KeyError):
-        cache.fetch("nonexistent")
+        _ = cache["nonexistent"]
 
 
 @pytest.mark.unit
@@ -34,16 +34,16 @@ def test_update_accepts_any_value():
     """Test update accepts non-tensor values."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     cache.update("key", "not a tensor")  # Should not raise
-    assert cache.fetch("key") == "not a tensor"
+    assert cache["key"] == "not a tensor"
 
 @pytest.mark.unit
 def test_append():
     """Test append adds to existing list."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
-    cache.append(("key", None), [1, 2])
-    cache.append(("key", None), [3, 4])
-    assert cache.fetch(("key", 0)) == [1, 2]
-    assert cache.fetch(("key", 1)) == [3, 4]
+    cache.append("key", [1, 2])
+    cache.append("key", [3, 4])
+    assert cache[("key", 0)] == [1, 2]
+    assert cache[("key", 1)] == [3, 4]
 
 @pytest.mark.unit
 def test_delete():
@@ -83,20 +83,20 @@ def test_iter_prefetch():
 
 
 @pytest.mark.unit
-def test_iter_prefetch_with_wildcard():
-    """Test iter_prefetch with wildcard pattern."""
+def test_iter_prefetch_with_prefix():
+    """Test iter_prefetch with prefix pattern."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
 
-    # Store batch dicts like sequential pipeline
+    # Store batch dicts like sequential pipeline with module prefix
     for batch_idx in range(3):
         batch_dict = {
             "input_ids": torch.tensor([batch_idx]),
             "attention_mask": torch.tensor([1]),
         }
-        cache.update((batch_idx,), batch_dict)
+        cache.update(("module", batch_idx), batch_dict)
 
-    # Use wildcard pattern (None,) to match all batches
-    batches = list(cache.iter_prefetch([(None,)]))
+    # Use prefix "module" to match all (module, 0), (module, 1), etc.
+    batches = list(cache.iter_prefetch(["module"]))
     assert len(batches) == 3
     for i, batch in enumerate(batches):
         assert "input_ids" in batch

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass, fields, is_dataclass
+import threading
+import time
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -7,7 +10,7 @@ from llmcompressor.pipelines.cache import IntermediatesCache, OverrideEqMode
 
 
 @pytest.mark.unit
-def test_new_fetch_update_roundtrip():
+def test_fetch_update_roundtrip():
     """Test basic fetch/update roundtrip with flat key-value."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     tensor = torch.randn(2, 3)
@@ -19,7 +22,7 @@ def test_new_fetch_update_roundtrip():
 
 
 @pytest.mark.unit
-def test_new_fetch_key_not_found():
+def test_fetch_key_not_found():
     """Test KeyError raised when key not found."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     with pytest.raises(KeyError):
@@ -27,15 +30,23 @@ def test_new_fetch_key_not_found():
 
 
 @pytest.mark.unit
-def test_new_update_accepts_any_value():
+def test_update_accepts_any_value():
     """Test update accepts non-tensor values."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     cache.update("key", "not a tensor")  # Should not raise
     assert cache.fetch("key") == "not a tensor"
 
+@pytest.mark.unit
+def test_append():
+    """Test append adds to existing list."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    cache.append(("key", None), [1, 2])
+    cache.append(("key", None), [3, 4])
+    assert cache.fetch(("key", 0)) == [1, 2]
+    assert cache.fetch(("key", 1)) == [3, 4]
 
 @pytest.mark.unit
-def test_new_delete():
+def test_delete():
     """Test delete removes entry."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     cache.update("key", torch.randn(2, 3))
@@ -45,7 +56,7 @@ def test_new_delete():
 
 
 @pytest.mark.unit
-def test_new_contains():
+def test_contains():
     """Test __contains__ works correctly."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     tensor = torch.randn(2, 3)
@@ -56,7 +67,7 @@ def test_new_contains():
 
 
 @pytest.mark.unit
-def test_new_iter_prefetch():
+def test_iter_prefetch():
     """Test iter_prefetch with explicit key list."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     keys = ["a", "b", "c"]
@@ -72,57 +83,148 @@ def test_new_iter_prefetch():
 
 
 @pytest.mark.unit
-def test_iter_prefetch_grouped():
-    """Test iter_prefetch_grouped with (batch_idx, name) keys."""
+def test_iter_prefetch_with_wildcard():
+    """Test iter_prefetch with wildcard pattern."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
 
+    # Store batch dicts like sequential pipeline
     for batch_idx in range(3):
-        cache.update((batch_idx, "input_ids"), torch.tensor([batch_idx]))
-        cache.update((batch_idx, "attention_mask"), torch.tensor([1]))
+        batch_dict = {
+            "input_ids": torch.tensor([batch_idx]),
+            "attention_mask": torch.tensor([1]),
+        }
+        cache.update((batch_idx,), batch_dict)
 
-    keys = list(cache._store.keys())
-    groups = list(cache.iter_prefetch_grouped(keys, group_by=lambda k: k[0]))
-
-    assert len(groups) == 3
-    for i, group_dict in enumerate(groups):
-        assert (i, "input_ids") in group_dict
-        assert (i, "attention_mask") in group_dict
-        assert group_dict[(i, "input_ids")].item() == i
+    # Use wildcard pattern (None,) to match all batches
+    batches = list(cache.iter_prefetch([(None,)]))
+    assert len(batches) == 3
+    for i, batch in enumerate(batches):
+        assert "input_ids" in batch
+        assert batch["input_ids"].item() == i
 
 
 @pytest.mark.unit
-def test_iter_prefetch_grouped_awq_keys():
-    """Test iter_prefetch_grouped with AWQ (module, batch_idx, arg_name) keys."""
-    from torch.nn import Linear
-
+def test_iter_prefetch_runs_in_separate_thread():
+    """Test that iter_prefetch runs onload in a background thread."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
-    module1 = Linear(10, 10)
-    module2 = Linear(10, 10)
-
-    for batch_idx in range(2):
-        cache.update((module1, batch_idx, "hidden"), torch.tensor([batch_idx]))
-        cache.update((module2, batch_idx, "hidden"), torch.tensor([batch_idx + 10]))
-
-    keys = list(cache._store.keys())
-    groups = list(cache.iter_prefetch_grouped(keys, group_by=lambda k: (k[0], k[1])))
-
-    assert len(groups) == 4  # 2 modules x 2 batches
-    for group_dict in groups:
-        assert len(group_dict) == 1
-        key = next(iter(group_dict.keys()))
-        assert key[2] == "hidden"
+    
+    # Store several items
+    for i in range(5):
+        cache.update(i, torch.randn(10, 10))
+    
+    main_thread_id = threading.current_thread().ident
+    onload_thread_ids = []
+    
+    original_onload = IntermediatesCache._onload_value
+    
+    def tracking_onload(cls, value):
+        onload_thread_ids.append(threading.current_thread().ident)
+        return original_onload(value)
+    
+    with patch.object(IntermediatesCache, '_onload_value', tracking_onload):
+        keys = list(range(5))
+        results = list(cache.iter_prefetch(keys))
+        
+        # Verify all values fetched correctly
+        assert len(results) == 5
+        
+        # Verify that onload happened in different threads (ThreadPoolExecutor)
+        unique_threads = set(onload_thread_ids)
+        assert len(unique_threads) == 2, (
+            f"Expected onload to run in main and background threads, but all ran in thread {unique_threads}"
+        )
+        
+        # The first onload may be in main thread, but subsequent ones should be prefetched
+        # in background thread
+        assert main_thread_id in onload_thread_ids, "First item should load in main thread"
+        assert any(tid != main_thread_id for tid in onload_thread_ids), (
+            "Some items should be prefetched in background thread"
+        )
 
 
 @pytest.mark.unit
-def test_iter_prefetch_grouped_empty():
-    """Test iter_prefetch_grouped with empty keys."""
+def test_iter_prefetch_overlaps_onload_operations():
+    """Test that iter_prefetch overlaps onload with processing, reducing total time.
+    
+    Simulates realistic scenario:
+    - onload: time to transfer data (e.g., H2D transfer)
+    - processing: time to use data in main thread (e.g., forward pass)
+    
+    With prefetch: while main thread processes item N, background thread loads item N+1.
+    
+    Using large delays (50ms) to make threading overhead negligible, so we can
+    measure actual speedup from overlap.
+    """
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
-    groups = list(cache.iter_prefetch_grouped([], group_by=lambda k: k))
-    assert len(groups) == 0
+    
+    num_items = 10
+    onload_delay = 0.05  # 50ms - simulate data transfer
+    processing_delay = 0.05  # 50ms - simulate forward pass
+    
+    # Store items
+    for i in range(num_items):
+        cache.update(i, torch.randn(10, 10))
+    
+    onload_thread_ids = []
+    
+    original_onload = IntermediatesCache._onload_value
+    
+    def delayed_onload(cls, value):
+        onload_thread_ids.append(threading.current_thread().ident)
+        time.sleep(onload_delay)  # Simulate H2D transfer time
+        return original_onload(value)
+    
+    def simulate_processing(data):
+        time.sleep(processing_delay)  # Simulate forward pass time
+        return data
+    
+    # Test 1: Sequential (no prefetch)
+    with patch.object(IntermediatesCache, '_onload_value', delayed_onload):
+        onload_thread_ids.clear()
+        start_sequential = time.time()
+        for item in cache.iter(list(range(num_items))):
+            processed = simulate_processing(item)
+        sequential_time = time.time() - start_sequential
+    
+    # Test 2: Prefetch (overlap)
+    with patch.object(IntermediatesCache, '_onload_value', delayed_onload):
+        onload_thread_ids.clear()
+        start_prefetch = time.time()
+        for item in cache.iter_prefetch(list(range(num_items))):
+            processed = simulate_processing(item)
+        prefetch_time = time.time() - start_prefetch
+        prefetch_threads = set(onload_thread_ids)
+    
+    # Verify: onload calls happened in multiple threads (background prefetch works)
+    assert len(prefetch_threads) > 1, (
+        f"Expected multiple threads for prefetch, got threads: {prefetch_threads}"
+    )
+    
+    # Verify timing:
+    # Sequential: num_items * (onload + processing) = 10 * (0.05 + 0.05) = 1.0s
+    expected_sequential = num_items * (onload_delay + processing_delay)
+    assert sequential_time >= expected_sequential * 0.85, (
+        f"Sequential time {sequential_time:.3f}s should be ~{expected_sequential:.3f}s"
+    )
+    
+    # Prefetch with perfect overlap:
+    # - First onload (0.05s) + first processing starts
+    # - While processing N, onload N+1 happens in background
+    # - Total ≈ onload_delay + num_items * max(onload, processing) + small overhead
+    # When onload == processing: ≈ (num_items + 1) * delay = 0.55s (vs 1.0s sequential)
+    # Expected speedup: ~1.8x    
+    # Prefetch should be at least 70% faster than sequential (speedup >= 1.7x)
+    # With large delays, threading overhead becomes negligible
+    speedup = sequential_time / prefetch_time
+    assert speedup >= 1.7, (
+        f"Prefetch should provide significant speedup. "
+        f"Sequential: {sequential_time:.3f}s, Prefetch: {prefetch_time:.3f}s, "
+        f"Speedup: {speedup:.2f}x (expected >= 1.7x)"
+    )
 
 
 @pytest.mark.unit
-def test_new_iter():
+def test_iter():
     """Test __iter__ yields all tensors."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     keys = ["a", "b", "c"]
@@ -134,7 +236,7 @@ def test_new_iter():
 
 
 @pytest.mark.unit
-def test_new_clear():
+def test_clear():
     """Test clear empties cache."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     cache.update("key", torch.randn(2, 3))
@@ -189,32 +291,3 @@ def test_override_eq_mode():
     with OverrideEqMode():
         assert a == b
         assert not (a == c)
-
-
-@pytest.mark.integration
-def test_awq_cache_flow():
-    """Test IntermediatesCache works for AWQ parent args flow."""
-    from torch.nn import Module, Linear
-    import torch
-
-    cache = IntermediatesCache(offload_device=torch.device("cpu"))
-
-    # Simulate AWQ parent args cache behavior
-    module = Linear(10, 10)
-    batch_idx = 0
-
-    # Store args
-    hidden_states = torch.randn(2, 10)
-    attention_mask = torch.randn(2, 10)
-
-    cache.update((module, batch_idx, "hidden_states"), hidden_states)
-    cache.update((module, batch_idx, "attention_mask"), attention_mask)
-
-    # Fetch args for forward pass
-    fetched_kwargs = {
-        "hidden_states": cache.fetch((module, batch_idx, "hidden_states")),
-        "attention_mask": cache.fetch((module, batch_idx, "attention_mask")),
-    }
-
-    assert torch.equal(hidden_states, fetched_kwargs["hidden_states"])
-    assert torch.equal(attention_mask, fetched_kwargs["attention_mask"])

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -255,7 +255,8 @@ def deep_equal(a, b) -> bool:
 
 @pytest.mark.unit
 def test_fetch_no_onload_returns_unwrapped_value_on_offload_device():
-    """Test fetch_no_onload returns value without IntermediateValue wrappers on offload device."""
+    """Test fetch_no_onload returns value without IntermediateValue
+    wrappers on offload device."""
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
     tensor = torch.randn(2, 3)
     cache.update("key", tensor)

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -295,6 +295,107 @@ def deep_equal(a, b) -> bool:
             return a == b
 
 
+@pytest.mark.unit
+def test_fetch_no_onload_returns_unwrapped_value_on_offload_device():
+    """Test fetch_no_onload returns value without IntermediateValue wrappers on offload device."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    tensor = torch.randn(2, 3)
+    cache.update("key", tensor)
+
+    fetched = cache.fetch_no_onload("key")
+    assert isinstance(fetched, torch.Tensor)
+    assert torch.equal(fetched, tensor)
+    assert fetched.device.type == "cpu"
+
+
+@pytest.mark.unit
+def test_fetch_no_onload_nested_structure():
+    """Test fetch_no_onload unwraps IntermediateValue in nested dicts."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    value = {
+        "a": torch.randn(2, 3),
+        "b": torch.randn(4, 5),
+        "c": "string_value",
+    }
+    cache.update("batch", value)
+
+    fetched = cache.fetch_no_onload("batch")
+    assert isinstance(fetched, dict)
+    assert set(fetched.keys()) == {"a", "b", "c"}
+    assert torch.equal(fetched["a"], value["a"])
+    assert torch.equal(fetched["b"], value["b"])
+    assert fetched["c"] == "string_value"
+    assert fetched["a"].device.type == "cpu"
+    assert fetched["b"].device.type == "cpu"
+
+
+@pytest.mark.unit
+def test_fetch_no_onload_vs_regular_fetch():
+    """Test fetch_no_onload differs from regular fetch by not onloading."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    tensor = torch.randn(2, 3)
+    cache.update("key", tensor)
+
+    no_onload = cache.fetch_no_onload("key")
+    onloaded = cache["key"]
+
+    assert torch.equal(no_onload, onloaded)
+    assert no_onload.device.type == "cpu"
+
+
+@pytest.mark.unit
+def test_prefix_counters_and_indices():
+    """Test _prefix_counters and _prefix_indices are maintained correctly."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+
+    # update with integer keys
+    cache.update(0, "a")
+    cache.update(2, "b")
+    cache.update(5, "c")
+    assert cache._prefix_counters[()] == 6
+    assert sorted(cache._prefix_indices[()]) == [0, 2, 5]
+
+    # append uses the counter to generate next index
+    _, idx = cache.append(None, "d")
+    assert idx == 6
+    assert cache._prefix_counters[()] == 7
+
+    # append with tuple prefix
+    _, idx0 = cache.append("layer", "x")
+    _, idx1 = cache.append("layer", "y")
+    assert idx0 == 0 and idx1 == 1
+    assert cache._prefix_counters[("layer",)] == 2
+    assert cache._prefix_indices[("layer",)] == [0, 1]
+
+    # delete removes from both structures
+    cache.delete(2)
+    assert 2 not in cache
+    assert sorted(cache._prefix_indices[()]) == [0, 5, 6]
+    assert cache._prefix_counters[()] == 7
+
+    # delete max index should decrement counter
+    cache.delete(("layer", 1))
+    assert cache._prefix_counters[("layer",)] == 1
+
+    # iter_keys uses prefix_indices for fast sorted lookup
+    cache.update(("module", 3), "a")
+    cache.update(("module", 1), "b")
+    keys = cache.iter_keys("module")
+    assert keys == [("module", 1), ("module", 3)]
+
+    # multiple prefixes tracked independently
+    assert cache._prefix_counters[()] == 7
+    assert cache._prefix_counters[("layer",)] == 1
+
+
+@pytest.mark.unit
+def test_delete_nonexistent_key_no_error():
+    """Test deleting a key that doesn't exist does not raise."""
+    cache = IntermediatesCache(offload_device=torch.device("cpu"))
+    cache.delete("nonexistent")
+    assert len(cache) == 0
+
+
 def test_override_eq_mode():
     a = torch.tensor([1, 2, 3])
     b = a

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -161,82 +161,40 @@ def test_iter_prefetch_runs_in_separate_thread():
 
 @pytest.mark.unit
 def test_iter_prefetch_overlaps_onload_operations():
-    """Test that iter_prefetch overlaps onload with processing, reducing total time.
+    """Test that iter_prefetch overlaps onload with processing (background prefetch).
 
-    Simulates realistic scenario:
-    - onload: time to transfer data (e.g., H2D transfer)
-    - processing: time to use data in main thread (e.g., forward pass)
-
-    With prefetch: while main thread processes item N, background thread loads item N+1.
-
-    Using large delays (50ms) to make threading overhead negligible, so we can
-    measure actual speedup from overlap.
+    Uses synchronization primitives to deterministically detect concurrent execution:
+    if a background thread runs onload while the main thread is processing,
+    overlap is proven without relying on wall-clock timing.
     """
     cache = IntermediatesCache(offload_device=torch.device("cpu"))
 
-    num_items = 10
-    onload_delay = 0.05  # 50ms - simulate data transfer
-    processing_delay = 0.05  # 50ms - simulate forward pass
-
-    # Store items
+    num_items = 5
     for i in range(num_items):
         cache.update(i, torch.randn(10, 10))
 
-    onload_thread_ids = []
+    processing_active = threading.Event()
+    overlap_detected = threading.Event()
 
     original_onload = IntermediatesCache._onload_value
 
-    def delayed_onload(cls, value):
-        onload_thread_ids.append(threading.current_thread().ident)
-        time.sleep(onload_delay)  # Simulate H2D transfer time
+    def instrumented_onload(cls, value):
+        if (
+            processing_active.is_set()
+            and threading.current_thread() is not threading.main_thread()
+        ):
+            overlap_detected.set()
         return original_onload(value)
 
-    def simulate_processing(data):
-        time.sleep(processing_delay)  # Simulate forward pass time
-        return data
-
-    # Test 1: Sequential (no prefetch)
-    with patch.object(IntermediatesCache, "_onload_value", delayed_onload):
-        onload_thread_ids.clear()
-        start_sequential = time.time()
-        for item in cache.iter(list(range(num_items))):
-            simulate_processing(item)
-        sequential_time = time.time() - start_sequential
-
-    # Test 2: Prefetch (overlap)
-    with patch.object(IntermediatesCache, "_onload_value", delayed_onload):
-        onload_thread_ids.clear()
-        start_prefetch = time.time()
+    with patch.object(IntermediatesCache, "_onload_value", instrumented_onload):
         for item in cache.iter_prefetch(list(range(num_items))):
-            simulate_processing(item)
-        prefetch_time = time.time() - start_prefetch
-        prefetch_threads = set(onload_thread_ids)
+            processing_active.set()
+            time.sleep(0.02)
+            processing_active.clear()
 
-    # Verify: onload calls happened in multiple threads (background prefetch works)
-    assert (
-        len(prefetch_threads) > 1
-    ), f"Expected multiple threads for prefetch, got threads: {prefetch_threads}"
-
-    # Verify timing:
-    # Sequential: num_items * (onload + processing) = 10 * (0.05 + 0.05) = 1.0s
-    expected_sequential = num_items * (onload_delay + processing_delay)
-    assert (
-        sequential_time >= expected_sequential * 0.85
-    ), f"Sequential time {sequential_time:.3f}s should be ~{expected_sequential:.3f}s"
-
-    # Prefetch with perfect overlap:
-    # - First onload (0.05s) + first processing starts
-    # - While processing N, onload N+1 happens in background
-    # - Total ≈ onload_delay + num_items * max(onload, processing) + small overhead
-    # When onload == processing: ≈ (num_items + 1) * delay = 0.55s (vs 1.0s sequential)
-    # Expected speedup: ~1.8x
-    # Prefetch should be at least 70% faster than sequential (speedup >= 1.7x)
-    # With large delays, threading overhead becomes negligible
-    speedup = sequential_time / prefetch_time
-    assert speedup >= 1.7, (
-        f"Prefetch should provide significant speedup. "
-        f"Sequential: {sequential_time:.3f}s, Prefetch: {prefetch_time:.3f}s, "
-        f"Speedup: {speedup:.2f}x (expected >= 1.7x)"
+    assert overlap_detected.is_set(), (
+        "iter_prefetch should overlap background onload with main-thread processing, "
+        "but no concurrent execution was detected"
     )
 
 

--- a/tests/llmcompressor/pipelines/test_cache.py
+++ b/tests/llmcompressor/pipelines/test_cache.py
@@ -323,7 +323,7 @@ def test_prefix_counters_and_indices():
     _, idx1 = cache.append("layer", "y")
     assert idx0 == 0 and idx1 == 1
     assert cache._prefix_counters[("layer",)] == 2
-    assert cache._prefix_indices[("layer",)] == [0, 1]
+    assert cache._prefix_indices[("layer",)] == {0, 1}
 
     # delete removes from both structures
     cache.delete(2)


### PR DESCRIPTION
SUMMARY:
According to the discuss in this issue https://github.com/vllm-project/llm-compressor/issues/2490 and slack thread, the PR refactors IntermediatesCache to use a flat key-value store with generic keys instead of a batch-indexed structure, enabling more flexible caching patterns, and replace the adhoc offloading logic with this IntermediatesCache.

Key changes:
* **Cache refactor**: `IntermediatesCache` changed from a batch-indexed nested structure (`list[dict[str, IntermediateValue]]`) with string keys to a flat generic key-value store (`dict[TKey, Any]`) supporting arbitrary key types. `IntermediateValue` simplified from recursive wrapping of nested containers to only wrapping tensor leaves, using pytree utilities for handling nested structures.
* pipelines/sequential/pipeline.py: Batch data keys changed from implicit list indexing (batch_intermediates[batch_idx]) to explicit integer keys (batch_idx). Loss mask, update, and delete operations now use tuple keys (batch_idx, name) for individual item access instead of batch-level dictionary operations.
* modifiers/awq/base.py: _parent_args_cache replaced dict[Module, IntermediatesCache] (per-module separate caches) with a single IntermediatesCache using composite tuple keys (module, batch_idx, arg_name). Added _parent_args_batch_idx counter per module. _smooth_activation_stats replaced dict[str, list[torch.Tensor]] with IntermediatesCache using string keys.
* modifiers/gptq/base.py: _hessians_cache replaced dict[torch.nn.Module, torch.Tensor] with IntermediatesCache using module keys. Removed _maybe_onload_hessian context manager since offloading is now handled automatically by the cache.
* modifiers/pruning/sparsegpt/base.py and sgpt_sparsify.py: _hessians_cache replaced dict[torch.nn.Module, torch.Tensor] with IntermediatesCache using module keys. sparsify_weight function changed from accepting hessians_dict and manually deleting entries to accepting a single hessian tensor. Removed _maybe_onload_hessian context manager.


|Feature|	Old IntermediatesCache|	New IntermediatesCache|
|-|-|-|
|Storage|	list[dict[str, IntermediateValue]]|	dict[TKey, Any]|
|Type|	Non-generic|	Generic[TKey]|
|Key Type|	str only (nested by batch index)|	Any hashable type (int, tuple, str, etc.)|
|Constructor|	empty(num_batches, offload_device) or __init__(batch_intermediates)|	__init__(offload_device)|
|Fetch|	fetch(batch_index, input_names=None) -> dict|	__getitem__(key) / fetch(key) -> Any|
|Update|	update(batch_index, values: dict)|	update(key, value)|
|Delete|	delete(batch_index, consumed_names=None)|	delete(key)|
|Append|	append(values: dict) (auto batch index)|	append(key_prefix, value) -> (key, index)|
|Clear|	N/A|	clear()|
|Iterate|	iter(input_names=None)/iter_prefetch(input_names=None)|	iter(keys=None) / iter_prefetch(keys=None)|
|Nested handling|	Custom recursive match|	Pytree tree_flatten/tree_unflatten|


TEST PLAN:
make style
make quality
make test passed.

I noticed the local testing didn't fully cover all the changes like GPTQ, sparsegpt, any more tests suggested?