### PR TITLE
fix bug fused obs + sequential targets

### DIFF
--- a/docs/guides/observers.md
+++ b/docs/guides/observers.md
@@ -31,8 +31,8 @@ This class is not used directly but provides the scaffolding for all custom obse
 |--------|-------------|
 | `forward(observed)` | Accumulates statistics from the observed tensor. Returns `self` (for chaining). Does **not** compute qparams. |
 | `update_statistics_from_observed(observed)` | Abstract. Subclasses implement this to accumulate statistics from a pre-shaped tensor. |
-| `get_qparams()` | Converts accumulated statistics into a `QParamsDict` with keys `scale`, `zero_point`, and `global_scale`. Default implementation uses `min_vals`/`max_vals`. Override for custom statistics. |
-| `Observer.fuse(observers)` | Static method. Links observers so they share `global_scale` computed from combined statistics. |
+| `get_qparams()` | Converts accumulated statistics into a `QParamsDict` with keys `scale`, `zero_point`, and `global_scale`. For TENSOR_GROUP, auto-observes any fused observers without statistics before computing shared `global_scale`. Default implementation uses `min_vals`/`max_vals`. Override for custom statistics. |
+| `Observer.fuse(observers_and_modules)` | Static method. Takes an iterable of `(observer, module)` tuples. Links observers with weak module references so they share `global_scale` computed from combined statistics. |
 | `sync_activation_stats()` | All-reduces accumulated statistics across DDP ranks using `_act_sync_dict`. |
 | `has_statistics` | Property. Returns `True` if the observer has been called at least once. Default checks for `min_vals`; override for custom statistics. |
 
@@ -134,8 +134,13 @@ At the end of the calibration epoch, it calls `observer.detach()` on each instru
 
 For TENSOR_GROUP quantization schemes (e.g., NVFP4), layers that are fused at inference time (Q/K/V projections, gate/up MLP projections) must share the same `global_scale`. This is handled automatically by observer fusion:
 
-1. `fuse_weight_observers(model)` scans the model for known fused layer groups and calls `Observer.fuse()` to link their weight observers
-2. When any fused observer computes `get_qparams()`, it takes the absmax across its own statistics **and** all fused observers' statistics to produce a shared `global_scale`
+1. `fuse_weight_observers(model)` scans the model for known fused layer groups and calls `Observer.fuse(observers_and_modules)` with `(observer, module)` tuples
+2. Each observer stores weak references to its fused partners' modules in `_fusions: dict[Observer, ref[Module]]`
+3. When `get_qparams()` is called on any fused observer:
+   - It automatically observes any fused observers that don't have statistics yet by calling them with their stored module references
+   - It computes `global_scale` from the absmax across its own statistics **and** all fused observers' statistics
+
+This design eliminates the need to explicitly observe all fused modules before calling `get_qparams()` - unobserved fused modules are handled on-demand. The weak references prevent circular reference cycles between observers and modules. It also handles situations where the subgraphs being quantized at the same time don't include all fused modules.
 
 The fused layer groups are defined in `FUSED_LAYER_NAMES`:
 - `gate_proj` / `up_proj` (MLP)

