### PR TITLE
use num_calibration_samples instead of putting it in split

### DIFF
--- a/tests/lmeval/vl_configs/vl_int8_w8a8_dynamic_per_token.yaml
+++ b/tests/lmeval/vl_configs/vl_int8_w8a8_dynamic_per_token.yaml
@@ -4,7 +4,8 @@ model_class: Qwen3VLForConditionalGeneration
 recipe: tests/e2e/recipes/INT8/recipe_int8_channel_weight_dynamic_per_token.yaml
 dataset_id: neuralmagic/calibration
 dataset_config: LLM
-dataset_split: "train[:512]"
+dataset_split: "train"
+num_calibration_samples: 512
 lmeval:
   model: vllm-vlm
   task: chartqa

--- a/tests/lmeval/vl_configs/vl_nvfp4_fp8.yaml
+++ b/tests/lmeval/vl_configs/vl_nvfp4_fp8.yaml
@@ -4,7 +4,7 @@ model_class: Qwen3VLForConditionalGeneration
 recipe: tests/e2e/recipes/non_uniform/recipe_nvfp4_fp8_mixed.yaml
 dataset_id: neuralmagic/calibration
 dataset_config: LLM
-dataset_split: "train[:20]"
+dataset_split: "train"
 num_calibration_samples: 20
 lmeval:
   model: vllm-vlm

--- a/tests/lmeval/vl_configs/vl_w4a16_actorder_weight.yaml
+++ b/tests/lmeval/vl_configs/vl_w4a16_actorder_weight.yaml
@@ -4,7 +4,8 @@ model_class: Qwen3VLForConditionalGeneration
 recipe: tests/e2e/recipes/actorder/recipe_w4a16_actorder_weight.yaml
 dataset_id: neuralmagic/calibration
 dataset_config: LLM
-dataset_split: "train[:512]"
+dataset_split: "train"
+num_calibration_samples: 512
 lmeval:
   model: vllm-vlm
   task: chartqa

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -218,7 +218,8 @@ class BaseTestConfig(BaseModel):
         description="Dataset config/subset (e.g. 'LLM' for neuralmagic/calibration)",
     )
     dataset_split: Optional[str] = Field(
-        None, description="Dataset split (e.g. 'train_sft', 'train'). Use num_calibration_samples to control sample count."
+        None,
+        description="Dataset split (e.g. 'train_sft', 'train').",
     )
     num_calibration_samples: int = Field(
         512, description="Number of calibration samples"

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -132,7 +132,7 @@ class BaseTestConfig(BaseModel):
         model: meta-llama/Meta-Llama-3-8B-Instruct
         scheme: FP8_DYNAMIC
         dataset_id: HuggingFaceH4/ultrachat_200k
-        dataset_split: train[:512]
+        dataset_split: train_sft
         num_calibration_samples: 512
         ```
 
@@ -218,7 +218,7 @@ class BaseTestConfig(BaseModel):
         description="Dataset config/subset (e.g. 'LLM' for neuralmagic/calibration)",
     )
     dataset_split: Optional[str] = Field(
-        None, description="Dataset split (e.g. 'train_sft', 'train[:512]')"
+        None, description="Dataset split (e.g. 'train_sft', 'train'). Use num_calibration_samples to control sample count."
     )
     num_calibration_samples: int = Field(
         512, description="Number of calibration samples"


### PR DESCRIPTION
SUMMARY:
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/26647735833/job/78537789736 was failing because of this

get_rank_partition needs split and num_calibration_samples and can't handle split = "train[:512]"

TEST PLAN:
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/26652998041
