### PR TITLE
[Bugfix] Fix --no-cov flag error in torchrun DDP tests

### DIFF
--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -347,8 +347,14 @@ def torchrun(world_size: int = 1):
                     "pytest",
                     f"{file_path}::{func_name}",
                     "-sx",
-                    "--no-cov",
                 ]
+
+                # If coverage is enabled (--cov in PYTEST_ADDOPTS), prevent
+                # pytest-cov from loading in workers by adding --no-cov.
+                # Worker coverage data is still collected via .coveragerc's
+                # patch = subprocess + parallel = True.
+                if "--cov" in os.environ.get("PYTEST_ADDOPTS", ""):
+                    cmd.append("--no-cov")
 
                 proc = subprocess.run(cmd)
                 assert proc.returncode == 0


### PR DESCRIPTION
## Summary

https://github.com/vllm-project/llm-compressor/pull/2757 fixed the issue when coverage is enabled (weekly runs) but introduced an error when pytest-cov is not installed  because coverage is not enabled (nightly runs) since --no-cov isn't a valid command without pytest-cov.

options: 
1) check for --cov and remove it
2) check for --cov and add --no-cov

we choose option 2 because its simpler, option 1 would require checking for ancillary arguments like --cov-config, --cov-report, --cov-fail-under and could cause issues if invoked like `<command> --cov llm-compressor` instead of `<command> --cov=llm-compressor`

  - Unit-integration WITHOUT coverage: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/26530709062 (this was failing before)
  - Unit-integration WITH coverage: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/26530715963 (this is what was fixed in 2757)

🤖 Generated with [Claude Code](https://claude.com/claude-code)