--- a/src/llmcompressor/entrypoints/model_free/process.py
+++ b/src/llmcompressor/entrypoints/model_free/process.py
@@ -207,7 +207,7 @@ def process_file_microscale_scheme(
     # Compress fused modules with shared global scale
     for named_modules in fused_modules.values():
         # 2. fuse observers, observe weights, and get qparams
-        Observer.fuse([mod.weight_observer for mod in named_modules.values()])
+        Observer.fuse([(mod.weight_observer, mod) for mod in named_modules.values()])
         observe(named_modules.values(), base_name="weight")
         update_qparams(named_modules.values(), base_name="weight")
 

--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -130,10 +130,10 @@ class Observer(InternalModule, RegistryMixin):
         :param observers_and_modules: list of (observer, module) tuples
         """
         pairs = list(observers_and_modules)
-        for obs, _module in pairs:
+        for obs, _ in pairs:
             for fuse_obs, fuse_mod in pairs:
-                obs._fusions[fuse_obs] = ref(fuse_mod)
-                del obs._fusions[obs] # don't fuse with itself
+                if fuse_obs is not obs:
+                    obs._fusions[fuse_obs] = ref(fuse_mod)
 
     def sync_activation_stats(self) -> List[dist.Work]:
         """All-reduce accumulated activation statistics across DDP ranks.

--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 from typing import Dict, Iterable, List, Optional, Tuple, TypedDict
+from weakref import ref
 
 import torch
 from compressed_tensors import InternalModule
@@ -8,6 +9,7 @@ from compressed_tensors.quantization import QuantizationArgs, QuantizationStrate
 from compressed_tensors.quantization.utils import calculate_qparams, generate_gparam
 from compressed_tensors.registry.registry import RegistryMixin
 from torch import distributed as dist
+from torch.nn import Module
 
 from llmcompressor.observers.helpers import flatten_for_calibration
 
@@ -50,7 +52,7 @@ class Observer(InternalModule, RegistryMixin):
         self.args.observer_kwargs = self.args.observer_kwargs or {}
         self.args.observer_kwargs.update(observer_kwargs)
 
-        self._fused_observers: set["Observer"] = set()
+        self._fusions: dict["Observer", ref[Module]] = {}
 
     @property
     def has_statistics(self) -> bool:
@@ -72,9 +74,7 @@ class Observer(InternalModule, RegistryMixin):
         Compute quantization parameters from accumulated statistics.
 
         For TENSOR_GROUP, global_scale is computed from the absmax of
-        this observer and all fused observers. Fused observers must
-        already have statistics — call observe_weight on all modules
-        before calling get_qparams on any of them.
+        this observer and all fused observers.
 
         :return: dict with keys "scale", "zero_point", and "global_scale"
         """
@@ -83,14 +83,16 @@ class Observer(InternalModule, RegistryMixin):
         ), "No statistics available. Call observer(value) first."
 
         global_scale = None
+        msg = "Fused module has been garbage collected before its weight was observed"
         if self.args.strategy == QuantizationStrategy.TENSOR_GROUP:
             global_absmax = torch.max(-self.min_vals.min(), self.max_vals.max())
-            for obs in self._fused_observers:
-                assert (
-                    obs.has_statistics
-                ), "All fused observers must be run before get_qparams."
-                global_absmax = torch.max(global_absmax, -obs.min_vals.min())
-                global_absmax = torch.max(global_absmax, obs.max_vals.max())
+            for fused_obs in self._fusions.keys():
+                if not fused_obs.has_statistics:
+                    fused_mod = self._fusions[fused_obs]()
+                    assert fused_mod is not None, msg
+                    fused_obs(fused_mod.weight)
+                global_absmax = torch.max(global_absmax, -fused_obs.min_vals.min())
+                global_absmax = torch.max(global_absmax, fused_obs.max_vals.max())
             global_scale = generate_gparam(
                 -global_absmax.reshape(1), global_absmax.reshape(1)
             )
@@ -120,17 +122,18 @@ class Observer(InternalModule, RegistryMixin):
         return self
 
     @staticmethod
-    def fuse(observers: Iterable["Observer"]) -> None:
+    def fuse(observers_and_modules: Iterable[tuple["Observer", Module]]) -> None:
         """
         Link all observers in the list with each other for shared global_scale.
+        Capture module weak-references for auto-observation in get_qparams().
 
-        :param observers: list of observers to fuse together
+        :param observers_and_modules: list of (observer, module) tuples
         """
-        observers = list(observers)
-        for obs in observers:
-            for other in observers:
-                if other is not obs:
-                    obs._fused_observers.add(other)
+        pairs = list(observers_and_modules)
+        for obs, _module in pairs:
+            for fuse_obs, fuse_mod in pairs:
+                obs._fusions[fuse_obs] = ref(fuse_mod)
+                del obs._fusions[obs] # don't fuse with itself
 
     def sync_activation_stats(self) -> List[dist.Work]:
         """All-reduce accumulated activation statistics across DDP ranks.

--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -26,7 +26,9 @@ class QParamsDict(TypedDict, total=False):
     zero_point: torch.Tensor
     global_scale: Optional[torch.Tensor]
 
+
 _msg = "Fused module has been garbage collected before its weight was observed"
+
 
 class Observer(InternalModule, RegistryMixin):
     """
@@ -85,7 +87,7 @@ class Observer(InternalModule, RegistryMixin):
         ), "No statistics available. Call observer(value) first."
 
         global_scale = None
-        
+
         if self.args.strategy == QuantizationStrategy.TENSOR_GROUP:
             global_absmax = torch.max(-self.min_vals.min(), self.max_vals.max())
             for fused_obs in self._fusions.keys():

--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -15,6 +15,7 @@ from llmcompressor.observers.helpers import flatten_for_calibration
 
 __all__ = ["Observer", "MinMaxTuple", "QParamsDict"]
 
+
 MinMaxTuple = Tuple[torch.Tensor, torch.Tensor]
 
 
@@ -25,6 +26,7 @@ class QParamsDict(TypedDict, total=False):
     zero_point: torch.Tensor
     global_scale: Optional[torch.Tensor]
 
+_msg = "Fused module has been garbage collected before its weight was observed"
 
 class Observer(InternalModule, RegistryMixin):
     """
@@ -83,13 +85,13 @@ class Observer(InternalModule, RegistryMixin):
         ), "No statistics available. Call observer(value) first."
 
         global_scale = None
