### PR TITLE
feat: add layerwise quantization pipeline for memory-efficient large …

### DIFF
--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -290,6 +290,14 @@ class DatasetArguments(CustomDatasetArguments):
             "for faster calibration when GPU memory allows (two batches on device)."
         },
     )
+    layerwise_resume_from: int = field(
+        default=0,
+        metadata={
+            "help": "Subgraph index to resume layerwise quantization from. "
+            "Subgraphs before this index are skipped (forward-only replay to "
+            "rebuild intermediates). Useful for resuming after a crash. Default 0."
+        },
+    )
 
     def is_dataset_provided(self) -> bool:
         return self.dataset is not None or self.dataset_path is not None

--- a/src/llmcompressor/args/model_arguments.py
+++ b/src/llmcompressor/args/model_arguments.py
@@ -86,3 +86,13 @@ class ModelArguments:
             "(can be a branch name, tag name or commit id)"
         },
     )
+    layerwise: bool = field(
+        default=False,
+        metadata={
+            "help": "Enable layerwise quantization mode. When True, the model is "
+            "loaded on meta device (no memory) and weights are loaded from "
+            "safetensors files per-subgraph during calibration. This allows "
+            "quantizing models that are too large to fit in memory. "
+            "Requires the model to be saved in safetensors format."
+        },
+    )

--- a/src/llmcompressor/core/state.py
+++ b/src/llmcompressor/core/state.py
@@ -105,6 +105,7 @@ class State:
     loss_masks: list[torch.Tensor] | None = None
     current_batch_idx: int = -1
     sequential_prefetch: bool = False
+    pipeline_type: str = "basic"
 
     @property
     def compression_ready(self) -> bool:

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -9,11 +9,14 @@ with various pipeline configurations for efficient model optimization.
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
+from compressed_tensors import ModelCompressor
 from loguru import logger
 from torch.utils.data import DataLoader
 from transformers import PreTrainedModel, PreTrainedTokenizerBase, ProcessorMixin
@@ -25,6 +28,13 @@ from llmcompressor.entrypoints.utils import post_process, pre_process
 from llmcompressor.modeling.moe_context import moe_calibration_context
 from llmcompressor.modeling.offset_norm import norm_calibration_context
 from llmcompressor.pipelines import CalibrationPipeline
+from llmcompressor.pytorch.model_load.helpers import (
+    copy_python_files_from_model_cache,
+)
+from llmcompressor.transformers.compression.compressed_tensors_utils import (
+    modify_save_pretrained,
+    update_and_save_recipe,
+)
 
 __all__ = ["Oneshot", "oneshot"]
 
@@ -186,15 +196,128 @@ class Oneshot:
         calibration_dataloader = get_calibration_dataloader(
             self.dataset_args, self.processor
         )
+
+        # For layerwise compress-as-you-go: pass output_dir to the pipeline
+        # so it can save compressed shards incrementally.
+        # Account for recipe stage so shards, config, and tokenizer all land
+        # in the same directory.
+        if getattr(self.model_args, "layerwise", False) and self.output_dir:
+            layerwise_output_dir = self.output_dir
+            if (
+                self.recipe_args is not None
+                and getattr(self.recipe_args, "stage", None) is not None
+            ):
+                layerwise_output_dir = os.path.join(
+                    layerwise_output_dir, self.recipe_args.stage
+                )
+                os.makedirs(layerwise_output_dir, exist_ok=True)
+            self.dataset_args.output_dir = layerwise_output_dir
+
         self.apply_recipe_modifiers(
             calibration_dataloader=calibration_dataloader,
             recipe_stage=self.recipe_args.stage,
         )
