### PR TITLE
Add AWQ model mappings for Step3p5

### DIFF
--- a/examples/awq/step3p5_example.py
+++ b/examples/awq/step3p5_example.py
@@ -27,7 +27,6 @@ MAX_SEQUENCE_LENGTH = 512
 
 # Load dataset and preprocess.
 ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
-ds = ds.shuffle(seed=42)
 
 
 def preprocess(example):
@@ -40,6 +39,20 @@ def preprocess(example):
 
 
 ds = ds.map(preprocess)
+
+
+# Tokenize inputs.
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
 
 # Configure the quantization algorithm to run.
 # The Step3p5 AWQ mapping is selected automatically from the model architecture.

--- a/examples/awq/step3p5_example.py
+++ b/examples/awq/step3p5_example.py
@@ -1,0 +1,79 @@
+from compressed_tensors.offload import dispatch_model
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.modifiers.transform.awq import AWQModifier
+
+# Step3p5 uses custom modeling code from the Hub.
+MODEL_ID = "stepfun-ai/Step-3.5-Flash"
+
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_ID,
+    torch_dtype="auto",
+    trust_remote_code=True,
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
+
+# Select calibration dataset.
+DATASET_ID = "HuggingFaceH4/ultrachat_200k"
+DATASET_SPLIT = "train_sft"
+
+# Select number of samples. 256 samples is a good place to start.
+# Increasing the number of samples can improve accuracy.
+NUM_CALIBRATION_SAMPLES = 256
+MAX_SEQUENCE_LENGTH = 512
+
+# Load dataset and preprocess.
+ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {
+        "text": tokenizer.apply_chat_template(
+            example["messages"],
+            tokenize=False,
+        )
+    }
+
+
+ds = ds.map(preprocess)
+
+# Configure the quantization algorithm to run.
+# The Step3p5 AWQ mapping is selected automatically from the model architecture.
+# Keep the MoE router in higher precision because Step3p5 routes with fp32 gates.
+recipe = [
+    AWQModifier(),
+    QuantizationModifier(
+        ignore=["lm_head", "re:.*moe.gate$"],
+        scheme="W4A16",
+        targets=["Linear"],
+    ),
+]
+
+# Apply algorithms.
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+# Confirm generations of the quantized model look sane.
+print("\n\n")
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(
+    model.device
+)
+output = model.generate(input_ids, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================\n\n")
+
+# Save to disk compressed.
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-awq-sym"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/examples/awq/step3p5_example.py
+++ b/examples/awq/step3p5_example.py
@@ -60,6 +60,7 @@ oneshot(
     recipe=recipe,
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    trust_remote_code_model=True,
 )
 
 # Confirm generations of the quantized model look sane.

--- a/src/llmcompressor/modifiers/transform/awq/dynamic_mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/dynamic_mappings.py
@@ -7,6 +7,7 @@ model size. This module provides runtime detection and mapping generation
 for such architectures (e.g. Qwen3Next, Qwen3.5).
 """
 
+import re
 from collections.abc import Callable
 
 from loguru import logger
@@ -145,12 +146,88 @@ def build_hybrid_attention_mappings(model: Module) -> list[AWQMapping] | None:
     return mappings
 
 
+def build_step3p5_mappings(model: Module) -> list[AWQMapping] | None:
+    """
+    Dynamically build AWQ mappings for Step3p5 models.
+
+    Step-3.5-Flash uses dense FFN layers early in the stack and MoE FFN layers
+    later in the stack. The dense and MoE post-attention mappings must be
+    layer-index-specific so AWQ only groups each norm with balance layers that
+    exist in the same decoder layer.
+    """
+    dense_indices, moe_indices = _detect_step3p5_ffn_layer_indices(model)
+
+    if not dense_indices and not moe_indices:
+        logger.warning(
+            "Step3p5 model detected but dense/MoE FFN layer indices could not be "
+            "inferred. Falling back."
+        )
+        return None
+
+    mappings = [
+        AWQMapping(
+            "re:.*input_layernorm$",
+            [
+                "re:.*self_attn.q_proj$",
+                "re:.*self_attn.k_proj$",
+                "re:.*self_attn.v_proj$",
+                "re:.*self_attn.g_proj$",
+            ],
+        ),
+        AWQMapping("re:.*self_attn.v_proj$", ["re:.*self_attn.o_proj$"]),
+    ]
+
+    if dense_indices:
+        dense_re = "|".join(str(i) for i in dense_indices)
+        mappings.append(
+            AWQMapping(
+                f"re:.*layers\\.({dense_re})\\.post_attention_layernorm$",
+                [
+                    "re:.*mlp.gate_proj$",
+                    "re:.*mlp.up_proj$",
+                ],
+            )
+        )
+
+    if moe_indices:
+        moe_re = "|".join(str(i) for i in moe_indices)
+        mappings.append(
+            AWQMapping(
+                f"re:.*layers\\.({moe_re})\\.post_attention_layernorm$",
+                [
+                    "re:.*moe.gate$",
+                    "re:.*moe.gate_proj$",
+                    "re:.*moe.up_proj$",
+                    "re:.*share_expert.gate_proj$",
+                    "re:.*share_expert.up_proj$",
+                ],
+            )
+        )
+
+    # The packed moe.up_proj -> moe.down_proj path is intentionally excluded
+    # because AWQ's smooth-layer update assumes a 1D/2D smooth weight.
+    mappings.append(
+        AWQMapping(
+            "re:.*(mlp|share_expert).up_proj$",
+            ["re:.*(mlp|share_expert).down_proj$"],
+        )
+    )
+
+    logger.info(
+        f"Built dynamic Step3p5 AWQ mappings: "
+        f"{len(dense_indices)} dense layers, {len(moe_indices)} MoE layers"
+    )
+
+    return mappings
+
+
 AWQ_DYNAMIC_MAPPING_REGISTRY: dict[str, Callable[[Module], list[AWQMapping] | None]] = {
     "Qwen3NextForCausalLM": build_hybrid_attention_mappings,
     "Qwen3_5ForCausalLM": build_hybrid_attention_mappings,
     "Qwen3_5ForConditionalGeneration": build_hybrid_attention_mappings,
     "Qwen3_5MoeForCausalLM": build_hybrid_attention_mappings,
     "Qwen3_5MoeForConditionalGeneration": build_hybrid_attention_mappings,
+    "Step3p5ForCausalLM": build_step3p5_mappings,
 }
 
 
@@ -174,3 +251,30 @@ def _detect_linear_attn_projections(model: Module) -> list[str]:
             proj_names.append(sub)
     # Deduplicate while preserving order (same projections repeat per layer)
     return list(dict.fromkeys(proj_names))
+
+
+_STEP3P5_FFN_LAYER_PATTERN = re.compile(
+    r"(?:^|\.)layers\.(?P<idx>\d+)\.(?P<ffn>mlp|moe|share_expert)(?:\.|$)"
+)
+
+
+def _detect_step3p5_ffn_layer_indices(model: Module) -> tuple[list[int], list[int]]:
+    """
+    Detect which Step3p5 decoder layers use dense MLPs and which use MoE blocks.
+    """
+    dense_indices: set[int] = set()
+    moe_indices: set[int] = set()
+
+    for name, _ in model.named_modules():
+        match = _STEP3P5_FFN_LAYER_PATTERN.search(name)
+        if match is None:
+            continue
+
+        layer_idx = int(match.group("idx"))
+        ffn_type = match.group("ffn")
+        if ffn_type == "mlp":
+            dense_indices.add(layer_idx)
+        else:
+            moe_indices.add(layer_idx)
+
+    return sorted(dense_indices), sorted(moe_indices)

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -235,10 +235,7 @@ _afmoe_mappings = [
     ),
 ]
 
-# Step3p5 (Step-3.5-Flash): GQA self-attention with head-wise g_proj, dense early
-# layers (mlp), MoE layers (moe + share_expert) with packed MoELinear experts.
-# The packed moe.up_proj -> moe.down_proj path is intentionally excluded from the
-# up/down mapping because AWQ's smooth-layer update assumes a 1D/2D smooth weight.
+# Step-3.5-Flash
 _step3p5_mappings = [
     AWQMapping(
         "re:.*input_layernorm$",

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -235,41 +235,6 @@ _afmoe_mappings = [
     ),
 ]
 
-# Step-3.5-Flash
-_step3p5_mappings = [
-    AWQMapping(
-        "re:.*input_layernorm$",
-        [
-            "re:.*self_attn.q_proj$",
-            "re:.*self_attn.k_proj$",
-            "re:.*self_attn.v_proj$",
-            "re:.*self_attn.g_proj$",
-        ],
-    ),
-    AWQMapping("re:.*self_attn.v_proj$", ["re:.*self_attn.o_proj$"]),
-    AWQMapping(
-        "re:.*post_attention_layernorm$",
-        [
-            "re:.*mlp.gate_proj$",
-            "re:.*mlp.up_proj$",
-        ],
-    ),
-    AWQMapping(
-        "re:.*post_attention_layernorm$",
-        [
-            "re:.*moe.gate$",
-            "re:.*moe.gate_proj$",
-            "re:.*moe.up_proj$",
-            "re:.*share_expert.gate_proj$",
-            "re:.*share_expert.up_proj$",
-        ],
-    ),
-    AWQMapping(
-        "re:.*(mlp|share_expert).up_proj$",
-        ["re:.*(mlp|share_expert).down_proj$"],
-    ),
-]
-
 # Example mapping for MoE models with parallel transformer blocks, where
 # attention and MoE share the same input. This is the only case where
 # activation_hook_target is needed. Without it, the hook lands on
@@ -322,7 +287,6 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Qwen3MoeForCausalLM": _moe_default_mappings,
     "SeedOssForCausalLM": default_mappings,
     "Ernie4_5_MoeForCausalLM": default_mappings,
-    "Step3p5ForCausalLM": _step3p5_mappings,
 }
 
 

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -255,6 +255,11 @@ _step3p5_mappings = [
         [
             "re:.*mlp.gate_proj$",
             "re:.*mlp.up_proj$",
+        ],
+    ),
+    AWQMapping(
+        "re:.*post_attention_layernorm$",
+        [
             "re:.*moe.gate$",
             "re:.*moe.gate_proj$",
             "re:.*moe.up_proj$",

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -235,6 +235,39 @@ _afmoe_mappings = [
     ),
 ]
 
+# Step3p5 (Step-3.5-Flash): GQA self-attention with head-wise g_proj, dense early
+# layers (mlp), MoE layers (moe + share_expert) with packed MoELinear experts.
+# The packed moe.up_proj -> moe.down_proj path is intentionally excluded from the
+# up/down mapping because AWQ's smooth-layer update assumes a 1D/2D smooth weight.
+_step3p5_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm$",
+        [
+            "re:.*self_attn.q_proj$",
+            "re:.*self_attn.k_proj$",
+            "re:.*self_attn.v_proj$",
+            "re:.*self_attn.g_proj$",
+        ],
+    ),
+    AWQMapping("re:.*self_attn.v_proj$", ["re:.*self_attn.o_proj$"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm$",
+        [
+            "re:.*mlp.gate_proj$",
+            "re:.*mlp.up_proj$",
+            "re:.*moe.gate$",
+            "re:.*moe.gate_proj$",
+            "re:.*moe.up_proj$",
+            "re:.*share_expert.gate_proj$",
+            "re:.*share_expert.up_proj$",
+        ],
+    ),
+    AWQMapping(
+        "re:.*(mlp|share_expert).up_proj$",
+        ["re:.*(mlp|share_expert).down_proj$"],
+    ),
+]
+
 # Example mapping for MoE models with parallel transformer blocks, where
 # attention and MoE share the same input. This is the only case where
 # activation_hook_target is needed. Without it, the hook lands on
@@ -287,6 +320,7 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Qwen3MoeForCausalLM": _moe_default_mappings,
     "SeedOssForCausalLM": default_mappings,
     "Ernie4_5_MoeForCausalLM": default_mappings,
+    "Step3p5ForCausalLM": _step3p5_mappings,
 }
 
 

--- a/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
+++ b/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
@@ -1,11 +1,16 @@
 import pytest
 import torch
+from compressed_tensors.quantization import apply_quantization_config
 from torch.nn import Linear
 
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.modifiers.transform.awq import AWQModifier
 from llmcompressor.modifiers.transform.awq.dynamic_mappings import (
     AWQ_DYNAMIC_MAPPING_REGISTRY,
     _detect_linear_attn_projections,
+    _detect_step3p5_ffn_layer_indices,
     build_hybrid_attention_mappings,
+    build_step3p5_mappings,
     get_layer_mappings_from_model,
 )
 from llmcompressor.modifiers.transform.utils.hybrid_attention import (
@@ -158,6 +163,66 @@ def _make_standard_model():
     return model
 
 
+def _make_step3p5_model(num_layers=6, moe_start=2):
+    """Build a minimal Step3p5-shaped model with dense and MoE FFN layers."""
+    layers = []
+    for i in range(num_layers):
+        layer = torch.nn.ModuleDict(
+            {
+                "self_attn": torch.nn.ModuleDict(
+                    {
+                        "q_proj": Linear(8, 8),
+                        "k_proj": Linear(8, 8),
+                        "v_proj": Linear(8, 8),
+                        "g_proj": Linear(8, 8),
+                        "o_proj": Linear(8, 8),
+                    }
+                ),
+                "input_layernorm": torch.nn.LayerNorm(8),
+                "post_attention_layernorm": torch.nn.LayerNorm(8),
+            }
+        )
+
+        if i < moe_start:
+            layer["mlp"] = torch.nn.ModuleDict(
+                {
+                    "gate_proj": Linear(8, 8),
+                    "up_proj": Linear(8, 8),
+                    "down_proj": Linear(8, 8),
+                }
+            )
+        else:
+            layer["moe"] = torch.nn.ModuleDict(
+                {
+                    "gate": Linear(8, 8),
+                    "gate_proj": Linear(8, 8),
+                    "up_proj": Linear(8, 8),
+                    "down_proj": Linear(8, 8),
+                }
+            )
+            layer["share_expert"] = torch.nn.ModuleDict(
+                {
+                    "gate_proj": Linear(8, 8),
+                    "up_proj": Linear(8, 8),
+                    "down_proj": Linear(8, 8),
+                }
+            )
+
+        layers.append(layer)
+
+    model = torch.nn.ModuleDict(
+        {
+            "model": torch.nn.ModuleDict(
+                {
+                    "layers": torch.nn.ModuleList(layers),
+                }
+            )
+        }
+    )
+    model.config = type("Config", (), {"num_hidden_layers": num_layers})()
+    return model
+
+
 @pytest.mark.unit
 class TestGetHybridAttentionConfig:
     def test_returns_config_for_hybrid_model(self):
@@ -204,6 +269,93 @@ class TestDetectLinearAttnProjections:
         projs = _detect_linear_attn_projections(model)
         # 6 linear layers but should only return unique projection names
         assert len(projs) == len(set(projs))
+
+
+@pytest.mark.unit
+class TestStep3p5Mappings:
+    def test_detects_dense_and_moe_ffn_layer_indices(self):
+        model = _make_step3p5_model(num_layers=6, moe_start=2)
+        dense_indices, moe_indices = _detect_step3p5_ffn_layer_indices(model)
+        assert dense_indices == [0, 1]
+        assert moe_indices == [2, 3, 4, 5]
+
+    def test_builds_split_dense_and_moe_mappings(self):
+        model = _make_step3p5_model(num_layers=6, moe_start=2)
+        mappings = build_step3p5_mappings(model)
+        assert mappings is not None
+        assert len(mappings) == 5
+
+        dense_mapping = mappings[2]
+        assert "0|1" in dense_mapping.smooth_layer
+        assert all("mlp." in balance for balance in dense_mapping.balance_layers)
+
+        moe_mapping = mappings[3]
+        assert "2|3|4|5" in moe_mapping.smooth_layer
+        assert any("moe." in balance for balance in moe_mapping.balance_layers)
+        assert any("share_expert." in balance for balance in moe_mapping.balance_layers)
+        assert not any("mlp." in balance for balance in moe_mapping.balance_layers)
+
+    def test_dynamic_registry_model_uses_step3p5_dynamic_path(self):
+        model = _make_step3p5_model(num_layers=6, moe_start=2)
+        model.__class__ = type("Step3p5ForCausalLM", (model.__class__,), {})
+        assert model.__class__.__name__ in AWQ_DYNAMIC_MAPPING_REGISTRY
+
+        mappings = get_layer_mappings_from_model(model)
+        assert len(mappings) == 5
+        assert mappings[2].smooth_layer.endswith("(0|1)\\.post_attention_layernorm$")
+        assert mappings[3].smooth_layer.endswith(
+            "(2|3|4|5)\\.post_attention_layernorm$"
+        )
+
+    def test_step3p5_mappings_resolve_per_layer(self):
+        model = _make_step3p5_model(num_layers=6, moe_start=2)
+        mappings = build_step3p5_mappings(model)
+        assert mappings is not None
+
+        apply_quantization_config(
+            model,
+            config=QuantizationModifier(
+                scheme="W4A16_ASYM"
+            ).resolve_quantization_config(),
+        )
+        awq = AWQModifier(mappings=mappings)
+        awq._set_resolved_mappings(model)
+
+        post_attention_mappings = [
+            mapping
+            for mapping in awq._resolved_mappings
+            if mapping.smooth_name.endswith("post_attention_layernorm")
+        ]
+        assert len(post_attention_mappings) == 6
+
+        dense_mappings = [
+            mapping
+            for mapping in post_attention_mappings
+            if ".layers.0." in mapping.smooth_name
+            or ".layers.1." in mapping.smooth_name
+        ]
+        assert len(dense_mappings) == 2
+        assert all(
+            all(".mlp." in name for name in mapping.balance_names)
+            for mapping in dense_mappings
+        )
+
+        moe_mappings = [
+            mapping
+            for mapping in post_attention_mappings
+            if ".layers.2." in mapping.smooth_name
+            or ".layers.3." in mapping.smooth_name
+            or ".layers.4." in mapping.smooth_name
+            or ".layers.5." in mapping.smooth_name
+        ]
+        assert len(moe_mappings) == 4
+        assert all(
+            all(
+                ".moe." in name or ".share_expert." in name
+                for name in mapping.balance_names
+            )
+            for mapping in moe_mappings
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
- Closes: https://github.com/vllm-project/llm-compressor/issues/2386

## SUMMARY:
- Add mappings for https://huggingface.co/stepfun-ai/Step-3.5-Flash/blob/main/modeling_step3p5.py
- Add example script (untested) in `step3p5_example.py`

Thanks so much!

## Architecture Notes
Step-3.5-Flash:
- **GQA attention** with standard `q_proj`, `k_proj`, `v_proj`, plus optional head-wise attention gating via `g_proj` (which we included)
- **Mixed dense/MoE FFN**:
  - Dense layers use standard SwiGLU MLP (`gate_proj`, `up_proj`, `down_proj`)
  - MoE layers use routed experts implemented with packed `MoELinear`
  - MoE blocks also include a dense `share_expert` branch with standard MLP structure

## TEST PLAN:
None at the moment as I don't have enough resources/GPU VRAM. However, the following files/tests should be ran:

- `python3 ./examples/awq/step3p5_example.py`
- `pytest ./tests/llmcompressor/modifiers/transform/awq/test_base.py ./tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py`