### PR TITLE
[Bugfix] Ignore .pytest_cache directory in test fixture

### DIFF
--- a/tests/llmcompressor/conftest.py
+++ b/tests/llmcompressor/conftest.py
@@ -47,7 +47,7 @@ def _files_size_mb(path_list: List[str]) -> int:
 
 @pytest.fixture(scope="session", autouse=True)
 def check_for_created_files():
-    local_ignore_dirs = ["__pycache__", "sparse_logs", "test-results"]
+    local_ignore_dirs = ["__pycache__", "sparse_logs", "test-results", ".pytest_cache"]
     local_ignore_files = [".coverage"]
     tmp_ignore_dirs = ["pytest-of", "torchinductor"]
     start_files_root = _get_files(


### PR DESCRIPTION
## Summary
- Adds `.pytest_cache` to the ignored directories list in the `check_for_created_files` fixture

## Problem
CI was failing because pytest creates a `.pytest_cache` directory during test runs, and the `check_for_created_files` fixture was flagging these cache files as unexpected file creation.

Error message:
```
AssertionError: 4 files created in current working directory during pytest run. 
Created files: {'.pytest_cache/v/cache/nodeids', '.pytest_cache/README.md', 
'.pytest_cache/.gitignore', '.pytest_cache/CACHEDIR.TAG'}
```

## Solution
Added `.pytest_cache` to the `local_ignore_dirs` list, similar to how `__pycache__` and `sparse_logs` are already ignored.

## Test plan

run just failing test: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/25755134895/job/75641474877

🤖 Generated with [Claude Code](https://claude.com/claude-code)