-        msg = "Fused module has been garbage collected before its weight was observed"
+        
         if self.args.strategy == QuantizationStrategy.TENSOR_GROUP:
             global_absmax = torch.max(-self.min_vals.min(), self.max_vals.max())
             for fused_obs in self._fusions.keys():
                 if not fused_obs.has_statistics:
                     fused_mod = self._fusions[fused_obs]()
-                    assert fused_mod is not None, msg
+                    assert fused_mod is not None, _msg
                     fused_obs(fused_mod.weight)
                 global_absmax = torch.max(global_absmax, -fused_obs.min_vals.min())
                 global_absmax = torch.max(global_absmax, fused_obs.max_vals.max())

--- a/src/llmcompressor/observers/helpers.py
+++ b/src/llmcompressor/observers/helpers.py
@@ -185,21 +185,32 @@ def fuse_weight_observers(model: Module):
     from llmcompressor.observers import Observer
 
     for submodule in model.modules():
-        for layers_to_fuse in FUSED_LAYER_NAMES:
-            if not all(hasattr(submodule, name) for name in layers_to_fuse):
+        for fusion_name_group in FUSED_LAYER_NAMES:
+            if not all(hasattr(submodule, name) for name in fusion_name_group):
                 continue
-
-            layers = [getattr(submodule, name) for name in layers_to_fuse]
-            observers = []
-            for layer in layers:
+            layers_to_fuse = [getattr(submodule, name) for name in fusion_name_group]
+            
+            only_obs = True
+            only_tensor_group = True
+            observers_and_modules = []
+            for layer in layers_to_fuse:
                 obs = getattr(layer, "weight_observer", None)
                 if obs is None:
-                    break
+                    only_obs = False
+                    continue
                 if obs.args.strategy != QuantizationStrategy.TENSOR_GROUP:
-                    break
-                observers.append(obs)
-            else:
-                Observer.fuse(observers)
+                    only_tensor_group = False
+                    continue
+                observers_and_modules.append((obs, layer))
+            if len(observers_and_modules) == 0:
+                continue
+            
+            start = f"Some layers in fused group: {fusion_name_group} have"
+            end = ", need all fused layers to have same quantization"
+            assert only_obs, f"{start} no weight observer{end}"
+            assert only_tensor_group, f"{start} non-TENSOR_GROUP quantization{end}"
+
+            Observer.fuse(observers_and_modules)
 
 
 def lerp(start: torch.Tensor, end: torch.Tensor, weight: float) -> torch.Tensor:

--- a/src/llmcompressor/observers/helpers.py
+++ b/src/llmcompressor/observers/helpers.py
@@ -189,7 +189,7 @@ def fuse_weight_observers(model: Module):
             if not all(hasattr(submodule, name) for name in fusion_name_group):
                 continue
             layers_to_fuse = [getattr(submodule, name) for name in fusion_name_group]
-            
+
             only_obs = True
             only_tensor_group = True
             observers_and_modules = []
@@ -204,7 +204,7 @@ def fuse_weight_observers(model: Module):
                 observers_and_modules.append((obs, layer))
             if len(observers_and_modules) == 0:
                 continue
