### PR TITLE
[Tests] [Bugfix] Fix race condition offload tests

### DIFF
--- a/tests/llmcompressor/conftest.py
+++ b/tests/llmcompressor/conftest.py
@@ -49,7 +49,7 @@ def _files_size_mb(path_list: List[str]) -> int:
 def check_for_created_files():
     local_ignore_dirs = ["__pycache__", "sparse_logs", "test-results", ".pytest_cache"]
     local_ignore_files = [".coverage"]
-    tmp_ignore_dirs = ["pytest-of", "torchinductor", "torchrun-logs"]
+    tmp_ignore_dirs = ["pytest-of", "torchinductor"]
     start_files_root = _get_files(
         directory=r".", ignore_dirs=local_ignore_dirs, ignore_files=local_ignore_files
     )

--- a/tests/llmcompressor/conftest.py
+++ b/tests/llmcompressor/conftest.py
@@ -49,7 +49,7 @@ def _files_size_mb(path_list: List[str]) -> int:
 def check_for_created_files():
     local_ignore_dirs = ["__pycache__", "sparse_logs", "test-results", ".pytest_cache"]
     local_ignore_files = [".coverage"]
-    tmp_ignore_dirs = ["pytest-of", "torchinductor"]
+    tmp_ignore_dirs = ["pytest-of", "torchinductor", "torchrun-logs"]
     start_files_root = _get_files(
         directory=r".", ignore_dirs=local_ignore_dirs, ignore_files=local_ignore_files
     )

--- a/tests/llmcompressor/transformers/test_dist_disk_offload.py
+++ b/tests/llmcompressor/transformers/test_dist_disk_offload.py
@@ -10,7 +10,6 @@ from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
 from datasets import Dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from llmcompressor import oneshot
 from llmcompressor.modifiers.gptq import GPTQModifier
 from tests.testing_utils import requires_gpu, torchrun
 
@@ -25,7 +24,12 @@ EVAL_TEXT = "Paris is the capital of France"
 @contextlib.contextmanager
 def _disk_offloaded_model():
     """Load a disk-offloaded model using a temporary offload folder."""
-    offload_dir = tempfile.mkdtemp(prefix="disk_offload_test_")
+    if dist.get_rank() == 0:
+        offload_dir = [tempfile.mkdtemp(prefix="disk_offload_test_")]
+    else:
+        offload_dir = [None]
+    dist.broadcast_object_list(offload_dir, src=0)
+
     try:
         with load_offloaded_model():
             model = AutoModelForCausalLM.from_pretrained(
@@ -33,11 +37,13 @@ def _disk_offloaded_model():
                 torch_dtype=torch.float32,
                 device_map="auto_offload",
                 max_memory={"cpu": MAX_CPU_MEMORY},
-                offload_folder=offload_dir,
+                offload_folder=offload_dir[0],
             )
         yield model
     finally:
-        shutil.rmtree(offload_dir, ignore_errors=True)
+        if dist.get_rank() == 0:
+            shutil.rmtree(offload_dir[0], ignore_errors=True)
+        dist.barrier()
 
 
 def _dataset():
@@ -81,13 +87,14 @@ def test_gptq_distributed_disk_offload():
 
     init_dist()
     with _disk_offloaded_model() as model:
-        oneshot(
-            model=model,
-            dataset=_dataset(),
-            recipe=_recipe(),
-            num_calibration_samples=NUM_CALIBRATION_SAMPLES,
-            max_seq_length=MAX_SEQ_LENGTH,
-        )
+        # oneshot(
+        #     model=model,
+        #     dataset=_dataset(),
+        #     recipe=_recipe(),
+        #     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+        #     max_seq_length=MAX_SEQ_LENGTH,
+        # )
+        print("pretend oneshot")
 
         torch.distributed.barrier()
 

--- a/tests/llmcompressor/transformers/test_dist_disk_offload.py
+++ b/tests/llmcompressor/transformers/test_dist_disk_offload.py
@@ -10,6 +10,7 @@ from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
 from datasets import Dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from llmcompressor import oneshot
 from llmcompressor.modifiers.gptq import GPTQModifier
 from tests.testing_utils import requires_gpu, torchrun
 
@@ -87,14 +88,13 @@ def test_gptq_distributed_disk_offload():
 
     init_dist()
     with _disk_offloaded_model() as model:
-        # oneshot(
-        #     model=model,
-        #     dataset=_dataset(),
-        #     recipe=_recipe(),
-        #     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
-        #     max_seq_length=MAX_SEQ_LENGTH,
-        # )
-        print("pretend oneshot")
+        oneshot(
+            model=model,
+            dataset=_dataset(),
+            recipe=_recipe(),
+            num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+            max_seq_length=MAX_SEQ_LENGTH,
+        )
 
         torch.distributed.barrier()
 

--- a/tests/llmcompressor/transformers/test_dist_disk_offload.py
+++ b/tests/llmcompressor/transformers/test_dist_disk_offload.py
@@ -41,7 +41,9 @@ def _disk_offloaded_model():
                 offload_folder=offload_dir[0],
             )
         yield model
+
     finally:
+        dist.barrier()
         if dist.get_rank() == 0:
             shutil.rmtree(offload_dir[0], ignore_errors=True)
         dist.barrier()
@@ -95,8 +97,6 @@ def test_gptq_distributed_disk_offload():
             num_calibration_samples=NUM_CALIBRATION_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,
         )
-
-        torch.distributed.barrier()
 
         if dist.get_rank() == 0:
             ppl = _compute_perplexity(model, EVAL_TEXT)


### PR DESCRIPTION
## Purpose ##
* Fix test failure where was failing due to a race condition; ranks are detecting offloaded files before they are cleaned up
  * The race condition has been intermittently replicated locally
  * The race condition never appears on this branch

## Changes ##
* Add sync step to ensure that the disk folder created by rank zero is propagated
* Add sync step to ensure that only rank 0 deletes the offload folder, and that other ranks wait for rank 0 to finish deleting before testing for excess files

## Testing ##
* Race condition does not appear locally on this branch after 10 tries