### PR TITLE
[Autowrapper] [Tracing] Unpin Gemma4, support tracing `UserDict` and `IfExp`

### DIFF
--- a/examples/multimodal_vision/gemma4_example.py
+++ b/examples/multimodal_vision/gemma4_example.py
@@ -1,6 +1,6 @@
-# NOTE: LLM Compressor quantization with Gemma4 requires `transformers==5.8.1`
+# NOTE: LLM Compressor quantization with Gemma4 requires `transformers>=5.5.0`
 # Please install using the following command:
-#   pip install -U transformers==5.8.1
+#   pip install -U transformers>=5.5.0
 
 # Checkpoint available at https://huggingface.co/RedHatAI/gemma-4-31B-it-NVFP4
 

--- a/examples/quantization_w4a16_fp4/nvfp4/gemma4_example.py
+++ b/examples/quantization_w4a16_fp4/nvfp4/gemma4_example.py
@@ -1,6 +1,6 @@
-# NOTE: LLM Compressor quantization with Gemma4 requires `transformers==5.8.1`
+# NOTE: LLM Compressor quantization with Gemma4 requires `transformers>=5.5.0`
 # Please install using the following command:
-#   pip install -U transformers==5.8.1
+#   pip install -U transformers>=5.5.0
 
 from compressed_tensors.offload import dispatch_model
 from transformers import AutoModelForImageTextToText, AutoProcessor

--- a/examples/quantization_w4a4_fp4/gemma4_example.py
+++ b/examples/quantization_w4a4_fp4/gemma4_example.py
@@ -1,6 +1,6 @@
-# NOTE: LLM Compressor quantization with Gemma4 requires `transformers==5.8.1`
+# NOTE: LLM Compressor quantization with Gemma4 requires `transformers>=5.5.0`
 # Please install using the following command:
-#   pip install -U transformers==5.8.1
+#   pip install -U transformers>=5.5.0
 
 import torch
 from datasets import load_dataset

--- a/examples/quantization_w8a8_fp8/gemma4_example.py
+++ b/examples/quantization_w8a8_fp8/gemma4_example.py
@@ -1,6 +1,6 @@
-# NOTE: LLM Compressor quantization with Gemma4 requires `transformers==5.8.1`
+# NOTE: LLM Compressor quantization with Gemma4 requires `transformers>=5.5.0`
 # Please install using the following command:
-#   pip install -U transformers==5.8.1
+#   pip install -U transformers>=5.5.0
 
 # Checkpoint available at https://huggingface.co/RedHatAI/gemma-4-26B-A4B-it-FP8-Dynamic
 