-            
+
             start = f"Some layers in fused group: {fusion_name_group} have"
             end = ", need all fused layers to have same quantization"
             assert only_obs, f"{start} no weight observer{end}"

--- a/tests/llmcompressor/modifiers/utils/test_update_fused_layer_weights.py
+++ b/tests/llmcompressor/modifiers/utils/test_update_fused_layer_weights.py
@@ -173,7 +173,7 @@ def test_non_tensor_group_not_affected():
     # Verify observers have no fused partners
     for name in ["q_proj", "k_proj", "v_proj"]:
         layer = getattr(module, name)
-        assert len(layer.weight_observer._fused_observers) == 0
+        assert len(layer.weight_observer._fusions) == 0
 
 
 @pytest.mark.unit

--- a/tests/llmcompressor/observers/test_fused_observers.py
+++ b/tests/llmcompressor/observers/test_fused_observers.py
@@ -1,0 +1,73 @@
+"""
+Test that fused observers work correctly with sequential calibration.
+
+This tests the fix for fused observer handling where sequential calibration
+with TENSOR_GROUP quantization would fail because only some fused observers
+would be observed (e.g., q_proj observed but k_proj and v_proj skipped).
+"""
+
+import torch
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+
+def test_fused_observers_with_linear_sequential_targets(tmp_path):
+    """
+    Test that oneshot with sequential_targets properly handles fused observers.
+
+    This test uses TENSOR_GROUP quantization (like NVFP4) which requires q/k/v
+    observers to be fused (share global_scale). With sequential_targets=["Linear"],
+    the sequential pipeline processes each Linear individually.
+    """
+    from transformers import AutoModelForCausalLM
+
+    model_id = "nm-testing/tinysmokellama-3.2"
+    output = tmp_path / "quantized_output"
+
+    # Recipe with TENSOR_GROUP quantization (like NVFP4)
+    recipe = QuantizationModifier(
+        targets=["Linear"],
+        scheme="NVFP4",  # Uses TENSOR_GROUP strategy
+    )
+
+    # Run oneshot with sequential_targets=["Linear"]
+    # This triggers sequential calibration at the Linear layer level
+    # On main, this would fail with:
+    # "All fused observers must be run before get_qparams"
+    # because when processing q_proj, k_proj and v_proj don't get observed
+    oneshot(
+        model=model_id,
+        dataset="open_platypus",
+        recipe=recipe,
+        output_dir=output,
+        num_calibration_samples=4,
+        splits={"calibration": "train[:4]"},
+        sequential_targets=["Linear"],  # Sequential calibration at Linear level
+    )
+
+    # Load the quantized model to verify
+    model = AutoModelForCausalLM.from_pretrained(output)
+
+    # Verify all fused modules have qparams
+    # Check the first layer's attention q/k/v projections
+    first_attn = model.model.layers[0].self_attn
+
+    # All should have global_scale (TENSOR_GROUP qparam)
+    assert hasattr(
+        first_attn.q_proj, "weight_global_scale"
+    ), "q_proj should have weight_global_scale"
+    assert hasattr(
+        first_attn.k_proj, "weight_global_scale"
+    ), "k_proj should have weight_global_scale (FAILS on main)"
+    assert hasattr(
+        first_attn.v_proj, "weight_global_scale"
+    ), "v_proj should have weight_global_scale (FAILS on main)"
+
+    # Global scales should be equal (fused)
+    q_scale = first_attn.q_proj.weight_global_scale
+    k_scale = first_attn.k_proj.weight_global_scale
+    v_scale = first_attn.v_proj.weight_global_scale
+
+    assert torch.allclose(q_scale, k_scale), "q and k should have same global_scale"
+    assert torch.allclose(q_scale, v_scale), "q and v should have same global_scale"


### PR DESCRIPTION
Summary:

observers need stats of their fused observers to calculate global_scale properly.

we run all observers in a chunk at the same time so normally this isn't an issue.

if sequential targets is set to linear or something else small, the fused observers will not be in the current chunk and so when get_qparams is called, it will error. see new unit test which fails on main

fix: observers have a record of other observers in their fusion list, now it includes those observers' parent modules so they can run them when needed. Mostly this won't matter but in the situation where the sequential targets is really small, it will solve the problem.

Test Plan:
see unit test
