### PR TITLE
Implement REAP pruning modifier for MoE expert pruning

### DIFF
--- a/examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
+++ b/examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
@@ -1,0 +1,76 @@
+"""
+REAP Expert Pruning: Qwen3-30B-A3B at 25% compression.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=0,1,2,3 uv run python examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
+"""
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+
+# ── Configuration ──────────────────────────────────────────────────────────
+
+MODEL_ID = "/home/eldarkurtic/hf_models/Qwen/Qwen3-30B-A3B-Instruct-2507"
+OUTPUT_DIR = "/home/eldarkurtic/github/eldarkurtic/llm-compressor/output_dir/Qwen3-30B-A3B-Instruct-2507_REAP_sp25"
+COMPRESSION_RATIO = 0.25
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQ_LENGTH = 2048
+DATASET = "open_platypus"
+
+# ── Recipe ─────────────────────────────────────────────────────────────────
+
+RECIPE = """
+pruning_stage:
+  pruning_modifiers:
+    REAPPruningModifier:
+      compression_ratio: 0.25
+"""
+
+# ── Run pruning ────────────────────────────────────────────────────────────
+
+print(f"Model:             {MODEL_ID}")
+print(f"Compression ratio: {COMPRESSION_RATIO}")
+print(f"Output:            {OUTPUT_DIR}")
+print(f"Calibration:       {NUM_CALIBRATION_SAMPLES} samples, {MAX_SEQ_LENGTH} max seq len")
+print()
+
+oneshot(
+    model=MODEL_ID,
+    recipe=RECIPE,
+    dataset=DATASET,
+    output_dir=OUTPUT_DIR,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    max_seq_length=MAX_SEQ_LENGTH,
+)
+
+print(f"\nDone! Pruned model saved to: {OUTPUT_DIR}")
+
+# ── Quick smoke test ───────────────────────────────────────────────────────
+
+print("\nRunning generation smoke test...")
+
+tokenizer = AutoTokenizer.from_pretrained(OUTPUT_DIR)
+model = AutoModelForCausalLM.from_pretrained(
+    OUTPUT_DIR,
+    torch_dtype=torch.bfloat16,
+    device_map="auto",
+)
+model.eval()
+
+prompt = "Write a Python function that checks if a number is prime."
+messages = [{"role": "user", "content": prompt}]
+text = tokenizer.apply_chat_template(
+    messages, tokenize=False, add_generation_prompt=True, enable_thinking=False
+)
+inputs = tokenizer(text, return_tensors="pt").to(model.device)
+
+with torch.no_grad():
+    output_ids = model.generate(**inputs, max_new_tokens=1000, do_sample=False)
+
+new_tokens = output_ids[0][inputs["input_ids"].shape[1] :]
+response = tokenizer.decode(new_tokens, skip_special_tokens=True)
+
+print(f"\nPrompt: {prompt}")
+print(f"Response: {response}")

--- a/examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
+++ b/examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
@@ -1,8 +1,8 @@
 """
-REAP Expert Pruning: Qwen3-30B-A3B at 25% compression.
+REAP Expert Pruning: Qwen3-30B-A3B at 25% sparsity.
 
 Usage:
-    CUDA_VISIBLE_DEVICES=0,1,2,3 uv run python examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
+CUDA_VISIBLE_DEVICES=0,1 python examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
 """
 
 import torch
@@ -10,31 +10,22 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 
-# ── Configuration ──────────────────────────────────────────────────────────
-
-MODEL_ID = "/home/eldarkurtic/hf_models/Qwen/Qwen3-30B-A3B-Instruct-2507"
-OUTPUT_DIR = "/home/eldarkurtic/github/eldarkurtic/llm-compressor/output_dir/Qwen3-30B-A3B-Instruct-2507_REAP_sp25"
-COMPRESSION_RATIO = 0.25
+MDL = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+SPARSITY = 0.25
+BASE_PATH = "/home/eldarkurtic/"
+OUT_PATH = "github/eldarkurtic/llm-compressor/output_dir/"
+MODEL_ID = BASE_PATH + "hf_models/" + MDL
+OUTPUT_DIR = BASE_PATH + OUT_PATH + MDL + "_REAP_sp" + str(int(SPARSITY * 100))
 NUM_CALIBRATION_SAMPLES = 512
 MAX_SEQ_LENGTH = 2048
 DATASET = "open_platypus"
