### PR TITLE
docs: fix all the autoround example links

### DIFF
--- a/examples/autoround/README.md
+++ b/examples/autoround/README.md
@@ -63,15 +63,15 @@ The accuracy of the quantized model is configured by tuning-related parameters. 
 ### Support Matrix
 | Scheme              | Examples                                                                  | Note                                  |
 | ------------------- | ------------------------------------------------------------------------- | ------------------------------------- |
-| `wNa16`             | [llama3_example](./quantization_w4a16/llama3_example.py)                  |                                       |
-| `wNa16`             | [qwen3_example](./quantization_w4a16/qwen3_example.py)                    | Multiple cards for `Qwen3-235B-A22B`  |
-| `wNa16` + `FP8KV`   | [llama3_example](./quantization_kv_cache/llama3_example.py)               |                                       |
-| `W8A8-FP8` Static   | [llama4_example](./quantization_w8a8_fp8/llama4_static_quant_example.py) |                                       |
-| `W8A8-FP8` Dynamic  | [llama4_example](./quantization_w8a8_fp8/llama4_dynamic_quant_example.py)  |                                       |
-| `W8A8-FP8` Block    | [llama3.1_example](./quantization_w8a8_fp8/llama3.1_block_quant_example.py) |                                     |
-| `MXFP8`  | [example](./quantization_w8a8_mxfp8/autoround_example.py)  | Usage: `python autoround_example.py ${model_id}`. For `Qwen/Qwen3-32B`, use `--batch_size 4 --max_seq_length 1024`; for `Qwen/Qwen3-30B-A3B-Instruct-2507`, use `--max_seq_length 1024`. |
-| `MXFP4`  | [example](./quantization_w4a4_mxfp4/autoround_example.py)  | Usage: `python autoround_example.py ${model_id}` |
-| `NVFP4`  | [llama3.1_example](./quantization_w4a4_fp4/llama3.1_example.py)  |                                       |
+| `wNa16`             | [llama3_example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_w4a16/llama3_example.py) |                                       |
+| `wNa16`             | [qwen3_example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_w4a16/qwen3_example.py) | Multiple cards for `Qwen3-235B-A22B`  |
+| `wNa16` + `FP8KV`   | [llama3_example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_kv_cache/llama3_example.py) |                                       |
+| `W8A8-FP8` Static   | [llama4_example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_w8a8_fp8/llama4_static_quant_example.py) |                                       |
+| `W8A8-FP8` Dynamic  | [llama4_example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_w8a8_fp8/llama4_dynamic_quant_example.py) |                                       |
+| `W8A8-FP8` Block    | [llama3.1_example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_w8a8_fp8/llama3.1_block_quant_example.py) |                                       |
+| `MXFP8`  | [example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_w8a8_mxfp8/autoround_example.py) | Usage: `python autoround_example.py ${model_id}`. For `Qwen/Qwen3-32B`, use `--batch_size 4 --max_seq_length 1024`; for `Qwen/Qwen3-30B-A3B-Instruct-2507`, use `--max_seq_length 1024`. |
+| `MXFP4`  | [example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_w4a4_mxfp4/autoround_example.py) | Usage: `python autoround_example.py ${model_id}` |
+| `NVFP4`  | [llama3.1_example](https://github.com/vllm-project/llm-compressor/blob/main/examples/autoround/quantization_w4a4_fp4/llama3.1_example.py) |                                       |
 
 
 ### Known Issues


### PR DESCRIPTION
when i was looking at the examples for autoround, all the links return blank 404 when clicked - https://docs.vllm.ai/projects/llm-compressor/en/latest/examples/autoround/#support-matrix

so i changed them to point directly to the github files itself