### PR TITLE
[Docs] Add pre-quantized checkpoints to Qwen3.5 docs

### DIFF
--- a/docs/key-models/qwen3.5/index.md
+++ b/docs/key-models/qwen3.5/index.md
@@ -13,13 +13,15 @@ Quantization examples for the Qwen3.5 family of models, including dense vision-l
 
 ## Pre-quantized Checkpoints
 
-- [RedHatAI/Qwen3.5-4B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-4B-FP8-dynamic)
-- [RedHatAI/Qwen3.5-4B-quantized.w4a16](https://huggingface.co/RedHatAI/Qwen3.5-4B-quantized.w4a16)
-- [RedHatAI/Qwen3.5-4B-quantized.w8a8](https://huggingface.co/RedHatAI/Qwen3.5-4B-quantized.w8a8)
-- [RedHatAI/Qwen3.5-9B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-9B-FP8-dynamic)
-- [RedHatAI/Qwen3.5-9B-quantized.w4a16](https://huggingface.co/RedHatAI/Qwen3.5-9B-quantized.w4a16)
-- [RedHatAI/Qwen3.5-9B-quantized.w8a8](https://huggingface.co/RedHatAI/Qwen3.5-9B-quantized.w8a8)
-- [RedHatAI/Qwen3.5-35B-A3B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-35B-A3B-FP8-dynamic)
-- [RedHatAI/Qwen3.5-122B-A10B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-122B-A10B-FP8-dynamic)
-- [RedHatAI/Qwen3.5-122B-A10B-NVFP4](https://huggingface.co/RedHatAI/Qwen3.5-122B-A10B-NVFP4)
-- [RedHatAI/Qwen3.5-397B-A17B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-397B-A17B-FP8-dynamic)
+| Model | Format | Hugging Face Link |
+| :--- | :--- | :--- |
+| Qwen3.5-4B | FP8-dynamic | [RedHatAI/Qwen3.5-4B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-4B-FP8-dynamic) |
+| Qwen3.5-4B | W4A16 | [RedHatAI/Qwen3.5-4B-quantized.w4a16](https://huggingface.co/RedHatAI/Qwen3.5-4B-quantized.w4a16) |
+| Qwen3.5-4B | W8A8 | [RedHatAI/Qwen3.5-4B-quantized.w8a8](https://huggingface.co/RedHatAI/Qwen3.5-4B-quantized.w8a8) |
+| Qwen3.5-9B | FP8-dynamic | [RedHatAI/Qwen3.5-9B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-9B-FP8-dynamic) |
+| Qwen3.5-9B | W4A16 | [RedHatAI/Qwen3.5-9B-quantized.w4a16](https://huggingface.co/RedHatAI/Qwen3.5-9B-quantized.w4a16) |
+| Qwen3.5-9B | W8A8 | [RedHatAI/Qwen3.5-9B-quantized.w8a8](https://huggingface.co/RedHatAI/Qwen3.5-9B-quantized.w8a8) |
+| Qwen3.5-35B-A3B | FP8-dynamic | [RedHatAI/Qwen3.5-35B-A3B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-35B-A3B-FP8-dynamic) |
+| Qwen3.5-122B-A10B | FP8-dynamic | [RedHatAI/Qwen3.5-122B-A10B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-122B-A10B-FP8-dynamic) |
+| Qwen3.5-122B-A10B | NVFP4 | [RedHatAI/Qwen3.5-122B-A10B-NVFP4](https://huggingface.co/RedHatAI/Qwen3.5-122B-A10B-NVFP4) |
+| Qwen3.5-397B-A17B | FP8-dynamic | [RedHatAI/Qwen3.5-397B-A17B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-397B-A17B-FP8-dynamic) |

--- a/docs/key-models/qwen3.5/index.md
+++ b/docs/key-models/qwen3.5/index.md
@@ -10,3 +10,16 @@ Quantization examples for the Qwen3.5 family of models, including dense vision-l
 
 - [NVFP4A16 Vision-Language Example](nvfp4-vl-example.md)
 - [NVFP4 MoE Example](nvfp4-moe-example.md)
+
+## Pre-quantized Checkpoints
+
+- [RedHatAI/Qwen3.5-4B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-4B-FP8-dynamic)
+- [RedHatAI/Qwen3.5-4B-quantized.w4a16](https://huggingface.co/RedHatAI/Qwen3.5-4B-quantized.w4a16)
+- [RedHatAI/Qwen3.5-4B-quantized.w8a8](https://huggingface.co/RedHatAI/Qwen3.5-4B-quantized.w8a8)
+- [RedHatAI/Qwen3.5-9B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-9B-FP8-dynamic)
+- [RedHatAI/Qwen3.5-9B-quantized.w4a16](https://huggingface.co/RedHatAI/Qwen3.5-9B-quantized.w4a16)
+- [RedHatAI/Qwen3.5-9B-quantized.w8a8](https://huggingface.co/RedHatAI/Qwen3.5-9B-quantized.w8a8)
+- [RedHatAI/Qwen3.5-35B-A3B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-35B-A3B-FP8-dynamic)
+- [RedHatAI/Qwen3.5-122B-A10B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-122B-A10B-FP8-dynamic)
+- [RedHatAI/Qwen3.5-122B-A10B-NVFP4](https://huggingface.co/RedHatAI/Qwen3.5-122B-A10B-NVFP4)
+- [RedHatAI/Qwen3.5-397B-A17B-FP8-dynamic](https://huggingface.co/RedHatAI/Qwen3.5-397B-A17B-FP8-dynamic)


### PR DESCRIPTION
## Summary

- Adds a `## Pre-quantized Checkpoints` section to `docs/key-models/qwen3.5/index.md`
- Lists all 10 RedHatAI Qwen3.5 checkpoints from https://huggingface.co/RedHatAI/models?search=qwen3.5, covering FP8-dynamic, W4A16, W8A8, and NVFP4 formats across 4B–397B model sizes
- Matches the format used in the Qwen3.6 docs