-
-# ── Recipe ─────────────────────────────────────────────────────────────────
 
 RECIPE = """
 pruning_stage:
   pruning_modifiers:
     REAPPruningModifier:
-      compression_ratio: 0.25
-"""
-
-# ── Run pruning ────────────────────────────────────────────────────────────
-
-print(f"Model:             {MODEL_ID}")
-print(f"Compression ratio: {COMPRESSION_RATIO}")
-print(f"Output:            {OUTPUT_DIR}")
-print(f"Calibration:       {NUM_CALIBRATION_SAMPLES} samples, {MAX_SEQ_LENGTH} max seq len")
-print()
+      sparsity: {SPARSITY}
+""".format(SPARSITY=SPARSITY)
 
 oneshot(
     model=MODEL_ID,
@@ -46,9 +37,6 @@ oneshot(
 )
 
 print(f"\nDone! Pruned model saved to: {OUTPUT_DIR}")
-
-# ── Quick smoke test ───────────────────────────────────────────────────────
-
 print("\nRunning generation smoke test...")
 
 tokenizer = AutoTokenizer.from_pretrained(OUTPUT_DIR)

--- a/src/llmcompressor/modifiers/pruning/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/__init__.py
@@ -2,5 +2,6 @@
 
 from .constant import *
 from .magnitude import *
+from .reap import *
 from .wanda import *
 from .sparsegpt import *

--- a/src/llmcompressor/modifiers/pruning/reap/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/reap/__init__.py
@@ -1,0 +1,3 @@
+# ruff: noqa
+
+from .base import REAPPruningModifier

--- a/src/llmcompressor/modifiers/pruning/reap/base.py
+++ b/src/llmcompressor/modifiers/pruning/reap/base.py
@@ -1,0 +1,256 @@
+"""
+REAP (Router-weighted Expert Activation Pruning) modifier for MoE models.
+
+See: https://arxiv.org/abs/2510.13999
+"""
+
+from functools import partial
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from loguru import logger
+from pydantic import Field, PrivateAttr, model_validator
+
+from llmcompressor.core import Event, EventType, State
+from llmcompressor.modifiers import Modifier
+from llmcompressor.modifiers.pruning.reap.utils import (
+    MoEModelAttrs,
+    REAPSaliencyTracker,
+    detect_moe_attrs,
+    find_moe_layers,
+    get_num_experts,
+    prune_moe_layer,
+    update_model_config,
+)
+
+__all__ = ["REAPPruningModifier"]
+
+
+class REAPPruningModifier(Modifier):
+    """
+    Prunes experts from MoE layers using the REAP saliency metric:
+    S_j = mean(g_j * ||f_j||_2), averaged over tokens routed to expert j.
+
+    :param compression_ratio: fraction of experts to remove per layer (0, 1).
+    :param ignore: module name patterns to skip during MoE layer detection.
+
+    Example recipe::
+
+        REAPPruningModifier:
+          compression_ratio: 0.5
+    """
+
+    compression_ratio: float = 0.5
+    ignore: list[str] = Field(default_factory=list)
+
+    _attrs: MoEModelAttrs | None = PrivateAttr(default=None)
+    _moe_layer_names: list[str] = PrivateAttr(default_factory=list)
+    _saliency_trackers: dict[str, REAPSaliencyTracker] = PrivateAttr(
+        default_factory=dict
+    )
+    _top_k: int = PrivateAttr(default=2)
+    _n_experts_to_drop: int = PrivateAttr(default=0)
+    _norm_buffers: dict[str, dict[int, torch.Tensor]] = PrivateAttr(
+        default_factory=dict
+    )
+    _routing_cache: dict = PrivateAttr(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_compression_ratio(self) -> "REAPPruningModifier":
+        if not 0.0 < self.compression_ratio < 1.0:
+            raise ValueError(
+                f"compression_ratio must be in (0, 1), got {self.compression_ratio}"
+            )
+        return self
+
+    def on_initialize(self, state: State, **kwargs) -> bool:
+        model = state.model
+
+        self._attrs = detect_moe_attrs(model)
+        if self._attrs is None:
+            raise ValueError(
+                "Could not detect MoE architecture. Ensure the model is an "
+                "MoE model or specify 'targets' explicitly."
+            )
+
+        moe_layers = find_moe_layers(model, self._attrs, self.ignore)
+        if not moe_layers:
+            raise ValueError("No MoE layers found in model.")
+        self._moe_layer_names = list(moe_layers.keys())
+
+        config = model.config
+        text_config = getattr(config, "text_config", config)
+        self._top_k = getattr(text_config, "num_experts_per_tok", 2)
+
+        sample_module = next(iter(moe_layers.values()))
+        num_experts = get_num_experts(sample_module, self._attrs)
+        self._n_experts_to_drop = int(num_experts * self.compression_ratio)
+
+        if self._n_experts_to_drop == 0:
+            logger.warning(
+                f"compression_ratio={self.compression_ratio} results in 0 "
+                f"experts to drop (out of {num_experts}). No pruning will "
+                "be performed."
+            )
+
+        logger.info(
+            f"REAP initialized: {len(moe_layers)} MoE layers, "
+            f"{num_experts} experts/layer, will drop "
+            f"{self._n_experts_to_drop} ({self.compression_ratio:.0%})"
+        )
+
+        return True
+
+    def on_start(self, state: State, event: Event, **kwargs):
+        self.started_ = True
+        model = state.model
+
+        for layer_name in self._moe_layer_names:
+            module = model.get_submodule(layer_name)
+            num_experts = get_num_experts(module, self._attrs)
+            self._saliency_trackers[layer_name] = REAPSaliencyTracker(num_experts)
+            self._norm_buffers[layer_name] = {}
+
+            if hasattr(module, "calibrate_all_experts"):
+                module.calibrate_all_experts = True
+
+            self.register_hook(
+                module,
+                partial(self._moe_pre_hook, layer_name),
+                "forward_pre",
+            )
+
+            experts = getattr(module, self._attrs.experts_attr)
+            for idx, expert in enumerate(experts.children()):
+                self.register_hook(
+                    expert,
+                    partial(self._expert_hook, layer_name, idx),
+                    "forward",
+                )
+
+            self.register_hook(
+                module,
+                partial(self._moe_post_hook, layer_name),
+                "forward",
+            )
+
+    def on_event(self, state: State, event: Event, **kwargs):
+        if event.type_ == EventType.CALIBRATION_EPOCH_START:
+            if not self.started_:
+                self.on_start(state, None)
+
+        if event.type_ == EventType.CALIBRATION_EPOCH_END:
+            if not self.ended_:
+                self.on_end(state, None)
+
+    def on_end(self, state: State, event: Event, **kwargs):
+        self.ended_ = True
+        self.remove_hooks()
+
+    def on_finalize(self, state: State, **kwargs) -> bool:
+        # Prune in on_finalize (not on_end) so we act on actual modules,
+        # not calibration wrappers that get restored after the context exits.
+        if not self.ended_:
+            self.on_end(state, None)
+
+        if self._n_experts_to_drop == 0:
+            logger.info("REAP: nothing to prune (n_experts_to_drop=0)")
+            return True
+
+        model = state.model
+
+        for layer_name in self._moe_layer_names:
+            tracker = self._saliency_trackers[layer_name]
+            saliency = tracker.mean_saliency
+
+            logger.debug(f"REAP saliency for {layer_name}: {saliency.tolist()}")
+
+            prune_moe_layer(
+                model,
+                layer_name,
+                saliency,
+                self._n_experts_to_drop,
+                self._attrs,
+            )
+
+        sample_module = model.get_submodule(self._moe_layer_names[0])
+        new_num_experts = get_num_experts(sample_module, self._attrs)
+        update_model_config(model, self._attrs, new_num_experts)
+        self._saliency_trackers.clear()
+
+        return True
+
+    def _moe_pre_hook(
+        self, layer_name: str, module: torch.nn.Module, args: tuple
+    ):
+        """Run the router (one Linear layer) and cache routing decisions."""
+        hidden_states = args[0]
+        if hidden_states.dim() == 3:
+            hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+
+        router = getattr(module, self._attrs.router_attr)
+
+        with torch.no_grad():
+            router_output = router(hidden_states)
+            if isinstance(router_output, tuple):
+                router_logits = router_output[-1]
+            else:
+                router_logits = router_output
+
+            routing_weights = F.softmax(
+                router_logits, dim=-1, dtype=torch.float32
+            )
+            _, topk_indices = torch.topk(
+                routing_weights, self._top_k, dim=-1
+            )
+
+        self._routing_cache[layer_name] = {
+            "routing_weights": routing_weights,
+            "topk_indices": topk_indices,
+        }
+
+    def _expert_hook(
+        self,
+        layer_name: str,
+        expert_idx: int,
+        module: torch.nn.Module,
+        args: tuple,
+        output: Any,
+    ):
+        """Buffer output norms from the calibration forward pass."""
+        if isinstance(output, tuple):
+            output = output[0]
+        with torch.no_grad():
+            norms = torch.linalg.norm(output.float(), dim=-1)
+        self._norm_buffers[layer_name][expert_idx] = norms
+
+    def _moe_post_hook(
+        self,
+        layer_name: str,
+        module: torch.nn.Module,
+        args: tuple,
+        output: Any,
+    ):
+        """Combine cached routing decisions with buffered expert norms."""
+        cache = self._routing_cache[layer_name]
+        routing_weights = cache["routing_weights"]
+        topk_indices = cache["topk_indices"]
+        tracker = self._saliency_trackers[layer_name]
+
+        with torch.no_grad():
+            for expert_idx in range(tracker.num_experts):
+                norms = self._norm_buffers[layer_name].get(expert_idx)
+                if norms is None:
+                    continue
+
+                token_mask = (topk_indices == expert_idx).any(dim=-1)
+                if not token_mask.any():
+                    continue
+
+                gate_vals = routing_weights[token_mask, expert_idx]
+                routed_norms = norms[token_mask]
+                tracker.update(expert_idx, gate_vals, routed_norms)
+
+        self._norm_buffers[layer_name].clear()
+        self._routing_cache[layer_name] = None

--- a/src/llmcompressor/modifiers/pruning/reap/base.py
+++ b/src/llmcompressor/modifiers/pruning/reap/base.py
@@ -32,16 +32,16 @@ class REAPPruningModifier(Modifier):
     Prunes experts from MoE layers using the REAP saliency metric:
     S_j = mean(g_j * ||f_j||_2), averaged over tokens routed to expert j.
 
-    :param compression_ratio: fraction of experts to remove per layer (0, 1).
+    :param sparsity: fraction of experts to remove per layer (0, 1).
     :param ignore: module name patterns to skip during MoE layer detection.
 
     Example recipe::
 
         REAPPruningModifier:
-          compression_ratio: 0.5
+          sparsity: 0.5
     """
 