-        post_process(
-            model_args=self.model_args,
-            recipe_args=self.recipe_args,
-            output_dir=self.output_dir,
+
+        # Check if compress-as-you-go already saved the shards
+        layerwise_saved = getattr(self.model_args, "layerwise", False) and (
+            getattr(self.dataset_args, "output_dir", None)
+            and os.path.exists(
+                os.path.join(
+                    self.dataset_args.output_dir, "model.safetensors.index.json"
+                )
+            )
         )
+
+        if layerwise_saved:
+            # Shards already compressed and saved by the pipeline.
+            # Just save config, tokenizer, and recipe.
+            output_dir = self.dataset_args.output_dir
+
+            # Save model config with quantization metadata.
+            # For VL/multimodal models, the CausalLM model's config is the
+            # text-only subconfig. Use the original config from model_path so
+            # the output can be loaded as the full VL model at inference.
+            from transformers import AutoConfig
+
+            try:
+                original_config = AutoConfig.from_pretrained(
+                    self.model.name_or_path,
+                    trust_remote_code=self.model_args.trust_remote_code_model,
+                )
+                original_config.save_pretrained(output_dir)
+            except (OSError, ValueError):
+                self.model.config.save_pretrained(output_dir)
+
+            # Update config with compression info
+            compressor = ModelCompressor.from_pretrained_model(self.model)
+            compressor.update_config(output_dir)
+
+            # Add passthrough module names to quantization config ignore
+            # list and fix status. Passthrough weights (visual encoder, MTP)
+            # are saved as regular float tensors. Without explicit ignore
+            # entries, serving frameworks treat them as quantized and fail.
+            config_path = os.path.join(output_dir, "config.json")
+            with open(config_path, encoding="utf-8") as f:
+                config_data = json.load(f)
+            if "quantization_config" in config_data:
+                qconfig = config_data["quantization_config"]
+
+                # Status must be "compressed" since layerwise saves
+                # pack-quantized weights directly to disk.
+                qconfig["quantization_status"] = "compressed"
+
+                # Add explicit module names for passthrough layers
+                passthrough_names = getattr(
+                    self.dataset_args, "passthrough_module_names", None
+                )
+                if passthrough_names:
+                    ignore = qconfig.get("ignore", [])
+                    for name in passthrough_names:
+                        if name not in ignore:
+                            ignore.append(name)
+                    qconfig["ignore"] = ignore
+                    logger.info(
+                        f"Added {len(passthrough_names)} passthrough "
+                        f"modules to ignore list"
+                    )
+
+                with open(config_path, "w", encoding="utf-8") as f:
+                    json.dump(config_data, f, indent=2, sort_keys=True)
+
+            # Save tokenizer/processor
+            if self.model_args.processor is not None:
+                self.model_args.processor.save_pretrained(output_dir)
+
+            # Copy auxiliary processor configs that processor.save_pretrained
+            # doesn't write (e.g. preprocessor_config.json for VL models).
+            # These are needed by serving frameworks like vLLM to load the
+            # image/video processor.
+            model_path = self.model.name_or_path
+            for aux_file in (
+                "preprocessor_config.json",
+                "video_preprocessor_config.json",
+                "generation_config.json",
+            ):
+                src = os.path.join(model_path, aux_file)
+                dst = os.path.join(output_dir, aux_file)
+                if os.path.exists(src) and not os.path.exists(dst):
+                    shutil.copy2(src, dst)
+
+            # Save recipe
+            update_and_save_recipe(self.model.name_or_path, output_dir)
+            copy_python_files_from_model_cache(self.model, output_dir)
+
+            logger.info(f"Layerwise compress-as-you-go: saved to {output_dir}")
+        else:
+            # Legacy path: wrap save_pretrained for compressed saving
+            if getattr(self.model_args, "layerwise", False):
+                modify_save_pretrained(self.model)
+
+            post_process(
+                model_args=self.model_args,
+                recipe_args=self.recipe_args,
+                output_dir=self.output_dir,
+            )
 
     def apply_recipe_modifiers(
         self,
@@ -234,6 +357,9 @@ class Oneshot:
             )
 
             user_pipeline = self.dataset_args.pipeline
+            # Auto-select layerwise pipeline when model is on meta device
+            if hasattr(self.model, "device") and self.model.device.type == "meta":
+                user_pipeline = "layerwise"
             pipeline = CalibrationPipeline.from_modifiers(
                 session.lifecycle.recipe.modifiers, user=user_pipeline
             )
@@ -259,6 +385,7 @@ def oneshot(
     trust_remote_code_model: bool = False,
     save_compressed: bool = True,
     model_revision: str = "main",
+    layerwise: bool = False,
     # Recipe arguments
     recipe: str | list[str] | None = None,
     recipe_args: list[str] | None = None,
@@ -302,6 +429,7 @@ def oneshot(
     sequential_offload_device: str = "cpu",
     quantization_aware_calibration: bool = True,
     sequential_prefetch: bool = False,
+    layerwise_resume_from: int = 0,
     # Miscellaneous arguments
     output_dir: str | None = None,
     log_dir: str | None = None,
@@ -331,6 +459,9 @@ def oneshot(
     :param save_compressed: Whether to compress sparse models during save.
     :param model_revision: The specific model version to use (can be branch name,
         tag, or commit id).
+    :param layerwise: Enable layerwise quantization mode. When True, the model is
+        loaded on meta device and weights are loaded per-subgraph from safetensors
+        during calibration. This allows quantizing models too large for memory.
 
     # Recipe arguments
     :param recipe: Path to a LLM Compressor recipe, or a list of paths
@@ -395,6 +526,9 @@ def oneshot(
     :param sequential_prefetch: When using the sequential pipeline, prefetch the
         next batch in a background thread to overlap onload with forward. Default
         False; set True for faster calibration when GPU memory allows.
+    :param layerwise_resume_from: Subgraph index to resume layerwise quantization
+        from. Subgraphs before this index are skipped (forward-only replay to
+        rebuild intermediates). Useful for resuming after a crash. Default 0.
     # Miscellaneous arguments
     :param output_dir: Path to save the output model after calibration.
         Nothing is saved if None.

--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -10,6 +10,7 @@ workflows.
 import os
 from pathlib import PosixPath
 
+import torch
 from compressed_tensors.offload import from_accelerate, is_distributed
 from loguru import logger
 from transformers import (
@@ -87,6 +88,11 @@ def pre_process(
     # untie tie_word_embeddings weights
     if not model_args.tie_word_embeddings:
         untie_word_embeddings(model_args.model)
+
+    # Skip accelerate conversion and save_pretrained patching for layerwise mode
+    # (model is on meta device and has no real weights)
+    if getattr(model_args, "layerwise", False):
+        return
 
     # if the model was loaded with accelerate offloading, convert to CT offloading
     if hasattr(model_args.model, "hf_device_map"):
@@ -176,7 +182,32 @@ def initialize_model_from_path(
             run_compressed=False
         )
 
-    model = AutoModelForCausalLM.from_pretrained(model_path, **model_kwargs)
+    if getattr(model_args, "layerwise", False):
+        # Layerwise mode: load model structure on meta device without weights.
+        # Weights will be loaded per-subgraph from safetensors during calibration.
+        from accelerate import init_empty_weights
+
+        logger.info(
+            "Layerwise mode enabled: loading model on meta device (no weights). "
+            "Weights will be loaded per-subgraph during calibration."
+        )
+        # Resolve dtype for from_config (can't use "auto")
+        dtype = parse_dtype(model_args.precision)
+        if dtype is None or dtype == "auto":
+            dtype = getattr(config, "torch_dtype", torch.bfloat16)
+
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_config(
+                config,
+                torch_dtype=dtype,
+                trust_remote_code=model_kwargs.get("trust_remote_code", False),
+            )
+        # Preserve the original model path for weight loading
+        model.name_or_path = str(model_path)
+        model.config._name_or_path = str(model_path)
+    else:
+        model = AutoModelForCausalLM.from_pretrained(model_path, **model_kwargs)
+
     if "sequence_length" in model_kwargs:
         model.seqlen = model_kwargs["sequence_length"]
 

--- a/src/llmcompressor/modeling/moe_context.py
+++ b/src/llmcompressor/modeling/moe_context.py
@@ -104,6 +104,14 @@ def moe_calibration_context(
         if _is_registered(class_name, MoECalibrationModule):
             modules_to_replace.append((name, class_name))
 
+    # Detect meta device (layerwise mode): create replacements on meta so
+    # expert weight copies are meta->meta (no-op) instead of meta->cpu (crash)
+    try:
+        is_meta = next(model.parameters()).device.type == "meta"
+    except StopIteration:
+        is_meta = False
+    device_ctx = torch.device("meta") if is_meta else contextlib.nullcontext()
+
     # Step 2: Replace modules with progress bar
     if modules_to_replace:
         logger.info(f"Found {len(modules_to_replace)} MoE modules to replace")
@@ -111,12 +119,13 @@ def moe_calibration_context(
             modules_to_replace, desc="Replacing MoE modules for calibration"
         ):
             module = model.get_submodule(name)
-            replacement = MoECalibrationModule.load_from_registry(
-                class_name,
-                original=module,
-                config=model.config,
-                calibrate_all_experts=calibrate_all_experts,
-            )
+            with device_ctx:
+                replacement = MoECalibrationModule.load_from_registry(
+                    class_name,
+                    original=module,
+                    config=model.config,
+                    calibrate_all_experts=calibrate_all_experts,
+                )
             # Apply the same offloading settings as the original module
             _apply_offloading_to_replacement(module, replacement)
 

--- a/src/llmcompressor/modeling/offset_norm.py
+++ b/src/llmcompressor/modeling/offset_norm.py
@@ -50,6 +50,43 @@ class NormCalibrationModule(ABC, torch.nn.Module, RegistryMixin):
         """
         ...
 
+    def transform_loaded_weight(
+        self, param_name: str, tensor: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Transform a weight tensor after it is loaded from safetensors.
+
+        In layerwise mode, weights are loaded per-subgraph AFTER the norm
+        calibration context has replaced norm modules. This method applies
+        the necessary transformation so that the loaded raw weights are
+        converted to the calibration convention.
+
+        Default implementation: no transformation (identity).
+
+        :param param_name: the local parameter name (e.g., "weight")
+        :param tensor: the raw tensor loaded from safetensors
+        :return: the transformed tensor
+        """
+        return tensor
+
+    def transform_save_weight(
+        self, param_name: str, tensor: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Transform a weight tensor before it is saved to safetensors.
+
+        In layerwise compress-as-you-go, subgraph weights are saved while
+        inside norm_calibration_context. This method reverses the calibration
+        transformation so that saved weights are in the original convention.
+
+        Default implementation: no transformation (identity).
+
+        :param param_name: the local parameter name (e.g., "weight")
+        :param tensor: the calibration-convention tensor
+        :return: the tensor in original (saveable) convention
+        """
+        return tensor
+
 
 @NormCalibrationModule.register(
     "GemmaRMSNorm",
@@ -80,6 +117,31 @@ class CalibrationOffsetNorm(NormCalibrationModule):
             (1.0 + original.weight.data.float()).to(original.weight.dtype)
         )
 
+    def transform_loaded_weight(
+        self, param_name: str, tensor: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Apply the offset transformation (1 + weight) when weights are loaded
+        from safetensors in layerwise mode. The raw safetensors weight is in
+        offset convention (forward computes output * (1 + weight)), but this
+        module expects standard convention (forward computes output * weight).
+        """
+        if param_name == "weight":
+            return (1.0 + tensor.float()).to(tensor.dtype)
+        return tensor
+
+    def transform_save_weight(
+        self, param_name: str, tensor: torch.Tensor
+    ) -> torch.Tensor:
+        """
+        Reverse the offset transformation (weight - 1) when saving weights
+        during layerwise compress-as-you-go. Converts from calibration
+        convention (weight) back to offset convention (weight - 1).
+        """
+        if param_name == "weight":
+            return (tensor.float() - 1.0).to(tensor.dtype)
+        return tensor
+
     def _norm(self, x: torch.Tensor) -> torch.Tensor:
         return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
 
@@ -89,7 +151,15 @@ class CalibrationOffsetNorm(NormCalibrationModule):
         return output.type_as(x)
 
     def restore(self, original: torch.nn.Module) -> torch.nn.Module:
-        original.weight.data = (self.weight.data.float() - 1.0).to(self._orig_dtype)
+        restored_weight = (self.weight.data.float() - 1.0).to(self._orig_dtype)
+        if original.weight.device.type == "meta":
+            # In layerwise mode, original may still be on meta device.
+            # Replace the parameter entirely instead of using .data assignment.
+            original.weight = torch.nn.Parameter(
+                restored_weight, requires_grad=original.weight.requires_grad
+            )
+        else:
+            original.weight.data = restored_weight
         return original
 
 

--- a/src/llmcompressor/modifiers/quantization/calibration.py
+++ b/src/llmcompressor/modifiers/quantization/calibration.py
@@ -154,7 +154,15 @@ def update_qparams(
             if not only_update_onload:  # update offload + onload
                 update_offload_parameter(module, full_param_name, param_val)
             else:  # only update onload
-                getattr(module, full_param_name).data = param_val
+                target = getattr(module, full_param_name)
+                if target.device.type == "meta":
+                    # In layerwise mode, qparams may still be on meta device.
+                    # Replace the parameter entirely instead of .data assignment.
+                    module._parameters[full_param_name] = torch.nn.Parameter(
+                        param_val, requires_grad=target.requires_grad
+                    )
+                else:
+                    target.data = param_val
 
 
 def calibrate_input_hook(module: Module, args: Any):

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -536,6 +536,25 @@ class AWQModifier(Modifier):
                     del self._smooth_activation_stats[mapping.smooth_name]
                     continue
 
+                # Move fp16 reference outputs to CPU to free GPU memory
+                # during grid search (only for layerwise quantization where
+                # GPU memory is constrained by sequential onloading).
+                # Optimization: check available VRAM first — if enough headroom,
+                # keep on GPU to avoid repeated CPU↔GPU transfers during grid
+                # search (n_grid × n_batches transfers otherwise).
+                is_layerwise = active_session().state.pipeline_type == "layerwise"
+                if is_layerwise:
+                    fp16_bytes = sum(t.nbytes for t in fp16_outputs)
+                    try:
+                        device = get_execution_device(parent_module)
+                        free_vram, _ = torch.cuda.mem_get_info(device)
+                        # Keep on GPU if fp16_outputs fit within 50% of free VRAM
+                        if fp16_bytes >= free_vram * 0.5:
+                            fp16_outputs = [t.cpu() for t in fp16_outputs]
+                    except Exception:
+                        # Fallback: offload to be safe
+                        fp16_outputs = [t.cpu() for t in fp16_outputs]
+
                 orig_layer_weights = {
                     balance_layer: balance_layer.weight.clone()
                     for balance_layer in mapping.balance_layers
@@ -599,11 +618,58 @@ class AWQModifier(Modifier):
         use_prefetch = active_session().state.sequential_prefetch
         batch_iter = cache.iter_prefetch() if use_prefetch else cache
         outputs = [module(**batch_kwargs) for batch_kwargs in batch_iter]
-        return [
+        results = [
             # If tuple, assume that first argument is the input
             output[0] if isinstance(output, tuple) else output
             for output in outputs
         ]
+        return results
+
+    @torch.no_grad()
+    def _run_samples_and_compute_loss(
+        self, module: Module, fp16_outputs: list[torch.Tensor]
+    ) -> float:
+        """Run samples through module and compute loss against fp16_outputs
+        in a streaming fashion to avoid holding all outputs in GPU memory."""
+        session = active_session()
+        loss_masks = session.state.loss_masks if session.state else None
+
+        cache = self._parent_args_cache[module]
+        use_prefetch = active_session().state.sequential_prefetch
+        batch_iter = cache.iter_prefetch() if use_prefetch else cache
+
+        device = get_execution_device(module)
+        loss = torch.tensor(0.0, device=device)
+        num_elements = torch.tensor(0, device=device)
+
+        for batch_idx, batch_kwargs in enumerate(batch_iter):
+            output = module(**batch_kwargs)
+            int_w_batch = output[0] if isinstance(output, tuple) else output
+
+            fp16_batch = fp16_outputs[batch_idx]
+            if fp16_batch.device != device:
+                fp16_batch = fp16_batch.to(device)
+
+            loss_mask = loss_masks[batch_idx] if loss_masks else None
+            if loss_mask is not None:
+                token_mask = loss_mask.to(device) == 1
+                fp16_masked = fp16_batch[token_mask]
+                int_w_masked = int_w_batch[token_mask]
+                loss += torch.nn.functional.mse_loss(
+                    fp16_masked.float(), int_w_masked.float(), reduction="sum"
+                )
+                num_elements += fp16_masked.numel()
+            else:
+                loss += torch.nn.functional.mse_loss(
+                    fp16_batch.float(),
+                    int_w_batch.float(),
+                    reduction="sum",
+                )
+                num_elements += fp16_batch.numel()
+
+            del output, int_w_batch, fp16_batch
+
+        return (loss / num_elements).item() if num_elements > 0 else 0.0
 
     def _compute_best_scale(
         self,
@@ -664,6 +730,21 @@ class AWQModifier(Modifier):
             ],
         ):
             fuse_weight_observers(mapping.parent)
+
+            # Pre-move fp16_outputs to GPU before grid search to avoid
+            # repeated CPU→GPU transfers (n_grid × n_batches otherwise).
+            # Only do this when outputs are on CPU and there's enough VRAM.
+            _fp16_premoved = False
+            if fp16_outputs and fp16_outputs[0].device.type == "cpu":
+                fp16_bytes = sum(t.nbytes for t in fp16_outputs)
+                try:
+                    free_vram, _ = torch.cuda.mem_get_info(device)
+                    if fp16_bytes < free_vram * 0.4:
+                        fp16_outputs = [t.to(device) for t in fp16_outputs]
+                        _fp16_premoved = True
+                except Exception:
+                    pass
+
             pbar = tqdm(
                 self._get_grid_search_params(),
                 desc=f"Grid search for {mapping.smooth_name}",
@@ -708,12 +789,16 @@ class AWQModifier(Modifier):
                         / _scalesview
                     ).to(balance_layer.weight.dtype)
 
-                # W_q * X
-                int_w_outputs = self._run_samples(mapping.parent)
-
-                # compute mean squared error (L2 norm)
-                loss = self._compute_loss(fp16_outputs, int_w_outputs)
-                del int_w_outputs
+                # W_q * X (streaming loss computation — no bulk output storage)
+                is_layerwise = active_session().state.pipeline_type == "layerwise"
+                if is_layerwise:
+                    loss = self._run_samples_and_compute_loss(
+                        mapping.parent, fp16_outputs
+                    )
+                else:
+                    int_w_outputs = self._run_samples(mapping.parent)
+                    loss = self._compute_loss(fp16_outputs, int_w_outputs)
+                    del int_w_outputs
 
                 if initial_error is None:
                     initial_error = loss
@@ -727,6 +812,12 @@ class AWQModifier(Modifier):
                     best_scales = scales.clone()
                 pbar.set_postfix({"best_error": f"{best_error:.3e}"})
 
+        # Free pre-moved fp16_outputs from GPU after grid search
+        if _fp16_premoved:
+            fp16_outputs = [t.cpu() for t in fp16_outputs]
+            del fp16_outputs
+            torch.cuda.empty_cache()
+
         if best_ratio == -1:
             logger.debug(history)
             raise Exception(
@@ -737,12 +828,6 @@ class AWQModifier(Modifier):
             )
 
         err_reduction = best_error / initial_error if initial_error > 0 else 1.0
-        logger.debug(
-            f"AWQ grid search for {mapping.smooth_name}: "
-            f"initial error = {initial_error:.3e}, "
-            f"best error = {best_error:.3e}, "
-            f"error reduction rate (best/initial) = {err_reduction * 100:.3f}%"
-        )
 
         # Store error metrics for this layer
         self._error_metrics.append(

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -170,6 +170,79 @@ _deepseek_mappings = [
     AWQMapping("re:.*up_proj$", ["re:.*down_proj$"]),
 ]
 
+# Glm4MoeLite (GLM-4.7-Flash) — MLA attention like DeepSeek, but
+# first_k_dense_replace=1 means layer 0 is a plain MLP with no router.
+# The router (mlp.gate) is excluded from post_attention_layernorm balance
+# so the mapping resolves uniformly across both dense and MoE layers.
+_glm4_moe_lite_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm$",
+        ["re:.*q_a_proj$", "re:.*kv_a_proj_with_mqa$"],
+    ),
+    AWQMapping("re:.*q_a_layernorm$", ["re:.*q_b_proj$"]),
+    AWQMapping("re:.*kv_a_layernorm$", ["re:.*kv_b_proj$"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm$",
+        ["re:.*gate_proj$", "re:.*up_proj$"],
+    ),
+    AWQMapping("re:.*up_proj$", ["re:.*down_proj$"]),
+]
+
+# Qwen3.5 uses a hybrid attention architecture: some layers have standard
+# self_attn (q/k/v/o_proj) while others use linear_attn (GatedDeltaNet with
+# in_proj_qkv, in_proj_z, in_proj_a, in_proj_b, out_proj). Both patterns
+# must be included so AWQ smooths all layers.
+_qwen3_5_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm$",
+        [
+            # self_attn layers
+            "re:.*self_attn.q_proj$",
+            "re:.*self_attn.k_proj$",
+            "re:.*self_attn.v_proj$",
+            # linear_attn (GatedDeltaNet) layers
+            "re:.*linear_attn.in_proj_qkv$",
+            "re:.*linear_attn.in_proj_z$",
+            "re:.*linear_attn.in_proj_a$",
+            "re:.*linear_attn.in_proj_b$",
+        ],
+    ),
+    AWQMapping("re:.*v_proj$", ["re:.*o_proj$"]),
+    AWQMapping("re:.*linear_attn.norm$", ["re:.*linear_attn.out_proj$"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm$",
+        ["re:.*gate_proj$", "re:.*up_proj$"],
+    ),
+    AWQMapping("re:.*up_proj$", ["re:.*down_proj$"]),
+]
+
+_qwen3_5_moe_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm$",
+        [
+            # self_attn layers
+            "re:.*self_attn.q_proj$",
+            "re:.*self_attn.k_proj$",
+            "re:.*self_attn.v_proj$",
+            # linear_attn (GatedDeltaNet) layers
+            "re:.*linear_attn.in_proj_qkv$",
+            "re:.*linear_attn.in_proj_z$",
+            "re:.*linear_attn.in_proj_a$",
+            "re:.*linear_attn.in_proj_b$",
+        ],
+    ),
+    AWQMapping("re:.*v_proj$", ["re:.*o_proj$"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm$",
+        [
+            "re:.*mlp.gate$",
+            "re:.*mlp.experts.*.gate_proj$",
+            "re:.*mlp.experts.*.up_proj$",
+        ],
+    ),
+    AWQMapping("re:.*up_proj$", ["re:.*down_proj$"]),
+]
+
 _bloom_mappings = [
     AWQMapping("re:.*input_layernorm$", ["re:.*query_key_value$"]),
     AWQMapping("re:.*post_attention_layernorm$", ["re:.*dense_h_to_4h$"]),
@@ -251,6 +324,7 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Gemma3ForCausalLM": _gemma_mappings,
     "Gemma3ForConditionalGeneration": _gemma_mappings,
     "Glm4MoeForCausalLM": _moe_default_mappings,
+    "Glm4MoeLiteForCausalLM": _glm4_moe_lite_mappings,
     "GlmMoeDsaForCausalLM": _deepseek_mappings,
     "LlamaForCausalLM": default_mappings,
     "Llama4ForConditionalGeneration": _llama4_default_mappings,
@@ -264,6 +338,8 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Qwen2MoeForCausalLM": _moe_default_mappings,
     "Qwen3ForCausalLM": default_mappings,
     "Qwen3MoeForCausalLM": _moe_default_mappings,
+    "Qwen3_5ForCausalLM": _qwen3_5_mappings,
+    "Qwen3_5MoeForCausalLM": _qwen3_5_moe_mappings,
     "SeedOssForCausalLM": default_mappings,
     "Ernie4_5_MoeForCausalLM": default_mappings,
 }

--- a/src/llmcompressor/pipelines/__init__.py
+++ b/src/llmcompressor/pipelines/__init__.py
@@ -13,5 +13,6 @@ model optimization based on specific requirements and constraints.
 from .basic import *
 from .data_free import *
 from .independent import *
+from .layerwise import *
 from .registry import *
 from .sequential import *

--- a/src/llmcompressor/pipelines/layerwise/__init__.py
+++ b/src/llmcompressor/pipelines/layerwise/__init__.py
@@ -1,0 +1,10 @@
+# ruff: noqa
+
+"""
+Layerwise calibration pipeline for memory-efficient quantization.
+
+Enables quantization of models that are too large to fit in memory by loading
+weights per-subgraph from safetensors files during calibration.
+"""
+
+from .pipeline import *

--- a/src/llmcompressor/pipelines/layerwise/helpers.py
+++ b/src/llmcompressor/pipelines/layerwise/helpers.py
@@ -1,0 +1,1300 @@
+"""
+Helpers for layerwise weight loading and offloading from safetensors files.
+
+Optimizations:
+- On-demand shard downloads: only fetches the safetensors shards needed for
+  the current subgraph instead of downloading the full model upfront.
+- Compress-as-you-go: compresses and saves each subgraph immediately after
+  calibration, keeping only 1 subgraph of base weights in memory at a time.
+- Background prefetch: downloads the next subgraph's shards while the current
+  subgraph is being calibrated on GPU.
+"""
+
+import json
+import os
+import threading
+from pathlib import Path
+
+import torch
+from loguru import logger
+from safetensors import safe_open
+from safetensors.torch import save_file
+from torch.nn import Module
+
+__all__ = [
+    "build_weight_map",
+    "build_key_remapping",
+    "get_subgraph_weight_names",
+    "load_subgraph_weights",
+    "move_subgraph_buffers",
+    "offload_subgraph_weights",
+    "compress_and_save_subgraph",
+    "copy_passthrough_weights",
+    "write_safetensors_index",
+    "ShardPrefetcher",
+]
+
+
+def _all_named_parameters(model: Module):
+    """
+    Yield (name, param) for ALL parameters including tied duplicates.
+
+    Unlike ``model.named_parameters()`` which deduplicates by ``id(param)``,
+    this yields every parameter path. This is needed to detect tied weights
+    like ``lm_head.weight`` tied to ``model.embed_tokens.weight``.
+    """
+    for module_name, module in model.named_modules():
+        for param_name, param in module._parameters.items():
+            if param is not None:
+                full_name = f"{module_name}.{param_name}" if module_name else param_name
+                yield full_name, param
+
+
+def _detect_tied_weights(model: Module, weight_map: dict[str, str]) -> dict[str, str]:
+    """
+    Detect model parameters that are tied to other parameters but missing
+    from the weight map. Returns ``{tied_name: source_name}`` where
+    ``source_name`` is the key in ``weight_map`` that holds the data.
+
+    Uses two detection methods:
+    1. On meta device with tie_weights() called: tied params share same ``id()``.
+    2. Fallback: check model config's ``tie_word_embeddings`` flag for the
+       common lm_head <-> embed_tokens tying pattern (since ``from_config()``
+       with ``init_empty_weights()`` may not actually share tensor objects).
+    """
+    # Ensure tie_weights() is called so tied params share the same id
+    if hasattr(model, "tie_weights"):
+        model.tie_weights()
+
+    # Map tensor id -> first param name found in weight_map
+    id_to_source: dict[int, str] = {}
+    all_params: dict[str, torch.nn.Parameter] = {}
+
+    for name, param in _all_named_parameters(model):
+        all_params[name] = param
+        tid = id(param)
+        if name in weight_map and tid not in id_to_source:
+            id_to_source[tid] = name
+
+    tied: dict[str, str] = {}
+    for name, param in all_params.items():
+        if name not in weight_map:
+            source = id_to_source.get(id(param))
+            if source:
+                tied[name] = source
+
+    # Fallback: if id-based detection didn't find anything, check config
+    # for the common tie_word_embeddings pattern
+    if not tied:
+        config = getattr(model, "config", None)
+        if config and getattr(config, "tie_word_embeddings", False):
+            # Common pattern: lm_head.weight is tied to embed_tokens.weight
+            # Find the embed_tokens weight in weight_map
+            embed_key = None
+            for key in weight_map:
+                if "embed_tokens.weight" in key:
+                    embed_key = key
+
+            # Also find lm_head.weight in model params (even if not in wm)
+            lm_head_param = None
+            for name in all_params:
+                if name.endswith("lm_head.weight") or name == "lm_head.weight":
+                    lm_head_param = name
+
+            if embed_key and lm_head_param and lm_head_param not in weight_map:
+                tied[lm_head_param] = embed_key
+
+    if tied:
+        logger.info(
+            f"Detected {len(tied)} tied weight(s): "
+            + ", ".join(f"{t} -> {s}" for t, s in tied.items())
+        )
+    return tied
+
+
+def build_key_remapping(
+    weight_map: dict[str, str],
+    model: Module,
+) -> tuple[dict[str, str], dict[str, str], list[str], dict[str, str]]:
+    """
+    Auto-detect and build a bidirectional key remapping between safetensors
+    weight names and model parameter names.
+
+    This handles VL/multimodal models where safetensors keys use a different
+    prefix than the CausalLM model. For example:
+      - Safetensors: ``model.language_model.layers.0.*``
+      - CausalLM:    ``model.layers.0.*``
+
+    Also detects tied weights (e.g., ``lm_head.weight`` tied to
+    ``model.embed_tokens.weight``) and adds them to the weight map.
+
+    :param weight_map: raw mapping from safetensors weight name to file path
+    :param model: the model (on meta device)
+    :return: tuple of:
+        - remapped_weight_map: weight_map with keys changed to model param names
+        - model_to_safetensors: mapping from model param name back to original
+          safetensors key (for saving with original naming)
+        - passthrough_keys: safetensors keys that don't map to any model param
+          (e.g., visual encoder, mtp weights) — to be copied as-is to output
+        - tied_weights: mapping from tied param name to source param name
+          (for loading tied weights from the source key in safetensors)
+    """
+    # Use _all_named_parameters to avoid dedup (finds tied weights)
+    model_params = set(name for name, _ in _all_named_parameters(model))
+    safetensors_keys = set(weight_map.keys())
+
+    # Fast path: if keys already match substantially, no remapping needed.
+    # Check overlap relative to safetensors keys (which are unique/non-dedup),
+    # since model_params from _all_named_parameters can be inflated by
+    # tied/shared weights appearing at multiple paths.
+    overlap = model_params & safetensors_keys
+    overlap_ratio = len(overlap) / len(safetensors_keys) if safetensors_keys else 0
+    if overlap_ratio > 0.5:
+        # Keys match directly — passthrough is anything not in model
+        passthrough = sorted(safetensors_keys - model_params)
+        if passthrough:
+            logger.info(
+                f"Key remapping: {len(passthrough)} passthrough weights "
+                f"(not in model, will be copied as-is)"
+            )
+        result_wm = dict(weight_map)
+        # Detect tied weights (e.g., lm_head.weight tied to embed_tokens.weight)
+        # Add to weight_map so subgraph assignment works, but keep separate
+        # from model_to_safetensors so saving uses the model key (not source).
+        tied = _detect_tied_weights(model, result_wm)
+        for tied_name, source_name in tied.items():
+            result_wm[tied_name] = result_wm[source_name]
+        return result_wm, {}, passthrough, tied
+
+    if overlap:
+        logger.info(
+            f"Key remapping: partial overlap ({len(overlap)}/{len(model_params)} "
+            f"= {overlap_ratio:.1%} of model params). Attempting prefix remapping."
+        )
+
+    # No/low overlap — try to detect a common prefix mismatch.
+    # Strategy: pick a model param NOT in the direct overlap and find the
+    # safetensors key that shares the same suffix but with a different prefix.
+    # Example: model has "model.layers.0.self_attn.q_proj.weight"
+    #          safetensors has "model.language_model.layers.0.self_attn.q_proj.weight"
+    #          => prefix_to_strip = "model.language_model."
+    #          => prefix_to_add   = "model."
+    prefix_to_strip = None
+    prefix_to_add = None
+
+    # Skip params that already match directly (e.g., lm_head.weight) —
+    # they would yield empty prefixes and mask the real mismatch.
+    mismatched_params = sorted(model_params - overlap)
+
+    for model_param in mismatched_params:
+        # Find a safetensors key that ends with a suffix matching this param
+        # after stripping the common model prefix
+        for sf_key in safetensors_keys:
+            if sf_key == model_param:
+                continue  # exact match, not useful for prefix detection
+            if sf_key.endswith(model_param):
+                # e.g., sf_key = "model.language_model.layers.0.weight"
+                #        model_param = "model.layers.0.weight"
+                # => prefix_to_strip = "model.language_model."
+                # => prefix_to_add   = "model."
+                # But this is the degenerate case; more robust:
+                prefix_to_strip = sf_key[: len(sf_key) - len(model_param)]
+                prefix_to_add = ""
+                break
+            # Try matching by the portion after the first dot segment
+            # e.g., model="model.layers.0.weight" vs
+            # sf="model.language_model.layers.0.weight"
+            # Find common suffix
+            mp_parts = model_param.split(".")
+            sf_parts = sf_key.split(".")
+            # Align from the end
+            common_suffix_len = 0
+            for i in range(1, min(len(mp_parts), len(sf_parts)) + 1):
+                if mp_parts[-i] == sf_parts[-i]:
+                    common_suffix_len = i
+                else:
+                    break
+            if common_suffix_len >= 3:  # need at least module.param_type.weight
+                sf_prefix = ".".join(sf_parts[: len(sf_parts) - common_suffix_len])
+                mp_prefix = ".".join(mp_parts[: len(mp_parts) - common_suffix_len])
+                prefix_to_strip = sf_prefix + "." if sf_prefix else ""
+                prefix_to_add = mp_prefix + "." if mp_prefix else ""
+                break
+        if prefix_to_strip is not None:
+            break
+
+    if prefix_to_strip is None:
+        logger.warning(
+            "Key remapping: could not detect prefix mismatch between "
+            "safetensors keys and model parameters. Proceeding without remapping."
+        )
+        result_wm = dict(weight_map)
+        tied = _detect_tied_weights(model, result_wm)
+        for tied_name, source_name in tied.items():
+            result_wm[tied_name] = result_wm[source_name]
+        return result_wm, {}, sorted(safetensors_keys - model_params), tied
+
+    logger.info(
+        f"Key remapping: detected prefix mismatch\n"
+        f"  safetensors prefix: '{prefix_to_strip}'\n"
+        f"  model prefix:       '{prefix_to_add}'\n"
+        f"  Remapping {len(safetensors_keys)} safetensors keys"
+    )
+
+    remapped_weight_map: dict[str, str] = {}
+    model_to_safetensors: dict[str, str] = {}
+    passthrough_keys: list[str] = []
+
+    # Build set of named module paths for detecting fused weights.
+    # E.g., fused MoE expert tensors (gate_up_proj, down_proj) have parent
+    # modules that exist in the model but the fused weight itself is not a
+    # regular nn.Parameter (it gets unfused during calibration).
+    model_modules = set(name for name, _ in model.named_modules())
+
+    for sf_key, file_path in weight_map.items():
+        if sf_key.startswith(prefix_to_strip):
+            model_key = prefix_to_add + sf_key[len(prefix_to_strip) :]
+            if model_key in model_params:
+                remapped_weight_map[model_key] = file_path
+                model_to_safetensors[model_key] = sf_key
+            elif "." in model_key and model_key.rsplit(".", 1)[0] in model_modules:
+                # Fused weight: parent module exists but this specific weight
+                # is not a regular parameter (e.g., fused MoE expert tensors).
+                # Keep in remapped map so subgraph assignment works.
+                remapped_weight_map[model_key] = file_path
+                model_to_safetensors[model_key] = sf_key
+            else:
+                passthrough_keys.append(sf_key)
+        elif sf_key in model_params:
+            # Direct match (e.g., MTP keys that already use the model's naming)
+            remapped_weight_map[sf_key] = file_path
+        else:
+            passthrough_keys.append(sf_key)
+
+    # Count fused vs param matches
+    fused_count = sum(1 for k in remapped_weight_map if k not in model_params)
+    matched = len(remapped_weight_map)
+    logger.info(
+        f"Key remapping: {matched} matched ({matched - fused_count} params, "
+        f"{fused_count} fused), "
+        f"{len(passthrough_keys)} passthrough (visual/mtp/etc)"
+    )
+    if passthrough_keys[:3]:
+        logger.debug(f"  Sample passthrough: {passthrough_keys[:3]}")
+
+    # Detect tied weights in the slow path too
+    tied = _detect_tied_weights(model, remapped_weight_map)
+    for tied_name, source_name in tied.items():
+        remapped_weight_map[tied_name] = remapped_weight_map[source_name]
+        # Don't add to model_to_safetensors — that's used for save remapping.
+        # Tied weights should save under their model key, not the source key.
+
+    return remapped_weight_map, model_to_safetensors, passthrough_keys, tied
+
+
+def copy_passthrough_weights(
+    passthrough_keys: list[str],
+    weight_map: dict[str, str],
+    output_dir: str | os.PathLike,
+    shard_weight_map: dict[str, str],
+    model_path: str | None = None,
+) -> int:
+    """
+    Copy passthrough weights (e.g., visual encoder, mtp) from source
+    safetensors directly to the output directory without modification.
+
+    These are weights present in the original model safetensors that are not
+    part of the CausalLM model (e.g., vision encoder for VL models).
+
+    :param passthrough_keys: list of safetensors key names to copy
+    :param weight_map: raw (un-remapped) weight_map from build_weight_map()
+    :param output_dir: directory to save the passthrough shard
+    :param shard_weight_map: dict to update with weight_name -> shard_file
+    :param model_path: HF Hub model ID for on-demand downloads
+    :return: total size in bytes of copied tensors
+    """
+    if not passthrough_keys:
+        return 0
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Group by source shard file
+    file_to_keys: dict[str, list[str]] = {}
+    for key in passthrough_keys:
+        if key in weight_map:
+            file_path = weight_map[key]
+            file_to_keys.setdefault(file_path, []).append(key)
+
+    # Load and save passthrough tensors
+    tensors: dict[str, torch.Tensor] = {}
+    for file_path, keys in file_to_keys.items():
+        resolved_path = _ensure_shard_available(file_path, model_path)
+        with safe_open(resolved_path, framework="pt", device="cpu") as f:
+            for key in keys:
+                tensors[key] = f.get_tensor(key)
+
+    if not tensors:
+        return 0
+
+    shard_name = "model-passthrough-of-99999.safetensors"
+    shard_path = output_dir / shard_name
+    save_file(tensors, str(shard_path))
+
+    total_size = sum(t.nbytes for t in tensors.values())
+    for key in tensors:
+        shard_weight_map[key] = shard_name
+
+    logger.info(
+        f"Copied {len(tensors)} passthrough weights "
+        f"({total_size / 1e9:.2f} GB) -> {shard_name}"
+    )
+    return total_size
+
+
+def build_weight_map(model_path: str | os.PathLike) -> dict[str, str]:
+    """
+    Build a mapping from weight name -> safetensors file path.
+
+    For HF Hub models, downloads only the index file (not full model weights).
+    Shard files are downloaded on-demand during load_subgraph_weights().
+
+    :param model_path: path to the model directory or HF hub model ID
+    :return: dict mapping weight name to absolute safetensors file path
+    """
+    model_path_str = str(model_path)
+    model_path = Path(model_path_str)
+
+    # If model_path is a local directory, use it directly
+    if model_path.is_dir():
+        return _build_weight_map_from_dir(model_path)
+
+    # For HF Hub model IDs, download only the index/config files first
+    from huggingface_hub import hf_hub_download
+
+    # Try to download just the index file (sharded model)
+    try:
+        index_path = hf_hub_download(model_path_str, "model.safetensors.index.json")
+        with open(index_path) as f:
+            index = json.load(f)
+
+        # The index file is in the snapshot dir — derive the model dir from it
+        snapshot_dir = Path(index_path).parent
+        weight_map = {}
+        for weight_name, shard_file in index["weight_map"].items():
+            weight_map[weight_name] = str(snapshot_dir / shard_file)
+        return weight_map
+    except Exception:
+        pass
+
+    # Try single-file model
+    try:
+        single_path = hf_hub_download(model_path_str, "model.safetensors")
+        weight_map = {}
+        with safe_open(single_path, framework="pt") as f:
+            for key in f.keys():
+                weight_map[key] = single_path
+        return weight_map
+    except Exception:
+        pass
+
+    # Fall back to full snapshot_download
+    from huggingface_hub import snapshot_download
+
+    model_path = Path(snapshot_download(model_path_str))
+    return _build_weight_map_from_dir(model_path)
+
+
+def _build_weight_map_from_dir(model_path: Path) -> dict[str, str]:
+    """Build weight map from a local directory."""
+    index_path = model_path / "model.safetensors.index.json"
+    if index_path.exists():
+        with open(index_path) as f:
+            index = json.load(f)
+        weight_map = {}
+        for weight_name, shard_file in index["weight_map"].items():
+            weight_map[weight_name] = str(model_path / shard_file)
+        return weight_map
+
+    single_file = model_path / "model.safetensors"
+    if single_file.exists():
+        weight_map = {}
+        with safe_open(str(single_file), framework="pt") as f:
+            for key in f.keys():
+                weight_map[key] = str(single_file)
+        return weight_map
+
+    raise FileNotFoundError(
+        f"No safetensors files found in {model_path}. "
+        "Layerwise quantization requires safetensors format."
+    )
+
+
+def _get_module_weight_names(
+    model: Module, subgraph_modules: set[Module]
+) -> dict[str, str]:
+    """
+    Get the full parameter names for all parameters in the given modules.
+
+    :param model: the full model (for resolving parameter names)
+    :param subgraph_modules: set of modules whose weights to load
+    :return: dict mapping parameter name -> module name
+    """
+    # Build a mapping from module to its fully qualified name
+    module_to_name = {module: name for name, module in model.named_modules()}
+
+    param_names = {}
+    for module in subgraph_modules:
+        module_name = module_to_name.get(module)
+        if module_name is None:
+            continue
+        for param_name, _ in module.named_parameters(recurse=True):
+            full_name = f"{module_name}.{param_name}" if module_name else param_name
+            param_names[full_name] = module_name
+
+    return param_names
+
+
+def get_subgraph_weight_names(
+    model: Module,
+    weight_map: dict[str, str],
+    sequential_targets: list[str],
+    subgraph_index: int,
+    num_subgraphs: int,
+) -> list[str]:
+    """
+    Determine which weight names belong to a given subgraph based on the
+    sequential target partitioning.
+
+    The subgraphs are laid out as:
+    - subgraph 0: head (embedding, pre-layer norms, etc.) — everything before
+      the first sequential target
+    - subgraph 1..N: one per sequential target (decoder layer)
+    - Note: the last subgraph may include post-layer modules (final norm, lm_head)
+
+    :param model: the model (on meta device)
+    :param weight_map: mapping from weight name to safetensors file path
+    :param sequential_targets: list of target module name patterns
+    :param subgraph_index: which subgraph (0-indexed)
+    :param num_subgraphs: total number of subgraphs
+    :return: list of weight names to load for this subgraph
+    """
+    from compressed_tensors.utils.match import match_named_modules
+
+    # Find actual target module names (preserving model order)
+    target_modules = list(match_named_modules(model, sequential_targets))
+    target_names = [name for name, _ in target_modules]
+
+    all_weight_names = list(weight_map.keys())
+    target_prefixes = [f"{name}." for name in target_names]
+
+    if subgraph_index == 0:
+        # First subgraph: non-target weights that come BEFORE the first target
+        # in the model's module definition order (e.g., embed_tokens)
+        module_order = {
+            name: idx for idx, (name, _) in enumerate(model.named_modules())
+        }
+        first_target_order = min(
+            module_order.get(name, float("inf")) for name in target_names
+        )
+        return [
+            w
+            for w in all_weight_names
+            if not any(w.startswith(p) for p in target_prefixes)
+            and module_order.get(w.rsplit(".", 1)[0] if "." in w else "", float("inf"))
+            < first_target_order
+        ]
+    elif subgraph_index == num_subgraphs - 1:
+        # Last subgraph: last target's weights + post-target non-target weights
+        # (e.g., model.norm, lm_head that come after all decoder layers)
+        target_idx = subgraph_index - 1
+        result = []
+        if target_idx < len(target_names):
+            prefix = f"{target_names[target_idx]}."
+            result = [w for w in all_weight_names if w.startswith(prefix)]
+
+        module_order = {
+            name: idx for idx, (name, _) in enumerate(model.named_modules())
+        }
+        last_target_order = max(module_order.get(name, 0) for name in target_names)
+        for w in all_weight_names:
+            if any(w.startswith(p) for p in target_prefixes):
+                continue
+            module_name = w.rsplit(".", 1)[0] if "." in w else ""
+            if module_order.get(module_name, -1) > last_target_order:
+                result.append(w)
+        return result
+    else:
+        # Middle subgraph: just the target's weights
+        target_idx = subgraph_index - 1
+        if target_idx < len(target_names):
+            prefix = f"{target_names[target_idx]}."
+            return [w for w in all_weight_names if w.startswith(prefix)]
+        return []
+
+
+def load_subgraph_weights(
+    model: Module,
+    weight_names: list[str],
+    weight_map: dict[str, str],
+    device: torch.device,
+    model_path: str | None = None,
+    model_to_safetensors: dict[str, str] | None = None,
+    tied_weights: dict[str, str] | None = None,
+) -> None:
+    """
+    Load weights from safetensors files for the given weight names,
+    replacing meta-device parameters with real tensors on the target device.
+
+    If a shard file does not exist locally, it will be downloaded on-demand
+    from the HF Hub using model_path as the repo ID.
+
+    :param model: the full model (meta device)
+    :param weight_names: list of parameter names (model param names) to load
+    :param weight_map: mapping from model param name to safetensors file path
+        (after remapping by build_key_remapping)
+    :param device: device to load weights onto
+    :param model_path: HF Hub model ID for on-demand shard downloads
+    :param model_to_safetensors: optional mapping from model param name to
+        the original safetensors key (for VL models where keys differ)
+    :param tied_weights: optional mapping from tied param name to source param
+        name (e.g., lm_head.weight -> model.embed_tokens.weight). Used to
+        resolve the safetensors key for tied weights.
+    """
+    if not weight_names:
+        return
+
+    # Group parameters by safetensors file for efficient loading
+    file_to_params: dict[str, list[str]] = {}
+    missing_params = []
+    for param_name in weight_names:
+        if param_name in weight_map:
+            file_path = weight_map[param_name]
+            file_to_params.setdefault(file_path, []).append(param_name)
+        else:
+            missing_params.append(param_name)
+
+    if missing_params:
+        logger.warning(
+            f"Could not find {len(missing_params)} parameters in weight map: "
+            f"{missing_params[:5]}{'...' if len(missing_params) > 5 else ''}"
+        )
+
+    # Load weights from each safetensors file, downloading on demand if needed
+    loaded_count = 0
+    for file_path, params in file_to_params.items():
+        resolved_path = _ensure_shard_available(file_path, model_path)
+        with safe_open(resolved_path, framework="pt", device=str(device)) as f:
+            for param_name in params:
+                # Use original safetensors key if remapping exists
+                sf_key = (
+                    model_to_safetensors.get(param_name, param_name)
+                    if model_to_safetensors
+                    else param_name
+                )
+                # For tied weights, load from the source param's key
+                if tied_weights and param_name in tied_weights:
+                    source = tied_weights[param_name]
+                    sf_key = (
+                        model_to_safetensors.get(source, source)
+                        if model_to_safetensors
+                        else source
+                    )
+                tensor = f.get_tensor(sf_key)
+                # Try normal set; fall back to fused MoE splitting
+                if not _try_set_fused_moe(model, param_name, tensor):
+                    _set_parameter(model, param_name, tensor)
+                loaded_count += 1
+
+    logger.debug(f"Loaded {loaded_count} parameters for subgraph onto {device}")
+
+    # Also move any quantization buffers (observers, scales, zero_points)
+    # that were initialized on meta device to the target device
+    _move_quantization_buffers(model, weight_names, device)
+
+
+def move_subgraph_buffers(
+    model: Module,
+    subgraph_modules: set,
+    device: torch.device,
+) -> None:
+    """
+    Move all buffers in a subgraph's modules from meta/CPU to the target device.
+
+    This is needed because some modules (e.g., RoPE rotary_emb) have buffers
+    like ``inv_freq`` that are not stored in safetensors and thus don't get
+    loaded by :func:`load_subgraph_weights`. In layerwise mode these buffers
+    stay on their init device (meta or CPU), causing device mismatches during
+    the forward pass.
+
+    :param model: the model (not used directly, but kept for API consistency)
+    :param subgraph_modules: set of modules from
+        ``subgraph.submodules(model, recurse=True)``
+    :param device: target device to move buffers to
+    """
+    moved = 0
+    for module in subgraph_modules:
+        for attr_name, buf in list(module._buffers.items()):
+            if buf is not None and buf.device != device:
+                module._buffers[attr_name] = buf.to(device)
+                moved += 1
+    if moved:
+        logger.debug(f"Moved {moved} subgraph buffers to {device}")
+
+
+def offload_subgraph_weights(
+    model: Module,
+    weight_names: list[str],
+    device: str = "meta",
+) -> None:
+    """
+    Offload subgraph weights to the specified device to free GPU memory.
+
+    :param model: the full model
+    :param weight_names: list of parameter names to offload
+    :param device: target device ("meta" to free all memory, "cpu" to keep on CPU)
+    """
+    target_device = torch.device(device)
+    freed_count = 0
+
+    # Extract unique module prefixes from weight names
+    module_prefixes = set()
+    for name in weight_names:
+        parts = name.rsplit(".", 1)
+        if len(parts) == 2:
+            module_prefixes.add(parts[0])
+
+    for prefix in module_prefixes:
+        try:
+            parts = prefix.split(".")
+            module = model
+            for part in parts:
+                module = getattr(module, part)
+        except AttributeError:
+            continue
+
+        # For unfused MoE experts, process all descendant modules
+        modules_to_process = [module]
+        if isinstance(module, torch.nn.ModuleList):
+            modules_to_process.extend(m for m in module.modules() if m is not module)
+
+        for mod in modules_to_process:
+            for attr_name in list(mod._parameters.keys()):
+                param = mod._parameters[attr_name]
+                if param is not None and param.device != target_device:
+                    if target_device.type == "meta":
+                        new_param = torch.nn.Parameter(
+                            torch.empty_like(param, device="meta"),
+                            requires_grad=param.requires_grad,
+                        )
+                    else:
+                        new_param = torch.nn.Parameter(
+                            param.data.to(target_device),
+                            requires_grad=param.requires_grad,
+                        )
+                    mod._parameters[attr_name] = new_param
+                    freed_count += 1
+
+            for attr_name in list(mod._buffers.keys()):
+                buf = mod._buffers[attr_name]
+                if buf is not None and buf.device != target_device:
+                    if target_device.type == "meta":
+                        mod._buffers[attr_name] = torch.empty_like(buf, device="meta")
+                    else:
+                        mod._buffers[attr_name] = buf.to(target_device)
+                    freed_count += 1
+
+    if freed_count > 0:
+        logger.debug(f"Offloaded {freed_count} parameters/buffers to {device}")
+        if device != "cpu":
+            torch.cuda.empty_cache()
+
+
+def save_subgraph_weights(
+    model: Module,
+    subgraph_modules: set[Module],
+    output_dir: str | os.PathLike,
+    shard_index: int,
+    weight_map_output: dict[str, str],
+) -> int:
+    """
+    Save the current weights of subgraph modules to a safetensors shard.
+
+    :param model: the full model
+    :param subgraph_modules: set of modules whose weights to save
+    :param output_dir: directory to save safetensors shards
+    :param shard_index: index for naming the shard file
+    :param weight_map_output: dict to update with weight_name -> shard_file mappings
+    :return: total size in bytes of saved tensors
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    param_names = _get_module_weight_names(model, subgraph_modules)
+    if not param_names:
+        return 0
+
+    # Collect tensors to save
+    tensors = {}
+    for param_name in param_names:
+        parts = param_name.split(".")
+        obj = model
+        for part in parts:
+            obj = getattr(obj, part)
+        if isinstance(obj, torch.Tensor) and obj.device.type != "meta":
+            tensors[param_name] = obj.contiguous().cpu()
+
+    if not tensors:
+        return 0
+
+    shard_name = f"model-{shard_index:05d}-of-99999.safetensors"
+    shard_path = output_dir / shard_name
+    save_file(tensors, str(shard_path))
+
+    total_size = sum(t.nbytes for t in tensors.values())
+    for name in tensors:
+        weight_map_output[name] = shard_name
+
+    logger.info(
+        f"Saved {len(tensors)} tensors ({total_size / 1e9:.2f} GB) to {shard_name}"
+    )
+    return total_size
+
+
+def _set_parameter(model: Module, param_name: str, tensor: torch.Tensor) -> None:
+    """
+    Set a parameter on the model by its fully qualified name,
+    replacing a meta-device parameter with a real tensor.
+
+    :param model: the model to set the parameter on
+    :param param_name: fully qualified parameter name (e.g., "model.layers.0.weight")
+    :param tensor: the real tensor to set
+    """
+    from llmcompressor.modeling.offset_norm import NormCalibrationModule
+
+    parts = param_name.split(".")
+    module = model
+    for part in parts[:-1]:
+        module = getattr(module, part)
+
+    param_attr = parts[-1]
+
+    # Apply weight transformation for norm calibration modules (e.g.,
+    # CalibrationOffsetNorm needs 1 + raw_weight when loaded from safetensors)
+    if isinstance(module, NormCalibrationModule):
+        tensor = module.transform_loaded_weight(param_attr, tensor)
+
+    old_param = getattr(module, param_attr, None)
+
+    if isinstance(old_param, torch.nn.Parameter):
+        new_param = torch.nn.Parameter(tensor, requires_grad=old_param.requires_grad)
+        module._parameters[param_attr] = new_param
+    else:
+        setattr(module, param_attr, tensor)
+
+
+def _try_set_fused_moe(model: Module, param_name: str, tensor: torch.Tensor) -> bool:
+    """
+    Handle fused MoE expert tensors when the model has been unfused by
+    MoE calibration modules (e.g., SequentialQwen3_5MoeExperts).
+
+    When ``moe_calibration_context`` replaces a fused ``Qwen3_5MoeExperts``
+    module with a ``ModuleList`` of individual MLPs, the fused parameter names
+    (e.g., ``experts.gate_up_proj``) no longer exist on the model. This function
+    detects such cases and splits the 3D tensor across individual experts.
+
+    :param model: the full model
+    :param param_name: weight name from the weight map (fused naming)
+    :param tensor: the fused 3D tensor loaded from safetensors
+    :return: True if handled (fused MoE split), False if not applicable
+    """
+    if tensor.dim() != 3:
+        return False
+
+    parts = param_name.split(".")
+    attr = parts[-1]  # e.g., "gate_up_proj" or "down_proj"
+
+    # Navigate to parent module
+    module = model
+    try:
+        for part in parts[:-1]:
+            module = getattr(module, part)
+    except AttributeError:
+        return False
+
+    # Check if parent is a ModuleList (unfused experts)
+    if not isinstance(module, torch.nn.ModuleList):
+        return False
+
+    num_experts = len(module)
+    if tensor.shape[0] != num_experts:
+        return False
+
+    if attr == "gate_up_proj":
+        intermediate_size = tensor.shape[1] // 2
+        for i in range(num_experts):
+            gate_up = tensor[i]  # [2*intermediate, hidden]
+            module[i].gate_proj.weight = torch.nn.Parameter(
+                gate_up[:intermediate_size, :].clone().contiguous()
+            )
+            module[i].up_proj.weight = torch.nn.Parameter(
+                gate_up[intermediate_size:, :].clone().contiguous()
+            )
+        logger.debug(
+            f"Split fused gate_up_proj into {num_experts} experts "
+            f"for {'.'.join(parts[:-1])}"
+        )
+        return True
+    elif attr == "down_proj":
+        for i in range(num_experts):
+            module[i].down_proj.weight = torch.nn.Parameter(
+                tensor[i].clone().contiguous()
+            )
+        logger.debug(
+            f"Split fused down_proj into {num_experts} experts "
+            f"for {'.'.join(parts[:-1])}"
+        )
+        return True
+
+    return False
+
+
+def _move_quantization_buffers(
+    model: Module, weight_names: list[str], device: torch.device
+) -> None:
+    """
+    Move quantization-related buffers and parameters (observers, scales, zero_points)
+    from meta device to the target device. These are created by QuantizationModifier
+    during initialization and may be on meta device for layerwise models.
+
+    :param model: the model
+    :param weight_names: list of weight names that were just loaded (used to
+        identify which modules to process)
+    :param device: device to move buffers to
+    """
+    # Extract unique module prefixes from weight names
+    module_prefixes = set()
+    for name in weight_names:
+        parts = name.rsplit(".", 1)
+        if len(parts) == 2:
+            module_prefixes.add(parts[0])
+
+    moved_count = 0
+    for prefix in module_prefixes:
+        try:
+            parts = prefix.split(".")
+            module = model
+            for part in parts:
+                module = getattr(module, part)
+        except AttributeError:
+            continue
+
+        # For unfused MoE experts (ModuleList), we need to process all
+        # descendant modules too, not just the container. The weight names
+        # use fused keys (e.g., "experts.gate_up_proj") but after MoE
+        # calibration the model has individual expert modules with their
+        # own quantization buffers (e.g., "experts.0.gate_proj.weight_scale").
+        modules_to_process = [module]
+        if isinstance(module, torch.nn.ModuleList):
+            modules_to_process.extend(m for m in module.modules() if m is not module)
+
+        for mod in modules_to_process:
+            # Move all meta-device parameters and buffers on this module
+            for attr_name in list(mod._parameters.keys()):
+                param = mod._parameters[attr_name]
+                if param is not None and param.device.type == "meta":
+                    new_param = torch.nn.Parameter(
+                        torch.zeros(param.shape, dtype=param.dtype, device=device),
+                        requires_grad=param.requires_grad,
+                    )
+                    mod._parameters[attr_name] = new_param
+                    moved_count += 1
+
+            for attr_name in list(mod._buffers.keys()):
+                buf = mod._buffers[attr_name]
+                if buf is not None and buf.device.type == "meta":
+                    mod._buffers[attr_name] = torch.zeros(
+                        buf.shape, dtype=buf.dtype, device=device
+                    )
+                    moved_count += 1
+
+            # Move observer modules if they exist
+            for attr_name in dir(mod):
+                if attr_name.endswith("_observer"):
+                    observer = getattr(mod, attr_name, None)
+                    if observer is not None and isinstance(observer, Module):
+                        for pname, param in observer.named_parameters():
+                            if param.device.type == "meta":
+                                parts_p = pname.split(".")
+                                target = observer
+                                for p in parts_p[:-1]:
+                                    target = getattr(target, p)
+                                target._parameters[parts_p[-1]] = torch.nn.Parameter(
+                                    torch.zeros(
+                                        param.shape, dtype=param.dtype, device=device
+                                    ),
+                                    requires_grad=param.requires_grad,
+                                )
+                                moved_count += 1
+                        for bname, buf in observer.named_buffers():
+                            if buf.device.type == "meta":
+                                parts_b = bname.split(".")
+                                target = observer
+                                for p in parts_b[:-1]:
+                                    target = getattr(target, p)
+                                target._buffers[parts_b[-1]] = torch.zeros(
+                                    buf.shape, dtype=buf.dtype, device=device
+                                )
+                                moved_count += 1
+
+    if moved_count > 0:
+        logger.debug(f"Moved {moved_count} quantization buffers/params to {device}")
+
+
+def _ensure_shard_available(file_path: str, model_path: str | None = None) -> str:
+    """
+    Ensure a safetensors shard file exists locally. If the file is missing
+    (because we only downloaded the index, not all shards), download it
+    on-demand from the HF Hub.
+
+    :param file_path: expected local path to the shard file
+    :param model_path: HF Hub model ID for downloading
+    :return: resolved local path to the shard file
+    """
+    if os.path.isfile(file_path):
+        return file_path
+
+    if model_path is None:
+        raise FileNotFoundError(
+            f"Shard file not found: {file_path}. "
+            "Provide model_path for on-demand downloading."
+        )
+
+    # Extract shard filename from the path
+    shard_filename = os.path.basename(file_path)
+    logger.info(f"Downloading shard on-demand: {shard_filename}")
+
+    from huggingface_hub import hf_hub_download
+
+    downloaded_path = hf_hub_download(model_path, shard_filename)
+    return downloaded_path
+
+
+def compress_and_save_subgraph(
+    model: Module,
+    weight_names: list[str],
+    output_dir: str | os.PathLike,
+    shard_index: int,
+    shard_weight_map: dict[str, str],
+    model_to_safetensors: dict[str, str] | None = None,
+    tied_weights: dict[str, str] | None = None,
+) -> int:
+    """
+    Compress quantized modules for the given weight names in-place, then save
+    all parameters (compressed weights + quantization params) to a safetensors
+    shard. After saving, offloads weights to meta device to free memory.
+
+    This enables "compress-as-you-go": each subgraph is compressed and saved
+    immediately after calibration, so only 1 subgraph's base weights are ever
+    in CPU/GPU memory at a time.
+
+    :param model: the full model
+    :param weight_names: list of parameter names belonging to this subgraph
+    :param output_dir: directory to save safetensors shards
+    :param shard_index: index for naming the shard file
+    :param shard_weight_map: dict to update with weight_name -> shard_file mappings
+    :param model_to_safetensors: optional mapping from model param name to
+        original safetensors key (for saving with original naming convention)
+    :return: total size in bytes of saved tensors
+    """
+    from compressed_tensors.compressors.base import compress_module
+    from compressed_tensors.quantization.utils.helpers import is_module_quantized
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Identify modules that contain the subgraph's weights
+    module_prefixes = set()
+    for name in weight_names:
+        parts = name.rsplit(".", 1)
+        if len(parts) == 2:
+            module_prefixes.add(parts[0])
+
+    # Compress quantized modules in this subgraph
+    compressed_count = 0
+    for prefix in module_prefixes:
+        try:
+            parts = prefix.split(".")
+            module = model
+            for part in parts:
+                module = getattr(module, part)
+        except AttributeError:
+            continue
+
+        # For unfused MoE experts (ModuleList), compress each child's
+        # quantized submodules instead of the ModuleList itself
+        modules_to_compress = []
+        if isinstance(module, torch.nn.ModuleList):
+            for child in module:
+                for _, submod in child.named_modules():
+                    modules_to_compress.append(submod)
+        else:
+            modules_to_compress.append(module)
+
+        for mod in modules_to_compress:
+            if is_module_quantized(mod):
+                # Ensure all params/buffers are on the same device before compression
+                devices = set()
+                for p in mod.parameters():
+                    if p.device.type != "meta":
+                        devices.add(p.device)
+                for b in mod.buffers():
+                    if b.device.type != "meta":
+                        devices.add(b.device)
+                if len(devices) > 1:
+                    # Move everything to CPU for consistent compression
+                    for pname, param in mod.named_parameters(recurse=False):
+                        if param.device.type != "cpu" and param.device.type != "meta":
+                            mod._parameters[pname] = torch.nn.Parameter(
+                                param.data.cpu(), requires_grad=param.requires_grad
+                            )
+                    for bname in list(mod._buffers.keys()):
+                        buf = mod._buffers[bname]
+                        if (
+                            buf is not None
+                            and buf.device.type != "cpu"
+                            and buf.device.type != "meta"
+                        ):
+                            mod._buffers[bname] = buf.cpu()
+                compress_module(mod)
+                compressed_count += 1
+
+    if compressed_count > 0:
+        logger.debug(f"Compressed {compressed_count} quantized modules in subgraph")
+
+    # Collect all non-meta tensors (parameters + buffers) from these modules.
+    # For unfused MoE (ModuleList), recurse into children to capture all
+    # individual expert parameters.
+    from llmcompressor.modeling.offset_norm import NormCalibrationModule
+
+    tensors = {}
+    for prefix in module_prefixes:
+        try:
+            parts = prefix.split(".")
+            module = model
+            for part in parts:
+                module = getattr(module, part)
+        except AttributeError:
+            continue
+
+        use_recurse = isinstance(module, torch.nn.ModuleList)
+
+        for pname, param in module.named_parameters(recurse=use_recurse):
+            full_name = f"{prefix}.{pname}"
+            if param.device.type != "meta":
+                tensor = param.data.contiguous().cpu()
+                # Reverse calibration transformation for norm modules so that
+                # saved weights are in the original (offset) convention
+                if isinstance(module, NormCalibrationModule):
+                    tensor = module.transform_save_weight(pname, tensor)
+                tensors[full_name] = tensor
+
+        for bname, buf in module.named_buffers(recurse=use_recurse):
+            full_name = f"{prefix}.{bname}"
+            if buf.device.type != "meta":
+                tensors[full_name] = buf.contiguous().cpu()
+
+    if not tensors:
+        return 0
+
+    # Skip tied weight aliases (e.g., lm_head.weight when tied to
+    # embed_tokens.weight). The canonical copy is saved under its own name;
+    # the framework restores the tie at load time via config flags.
+    if tied_weights:
+        for alias in tied_weights:
+            tensors.pop(alias, None)
+
+    if not tensors:
+        return 0
+
+    # Remap keys back to original safetensors naming for VL model compatibility.
+    # This handles both original weights (in model_to_safetensors) and new
+    # quantization params (weight_scale, weight_zero_point, etc.) that share
+    # the same module prefix but weren't in the original safetensors.
+    if model_to_safetensors:
+        # Build a prefix mapping from model prefix -> safetensors prefix
+        # e.g., "model.layers.0.self_attn.q_proj" ->
+        # "model.language_model.layers.0.self_attn.q_proj"
+        prefix_map: dict[str, str] = {}
+        for model_key, sf_key in model_to_safetensors.items():
+            model_prefix = model_key.rsplit(".", 1)[0] if "." in model_key else ""
+            sf_prefix = sf_key.rsplit(".", 1)[0] if "." in sf_key else ""
+            if model_prefix and sf_prefix and model_prefix not in prefix_map:
+                prefix_map[model_prefix] = sf_prefix
+
+        def _remap_prefix(name: str) -> str:
+            """Find the best prefix mapping for a tensor name.
+
+            First tries an exact prefix match, then walks up parent prefixes.
+            This handles unfused MoE expert names like
+            ``model.layers.0.mlp.experts.0.gate_proj.weight`` which have
+            prefix ``model.layers.0.mlp.experts`` in the map but the full
+            module prefix ``model.layers.0.mlp.experts.0.gate_proj`` is not.
+            """
+            module_prefix = name.rsplit(".", 1)[0] if "." in name else ""
+            param_suffix = name[len(module_prefix) + 1 :] if module_prefix else name
+
+            # Exact match
+            if module_prefix in prefix_map:
+                return f"{prefix_map[module_prefix]}.{param_suffix}"
+
+            # Walk up parent prefixes
+            parts = module_prefix.split(".")
+            for i in range(len(parts) - 1, 0, -1):
+                parent = ".".join(parts[:i])
+                if parent in prefix_map:
+                    child_suffix = ".".join(parts[i:])
+                    return f"{prefix_map[parent]}.{child_suffix}.{param_suffix}"
+
+            return name
+
+        remapped_tensors = {}
+        for name, tensor in tensors.items():
+            if name in model_to_safetensors:
+                # Exact match: use the known mapping
+                remapped_tensors[model_to_safetensors[name]] = tensor
+            else:
+                remapped_tensors[_remap_prefix(name)] = tensor
+        tensors = remapped_tensors
+
+    # Save to shard file
+    shard_name = f"model-{shard_index + 1:05d}-of-99999.safetensors"
+    shard_path = output_dir / shard_name
+    save_file(tensors, str(shard_path))
+
+    total_size = sum(t.nbytes for t in tensors.values())
+    for name in tensors:
+        shard_weight_map[name] = shard_name
+
+    logger.info(
+        f"Saved subgraph {shard_index + 1}: "
+        f"{len(tensors)} tensors ({total_size / 1e9:.2f} GB) -> {shard_name}"
+    )
+
+    # Offload to meta to free memory
+    offload_subgraph_weights(model, weight_names, device="meta")
+
+    return total_size
+
+
+def write_safetensors_index(
+    output_dir: str | os.PathLike,
+    shard_weight_map: dict[str, str],
+    total_size: int,
+) -> None:
+    """
+    Write the model.safetensors.index.json file and rename shard files to
+    reflect the actual total number of shards.
+
+    :param output_dir: directory containing the shard files
+    :param shard_weight_map: mapping of weight name -> shard filename
+    :param total_size: total size in bytes of all saved tensors
+    """
+    output_dir = Path(output_dir)
+
+    # Determine actual shard files used
+    shard_files = sorted(set(shard_weight_map.values()))
+    num_shards = len(shard_files)
+
+    # Rename shards to have correct total count
+    rename_map = {}
+    for i, old_name in enumerate(shard_files):
+        new_name = f"model-{i + 1:05d}-of-{num_shards:05d}.safetensors"
+        if old_name != new_name:
+            old_path = output_dir / old_name
+            new_path = output_dir / new_name
+            if old_path.exists():
+                old_path.rename(new_path)
+            rename_map[old_name] = new_name
+
+    # Update weight map with renamed shard files
+    final_weight_map = {}
+    for weight_name, shard_file in shard_weight_map.items():
+        final_weight_map[weight_name] = rename_map.get(shard_file, shard_file)
+
+    # Write index file
+    index = {
+        "metadata": {"total_size": total_size},
+        "weight_map": final_weight_map,
+    }
+    index_path = output_dir / "model.safetensors.index.json"
+    with open(index_path, "w") as f:
+        json.dump(index, f, indent=2)
+
+    logger.info(
+        f"Written safetensors index: {num_shards} shards, "
+        f"{total_size / 1e9:.2f} GB total"
+    )
+
+
+class ShardPrefetcher:
+    """
+    Background prefetcher that downloads the next subgraph's shard files
+    while the current subgraph is being calibrated on GPU.
+
+    Usage:
+        prefetcher = ShardPrefetcher(model_path)
+        prefetcher.prefetch(next_weight_names, weight_map)
+        # ... calibrate current subgraph ...
+        prefetcher.wait()  # ensure next shards are ready
+    """
+
+    def __init__(self, model_path: str | None = None):
+        self._model_path = model_path
+        self._thread: threading.Thread | None = None
+        self._error: Exception | None = None
+
+    def prefetch(
+        self,
+        weight_names: list[str],
+        weight_map: dict[str, str],
+    ) -> None:
+        """Start background download of shard files for the given weight names."""
+        self.wait()  # ensure previous prefetch is complete
+
+        # Determine unique shard files needed
+        shard_files = set()
+        for name in weight_names:
+            if name in weight_map:
+                shard_files.add(weight_map[name])
+
+        # Filter to only files that need downloading
+        files_to_download = [f for f in shard_files if not os.path.isfile(f)]
+        if not files_to_download:
+            return
+
+        self._error = None
+        self._thread = threading.Thread(
+            target=self._download_shards,
+            args=(files_to_download,),
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _download_shards(self, file_paths: list[str]) -> None:
+        """Download shard files in background thread."""
+        try:
+            for file_path in file_paths:
+                _ensure_shard_available(file_path, self._model_path)
+        except Exception as e:
+            self._error = e
+
+    def wait(self) -> None:
+        """Wait for background prefetch to complete. Raises if download failed."""
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+        if self._error is not None:
+            error = self._error
+            self._error = None
+            raise error

--- a/src/llmcompressor/pipelines/layerwise/pipeline.py
+++ b/src/llmcompressor/pipelines/layerwise/pipeline.py
@@ -1,0 +1,498 @@
+"""
+Layerwise calibration pipeline for memory-efficient quantization.
+
+This pipeline enables quantization of models that exceed available memory by
+loading weights from safetensors files per-subgraph during calibration, rather
+than loading the entire model at once.
+
+Resource optimizations:
+- Compress-as-you-go: each subgraph is compressed and saved immediately after
+  calibration, so only 1 subgraph of base weights is in memory at a time.
+  Peak CPU RAM = 1 subgraph instead of full model.
+- On-demand shard downloads: only the safetensors shard files needed for the
+  current subgraph are downloaded, not the full model. Disk = ~2 shards at peak.
+- Background prefetch: next subgraph's shard files are downloaded in a background
+  thread while the current subgraph calibrates on GPU.
+
+The pipeline follows the same structure as SequentialPipeline:
+1. Model is traced into subgraphs (using meta-device model structure)
+2. For each subgraph:
+   a. Weights are loaded from safetensors onto GPU (on-demand download if needed)
+   b. Calibration pass triggers modifier hooks (AWQ, GPTQ, etc.)
+   c. Quantization/smoothing is applied
+   d. Propagation pass captures compressed outputs
+   e. Subgraph is compressed and saved to a shard file
+   f. Weights are offloaded to meta device (freed from memory)
+3. Safetensors index is written to stitch shards together
+"""
+
+import contextlib
+from typing import TYPE_CHECKING, Iterator
+
+import torch
+from compressed_tensors.offload import disable_offloading
+from loguru import logger
+from safetensors import safe_open
+from torch.utils.data.dataloader import DataLoader
+from tqdm import tqdm
+
+from llmcompressor.core import LifecycleCallbacks, active_session
+from llmcompressor.modifiers.utils.hooks import HooksMixin
+from llmcompressor.pipelines.cache import IntermediatesCache
+from llmcompressor.pipelines.layerwise.helpers import (
+    ShardPrefetcher,
+    build_key_remapping,
+    build_weight_map,
+    compress_and_save_subgraph,
+    copy_passthrough_weights,
+    get_subgraph_weight_names,
+    load_subgraph_weights,
+    move_subgraph_buffers,
+    offload_subgraph_weights,
+    write_safetensors_index,
+)
+from llmcompressor.pipelines.registry import CalibrationPipeline
+from llmcompressor.pipelines.sequential.helpers import (
+    handle_sequential_oom,
+    trace_subgraphs,
+)
+from llmcompressor.utils.dev import get_main_device
+from llmcompressor.utils.helpers import DisableQuantization, calibration_forward_context
+from llmcompressor.utils.pytorch.module import infer_sequential_targets
+
+if TYPE_CHECKING:
+    from llmcompressor.args.dataset_arguments import DatasetArguments
+
+__all__ = ["LayerwisePipeline"]
+
+
+def _get_batches(
+    activations: IntermediatesCache,
+    num_batches: int,
+    input_names: list[str],
+    desc: str,
+    sequential_prefetch: bool = False,
+) -> Iterator[tuple[int, dict]]:
+    """
+    Yield (batch_idx, inputs) with optional prefetching.
+    """
+    batch_source = (
+        activations.iter_prefetch(input_names)
+        if sequential_prefetch
+        else activations.iter(input_names)
+    )
+    for batch_idx, inputs in tqdm(
+        enumerate(batch_source), total=num_batches, desc=desc
+    ):
+        yield batch_idx, inputs
+
+
+@CalibrationPipeline.register("layerwise")
+class LayerwisePipeline(CalibrationPipeline):
+    @staticmethod
+    @handle_sequential_oom
+    def __call__(
+        model: torch.nn.Module,
+        dataloader: DataLoader,
+        dataset_args: "DatasetArguments",
+    ):
+        """
+        Run a layerwise calibration pipeline for memory-efficient quantization.
+
+        This pipeline is identical to SequentialPipeline except that model weights
+        are loaded from safetensors files per-subgraph rather than being resident
+        in memory. This enables quantization of models that are too large to fit
+        in GPU or CPU memory.
+
+        Resource optimizations applied:
+        - Compress-as-you-go: each subgraph is compressed and saved to a shard
+          immediately after calibration. Only 1 subgraph in memory at a time.
+        - On-demand shard downloads: only the safetensors shards needed for the
+          current subgraph are downloaded, not the full model.
+        - Background prefetch: the next subgraph's shards are downloaded while
+          the current subgraph calibrates.
+
+        Requirements:
+        - The model must be on meta device (loaded with layerwise=True)
+        - The original model weights must be in safetensors format
+
+        :param model: model on meta device being calibrated
+        :param dataloader: loads data for calibration
+        :param dataset_args: dataset arguments relevant to pipelines
+        """
+        session = active_session()
+
+        # Determine model source path for weight loading
+        model_path = getattr(model.config, "_name_or_path", None) or getattr(
+            model, "name_or_path", None
+        )
+        if model_path is None:
+            raise ValueError(
+                "Cannot determine model source path for layerwise weight loading. "
+                "Ensure the model was loaded with layerwise=True."
+            )
+
+        # Build weight map from safetensors index (downloads only index, not shards)
+        raw_weight_map = build_weight_map(model_path)
+        logger.info(
+            f"Built weight map with {len(raw_weight_map)} parameters "
+            f"from {model_path}"
+        )
+
+        # Auto-detect key remapping for VL/multimodal models
+        # (e.g., safetensors uses "model.language_model.*" but CausalLM uses "model.*")
+        weight_map, model_to_safetensors, passthrough_keys, tied_weights = (
+            build_key_remapping(raw_weight_map, model)
+        )
+
+        # prepare model for sequential onloading
+        onload_device = get_main_device()
+        offload_device = torch.device(dataset_args.sequential_offload_device)
+
+        # prepare to trace subgraphs
+        sequential_targets = infer_sequential_targets(
+            model, dataset_args.sequential_targets
+        )
+        ignore = dataset_args.tracing_ignore
+
+        # For meta-device models, we need a sample input on meta device for tracing.
+        # torch.fx tracing is symbolic and doesn't need real values.
+        # Note: iter() creates a fresh iterator so no batch is consumed from
+        # subsequent full iterations over the dataloader.
+        sample_input = next(iter(dataloader))
+
+        # trace subgraphs (symbolic, works on meta device)
+        subgraphs = trace_subgraphs(
+            model,
+            sample_input,
+            sequential_targets,
+            ignore,
+            dataset_args.sequential_targets_per_subgraph,
+        )
+        num_subgraphs = len(subgraphs)
+        logger.info(f"Traced {num_subgraphs} subgraphs for layerwise calibration")
+
+        # Compute which weight_map keys are assigned to subgraphs.
+        # Keys NOT assigned to any subgraph (e.g., MTP extra layers) must
+        # be saved via passthrough. Keys that ARE assigned (e.g., individual
+        # MoE expert keys that get fused during loading) should NOT be in
+        # passthrough to avoid redundant copies.
+        assigned_keys: set[str] = set()
+        for si in range(num_subgraphs):
+            assigned_keys.update(
+                get_subgraph_weight_names(
+                    model,
+                    weight_map,
+                    sequential_targets,
+                    si,
+                    num_subgraphs,
+                )
+            )
+
+        # Filter passthrough: keep original passthrough keys (VL visual/mtp)
+        # that aren't assigned. Also add weight_map keys not assigned to any
+        # subgraph (e.g., GLM layer 47 MTP stored as model.layers.47.*).
+        original_passthrough = set(passthrough_keys)
+        unassigned_wm_keys = set(weight_map.keys()) - assigned_keys
+        passthrough_keys = sorted(
+            (original_passthrough | unassigned_wm_keys) - assigned_keys
+        )
+        # For passthrough copy, we need raw safetensors keys, not model keys.
+        # Convert any remapped keys back to their safetensors names.
+        raw_passthrough_keys = []
+        for k in passthrough_keys:
+            if k in model_to_safetensors:
+                raw_passthrough_keys.append(model_to_safetensors[k])
+            elif k in raw_weight_map:
+                raw_passthrough_keys.append(k)
+            # else: skip (shouldn't happen)
+
+        if passthrough_keys:
+            logger.info(
+                f"Passthrough keys after filtering: {len(raw_passthrough_keys)} "
+                f"(was {len(original_passthrough)} before)"
+            )
+
+        # Store passthrough module names so oneshot can add them to the
+        # quantization config's ignore list (prevents serving frameworks from
+        # treating passthrough float weights as quantized).
+        if raw_passthrough_keys:
+            # Convert weight keys to module names (strip .weight/.bias suffix)
+            # and deduplicate (some modules have both weight and bias)
+            module_names: set[str] = set()
+            for k in raw_passthrough_keys:
+                if k.endswith(".weight") or k.endswith(".bias"):
+                    module_names.add(k.rsplit(".", 1)[0])
+                else:
+                    module_names.add(k)
+            dataset_args.passthrough_module_names = sorted(module_names)
+
+        # Check for resume mode (skip already-completed subgraphs).
+        resume_from = getattr(dataset_args, "layerwise_resume_from", 0)
+        if resume_from >= num_subgraphs:
+            raise ValueError(
+                f"layerwise_resume_from={resume_from} is >= total "
+                f"subgraphs ({num_subgraphs}). Nothing to resume."
+            )
+        if resume_from > 0:
+            logger.info(
+                f"Resuming from subgraph {resume_from + 1}/{num_subgraphs} "
+                f"(replaying forward passes through {resume_from} completed "
+                f"subgraphs to rebuild intermediates)"
+            )
+
+        # Determine output directory for compress-as-you-go shard saving
+        output_dir = getattr(dataset_args, "output_dir", None)
+
+        # Track compressed shards for index writing
+        shard_weight_map: dict[str, str] = {}
+        total_saved_size = 0
+
+        # Initialize shard prefetcher for background downloads
+        prefetcher = ShardPrefetcher(model_path)
+
+        LifecycleCallbacks.calibration_epoch_start()
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(calibration_forward_context(model))
+            stack.enter_context(DisableQuantization(model))
+
+            # prepare intermediates cache
+            activations = IntermediatesCache.from_dataloader(
+                dataloader, onload_device, offload_device
+            )
+
+            # Populate loss_masks for AWQ masking support
+            use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
+            if use_loss_mask:
+                session.state.loss_masks = [
+                    activations.fetch(batch_idx, ["loss_mask"]).get("loss_mask")
+                    for batch_idx in range(len(dataloader))
+                ]
+            else:
+                session.state.loss_masks = None
+
+            sequential_prefetch = getattr(dataset_args, "sequential_prefetch", False)
+            session.state.sequential_prefetch = sequential_prefetch
+            session.state.pipeline_type = "layerwise"
+
+            for subgraph_index, subgraph in enumerate(subgraphs):
+                # Determine which weights this subgraph needs
+                weight_names = get_subgraph_weight_names(
+                    model,
+                    weight_map,
+                    sequential_targets,
+                    subgraph_index,
+                    num_subgraphs,
+                )
+
+                # Resume mode: replay forward pass to rebuild intermediates
+                if subgraph_index < resume_from:
+                    prefetcher.wait()
+                    if subgraph_index + 1 < num_subgraphs:
+                        next_wn = get_subgraph_weight_names(
+                            model,
+                            weight_map,
+                            sequential_targets,
+                            subgraph_index + 1,
+                            num_subgraphs,
+                        )
+                        prefetcher.prefetch(next_wn, weight_map)
+
+                    load_subgraph_weights(
+                        model,
+                        weight_names,
+                        weight_map,
+                        onload_device,
+                        model_path=model_path,
+                        model_to_safetensors=model_to_safetensors,
+                        tied_weights=tied_weights,
+                    )
+                    move_subgraph_buffers(
+                        model,
+                        subgraph.submodules(model, recurse=True),
+                        onload_device,
+                    )
+
+                    replay_desc = f"({subgraph_index + 1}/{num_subgraphs}): Replaying"
+                    num_batches = len(dataloader)
+                    with disable_offloading():
+                        with HooksMixin.disable_hooks():
+                            for batch_idx, inputs in _get_batches(
+                                activations,
+                                num_batches,
+                                subgraph.input_names,
+                                replay_desc,
+                                sequential_prefetch,
+                            ):
+                                output = subgraph.forward(model, **inputs)
+                                if subgraph_index < num_subgraphs - 1:
+                                    activations.update(batch_idx, output)
+                                    activations.delete(
+                                        batch_idx, subgraph.consumed_names
+                                    )
+
+                    offload_subgraph_weights(model, weight_names, device="meta")
+                    logger.info(
+                        f"Replayed subgraph "
+                        f"{subgraph_index + 1}/{num_subgraphs} (skipped)"
+                    )
+                    continue
+
+                # Wait for any prefetched shards to be ready
+                prefetcher.wait()
+
+                # Start prefetching next subgraph's shards in background
+                if subgraph_index + 1 < num_subgraphs:
+                    next_weight_names = get_subgraph_weight_names(
+                        model,
+                        weight_map,
+                        sequential_targets,
+                        subgraph_index + 1,
+                        num_subgraphs,
+                    )
+                    prefetcher.prefetch(next_weight_names, weight_map)
+
+                # Load weights for this subgraph (on-demand download if needed)
+                logger.info(
+                    f"Loading weights for subgraph "
+                    f"{subgraph_index + 1}/{num_subgraphs} "
+                    f"({len(weight_names)} parameters)"
+                )
+                load_subgraph_weights(
+                    model,
+                    weight_names,
+                    weight_map,
+                    onload_device,
+                    model_path=model_path,
+                    model_to_safetensors=model_to_safetensors,
+                    tied_weights=tied_weights,
+                )
+                move_subgraph_buffers(
+                    model,
+                    subgraph.submodules(model, recurse=True),
+                    onload_device,
+                )
+
+                # prepare tqdm description texts
+                calib_desc = f"({subgraph_index + 1}/{num_subgraphs}): Calibrating"
+                prop_desc = f"({subgraph_index + 1}/{num_subgraphs}): Propagating"
+
+                num_batches = len(dataloader)
+                with disable_offloading():
+                    # Calibration pass: triggers modifier hooks
+                    for batch_idx, inputs in _get_batches(
+                        activations,
+                        num_batches,
+                        subgraph.input_names,
+                        calib_desc,
+                        sequential_prefetch,
+                    ):
+                        session.state.current_batch_idx = batch_idx
+                        outputs = subgraph.forward(model, **inputs)
+
+                        if not dataset_args.propagate_error:
+                            if subgraph_index < num_subgraphs - 1:
+                                activations.update(batch_idx, outputs)
+                                activations.delete(batch_idx, subgraph.consumed_names)
+
+                    modules = list(subgraph.submodules(model))
+                    LifecycleCallbacks.sequential_epoch_end(modules)
+
+                    if dataset_args.propagate_error:
+                        # Propagation pass: capture outputs of compressed modules
+                        with HooksMixin.disable_hooks():
+                            for batch_idx, inputs in _get_batches(
+                                activations,
+                                num_batches,
+                                subgraph.input_names,
+                                prop_desc,
+                                sequential_prefetch,
+                            ):
+                                output = subgraph.forward(model, **inputs)
+                                if subgraph_index < num_subgraphs - 1:
+                                    activations.update(batch_idx, output)
+                                    activations.delete(
+                                        batch_idx, subgraph.consumed_names
+                                    )
+
+                # Compress-as-you-go: compress, save to shard, and free memory
+                if output_dir is not None:
+                    saved_size = compress_and_save_subgraph(
+                        model,
+                        weight_names,
+                        output_dir,
+                        subgraph_index,
+                        shard_weight_map,
+                        model_to_safetensors=model_to_safetensors,
+                        tied_weights=tied_weights,
+                    )
+                    total_saved_size += saved_size
+                    logger.info(
+                        f"Completed subgraph {subgraph_index + 1}/{num_subgraphs} "
+                        f"(compressed and saved)"
+                    )
+                else:
+                    # Fallback: offload to CPU (legacy behavior)
+                    offload_subgraph_weights(model, weight_names, device="cpu")
+                    logger.info(
+                        f"Completed subgraph {subgraph_index + 1}/{num_subgraphs}"
+                    )
+
+            # Write safetensors index if we saved shards
+            if output_dir is not None:
+                # Copy passthrough weights (visual encoder, mtp, etc.)
+                if raw_passthrough_keys:
+                    pt_size = copy_passthrough_weights(
+                        raw_passthrough_keys,
+                        raw_weight_map,
+                        output_dir,
+                        shard_weight_map,
+                        model_path=model_path,
+                    )
+                    total_saved_size += pt_size
+
+                if resume_from > 0:
+                    # Resume mode: scan all shard files (old + new) to build
+                    # a complete weight map for the index
+                    from pathlib import Path as _Path
+
+                    complete_weight_map: dict[str, str] = {}
+                    complete_total_size = 0
+                    for shard_path in sorted(
+                        _Path(output_dir).glob("model-*-of-*.safetensors")
+                    ):
+                        complete_total_size += shard_path.stat().st_size
+                        with safe_open(str(shard_path), framework="pt") as f:
+                            for key in f.keys():
+                                complete_weight_map[key] = shard_path.name
+                    if complete_weight_map:
+                        write_safetensors_index(
+                            output_dir, complete_weight_map, complete_total_size
+                        )
+                elif shard_weight_map:
+                    write_safetensors_index(
+                        output_dir, shard_weight_map, total_saved_size
+                    )
+
+            # If we didn't use compress-as-you-go, move remaining GPU tensors to CPU
+            if output_dir is None:
+                for name, param in model.named_parameters():
+                    if param.device.type == "cuda":
+                        parts = name.rsplit(".", 1)
+                        parent = model
+                        for p in parts[0].split("."):
+                            parent = getattr(parent, p)
+                        parent._parameters[parts[-1]] = torch.nn.Parameter(
+                            param.data.cpu(), requires_grad=param.requires_grad
+                        )
+                for name, buf in model.named_buffers():
+                    if buf.device.type == "cuda":
+                        parts = name.rsplit(".", 1)
+                        parent = model
+                        for p in parts[0].split("."):
+                            parent = getattr(parent, p)
+                        parent._buffers[parts[-1]] = buf.cpu()
+
+            # Finish any remaining compression
+            LifecycleCallbacks.calibration_epoch_end()

--- a/tests/llmcompressor/pipelines/layerwise/test_helpers.py
+++ b/tests/llmcompressor/pipelines/layerwise/test_helpers.py
@@ -1,0 +1,295 @@
+"""
+Unit tests for the layerwise pipeline helper functions.
+
+Tests cover:
+- build_weight_map: loading weight maps from local directories
+- build_key_remapping: prefix detection and passthrough filtering
+- get_subgraph_weight_names: subgraph partitioning logic
+- _detect_tied_weights: tied weight detection
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from transformers import AutoModelForCausalLM
+
+from llmcompressor.pipelines.layerwise.helpers import (
+    build_key_remapping,
+    build_weight_map,
+    get_subgraph_weight_names,
+    move_subgraph_buffers,
+    offload_subgraph_weights,
+)
+from llmcompressor.utils.dev import skip_weights_download, skip_weights_initialize
+
+MODEL_ID = "Qwen/Qwen3-0.6B"
+
+
+@pytest.fixture
+def qwen3_model():
+    """Load Qwen3-0.6B on meta device without downloading weights."""
+    with skip_weights_download(AutoModelForCausalLM):
+        model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype="auto")
+    return model
+
+
+@pytest.fixture
+def fake_safetensors_dir(qwen3_model):
+    """Create a temporary directory with a fake safetensors index and shard files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        # Gather all parameter names from the model
+        param_names = [name for name, _ in qwen3_model.named_parameters()]
+
+        # Split into 2 shards for testing
+        mid = len(param_names) // 2
+        shard1_params = param_names[:mid]
+        shard2_params = param_names[mid:]
+
+        # Create fake tensors (small ones since we just need the structure)
+        shard1_tensors = {}
+        for name in shard1_params:
+            shard1_tensors[name] = torch.zeros(1)
+        shard2_tensors = {}
+        for name in shard2_params:
+            shard2_tensors[name] = torch.zeros(1)
+
+        # Save shard files
+        save_file(shard1_tensors, str(tmpdir / "model-00001-of-00002.safetensors"))
+        save_file(shard2_tensors, str(tmpdir / "model-00002-of-00002.safetensors"))
+
+        # Write index
+        weight_map = {}
+        for name in shard1_params:
+            weight_map[name] = "model-00001-of-00002.safetensors"
+        for name in shard2_params:
+            weight_map[name] = "model-00002-of-00002.safetensors"
+
+        index = {"metadata": {"total_size": 0}, "weight_map": weight_map}
+        with open(tmpdir / "model.safetensors.index.json", "w") as f:
+            json.dump(index, f)
+
+        yield tmpdir
+
+
+class TestBuildWeightMap:
+    """Tests for build_weight_map."""
+
+    def test_build_from_local_dir(self, fake_safetensors_dir, qwen3_model):
+        """build_weight_map should load all parameter names from a local dir."""
+        weight_map = build_weight_map(str(fake_safetensors_dir))
+
+        # Should have entries for all model parameters
+        param_names = set(name for name, _ in qwen3_model.named_parameters())
+        assert set(weight_map.keys()) == param_names
+
+        # All values should be absolute paths
+        for path in weight_map.values():
+            assert Path(path).is_absolute()
+
+    def test_build_from_nonexistent_dir_raises(self):
+        """Should raise an error for non-existent local paths."""
+        with pytest.raises((FileNotFoundError, OSError, ValueError)):
+            build_weight_map("/nonexistent/model")
+
+    def test_single_shard_model(self, qwen3_model):
+        """build_weight_map should work with a single-file model."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = Path(tmpdir)
+            tensors = {
+                name: torch.zeros(1) for name, _ in qwen3_model.named_parameters()
+            }
+            save_file(tensors, str(tmpdir / "model.safetensors"))
+
+            weight_map = build_weight_map(str(tmpdir))
+            param_names = set(name for name, _ in qwen3_model.named_parameters())
+            assert set(weight_map.keys()) == param_names
+
+
+class TestBuildKeyRemapping:
+    """Tests for build_key_remapping."""
+
+    def test_no_remapping_needed(self, qwen3_model, fake_safetensors_dir):
+        """When model params match safetensors keys, no remapping should occur."""
+        weight_map = build_weight_map(str(fake_safetensors_dir))
+        _remapped_wm, model_to_sf, passthrough, _tied = build_key_remapping(
+            weight_map, qwen3_model
+        )
+
+        # No remapping needed — model_to_safetensors should be empty
+        assert model_to_sf == {}
+        # No passthrough for a standard causal LM
+        assert passthrough == []
+
+    def test_prefix_remapping(self, qwen3_model):
+        """Simulate a VL model where safetensors uses a different prefix."""
+        # Create a fake weight map with "model.language_model." prefix
+        fake_map = {}
+        for name, _ in qwen3_model.named_parameters():
+            if name.startswith("model."):
+                remapped = "model.language_model." + name[len("model.") :]
+                fake_map[remapped] = "/fake/shard.safetensors"
+            else:
+                fake_map[name] = "/fake/shard.safetensors"
+
+        remapped_wm, _model_to_sf, _passthrough, _tied = build_key_remapping(
+            fake_map, qwen3_model
+        )
+
+        # Should have remapped keys back to model param names
+        model_params = set(name for name, _ in qwen3_model.named_parameters())
+        # All model params should be in the remapped weight map
+        for param in model_params:
+            assert param in remapped_wm, f"{param} not in remapped weight map"
+
+    def test_passthrough_keys_detected(self, qwen3_model, fake_safetensors_dir):
+        """Extra keys in safetensors (e.g., visual encoder) become passthrough."""
+        weight_map = build_weight_map(str(fake_safetensors_dir))
+        # Add some fake visual encoder keys
+        weight_map["visual.encoder.layer.0.weight"] = "/fake/path.safetensors"
+        weight_map["visual.encoder.layer.1.weight"] = "/fake/path.safetensors"
+
+        _, _, passthrough, _ = build_key_remapping(weight_map, qwen3_model)
+        assert "visual.encoder.layer.0.weight" in passthrough
+        assert "visual.encoder.layer.1.weight" in passthrough
+
+    def test_tied_weights_detected(self, qwen3_model, fake_safetensors_dir):
+        """Tied weights (lm_head -> embed_tokens) should be detected."""
+        weight_map = build_weight_map(str(fake_safetensors_dir))
+
+        # Remove lm_head.weight from weight_map to simulate tied weights
+        # (like in real models where lm_head is tied to embed_tokens)
+        if "lm_head.weight" in weight_map:
+            del weight_map["lm_head.weight"]
+
+        # Force tie_word_embeddings in config
+        qwen3_model.config.tie_word_embeddings = True
+
+        _, _, _, tied = build_key_remapping(weight_map, qwen3_model)
+        # Should detect lm_head tied to embed_tokens
+        assert "lm_head.weight" in tied
+
+
+class TestGetSubgraphWeightNames:
+    """Tests for get_subgraph_weight_names."""
+
+    def test_first_subgraph_is_embeddings(self, qwen3_model, fake_safetensors_dir):
+        """Subgraph 0 should contain embedding weights."""
+        weight_map = build_weight_map(str(fake_safetensors_dir))
+        num_layers = len(qwen3_model.model.layers)
+        # +1 for head subgraph, +1 because last subgraph includes lm_head
+        num_subgraphs = num_layers + 1
+
+        names = get_subgraph_weight_names(
+            qwen3_model,
+            weight_map,
+            sequential_targets=["Qwen3DecoderLayer"],
+            subgraph_index=0,
+            num_subgraphs=num_subgraphs,
+        )
+
+        # Should include embed_tokens
+        assert any("embed_tokens" in n for n in names)
+        # Should NOT include any decoder layer weights
+        assert not any("layers." in n for n in names)
+
+    def test_middle_subgraph_is_one_layer(self, qwen3_model, fake_safetensors_dir):
+        """Middle subgraphs should contain exactly one decoder layer's weights."""
+        weight_map = build_weight_map(str(fake_safetensors_dir))
+        num_layers = len(qwen3_model.model.layers)
+        num_subgraphs = num_layers + 1
+
+        # Subgraph 1 should be layer 0
+        names = get_subgraph_weight_names(
+            qwen3_model,
+            weight_map,
+            sequential_targets=["Qwen3DecoderLayer"],
+            subgraph_index=1,
+            num_subgraphs=num_subgraphs,
+        )
+
+        # Should have layer 0 weights only
+        assert all("model.layers.0." in n for n in names)
+        assert len(names) > 0
+
+    def test_last_subgraph_includes_lm_head(self, qwen3_model, fake_safetensors_dir):
+        """Last subgraph should include final norm and lm_head."""
+        weight_map = build_weight_map(str(fake_safetensors_dir))
+        num_layers = len(qwen3_model.model.layers)
+        num_subgraphs = num_layers + 1
+
+        names = get_subgraph_weight_names(
+            qwen3_model,
+            weight_map,
+            sequential_targets=["Qwen3DecoderLayer"],
+            subgraph_index=num_subgraphs - 1,
+            num_subgraphs=num_subgraphs,
+        )
+
+        # Should include final norm or lm_head
+        has_final = any("model.norm" in n or "lm_head" in n for n in names)
+        assert has_final
+
+    def test_all_weights_covered(self, qwen3_model, fake_safetensors_dir):
+        """Union of all subgraph weights should cover all weight_map keys."""
+        weight_map = build_weight_map(str(fake_safetensors_dir))
+        num_layers = len(qwen3_model.model.layers)
+        num_subgraphs = num_layers + 1
+
+        all_names = set()
+        for i in range(num_subgraphs):
+            names = get_subgraph_weight_names(
+                qwen3_model,
+                weight_map,
+                sequential_targets=["Qwen3DecoderLayer"],
+                subgraph_index=i,
+                num_subgraphs=num_subgraphs,
+            )
+            all_names.update(names)
+
+        # All weight_map keys should be covered
+        # (lm_head may be missing if tied, which is fine)
+        uncovered = set(weight_map.keys()) - all_names
+        # Filter out tied weights (lm_head) which may not be assigned
+        uncovered = {k for k in uncovered if "lm_head" not in k}
+        assert uncovered == set(), f"Uncovered weights: {uncovered}"
+
+
+class TestOffloadSubgraphWeights:
+    """Tests for offload_subgraph_weights."""
+
+    def test_offload_to_meta(self):
+        """Offloading should move params to meta device."""
+        with skip_weights_initialize():
+            model = torch.nn.Sequential(
+                torch.nn.Linear(10, 10),
+                torch.nn.Linear(10, 10),
+            )
+        # Put real tensors
+        model[0].weight = torch.nn.Parameter(torch.randn(10, 10))
+        model[0].bias = torch.nn.Parameter(torch.randn(10))
+
+        offload_subgraph_weights(model, ["0.weight", "0.bias"], device="meta")
+
+        assert model[0].weight.device.type == "meta"
+        assert model[0].bias.device.type == "meta"
+        # Second layer should be untouched
+        assert model[1].weight.device.type != "meta"
+
+
+class TestMoveSubgraphBuffers:
+    """Tests for move_subgraph_buffers."""
+
+    def test_moves_buffers_to_target(self):
+        """Buffers should be moved to the target device."""
+        module = torch.nn.Module()
+        module.register_buffer("test_buf", torch.zeros(4))
+
+        # Move to CPU (since we may not have GPU in unit tests)
+        move_subgraph_buffers(None, {module}, torch.device("cpu"))
+        assert module.test_buf.device == torch.device("cpu")

--- a/tests/llmcompressor/pipelines/layerwise/test_pipeline.py
+++ b/tests/llmcompressor/pipelines/layerwise/test_pipeline.py
@@ -1,0 +1,141 @@
+"""
+Integration test for the layerwise quantization pipeline.
+
+Runs full layerwise AWQ + W4A16 quantization on Qwen/Qwen3-0.6B.
+Verifies the pipeline produces valid compressed safetensors output.
+"""
+
+from pathlib import Path
+
+import pytest
+from safetensors import safe_open
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.modifiers.transform import AWQModifier
+from tests.testing_utils import requires_gpu
+
+MODEL_ID = "Qwen/Qwen3-0.6B"
+
+
+@requires_gpu(1)
+class TestLayerwisePipeline:
+    """End-to-end tests for the layerwise quantization pipeline."""
+
+    @pytest.mark.parametrize(
+        "recipe,test_id",
+        [
+            pytest.param(
+                [
+                    AWQModifier(duo_scaling=False),
+                    QuantizationModifier(scheme="W4A16"),
+                ],
+                "awq_w4a16",
+                id="awq_w4a16",
+            ),
+            pytest.param(
+                [QuantizationModifier(scheme="W4A16")],
+                "w4a16_only",
+                id="w4a16_only",
+            ),
+        ],
+    )
+    def test_layerwise_quantization_e2e(self, recipe, test_id, tmp_path):
+        """
+        Full layerwise quantization should produce valid compressed safetensors.
+
+        This test verifies:
+        1. The pipeline runs without error on a real model
+        2. Output directory contains safetensors shards
+        3. A safetensors index file is written
+        4. Compressed weights are loadable
+        """
+        output_dir = str(tmp_path / test_id)
+
+        oneshot(
+            model=MODEL_ID,
+            recipe=recipe,
+            dataset="ultrachat_200k",
+            splits={"calibration": "train_sft[:32]"},
+            max_seq_length=512,
+            num_calibration_samples=32,
+            layerwise=True,
+            output_dir=output_dir,
+        )
+
+        output_path = Path(output_dir)
+
+        # Check safetensors index exists
+        index_file = output_path / "model.safetensors.index.json"
+        assert index_file.exists(), "Missing safetensors index file"
+
+        # Check at least one shard exists
+        shards = list(output_path.glob("model-*-of-*.safetensors"))
+        assert len(shards) > 0, "No safetensors shards found"
+
+        # Verify shards are loadable
+        for shard in shards:
+            with safe_open(str(shard), framework="pt") as f:
+                keys = list(f.keys())
+                assert len(keys) > 0, f"Shard {shard.name} has no keys"
+
+        # Check config.json was saved
+        assert (output_path / "config.json").exists(), "Missing config.json"
+
+    def test_layerwise_matches_sequential_output_shape(self, tmp_path):
+        """
+        Layerwise and sequential pipelines should produce weights with
+        the same shapes (validates that group quantization packs correctly).
+        """
+        recipe = [QuantizationModifier(scheme="W4A16")]
+
+        layerwise_dir = str(tmp_path / "layerwise")
+        oneshot(
+            model=MODEL_ID,
+            recipe=recipe,
+            dataset="ultrachat_200k",
+            splits={"calibration": "train_sft[:16]"},
+            max_seq_length=256,
+            num_calibration_samples=16,
+            layerwise=True,
+            output_dir=layerwise_dir,
+        )
+
+        sequential_dir = str(tmp_path / "sequential")
+        oneshot(
+            model=MODEL_ID,
+            recipe=recipe,
+            dataset="ultrachat_200k",
+            splits={"calibration": "train_sft[:16]"},
+            max_seq_length=256,
+            num_calibration_samples=16,
+            output_dir=sequential_dir,
+        )
+
+        # Compare weight shapes between both outputs
+        layerwise_path = Path(layerwise_dir)
+        sequential_path = Path(sequential_dir)
+
+        lw_shards = sorted(layerwise_path.glob("model*.safetensors"))
+        sq_shards = sorted(sequential_path.glob("model*.safetensors"))
+
+        # Collect all weight shapes from both
+        lw_shapes = {}
+        for shard in lw_shards:
+            with safe_open(str(shard), framework="pt") as f:
+                for key in f.keys():
+                    lw_shapes[key] = f.get_tensor(key).shape
+
+        sq_shapes = {}
+        for shard in sq_shards:
+            with safe_open(str(shard), framework="pt") as f:
+                for key in f.keys():
+                    sq_shapes[key] = f.get_tensor(key).shape
+
+        # All sequential keys should exist in layerwise output with same shape
+        for key in sq_shapes:
+            assert key in lw_shapes, f"Key {key} missing from layerwise output"
+            assert lw_shapes[key] == sq_shapes[key], (
+                f"Shape mismatch for {key}: "
+                f"layerwise={lw_shapes[key]} vs sequential={sq_shapes[key]}"
+            )

--- a/tests/llmcompressor/pipelines/test_registry.py
+++ b/tests/llmcompressor/pipelines/test_registry.py
@@ -13,6 +13,7 @@ from llmcompressor.modifiers.transform.imatrix import IMatrixGatherer
 from llmcompressor.pipelines import (
     CalibrationPipeline,
     DataFreePipeline,
+    LayerwisePipeline,
     SequentialPipeline,
 )
 
@@ -40,3 +41,9 @@ from llmcompressor.pipelines import (
 def test_infer_pipeline(modifiers, exp_pipeline):
     pipeline = CalibrationPipeline.from_modifiers(modifiers)
     assert isinstance(pipeline, exp_pipeline)
+
+
+def test_layerwise_pipeline_registered():
+    """LayerwisePipeline should be loadable by name from the registry."""
+    pipeline = CalibrationPipeline.load_from_registry("layerwise")
+    assert isinstance(pipeline, LayerwisePipeline)


### PR DESCRIPTION

## Summary

Adds a new `layerwise` pipeline that enables AWQ quantization of models too large to fit in GPU memory by processing one subgraph (layer) at a time. This allows quantizing models of any size on a single GPU including GLM-5 (744B), which requires ~1.5TB just to load weights in fp16, yet can be quantized on a single H100 with this pipeline.

## Problem

Models like GLM-5 (744B, 160 experts) require ~1500GB VRAM just to load weights far beyond any single GPU. Even "smaller" large models like Qwen3.5-35B-A3B (256 experts, ~70GB fp16) or GLM-4.7-Flash (64 experts, ~59GB) exceed single-GPU capacity for standard quantization workflows.

The existing pipelines require the full model to reside in GPU memory during calibration and quantization, forcing users toward expensive multi-node setups or giving up on quantizing these models entirely.

This layerwise pipeline removes that constraint: since layer-local quantization techniques (AWQ, GPTQ) only need one layer's weights and activations at a time, we never need the full model in memory. The pipeline loads, calibrates, quantizes, and saves each layer independently  bounded only by the size of the largest single layer.

**Practical benefits:**
- Quantize a 744B model on a single H100 (80GB)
- Run multiple quantization jobs in parallel on different GPUs (different models, or same model with different calibration data)
- Well-suited for any layer-local quantization technique

## Changes

### New Pipeline (`src/llmcompressor/pipelines/layerwise/`)
- Sequential onloading of model weights per subgraph
- Compress-as-you-go: quantize and save each subgraph immediately, then free memory
- On-demand shard downloads for HuggingFace Hub models
- Sequential prefetch for calibration batches
- Support for fused MoE experts, VL models, and tied weights

### AWQ Modifier Optimizations (`modifiers/transform/awq/base.py`)
- VRAM-aware fp16 output placement (CPU vs GPU based on available memory)
- Pre-move fp16 outputs to GPU before grid search to reduce CPU→GPU transfers
- Streaming MSE loss computation to avoid materializing all quantized outputs
- GPU memory cleanup after grid search

### Entrypoint & Supporting Changes
- `oneshot()` accepts `layerwise=True` and `sequential_prefetch=True`
- Offset-norm weight handling for layerwise pipeline
- GPU memory leak fix: offload compressed params to meta device
- Skip tied weight aliases in compress-as-you-go save
- AWQ mappings for additional model architectures

## Usage

```python
from llmcompressor import oneshot
from llmcompressor.modifiers.quantization import QuantizationModifier
from llmcompressor.modifiers.transform.awq import AWQModifier

oneshot(
    model="Qwen/Qwen3.5-35B-A3B",
    dataset=calib_dataset,
    recipe=[AWQModifier(duo_scaling="True"), QuantizationModifier(targets="Linear", scheme="W4A16")],
    max_seq_length=2048,
    num_calibration_samples=512,
    output_dir="./Qwen3.5-35B-AWQ-INT4",
    layerwise=True,
    sequential_prefetch=True,
)
```

## Validated On

| Model | Params | Layers | Experts | GPU | Status |
|-------|--------|--------|---------|-----|--------|
| GLM-5 | 744B | 92 | 160 (8 active) | 1× H100 80GB | ✅ |
| Qwen3.5-35B-A3B | 35B | 40 | 256 (8 active) | 1× L40S 46GB | ✅ |
| GLM-4.7-Flash | ~30B | 47 | 64 (4 active) | 1× L40S 46GB | ✅ |
| Qwen3.5-4B | 4B | 36 | dense | 1× L40S 46GB | ✅ |
| Qwen3-4B | 4B | 36 | dense | 1× L40S 46GB | ✅ |

## Tests

- Unit tests for layerwise helpers (weight map building, key remapping, subgraph partitioning, offload/move)
- Integration tests: full AWQ+W4A16 and W4A16-only e2e on Qwen3-0.6B
- Pipeline registry test for LayerwisePipeline discoverability

## Limitations

- Designed for **layer-local** quantization techniques (AWQ, GPTQ) where each layer can be quantized independently. Not applicable to methods requiring global model access.
