### PR TITLE
Fix coverage.py database corruption in DDP tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
+parallel = True
 patch = subprocess

--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,5 @@ build:
 clean:
 	rm -fr .pytest_cache;
 	rm -fr docs/_build docs/build;
+	rm -f .coverage .coverage.*;
 	find $(CHECKDIRS) | grep -E "(__pycache__|\.pyc|\.pyo)" | xargs rm -fr;


### PR DESCRIPTION
## Summary

problem: 
CI breaking for DDP tests due to DDP subprocesses both writing coverage files at the same time causes sqlite error

https://github.com/neuralmagic/llm-compressor-testing/actions/runs/25978123850/job/76540255696 

fix: 
Enable `parallel = True` in `.coveragerc` so each torchrun subprocess writes to its own unique coverage data file (`.coverage.<host>.<pid>.<random>`) [these will be combined together after both subprocesses complete]

https://coverage.readthedocs.io/en/latest/config.html#run-parallel

## Test plan

https://github.com/neuralmagic/llm-compressor-testing/actions/runs/26059469048
(fixed the error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)