-    compression_ratio: float = 0.5
+    sparsity: float
     ignore: list[str] = Field(default_factory=list)
 
     _attrs: MoEModelAttrs | None = PrivateAttr(default=None)
@@ -57,11 +57,9 @@ class REAPPruningModifier(Modifier):
     _routing_cache: dict = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")
-    def _validate_compression_ratio(self) -> "REAPPruningModifier":
-        if not 0.0 < self.compression_ratio < 1.0:
-            raise ValueError(
-                f"compression_ratio must be in (0, 1), got {self.compression_ratio}"
-            )
+    def _validate_sparsity(self) -> "REAPPruningModifier":
+        if not 0.0 < self.sparsity < 1.0:
+            raise ValueError(f"sparsity must be in (0, 1), got {self.sparsity}")
         return self
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -85,11 +83,11 @@ class REAPPruningModifier(Modifier):
 
         sample_module = next(iter(moe_layers.values()))
         num_experts = get_num_experts(sample_module, self._attrs)
-        self._n_experts_to_drop = int(num_experts * self.compression_ratio)
+        self._n_experts_to_drop = int(num_experts * self.sparsity)
 
         if self._n_experts_to_drop == 0:
             logger.warning(
-                f"compression_ratio={self.compression_ratio} results in 0 "
+                f"sparsity={self.sparsity} results in 0 "
                 f"experts to drop (out of {num_experts}). No pruning will "
                 "be performed."
             )
@@ -97,7 +95,7 @@ class REAPPruningModifier(Modifier):
         logger.info(
             f"REAP initialized: {len(moe_layers)} MoE layers, "
             f"{num_experts} experts/layer, will drop "
-            f"{self._n_experts_to_drop} ({self.compression_ratio:.0%})"
+            f"{self._n_experts_to_drop} ({self.sparsity:.0%})"
         )
 
         return True
@@ -181,9 +179,7 @@ class REAPPruningModifier(Modifier):
 
         return True
 
-    def _moe_pre_hook(
-        self, layer_name: str, module: torch.nn.Module, args: tuple
-    ):
+    def _moe_pre_hook(self, layer_name: str, module: torch.nn.Module, args: tuple):
         """Run the router (one Linear layer) and cache routing decisions."""
         hidden_states = args[0]
         if hidden_states.dim() == 3:
@@ -198,12 +194,8 @@ class REAPPruningModifier(Modifier):
             else:
                 router_logits = router_output
 
