### PR TITLE
[Distributed] Module parallel calibration for `QuantizationModifier`

### DIFF
--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -1,5 +1,11 @@
 import torch
-from compressed_tensors.offload.dist_utils import is_source_process as is_src
+import torch.distributed as dist
+from compressed_tensors.distributed import (
+    greedy_bin_packing,
+    is_distributed,
+    wait_for_comms,
+)
+from compressed_tensors.offload import get_execution_device
 from compressed_tensors.quantization.utils import is_module_quantized
 
 from llmcompressor.core import Event, State
@@ -12,6 +18,8 @@ from llmcompressor.modifiers.quantization.quantization.mixin import Quantization
 from llmcompressor.observers import ACTIVATION_OBS
 
 __all__ = ["QuantizationModifier"]
+
+_WEIGHT_Q_PARAMS = ["weight_scale", "weight_zero_point", "weight_global_scale"]
 
 
 class QuantizationModifier(Modifier, QuantizationMixin):
@@ -78,11 +86,49 @@ class QuantizationModifier(Modifier, QuantizationMixin):
     ):
         modules = [module for module in modules if is_module_quantized(module)]
         self.sync_obs_act_stats(modules)
-        observe(modules, "weight")
-        update_qparams(modules, ACTIVATION_OBS + ("weight",), not is_src())
+        update_qparams(modules, ACTIVATION_OBS)
+
+        ### Not Distributed
+        if not is_distributed():
+            observe(modules, "weight")
+            update_qparams(modules, "weight")
+            return
+
+        ### Distributed
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+
+        module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
+            modules,
+            world_size,
+            item_weight_fn=lambda mod: mod.weight.numel(),
+        )
+
+        observe(rank_to_modules[rank], "weight")
+        update_qparams(rank_to_modules[rank], "weight")
+        dist.barrier()  # wait for async offload updates to finish
+        self._broadcast_qparam_onloads(module_list, module_to_rank)
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """
         Finish calibrating by removing observers and calibration hooks
         """
         QuantizationMixin.end_calibration(self, state.model)
+
+    def _broadcast_qparam_onloads(
+        self,
+        module_list: list[torch.nn.Module],
+        module_to_rank: dict[torch.nn.Module, int],
+    ):
+        pending_comms = []
+        for module in module_list:
+            if get_execution_device(module) != torch.device("cpu"):
+                for qparam_name in _WEIGHT_Q_PARAMS:
+                    if (qparam := getattr(module, qparam_name, None)) is not None:
+                        pending_comms.append(
+                            dist.broadcast(
+                                qparam, src=module_to_rank[module], async_op=True
+                            )
+                        )
+
+        wait_for_comms(pending_comms)

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -1,6 +1,7 @@
 import torch
 import torch.distributed as dist
 from compressed_tensors.distributed import (
+    as_broadcastable,
     greedy_bin_packing,
     is_distributed,
     wait_for_comms,
@@ -127,7 +128,9 @@ class QuantizationModifier(Modifier, QuantizationMixin):
                     if (qparam := getattr(module, qparam_name, None)) is not None:
                         pending_comms.append(
                             dist.broadcast(
-                                qparam, src=module_to_rank[module], async_op=True
+                                as_broadcastable(qparam),
+                                src=module_to_rank[module],
+                                async_op=True,
                             )
                         )
 


### PR DESCRIPTION
## Purpose ##
* Accelerate distributed calibration for `QuantizationModifier` by performing weight calibration in parallel
  * The speedups from this change are minor: runtime is typically dominated by activation calibration, not weight calibration

## Changes ##
* Implement weight-parallel calibration of weights for `QuantizationModifier`

## Testing ##
The following times are taken from quantizing `Qwen/Qwen3.5-122B-A10B` to RTN `NVFP4` with full disk offloading and one calibration sample.

### Main ###
| world_size | oneshot time | e2e time |
| - | - | - |
| 1 | 8.67 | 15m |
| 2 | 10.81 | 19m |
| 3 | 8.77 | 17m |

### This Branch ###
| world_size | oneshot time | e2e time |
| - | - | - |
| 1 | 8.69m | 14m |
| 2 | 7.72m | 15m |
| 3 | 8.09m | 16m |

Non-linear speedups are due to fixed costs associated with calibration