### PR TITLE
refactor: modernize type hints in utils/ module (part of #1927)

### DIFF
--- a/src/llmcompressor/utils/metric_logging.py
+++ b/src/llmcompressor/utils/metric_logging.py
@@ -6,7 +6,7 @@ during module compression (optimization). Supports both NVIDIA and AMD GPU monit
 """
 
 import time
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 import torch
 from compressed_tensors.offload import is_distributed
@@ -29,8 +29,8 @@ class CompressionLogger:
 
     def set_results(
         self,
-        name: Optional[str] = None,
-        loss: Optional[float] = None,
+        name: str | None = None,
+        loss: float | None = None,
     ):
         self._name = name
         self._loss = loss

--- a/src/llmcompressor/utils/pytorch/module.py
+++ b/src/llmcompressor/utils/pytorch/module.py
@@ -3,7 +3,6 @@ Utility / helper functions
 """
 
 import warnings
-from typing import Dict, List, Union
 
 import torch
 from compressed_tensors.quantization.utils import is_module_quantized
@@ -27,7 +26,7 @@ ALL_PRUNABLE_TARGET = "__ALL_PRUNABLE__"
 ALL_QUANTIZABLE_TARGET = "__ALL_QUANTIZABLE__"
 
 
-def expand_special_targets(targets: Union[str, List[str]]) -> List[str]:
+def expand_special_targets(targets: str | list[str]) -> list[str]:
     """
     Expand special target constants to explicit class names with backward compatibility.
 
@@ -73,9 +72,9 @@ def expand_special_targets(targets: Union[str, List[str]]) -> List[str]:
 
 def build_parameterized_layers(
     model: Module,
-    targets: Union[str, List[str]],
+    targets: str | list[str],
     param_name: str = "weight",
-) -> Dict[str, ModelParameterizedLayer]:
+) -> dict[str, ModelParameterizedLayer]:
     """
     Build ModelParameterizedLayer objects for modules matching the given targets.
 
@@ -129,7 +128,7 @@ def qat_active(module: Module) -> bool:
     return False
 
 
-def get_no_split_params(model: PreTrainedModel) -> Union[str, List[str]]:
+def get_no_split_params(model: PreTrainedModel) -> str | list[str]:
     """
     Get list of module classes that shouldn't be split when sharding. For
     Hugging Face Transformer models, this is the decoder layer type. For other
@@ -150,8 +149,8 @@ def get_no_split_params(model: PreTrainedModel) -> Union[str, List[str]]:
 
 
 def infer_sequential_targets(
-    model: Module, sequential_targets: Union[str, List[str], None] = None
-) -> Union[str, List[str]]:
+    model: Module, sequential_targets: str | list[str] | None = None
+) -> str | list[str]:
     """
     Infer or validate sequential targets for layer-wise processing.
 


### PR DESCRIPTION
## SUMMARY

Part of #1927. Modernizes type hints in `src/llmcompressor/utils/` to use PEP 604 union syntax (`X | Y`) and PEP 585 built-in generics (`list`, `dict`).

Two files touched:
- `src/llmcompressor/utils/metric_logging.py`
- `src/llmcompressor/utils/pytorch/module.py`

Also moves `Iterable` import from `typing` to `collections.abc` in `metric_logging.py`, since `typing.Iterable` is deprecated in favor of the `collections.abc` alias under PEP 585.

No functional changes. Type annotations only.

## TEST PLAN

- [x] `make quality` (ruff check + ruff format --check) passes on both files
- [x] Modules byte-compile and import cleanly
- [x] Runtime smoke check: `expand_special_targets` returns expected values for str, list, and `__ALL_QUANTIZABLE__` inputs
- [ ] `pytest tests/sparsity/test_module.py -v` (touches `build_parameterized_layers` and `expand_special_targets`)
- [ ] `pytest tests -m smoke`

## DIFF STATS

```
src/llmcompressor/utils/metric_logging.py |  6 +++---
src/llmcompressor/utils/pytorch/module.py | 13 ++++++-------
2 files changed, 9 insertions(+), 10 deletions(-)
```

## NOTES FOR REVIEWERS

- Scope follows the umbrella's guidance ("keep PRs focused on one module"). All remaining `Union/Optional/List/Dict/Tuple` instances in `src/llmcompressor/utils/` are addressed here.
- `qat_active` and `get_module_to_name_dict` already used modern syntax and were not touched.
- Downstream importers (in `modifiers/`, `pipelines/`, `transformers/tracing/`, tests) only import the public names (`CompressionLogger`, `get_no_split_params`, `infer_sequential_targets`, `build_parameterized_layers`, `get_module_to_name_dict`); no other module imports the removed `typing` names from these files.