### PR TITLE
Use `static_minmax` for e2e tests

### DIFF
--- a/tests/e2e/recipes/INT8/recipe_int8_channel_weight_static_per_tensor_act.yaml
+++ b/tests/e2e/recipes/INT8/recipe_int8_channel_weight_static_per_tensor_act.yaml
@@ -8,5 +8,5 @@ quant_stage:
       config_groups:
         group_0:
           weights: {num_bits: 8, type: int, symmetric: true, strategy: channel}
-          input_activations: {num_bits: 8, type: int, symmetric: true, strategy: tensor}
+          input_activations: {num_bits: 8, type: int, symmetric: true, strategy: tensor, observer: static_minmax}
           targets: [Linear]

--- a/tests/e2e/recipes/INT8/recipe_w8a8_static_asym.yaml
+++ b/tests/e2e/recipes/INT8/recipe_w8a8_static_asym.yaml
@@ -8,5 +8,5 @@ quant_stage:
       config_groups:
         group_0:
           weights: {num_bits: 8, type: int, symmetric: true, strategy: channel}
-          input_activations: {num_bits: 8, symmetric: false, dynamic: false, strategy: tensor, type: int}
+          input_activations: {num_bits: 8, symmetric: false, dynamic: false, strategy: tensor, type: int, observer: static_minmax}
           targets: [Linear] 


### PR DESCRIPTION
#Summary
- Use `static_minmax` for static activations