-            routing_weights = F.softmax(
-                router_logits, dim=-1, dtype=torch.float32
-            )
-            _, topk_indices = torch.topk(
-                routing_weights, self._top_k, dim=-1
-            )
+            routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float32)
+            _, topk_indices = torch.topk(routing_weights, self._top_k, dim=-1)
 
         self._routing_cache[layer_name] = {
             "routing_weights": routing_weights,

--- a/src/llmcompressor/modifiers/pruning/reap/utils.py
+++ b/src/llmcompressor/modifiers/pruning/reap/utils.py
@@ -54,12 +54,10 @@ MOE_ATTR_REGISTRY: dict[str, MoEModelAttrs] = {
     "Glm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
     "CalibrationGlm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
     # Llama4
-    "Llama4TextMoe": MoEModelAttrs(
-        "router", "experts", "num_local_experts"    ),
+    "Llama4TextMoe": MoEModelAttrs("router", "experts", "num_local_experts"),
     "SequentialLlama4TextMoe": MoEModelAttrs("router", "experts", "num_local_experts"),
     # Gemma4
-    "Gemma4TextExperts": MoEModelAttrs(
-        "router", "experts", "num_experts"    ),
+    "Gemma4TextExperts": MoEModelAttrs("router", "experts", "num_experts"),
     "SequentialGemma4TextExperts": MoEModelAttrs("router", "experts", "num_experts"),
     # AfMoE
     "AfmoeMoE": MoEModelAttrs("router", "experts", "num_experts"),
@@ -189,7 +187,7 @@ def prune_moe_layer(
     drop_set = set(drop_indices.tolist())
     retained = sorted(i for i in range(num_experts) if i not in drop_set)
 
-    logger.info(
+    logger.debug(
         f"Pruning {layer_name}: dropping experts {sorted(drop_set)}, "
         f"retaining {retained} ({len(retained)}/{num_experts})"
     )
@@ -215,13 +213,9 @@ def prune_moe_layer(
 def _prune_router(router: nn.Module, retained: list[int]):
     retained_t = torch.tensor(retained, dtype=torch.long)
 
-    router.weight = nn.Parameter(
-        router.weight.data[retained_t, :], requires_grad=False
-    )
+    router.weight = nn.Parameter(router.weight.data[retained_t, :], requires_grad=False)
     if router.bias is not None:
-        router.bias = nn.Parameter(
-            router.bias.data[retained_t], requires_grad=False
-        )
+        router.bias = nn.Parameter(router.bias.data[retained_t], requires_grad=False)
     router.out_features = len(retained)
 
 

--- a/src/llmcompressor/modifiers/pruning/reap/utils.py
+++ b/src/llmcompressor/modifiers/pruning/reap/utils.py
@@ -1,0 +1,255 @@
+"""
+Utilities for REAP: MoE detection, saliency tracking, and expert pruning.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn as nn
+from loguru import logger
+
+__all__ = [
+    "MoEModelAttrs",
+    "REAPSaliencyTracker",
+    "detect_moe_attrs",
+    "find_moe_layers",
+    "get_num_experts",
+    "prune_moe_layer",
+    "update_model_config",
+]
+
+
+@dataclass
+class MoEModelAttrs:
+    router_attr: str
+    experts_attr: str
+    num_experts_config_key: str
+
+
+MOE_ATTR_REGISTRY: dict[str, MoEModelAttrs] = {
+    # Qwen3 family
+    "Qwen3MoeSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "CalibrationQwen3MoeSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts"
+    ),
+    "Qwen3_5MoeSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "SequentialQwen3_5MoeSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts"
+    ),
+    "Qwen3NextSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "CalibrationQwen3NextSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts"
+    ),
+    "Qwen3VLMoeTextSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "SequentialQwen3VLMoeTextSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts"
+    ),
+    # Mixtral
+    "MixtralSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_local_experts"),
+    # DeepSeek
+    "DeepseekV3MoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
+    "SequentialDeepseekV3MoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
+    # GLM4
+    "Glm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
+    "CalibrationGlm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
+    # Llama4
+    "Llama4TextMoe": MoEModelAttrs(
+        "router", "experts", "num_local_experts"    ),
+    "SequentialLlama4TextMoe": MoEModelAttrs("router", "experts", "num_local_experts"),
+    # Gemma4
+    "Gemma4TextExperts": MoEModelAttrs(
+        "router", "experts", "num_experts"    ),
+    "SequentialGemma4TextExperts": MoEModelAttrs("router", "experts", "num_experts"),
+    # AfMoE
+    "AfmoeMoE": MoEModelAttrs("router", "experts", "num_experts"),
+    "CalibrationAfmoeMoE": MoEModelAttrs("router", "experts", "num_experts"),
+}
+
+
+def detect_moe_attrs(model: nn.Module) -> MoEModelAttrs | None:
+    for _, module in model.named_modules():
+        class_name = module.__class__.__name__
+        if class_name in MOE_ATTR_REGISTRY:
+            attrs = MOE_ATTR_REGISTRY[class_name]
+            logger.info(
+                f"Detected MoE architecture: {class_name} "
+                f"(router={attrs.router_attr}, experts={attrs.experts_attr})"
+            )
+            return attrs
+
+    for _, module in model.named_modules():
+        router = _find_router_attr(module)
+        if router is not None and hasattr(module, "experts"):
+            attrs = MoEModelAttrs(
+                router_attr=router,
+                experts_attr="experts",
+                num_experts_config_key="num_experts",
+            )
+            logger.info(
+                f"Auto-detected MoE block: {module.__class__.__name__} "
+                f"(router={router})"
+            )
+            return attrs
+
+    return None
+
+
+def _find_router_attr(module: nn.Module) -> str | None:
+    for attr_name in ("gate", "router"):
+        val = getattr(module, attr_name, None)
+        if val is not None and isinstance(val, nn.Linear):
+            return attr_name
+    return None
+
+
+def find_moe_layers(
+    model: nn.Module,
+    attrs: MoEModelAttrs,
+    ignore: list[str] | None = None,
+) -> dict[str, nn.Module]:
+    ignore = ignore or []
+    moe_layers = {}
+
+    for name, module in model.named_modules():
+        has_router = hasattr(module, attrs.router_attr)
+        has_experts = hasattr(module, attrs.experts_attr)
+        if not (has_router and has_experts):
+            continue
+        if not isinstance(getattr(module, attrs.router_attr), nn.Module):
+            continue
+        if any(re.search(pattern, name) for pattern in ignore):
+            continue
+        moe_layers[name] = module
+
+    logger.info(f"Found {len(moe_layers)} MoE layers")
+    return moe_layers
+
+
+def get_num_experts(module: nn.Module, attrs: MoEModelAttrs) -> int:
+    experts = getattr(module, attrs.experts_attr)
+    if isinstance(experts, nn.ModuleList):
+        return len(experts)
+
+    if hasattr(experts, "num_experts"):
+        return experts.num_experts
+
+    for _, param in experts.named_parameters(recurse=False):
+        if param.dim() >= 2:
+            return param.shape[0]
+
+    raise ValueError(
+        f"Cannot determine number of experts from {module.__class__.__name__}"
+    )
+
+
+@dataclass
+class REAPSaliencyTracker:
+    """Accumulates S_j = mean(g_j * ||f_j||_2) per expert across batches."""
+
+    num_experts: int
+    sum_saliency: torch.Tensor = field(init=False)
+    count: torch.Tensor = field(init=False)
+
+    def __post_init__(self):
+        self.sum_saliency = torch.zeros(self.num_experts, dtype=torch.float64)
+        self.count = torch.zeros(self.num_experts, dtype=torch.int64)
+
+    def update(
+        self,
+        expert_idx: int,
+        gate_values: torch.Tensor,
+        output_norms: torch.Tensor,
+    ):
+        saliency = (gate_values.float() * output_norms.float()).sum()
+        self.sum_saliency[expert_idx] += saliency.cpu().to(torch.float64)
+        self.count[expert_idx] += gate_values.shape[0]
+
+    @property
+    def mean_saliency(self) -> torch.Tensor:
+        safe_count = self.count.clamp(min=1).to(torch.float64)
+        return self.sum_saliency / safe_count
+
+
+def prune_moe_layer(
+    model: nn.Module,
+    layer_name: str,
+    saliency: torch.Tensor,
+    n_experts_to_drop: int,
+    attrs: MoEModelAttrs,
+) -> list[int]:
+    num_experts = len(saliency)
+    if n_experts_to_drop >= num_experts:
+        raise ValueError(
+            f"Cannot drop {n_experts_to_drop} experts from {layer_name} "
+            f"which only has {num_experts} experts"
+        )
+
+    _, drop_indices = torch.topk(saliency, n_experts_to_drop, largest=False)
+    drop_set = set(drop_indices.tolist())
+    retained = sorted(i for i in range(num_experts) if i not in drop_set)
+
+    logger.info(
+        f"Pruning {layer_name}: dropping experts {sorted(drop_set)}, "
+        f"retaining {retained} ({len(retained)}/{num_experts})"
+    )
+
+    moe_block = model.get_submodule(layer_name)
+    router = getattr(moe_block, attrs.router_attr)
+    experts = getattr(moe_block, attrs.experts_attr)
+
+    if isinstance(experts, nn.ModuleList):
+        new_experts = nn.ModuleList([experts[i] for i in retained])
+        setattr(moe_block, attrs.experts_attr, new_experts)
+    else:
+        _prune_fused_experts(experts, retained)
+
+    _prune_router(router, retained)
+
+    if hasattr(moe_block, "num_experts"):
+        moe_block.num_experts = len(retained)
+
+    return retained
+
+
+def _prune_router(router: nn.Module, retained: list[int]):
+    retained_t = torch.tensor(retained, dtype=torch.long)
+
+    router.weight = nn.Parameter(
+        router.weight.data[retained_t, :], requires_grad=False
+    )
+    if router.bias is not None:
+        router.bias = nn.Parameter(
+            router.bias.data[retained_t], requires_grad=False
+        )
+    router.out_features = len(retained)
+
+
+def _prune_fused_experts(experts: nn.Module, retained: list[int]):
+    retained_t = torch.tensor(retained, dtype=torch.long)
+
+    for name, param in list(experts.named_parameters(recurse=False)):
+        if param.dim() >= 2:
+            new_param = param.data[retained_t]
+            setattr(experts, name, nn.Parameter(new_param, requires_grad=False))
+
+    if hasattr(experts, "num_experts"):
+        experts.num_experts = len(retained)
+
+
+def update_model_config(
+    model: nn.Module,
+    attrs: MoEModelAttrs,
+    new_num_experts: int,
+):
+    config = model.config
+    attr_name = attrs.num_experts_config_key
+
+    for cfg in (config, getattr(config, "text_config", None)):
+        if cfg is not None and hasattr(cfg, attr_name):
+            old_val = getattr(cfg, attr_name)
+            setattr(cfg, attr_name, new_num_experts)
+            logger.info(f"Updated config.{attr_name}: {old_val} -> {new_num_experts}")
+            return
+
+    logger.warning(f"Config attribute '{attr_name}' not found, skipping config update")

--- a/src/llmcompressor/pipelines/registry.py
+++ b/src/llmcompressor/pipelines/registry.py
@@ -64,6 +64,7 @@ class CalibrationPipeline(ABC, RegistryMixin):
                 "AWQModifier",
                 "AutoRoundModifier",
                 "IMatrixGatherer",
+                "REAPPruningModifier",
             ):
                 return True
             elif isinstance(modifier, QuantizationModifier):

--- a/tests/llmcompressor/modifiers/pruning/reap/test_base.py
+++ b/tests/llmcompressor/modifiers/pruning/reap/test_base.py
@@ -1,0 +1,364 @@
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from llmcompressor.core import Event, EventType, State
+from llmcompressor.modifiers.factory import ModifierFactory
+from llmcompressor.modifiers.pruning.reap import REAPPruningModifier
+from llmcompressor.modifiers.pruning.reap.utils import (
+    MoEModelAttrs,
+    REAPSaliencyTracker,
+    detect_moe_attrs,
+    find_moe_layers,
+    get_num_experts,
+    prune_moe_layer,
+    update_model_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers: tiny synthetic MoE model for testing
+# ---------------------------------------------------------------------------
+
+
+class FakeExpert(nn.Module):
+    """A simple feedforward expert."""
+
+    def __init__(self, hidden_dim: int, intermediate_dim: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_dim, intermediate_dim, bias=False)
+        self.up_proj = nn.Linear(hidden_dim, intermediate_dim, bias=False)
+        self.down_proj = nn.Linear(intermediate_dim, hidden_dim, bias=False)
+
+    def forward(self, x):
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class FakeMoEBlock(nn.Module):
+    """A minimal MoE block with a gate router and expert ModuleList."""
+
+    calibrate_all_experts = True
+
+    def __init__(self, hidden_dim: int, num_experts: int, top_k: int):
+        super().__init__()
+        self.gate = nn.Linear(hidden_dim, num_experts, bias=False)
+        self.experts = nn.ModuleList(
+            [FakeExpert(hidden_dim, hidden_dim * 2) for _ in range(num_experts)]
+        )
+        self.num_experts = num_experts
+        self.top_k = top_k
+
+    def forward(self, hidden_states):
+        batch_size, seq_len, hidden_dim = hidden_states.shape
+        flat = hidden_states.view(-1, hidden_dim)
+
+        router_logits = self.gate(flat)
+        routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float32)
+        topk_weights, topk_indices = torch.topk(routing_weights, self.top_k, dim=-1)
+
+        final = torch.zeros_like(flat)
+        expert_mask = F.one_hot(topk_indices, self.num_experts).permute(2, 1, 0)
+
+        for expert_idx, expert in enumerate(self.experts):
+            idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
+            out = expert(flat)
+            if len(top_x) > 0:
+                weighted = out[top_x] * topk_weights[top_x, idx, None]
+                final.index_add_(0, top_x, weighted.to(flat.dtype))
+
+        return final.view(batch_size, seq_len, hidden_dim), router_logits
+
+
+class FakeDecoderLayer(nn.Module):
+    def __init__(self, hidden_dim, num_experts, top_k):
+        super().__init__()
+        self.mlp = FakeMoEBlock(hidden_dim, num_experts, top_k)
+
+    def forward(self, x):
+        out, _ = self.mlp(x)
+        return x + out
+
+
+class FakeConfig:
+    def __init__(self, num_experts, top_k):
+        self.num_experts = num_experts
+        self.num_experts_per_tok = top_k
+
+
+class FakeMoEModel(nn.Module):
+    """A tiny 2-layer MoE model for testing."""
+
+    def __init__(
+        self,
+        hidden_dim: int = 32,
+        num_experts: int = 8,
+        top_k: int = 2,
+        num_layers: int = 2,
+    ):
+        super().__init__()
+        self.config = FakeConfig(num_experts, top_k)
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList(
+            [
+                FakeDecoderLayer(hidden_dim, num_experts, top_k)
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(self, x):
+        for layer in self.model.layers:
+            x = layer(x)
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Tests: REAPSaliencyTracker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestREAPSaliencyTracker:
+    def test_initial_state(self):
+        tracker = REAPSaliencyTracker(num_experts=4)
+        assert tracker.sum_saliency.shape == (4,)
+        assert tracker.count.shape == (4,)
+        assert (tracker.sum_saliency == 0).all()
+        assert (tracker.count == 0).all()
+
+    def test_update_single_expert(self):
+        tracker = REAPSaliencyTracker(num_experts=4)
+        gate_vals = torch.tensor([0.5, 0.3])
+        norms = torch.tensor([2.0, 4.0])
+
+        tracker.update(1, gate_vals, norms)
+
+        expected = 0.5 * 2.0 + 0.3 * 4.0
+        assert tracker.sum_saliency[1].item() == pytest.approx(expected)
+        assert tracker.count[1].item() == 2
+        assert tracker.count[0].item() == 0
+
+    def test_mean_saliency(self):
+        tracker = REAPSaliencyTracker(num_experts=3)
+
+        tracker.update(0, torch.tensor([0.6]), torch.tensor([3.0]))
+        tracker.update(0, torch.tensor([0.4]), torch.tensor([1.0]))
+        tracker.update(1, torch.tensor([0.5, 0.5]), torch.tensor([2.0, 2.0]))
+
+        mean = tracker.mean_saliency
+        # Expert 0: (0.6*3.0 + 0.4*1.0) / 2 = 2.2 / 2 = 1.1
+        assert mean[0].item() == pytest.approx(1.1)
+        # Expert 1: (0.5*2.0 + 0.5*2.0) / 2 = 2.0 / 2 = 1.0
+        assert mean[1].item() == pytest.approx(1.0)
+        # Expert 2: never routed -> 0
+        assert mean[2].item() == pytest.approx(0.0)
+
+    def test_zero_count_no_nan(self):
+        tracker = REAPSaliencyTracker(num_experts=2)
+        mean = tracker.mean_saliency
+        assert not torch.isnan(mean).any()
+        assert (mean == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Tests: MoE detection and pruning utilities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMoEDetection:
+    def test_detect_moe_attrs(self):
+        model = FakeMoEModel()
+        attrs = detect_moe_attrs(model)
+        # FakeMoEBlock is not in the registry, but auto-detection should
+        # find it via the "gate" + "experts" heuristic
+        assert attrs is not None
+        assert attrs.router_attr == "gate"
+        assert attrs.experts_attr == "experts"
+
+    def test_find_moe_layers(self):
+        model = FakeMoEModel(num_layers=3)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        assert len(layers) == 3
+
+    def test_find_moe_layers_with_ignore(self):
+        model = FakeMoEModel(num_layers=3)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs, ignore=["layers.1"])
+        assert len(layers) == 2
+        assert all("layers.1" not in name for name in layers)
+
+    def test_get_num_experts(self):
+        model = FakeMoEModel(num_experts=8)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        for module in layers.values():
+            assert get_num_experts(module, attrs) == 8
+
+
+@pytest.mark.unit
+class TestPruning:
+    def test_prune_moe_layer(self):
+        model = FakeMoEModel(num_experts=8)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        layer_name = list(layers.keys())[0]
+
+        # Give expert 0 the lowest saliency
+        saliency = torch.tensor(
+            [0.1, 0.5, 0.8, 0.3, 0.7, 0.2, 0.9, 0.4], dtype=torch.float64
+        )
+        retained = prune_moe_layer(model, layer_name, saliency, 3, attrs)
+
+        # Should drop experts 0, 3, 5 (indices with lowest saliency)
+        # Actually: sorted saliency: 0(0.1), 5(0.2), 3(0.3), 7(0.4), 1(0.5), ...
+        # Drop 3 lowest: experts 0, 5, 3
+        assert len(retained) == 5
+
+        # Verify the module was updated
+        moe_block = model.get_submodule(layer_name)
+        assert len(moe_block.experts) == 5
+        assert moe_block.gate.weight.shape[0] == 5
+
+    def test_prune_router_out_features(self):
+        model = FakeMoEModel(num_experts=6)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        layer_name = list(layers.keys())[0]
+
+        saliency = torch.arange(6, dtype=torch.float64)
+        prune_moe_layer(model, layer_name, saliency, 2, attrs)
+
+        moe_block = model.get_submodule(layer_name)
+        assert moe_block.gate.out_features == 4
+
+    def test_prune_too_many_raises(self):
+        model = FakeMoEModel(num_experts=4)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        layer_name = list(layers.keys())[0]
+
+        saliency = torch.arange(4, dtype=torch.float64)
+        with pytest.raises(ValueError, match="Cannot drop"):
+            prune_moe_layer(model, layer_name, saliency, 4, attrs)
+
+    def test_update_model_config(self):
+        model = FakeMoEModel(num_experts=8)
+        attrs = MoEModelAttrs("gate", "experts", "num_experts")
+        update_model_config(model, attrs, 4)
+        assert model.config.num_experts == 4
+
+    def test_model_still_runs_after_pruning(self):
+        """Verify the model produces output after experts are pruned."""
+        model = FakeMoEModel(hidden_dim=16, num_experts=8, top_k=2)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+
+        # Prune all layers
+        saliency = torch.arange(8, dtype=torch.float64)
+        for layer_name in layers:
+            prune_moe_layer(model, layer_name, saliency, 4, attrs)
+
+        update_model_config(model, attrs, 4)
+
+        # Model should still produce valid output
+        x = torch.randn(2, 4, 16)
+        out = model(x)
+        assert out.shape == (2, 4, 16)
+        assert not torch.isnan(out).any()
+
+
+# ---------------------------------------------------------------------------
+# Tests: REAPPruningModifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("setup_modifier_factory")
+def test_reap_is_registered():
+    modifier = ModifierFactory.create(
+        type_="REAPPruningModifier",
+        allow_experimental=False,
+        allow_registered=True,
+        compression_ratio=0.5,
+    )
+    assert isinstance(modifier, REAPPruningModifier)
+
+
+@pytest.mark.unit
+def test_reap_validation():
+    with pytest.raises(ValueError, match="compression_ratio"):
+        REAPPruningModifier(compression_ratio=0.0)
+
+    with pytest.raises(ValueError, match="compression_ratio"):
+        REAPPruningModifier(compression_ratio=1.0)
+
+    with pytest.raises(ValueError, match="compression_ratio"):
+        REAPPruningModifier(compression_ratio=-0.1)
+
+
+@pytest.mark.unit
+def test_reap_full_lifecycle():
+    """End-to-end test: initialize, calibrate, finalize, verify pruning."""
+    torch.manual_seed(42)
+
+    hidden_dim = 16
+    num_experts = 8
+    top_k = 2
+    model = FakeMoEModel(hidden_dim=hidden_dim, num_experts=num_experts, top_k=top_k)
+    model.eval()
+
+    modifier = REAPPruningModifier(compression_ratio=0.5)
+
+    # Create a minimal State
+    state = State(
+        model=model,
+        teacher_model=None,
+        optimizer=None,
+        optim_wrapped=False,
+        loss=None,
+        batch_data=None,
+    )
+
+    # Initialize
+    modifier.initialize(state)
+    assert modifier.initialized_
+    assert modifier._n_experts_to_drop == 4
+
+    # Simulate calibration: manually trigger start, run data, trigger end
+    start_event = Event(type_=EventType.CALIBRATION_EPOCH_START)
+    modifier.update_event(state, start_event)
+    assert modifier.started_
+
+    # Run calibration data (forward passes through model trigger hooks)
+    with torch.no_grad():
+        for _ in range(5):
+            x = torch.randn(2, 8, hidden_dim)
+            model(x)
+
+    end_event = Event(type_=EventType.CALIBRATION_EPOCH_END)
+    modifier.update_event(state, end_event)
+    assert modifier.ended_
+
+    # Verify saliency was accumulated
+    for tracker in modifier._saliency_trackers.values():
+        assert tracker.count.sum().item() > 0
+
+    # Finalize (triggers pruning)
+    modifier.finalize(state)
+    assert modifier.finalized_
+
+    # Verify pruning results
+    assert model.config.num_experts == 4
+
+    for layer in model.model.layers:
+        assert len(layer.mlp.experts) == 4
+        assert layer.mlp.gate.weight.shape[0] == 4
+        assert layer.mlp.gate.out_features == 4
+
+    # Verify model still runs
+    with torch.no_grad():
+        x = torch.randn(2, 4, hidden_dim)
+        out = model(x)
+        assert out.shape == (2, 4, hidden_dim)
+        assert not torch.isnan(out).any()

--- a/tests/llmcompressor/modifiers/pruning/reap/test_base.py
+++ b/tests/llmcompressor/modifiers/pruning/reap/test_base.py
@@ -7,13 +7,11 @@ from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers.factory import ModifierFactory
 from llmcompressor.modifiers.pruning.reap import REAPPruningModifier
 from llmcompressor.modifiers.pruning.reap.utils import (
-    MoEModelAttrs,
     REAPSaliencyTracker,
     detect_moe_attrs,
     find_moe_layers,
     get_num_experts,
     prune_moe_layer,
-    update_model_config,
 )
 
 # ---------------------------------------------------------------------------
@@ -118,13 +116,6 @@ class FakeMoEModel(nn.Module):
 
 @pytest.mark.unit
 class TestREAPSaliencyTracker:
-    def test_initial_state(self):
-        tracker = REAPSaliencyTracker(num_experts=4)
-        assert tracker.sum_saliency.shape == (4,)
-        assert tracker.count.shape == (4,)
-        assert (tracker.sum_saliency == 0).all()
-        assert (tracker.count == 0).all()
-
     def test_update_single_expert(self):
         tracker = REAPSaliencyTracker(num_experts=4)
         gate_vals = torch.tensor([0.5, 0.3])
@@ -151,12 +142,6 @@ class TestREAPSaliencyTracker:
         assert mean[1].item() == pytest.approx(1.0)
         # Expert 2: never routed -> 0
         assert mean[2].item() == pytest.approx(0.0)
-
-    def test_zero_count_no_nan(self):
-        tracker = REAPSaliencyTracker(num_experts=2)
-        mean = tracker.mean_saliency
-        assert not torch.isnan(mean).any()
-        assert (mean == 0).all()
 
 
 # ---------------------------------------------------------------------------
@@ -203,34 +188,24 @@ class TestPruning:
         attrs = detect_moe_attrs(model)
         layers = find_moe_layers(model, attrs)
         layer_name = list(layers.keys())[0]
+        moe_block = model.get_submodule(layer_name)
+        original_experts = list(moe_block.experts)
+        original_gate = moe_block.gate.weight.detach().clone()
 
-        # Give expert 0 the lowest saliency
         saliency = torch.tensor(
             [0.1, 0.5, 0.8, 0.3, 0.7, 0.2, 0.9, 0.4], dtype=torch.float64
         )
         retained = prune_moe_layer(model, layer_name, saliency, 3, attrs)
 
-        # Should drop experts 0, 3, 5 (indices with lowest saliency)
-        # Actually: sorted saliency: 0(0.1), 5(0.2), 3(0.3), 7(0.4), 1(0.5), ...
-        # Drop 3 lowest: experts 0, 5, 3
-        assert len(retained) == 5
-
-        # Verify the module was updated
-        moe_block = model.get_submodule(layer_name)
+        assert retained == [1, 2, 4, 6, 7]
         assert len(moe_block.experts) == 5
         assert moe_block.gate.weight.shape[0] == 5
-
-    def test_prune_router_out_features(self):
-        model = FakeMoEModel(num_experts=6)
-        attrs = detect_moe_attrs(model)
-        layers = find_moe_layers(model, attrs)
-        layer_name = list(layers.keys())[0]
-
-        saliency = torch.arange(6, dtype=torch.float64)
-        prune_moe_layer(model, layer_name, saliency, 2, attrs)
-
-        moe_block = model.get_submodule(layer_name)
-        assert moe_block.gate.out_features == 4
+        assert moe_block.gate.out_features == 5
+        assert all(
+            expert is original_experts[original_idx]
+            for expert, original_idx in zip(moe_block.experts, retained)
+        )
+        torch.testing.assert_close(moe_block.gate.weight, original_gate[retained])
 
     def test_prune_too_many_raises(self):
         model = FakeMoEModel(num_experts=4)
@@ -241,31 +216,6 @@ class TestPruning:
         saliency = torch.arange(4, dtype=torch.float64)
         with pytest.raises(ValueError, match="Cannot drop"):
             prune_moe_layer(model, layer_name, saliency, 4, attrs)
-
-    def test_update_model_config(self):
-        model = FakeMoEModel(num_experts=8)
-        attrs = MoEModelAttrs("gate", "experts", "num_experts")
-        update_model_config(model, attrs, 4)
-        assert model.config.num_experts == 4
-
-    def test_model_still_runs_after_pruning(self):
-        """Verify the model produces output after experts are pruned."""
-        model = FakeMoEModel(hidden_dim=16, num_experts=8, top_k=2)
-        attrs = detect_moe_attrs(model)
-        layers = find_moe_layers(model, attrs)
-
-        # Prune all layers
-        saliency = torch.arange(8, dtype=torch.float64)
-        for layer_name in layers:
-            prune_moe_layer(model, layer_name, saliency, 4, attrs)
-
-        update_model_config(model, attrs, 4)
-
-        # Model should still produce valid output
-        x = torch.randn(2, 4, 16)
-        out = model(x)
-        assert out.shape == (2, 4, 16)
-        assert not torch.isnan(out).any()
 
 
 # ---------------------------------------------------------------------------
@@ -280,21 +230,24 @@ def test_reap_is_registered():
         type_="REAPPruningModifier",
         allow_experimental=False,
         allow_registered=True,
-        compression_ratio=0.5,
+        sparsity=0.5,
     )
     assert isinstance(modifier, REAPPruningModifier)
 
 
 @pytest.mark.unit
 def test_reap_validation():
-    with pytest.raises(ValueError, match="compression_ratio"):
-        REAPPruningModifier(compression_ratio=0.0)
+    with pytest.raises(ValueError, match="sparsity"):
+        REAPPruningModifier()
 
-    with pytest.raises(ValueError, match="compression_ratio"):
-        REAPPruningModifier(compression_ratio=1.0)
+    with pytest.raises(ValueError, match="sparsity"):
+        REAPPruningModifier(sparsity=0.0)
 
-    with pytest.raises(ValueError, match="compression_ratio"):
-        REAPPruningModifier(compression_ratio=-0.1)
+    with pytest.raises(ValueError, match="sparsity"):
+        REAPPruningModifier(sparsity=1.0)
+
+    with pytest.raises(ValueError, match="sparsity"):
+        REAPPruningModifier(sparsity=-0.1)
 
 
 @pytest.mark.unit
@@ -308,7 +261,7 @@ def test_reap_full_lifecycle():
     model = FakeMoEModel(hidden_dim=hidden_dim, num_experts=num_experts, top_k=top_k)
     model.eval()
 
-    modifier = REAPPruningModifier(compression_ratio=0.5)
+    modifier = REAPPruningModifier(sparsity=0.5)
 
     # Create a minimal State
     state = State(


### PR DESCRIPTION
SUMMARY:
This PR implements REAP pruning from https://arxiv.org/abs/2510.13999 , following as much as possible the original codebase from https://github.com/CerebrasResearch/reap 

IMPLEMENTATION DETAILS:
REAP is implemented as `REAPPruningModifier`. This pruner is based on calibration data and therefore doesn't work with datafree pipeline. In short, it runs calibration, collects per-expert saliency scores via hooks, and then prunes experts. It also modifies corresponding field in `config.json` to indicate that the model has reduced number of experts.

The saliency score is: `S_j = mean(g_j * ||f_j||_2)`
where `g_j` is the router probability for expert `j`, and `f_j` is that expert’s output activation norm for routed tokens.

Example recipe:
```yaml
pruning_stage:
  pruning_modifiers:
    REAPPruningModifier:
      sparsity: 0.25
```

Modifier Lifecycle:
On initialize, it detects the MoE architecture. It has a class-name registry for known MoE blocks and a fallback heuristic looking for router/expert attributes. It then finds MoE layers and creates one saliency tracker per layer.
On calibration start, it registers three hook types:
  - MoE pre-hook: runs the router, computes softmax probabilities, and caches top-k expert indices.
  - Expert forward hook: just records `||expert_output||_2` for saliency score
  - MoE post-hook: combines router probabilities with expert output norms and updates `REAPSaliencyTracker`.

REAP deliberately prunes after the MoE calibration wrappers have been restored. That means saliency is collected on calibration modules, but pruning is applied to the real model modules.

TEST PLAN:
1) There are already some sanity check tests in `tests/llmcompressor/modifiers/pruning/reap/test_base.py`
2) I ran the example script `examples/reap_expert_pruning/reap_qwen3_30b_25pct.py` for 25% and 50% sparsity on Qwen3-30B-A3B-Instruct-2507 model with OpenPlatypus calibration data and obtained the following GSM8k scores with vLLM engine:
```bash
1) unpruned baseline
vllm ({'pretrained': '/home/eldarkurtic/hf_models/Qwen/Qwen3-30B-A3B-Instruct-2507', 'add_bos_token': True, 'tensor_parallel_size': 2, 'max_model_len': 8192}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8825|±  |0.0089|
|     |       |strict-match    |     5|exact_match|↑  |0.8734|±  |0.0092|

2) REAP sparsity = 0.25
vllm ({'pretrained': '/home/eldarkurtic/github/eldarkurtic/llm-compressor/output_dir/Qwen3-30B-A3B-Instruct-2507_REAP_sp25', 'add_bos_token': True, 'tensor_parallel_size': 2, 'max_model_len': 8192}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8870|±  |0.0087|
|     |       |strict-match    |     5|exact_match|↑  |0.8704|±  |0.0093|

3) REAP sparsity = 0.5
vllm ({'pretrained': '/home/eldarkurtic/github/eldarkurtic/llm-compressor/output_dir/Qwen3-30B-A3B-Instruct-2507_REAP_sp50', 'add_bos_token': True, 'tensor_parallel_size': 2, 'max_model_len': 8192}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8635|±  |0.0095|
|     |       |strict-match    |     5|exact_match|↑  |0.8582|±  |0.0096|
```
3) I've also checked the saved ckpts, and they are indeed pruned. Disk usage: `57GB --> 25%: 44GB --> 50%: 30GB`. Each model has updated `config.json` with the correct number of experts.


Note: before landing this modifier, it would be useful to run more testing. Specifically with other MoE architectures, possibly including the ones with fused experts (e.g. Llama), more eval benchmarks (e.g. calibrate on coding data, eval on coding and non-coding). Let's sync offline on the plan for these tests. 