### PR TITLE
test: add sanity checks for vLLM e2e generated output

### DIFF
--- a/tests/e2e/configs/fp8_weight_only_channel.yaml
+++ b/tests/e2e/configs/fp8_weight_only_channel.yaml
@@ -2,3 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/FP8/recipe_fp8_weight_only_channel.yaml
 scheme: FP8A16_channel
+# vLLM produces gibberish after this quantization scheme
+skip_sanity_check: true

--- a/tests/e2e/configs/fp8_weight_only_tensor.yaml
+++ b/tests/e2e/configs/fp8_weight_only_tensor.yaml
@@ -2,3 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/FP8/recipe_fp8_weight_only_per_tensor.yaml
 scheme: FP8A16_tensor
+# vLLM produces gibberish after this quantization scheme
+skip_sanity_check: true

--- a/tests/e2e/configs/int8_channel_weight_static_per_tensor_act.yaml
+++ b/tests/e2e/configs/int8_channel_weight_static_per_tensor_act.yaml
@@ -1,6 +1,8 @@
 cadence: "nightly"
 test_group: "rhaiis"
+# TinyLlama produces incoherent output after this quantization scheme
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+skip_sanity_check: true
 recipe: tests/e2e/recipes/INT8/recipe_int8_channel_weight_static_per_tensor_act.yaml
 dataset_id: HuggingFaceH4/ultrachat_200k
 dataset_split: train_sft

--- a/tests/e2e/configs/w8a8_static_asym.yaml
+++ b/tests/e2e/configs/w8a8_static_asym.yaml
@@ -1,5 +1,7 @@
 cadence: "nightly"
+# TinyLlama produces incoherent output after this quantization scheme
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+skip_sanity_check: true
 recipe: tests/e2e/recipes/INT8/recipe_w8a8_static_asym.yaml
 dataset_id: HuggingFaceH4/ultrachat_200k
 dataset_split: train_sft

--- a/tests/e2e/run_vllm.py
+++ b/tests/e2e/run_vllm.py
@@ -21,7 +21,8 @@ def parse_args():
 
 def run_vllm(llm_kwargs: dict, prompts: list[str]) -> None:
     """Run vLLM with given kwargs and prompts, then print outputs."""
-    sampling_params = SamplingParams(temperature=0.80, top_p=0.95)
+    # Use greedy decoding for deterministic output
+    sampling_params = SamplingParams(temperature=0.0)
 
     llm = LLM(**llm_kwargs)
     outputs = llm.generate(prompts, sampling_params)

--- a/tests/e2e/test_vllm.py
+++ b/tests/e2e/test_vllm.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import time
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 import torch
@@ -31,6 +32,19 @@ IS_VLLM_IMAGE = False
 if VLLM_PYTHON_ENV.lower() != "same" and (not Path(VLLM_PYTHON_ENV).exists()):
     IS_VLLM_IMAGE = True
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+
+class SanityPrompt(NamedTuple):
+    prompt: str
+    expected: str
+
+
+SANITY_PROMPTS = [
+    SanityPrompt("The capital of France is", "paris"),
+    SanityPrompt("The creator of the theory of relativity was Albert", "einstein"),
+    SanityPrompt("The classic game is called rock, paper,", "scissors"),
+]
+
 EXPECTED_SAVED_FILES = [
     "config.json",
     r"^model(?:-\d{5}-of-\d{5})?\.safetensors$",
@@ -87,11 +101,6 @@ class TestvLLM:
         logger.info("========== RUNNING ==============")
         logger.info(self.config.save_dir)
 
-        self.prompts = [
-            "The capital of France is",
-            "The president of the US is",
-            "My name is",
-        ]
         self.api = HfApi()
 
     def compress_model(self, test_data_file: str):
@@ -196,7 +205,8 @@ class TestvLLM:
 
         json_scheme = json.dumps(self.config.scheme)
         json_llm_kwargs = json.dumps(llm_kwargs)
-        json_prompts = json.dumps(self.prompts)
+        prompts = [sp.prompt for sp in SANITY_PROMPTS]
+        json_prompts = json.dumps(prompts)
 
         test_file_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -271,6 +281,16 @@ class TestvLLM:
 
         error_msg = f"ERROR: vLLM failed with exit code {result.returncode}: {stderr}"
         assert result.returncode == 0, error_msg
+
+        if self.config.skip_sanity_check:
+            logger.info("Skipping sanity check (skip_sanity_check=true)")
+            return
+
+        stdout_lower = stdout.lower()
+        for sp in SANITY_PROMPTS:
+            assert (
+                sp.expected in stdout_lower
+            ), f"Expected '{sp.expected}' in generated output:\n{stdout}"
 
     def _check_save_dir_has_expected_files(self):
         files = os.listdir(self.config.save_dir)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -284,6 +284,10 @@ class BaseTestConfig(BaseModel):
     test_group: Optional[str] = Field(
         None, description="CI test group tag (e.g. 'rhaiis') used to filter test runs"
     )
+    skip_sanity_check: bool = Field(
+        False,
+        description="Skip the sanity check that verifies vLLM generates coherent text",
+    )
 
     @model_validator(mode="after")
     def require_scheme_or_recipe(self) -> "BaseTestConfig":


### PR DESCRIPTION
## Summary
- Add sanity check assertions to e2e tests: verify vLLM generates coherent text by checking for expected keywords (Paris, Einstein, scissors) in greedy-decoded output.
- Set temperature to 0 for deterministic output.
- Add `skip_sanity_check` config flag to skip assertions for schemes that produce incoherent output and are expected to do so.
- 4 configs skip sanity check:
  - `fp8_weight_only_channel`, `fp8_weight_only_tensor` — vLLM produces gibberish (works fine via transformers)
  - `int8_channel_weight_static_per_tensor_act`, `w8a8_static_asym` — TinyLlama produces incoherent output after quantization

## Test plan
Manual workflow trigger: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/26649789189

🤖 Generated with [Claude Code](https://claude.com/claude-code)