### PR TITLE
fix: correct mypy files path from guidellm to llmcompressor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "setuptools_scm==8.2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.mypy]
-files = "src/guidellm"
+files = "src/llmcompressor"
 
 [tool.ruff]
 extend-exclude = ["env", "src/llmcompressor/transformers/tracing/", "src/llmcompressor/version.py"]


### PR DESCRIPTION
SUMMARY:
The `[tool.mypy]` config in `pyproject.toml` had `files = "src/guidellm"`, which appears to be an artifact from guidellm. Updated to `files = "src/llmcompressor"` so mypy checks the correct source tree.

TEST PLAN:
Verified that `src/llmcompressor` exists and `src/guidellm` does not. This is a config-only fix with no runtime impact.