--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -128,7 +128,7 @@ def post_process(
 
     else:
         logger.warning(
-            "Optimized model is not saved. To save, please provide"
+            "Optimized model is not saved. To save, please provide "
             "`output_dir` as input arg."
             "Ex. `oneshot(..., output_dir=...)`"
         )

--- a/src/llmcompressor/pipelines/sequential/ast_utils/auto_wrapper.py
+++ b/src/llmcompressor/pipelines/sequential/ast_utils/auto_wrapper.py
@@ -96,7 +96,9 @@ class AutoWrapper(ast.NodeTransformer):
 
         return ret
 
-    def visit_If(self, node: ast.If) -> ast.If | ast.Assign:
+    def visit_If(
+        self, node: ast.If | ast.IfExp
+    ) -> ast.If | ast.IfExp | ast.Assign | ast.Call:
         """
         Attempt to statically evaluate the condition of the `if` statement. If the
         condition can not be statically evaluated (1), then attmept to wrap the `if`
@@ -105,7 +107,7 @@ class AutoWrapper(ast.NodeTransformer):
         :param node: `if` statement which may be wrapped
         :return: if the `if` statement cannot be statically evaluated, return the
             `if` statement with the condition replaced by `True` or `False`.
-            Otherwise, return a wrapper function call
+            Otherwise, return a wrapper function call + assignment
         """
         try:
             value = bool(self._eval_expr(node.test))
@@ -121,6 +123,17 @@ class AutoWrapper(ast.NodeTransformer):
         else:
             node.test = ast.Constant(value=value)
             return super().generic_visit(node)
+
+    def visit_IfExp(self, node: ast.IfExp) -> ast.IfExp | ast.Call:
+        """
+        `if else` expressions are treated the same as `if` statements.
+
+        :param node: `if else` expression which may be wrapped
+        :return: if the `if else` expression cannot be statically evaluated, return the
+            `if else` expression with the condition replaced by `True` or `False`.
+            Otherwise, return a wrapper function call
+        """
+        return self.visit_If(node)
 
     def visit_Tuple(self, node: ast.Tuple) -> ast.Tuple | ast.Call:
         """

--- a/src/llmcompressor/pipelines/sequential/ast_utils/auto_wrapper.py
+++ b/src/llmcompressor/pipelines/sequential/ast_utils/auto_wrapper.py
@@ -105,7 +105,7 @@ class AutoWrapper(ast.NodeTransformer):
         statement
 
         :param node: `if` statement which may be wrapped
-        :return: if the `if` statement cannot be statically evaluated, return the
+        :return: if the `if` statement can be statically evaluated, return the
             `if` statement with the condition replaced by `True` or `False`.
             Otherwise, return a wrapper function call + assignment
         """
@@ -126,10 +126,10 @@ class AutoWrapper(ast.NodeTransformer):
 
     def visit_IfExp(self, node: ast.IfExp) -> ast.IfExp | ast.Call:
         """
-        `if else` expressions are treated the same as `if` statements.
+        `if else` expressions are treated the same as `if` statements. See `visit_If`.
 
         :param node: `if else` expression which may be wrapped
-        :return: if the `if else` expression cannot be statically evaluated, return the
+        :return: if the `if else` expression can be statically evaluated, return the
             `if else` expression with the condition replaced by `True` or `False`.
             Otherwise, return a wrapper function call
         """

--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -1,6 +1,6 @@
 import contextlib
 import inspect
-from collections import deque
+from collections import UserDict, deque
 from dataclasses import dataclass
 from functools import wraps
 from types import FunctionType, MethodType
@@ -179,6 +179,10 @@ class SequentialTracer(HFTracer):
         if isinstance(a, PretrainedConfig):
             kwargs = {k: self.create_arg(v) for k, v in a.to_dict().items()}
             return self.create_node("call_function", a.__class__, (), kwargs)
+
+        # special extension for supporting `UserDict`s (Gemma4 uses this)
+        elif isinstance(a, UserDict):
+            return self.create_arg(dict(a))
 
         else:
             return super().create_arg(a)

--- a/tests/llmcompressor/pipelines/sequential/ast_utils.py/test_auto_wrapper.py
+++ b/tests/llmcompressor/pipelines/sequential/ast_utils.py/test_auto_wrapper.py
@@ -66,7 +66,7 @@ def test_static_if_global_vars():
 
 
 def test_dynamic_if():
-    """Checks that non-resolvable if statements are ignored"""
+    """Checks that non-resolvable if statements are wrapped"""
 
     source = """
     def forward():
@@ -210,5 +210,26 @@ def test_walrus():
     
     def forward():
         (x,) = wrapped_0()  # skip: some envs use "(x,)" -> "x,"
+    """
+    check_wrapping(source, output)
+
+
+def test_dynamic_ifexp():
+    """Checks that non-resolvable if expressions statements are wrapped"""
+
+    source = """
+    def forward():
+        test = ...
+        out = 1 if test else 2
+    """
+    output = """
+    @torch.fx.wrap
+    def wrapped_0(test):
+        return 1 if test else 2
+        return ()
+
+    def forward():
+        test = ...
+        out = wrapped_0(test)
     """
     check_wrapping(source, output)

--- a/tests/llmcompressor/pipelines/sequential/ast_utils.py/test_auto_wrapper.py
+++ b/tests/llmcompressor/pipelines/sequential/ast_utils.py/test_auto_wrapper.py
@@ -215,7 +215,7 @@ def test_walrus():
 
 
 def test_dynamic_ifexp():
-    """Checks that non-resolvable if expressions statements are wrapped"""
+    """Checks that non-resolvable if expressions are wrapped"""
 
     source = """
     def forward():


### PR DESCRIPTION
## Purpose ##
* Support Gemma4 with the latest version of transformers
* Expand support for autowrapping model definitions which utilize
  * `UserDict`s
  * if expressions (`... if cond else ...`)

## Changes ##
* Support tracing objects which are instances of `UserDict`s
  * This is achieved by converting them to normal `dict` instances at capture time
* Support autowrapping models which use if expressions
  * If expressions have the same implementation as if statements; both can be wrapped
* Update Gemma4 examples to unpin to support latest transformers

<details><summary>Gemma 4 Debug Process</summary>

## Root Cause

Got it. So basically, AST sees an `if` statement that depends on a dynamic variable `per_layer_inputs` , and therefore tries to wrap it

```python
if per_layer_inputs is None and self.config.get_text_config().hidden_size_per_layer_input:
		pad_embedding = self.language_model.embed_tokens.weight[self.config.text_config.pad_token_id, :]
		multimodal_mask = multimodal_mask.to(inputs_embeds.device)
		llm_inputs_embeds = torch.where(multimodal_mask[..., None], pad_embedding.view(1, 1, -1), inputs_embeds)
		per_layer_inputs = self.language_model.get_per_layer_inputs(llm_input_ids, llm_inputs_embeds)
```

```python
llm_inputs_embeds, multimodal_mask, pad_embedding, per_layer_inputs = wrapped_3(inputs_embeds, llm_input_ids, multimodal_mask, per_layer_inputs)
```

However, we’ve now replaced the concrete tracer input `per_layer_inputs` , which would normally be concrete `None` with `Proxy(getitem_5)` .

The `fx.Tracer` then erroneously `per_layer_inputs` treats as real populated variable. While it should have crashed for conditioning on dynamic variables, it instead is bad and statically evaluates `is not None` , and therefore puts `per_layer_inputs[:, :, i, :]` in the graph.

```python
per_layer_input = per_layer_inputs[:, :, i, :] if per_layer_inputs is not None else None
```

This is the “autowrapper hides things from torch.fx” situation I once worried about. The autowrapper hides because it doesn’t (and cannot reliably) know which inputs are static and which inputs are not, in the same way that torch.fx can. Name matching is not robust.

## Solution

According to the autowrapper design philosophy, the autowrapper should steal as much control as it can from torch.fx. If you continue with this philosophy, it leads you to the natural question: Why didn’t the autowrapper wrap the conditional slice operation?

```python
per_layer_input = per_layer_inputs[:, :, i, :] if per_layer_inputs is not None else None
```

The reason is because this expression is represented with `ast.IfExp`, not `ast.If` ! If we add support for `visit_IfExp`, then the slice is executed eagerly (ie not at all) and everything is groovy once more.

```
IfExp(
    test=Compare(
        left=Name(id='per_layer_inputs', ctx=Load()),
        ops=[
            IsNot()],
        comparators=[
            Constant(value=None)]),
    body=Subscript(
        value=Name(id='per_layer_inputs', ctx=Load()),
        slice=Tuple(
            elts=[
                Slice(),
                Slice(),
                Name(id='i', ctx=Load()), 
                Slice()],
            ctx=Load()),
        ctx=Load()),
    orelse=Constant(value=None))
```

```python
def visit_IfExp(self, node: ast.IfExp) -> ast.IfExp | ast.Call:
    """
    `if else` expressions are treated the same as `if` statements.

    :param node: `if else` expression which may be wrapped
    :return: if the `if else` expression cannot be statically evaluated, return the
        `if else` expression with the condition replaced by `True` or `False`.
        Otherwise, return a wrapper function call
    """
    return self.visit_If(node)
```

</details>

## Testing ##
* Added `test_dynamic_ifexp`
* Ran `examples/multimodal_vision/gemma4_example.py` to completion with transformers main
```
========== SAMPLE GENERATION ==============
user
Please describe the animal in this image  
model
thought
The image shows a small, white kitten sitting directly on top of a white computer keyboard. The kitten has fluffy white fu
r and is crouched low, appearing small enough to fit almost entirely within the width of the keyboard.
==========================================
```