### PR TITLE
[Bugfix] Fix kv cache quantization 

### DIFF
--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -237,7 +237,8 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 self.on_start(state, None)
 
         if event.type_ == EventType.SEQUENTIAL_EPOCH_END:
-            modules = self._num_samples.keys()
+            parents = kwargs.get("modules", [])
+            modules = {m for parent in parents for m in parent.modules()}
             observe(modules, base_name="weight")
             self.sync_obs_act_stats(modules)
             update_qparams(modules, ACTIVATION_OBS, only_update_onload=not is_src())


### PR DESCRIPTION
## Background ##
#2585 and #2705 introduced updating qparams at the end of sequential epochs. However, GPTQ made the assumption that only modules with weight quantization needed qparam updating. This is not true for activation-only quantization such as kv quant.

## Purpose ##
* Fix kv quantization with `GPTQModifier`, as tested during nightly https://github.com/neuralmagic/llm-compressor-testing/actions/runs/26135944780/job/76871164400

## Changes ##
* Change GPTQ to update qparams for all quantized modules in subgraph, not just ones with gptq hessian hooks

## Testing ##
* Ran below command and tested that hf transformers generations were gibberish but are now fixed.

```bash
CADENCE=nightly TEST_DATA_FILE=tests/e2e/configs/kv_cache_gptq_tinyllama.yaml python3 -m pytest tests/e2e/test_vllm.py -sx
```