### PR TITLE
refactor: modernize type hints in modeling/ module (part of #1927)

### DIFF
--- a/src/llmcompressor/modeling/gpt_oss.py
+++ b/src/llmcompressor/modeling/gpt_oss.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
 
 import torch
 import torch.nn as nn
@@ -109,10 +108,8 @@ class LinearExperts(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,  # [B, T, H]
-        router_indices: Optional[
-            torch.Tensor
-        ] = None,  # [B, T, top_k] or [tokens, top_k]
-        routing_weights: Optional[torch.Tensor] = None,  # [B, T, E] or [tokens, E]
+        router_indices: torch.Tensor | None = None,  # [B, T, top_k] or [tokens, top_k]
+        routing_weights: torch.Tensor | None = None,  # [B, T, E] or [tokens, E]
     ) -> torch.Tensor:
         """
         Implements the MoE computation using the router outputs.
@@ -192,11 +189,11 @@ def set_module_by_path(root: nn.Module, dotpath: str, new_module: nn.Module) -> 
     setattr(parent, parts[-1], new_module)
 
 
-def find_experts(model: nn.Module) -> List[ExpertMeta]:
+def find_experts(model: nn.Module) -> list[ExpertMeta]:
     """
     Locate GPT-OSS MoE expert modules under model.model.layers[*].mlp.experts.
     """
-    metas: List[ExpertMeta] = []
+    metas: list[ExpertMeta] = []
     for li, layer in enumerate(model.model.layers):
         experts = layer.mlp.experts
         device = next(experts.parameters(), torch.zeros(())).device

--- a/src/llmcompressor/modeling/llama4.py
+++ b/src/llmcompressor/modeling/llama4.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import torch
 from transformers.models.llama4.configuration_llama4 import (
     Llama4Config,
@@ -46,7 +44,7 @@ class SequentialLlama4TextMoe(MoECalibrationModule):
         self.shared_expert = original.shared_expert
         self.calibrate_all_experts = calibrate_all_experts
 
-    def forward(self, hidden_states: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         hidden_states = hidden_states.reshape(-1, self.hidden_dim)
         router_scores, router_logits = self.router(hidden_states)
         out = self.shared_expert(hidden_states)


### PR DESCRIPTION
## SUMMARY

Part of #1927. Second PR in the umbrella (after #2777). Modernizes type hints in `src/llmcompressor/modeling/` to use PEP 604 union syntax (`X | Y`) and PEP 585 built-in generics (`list`, `tuple`).

Two files touched:
- `src/llmcompressor/modeling/gpt_oss.py`
- `src/llmcompressor/modeling/llama4.py`

The `src/llmcompressor/modeling/deepseekv32/` subdirectory is intentionally **not** touched. Those files are vendored from `DeepSeek-V3.2-Exp` (per the copyright header in each file) and modifying them would create diff parity issues against upstream. They should be modernized only if the maintainers decide to fork them from upstream.

No functional changes. Type annotations only.

## TEST PLAN

- [x] `make quality` (ruff check + ruff format --check, with the pinned `ruff~=0.4.8`) passes on both files
- [x] AST-parse and byte-compile clean
- [x] Function signatures verified post-change: `find_experts -> list[ExpertMeta]`, `LinearExperts.forward(..., router_indices: torch.Tensor | None, routing_weights: torch.Tensor | None)`, `SequentialLlama4TextMoe.forward(...) -> tuple[torch.Tensor, torch.Tensor]`
- [x] `pytest tests -m smoke` (blocked locally by the pre-existing Python 3.14 / pydantic incompatibility tracked in #2778; will be exercised by CI)

## DIFF STATS

```
src/llmcompressor/modeling/gpt_oss.py | 11 ++++-------
src/llmcompressor/modeling/llama4.py  |  4 +---
2 files changed, 5 insertions(+), 10 deletions(-)
```

## NOTES FOR REVIEWERS

- Opening as a **draft** intentionally to avoid stacking review load while #2777 is still pending. Will mark ready once #2777 lands (or sooner if reviewers prefer to batch-review both).
- Scope follows the umbrella's "one module per PR" guidance.
- Module-level grep confirms `src/llmcompressor/modeling/{gpt_oss,llama4}.py` have zero remaining `Union/Optional/List/Dict/Tuple[...]` instances in code (docstrings unchanged).
- `gpt_oss.py` uses `from __future__ import annotations`, so these changes are purely syntactic with no runtime evaluation difference. `llama4.py` does not, but PEP 585 / PEP 604 syntax is fully supported under the repo's pinned `python_requires=">=3.10"`.
- No downstream importer relied on the removed `typing.List` / `typing.Optional` / `typing.Tuple` re-exports from these modules.