### PR TITLE
Add ArceeForCausalLM mappings for AWQ and SmoothQuant

### DIFF
--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -191,6 +191,25 @@ _exaone4_mappings = [
     ),
 ]
 
+# Arcee uses an un-gated MLP: down_proj(act_fn(up_proj(x))) — no gate_proj.
+# Drop the gate_proj target from the post_attention_layernorm mapping;
+# otherwise identical to default_mappings.
+_arcee_mappings = [
+    AWQMapping(
+        "re:.*input_layernorm$",
+        ["re:.*q_proj$", "re:.*k_proj$", "re:.*v_proj$"],
+    ),
+    AWQMapping("re:.*v_proj$", ["re:.*o_proj$"]),
+    AWQMapping(
+        "re:.*post_attention_layernorm$",
+        ["re:.*up_proj$"],
+    ),
+    AWQMapping(
+        "re:.*up_proj$",
+        ["re:.*down_proj$"],
+    ),
+]
+
 # AFMOE uses dual normalization: pre_mlp_layernorm feeds the MLP
 # (not post_attention_layernorm) and attention has its own gate_proj
 # for gating mechanism
@@ -241,7 +260,7 @@ _example_parallel_transformer_block_mappings = [
 
 AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "AfmoeForCausalLM": _afmoe_mappings,
-    "ArceeForCausalLM": default_mappings,
+    "ArceeForCausalLM": _arcee_mappings,
     "BloomForCausalLM": _bloom_mappings,
     "CohereForCausalLM": _cohere_mappings,
     "Cohere2ForCausalLM": _cohere_mappings,

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -241,6 +241,7 @@ _example_parallel_transformer_block_mappings = [
 
 AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "AfmoeForCausalLM": _afmoe_mappings,
+    "ArceeForCausalLM": default_mappings,
     "BloomForCausalLM": _bloom_mappings,
     "CohereForCausalLM": _cohere_mappings,
     "Cohere2ForCausalLM": _cohere_mappings,

--- a/src/llmcompressor/modifiers/transform/smoothquant/utils.py
+++ b/src/llmcompressor/modifiers/transform/smoothquant/utils.py
@@ -67,6 +67,20 @@ DEEPSEEK_V2_SMOOTHQUANT_MAPPINGS: list[LayerMap] = [
     ),
 ]
 
+# Arcee uses an un-gated MLP: down_proj(act_fn(up_proj(x))) — no gate_proj.
+# Drop the gate_proj target from the MLP-side mapping; otherwise identical to
+# DEFAULT_SMOOTHQUANT_MAPPINGS.
+ARCEE_SMOOTHQUANT_MAPPINGS: list[LayerMap] = [
+    LayerMap(
+        balance_layers=["re:.*q_proj", "re:.*k_proj", "re:.*v_proj"],
+        smooth_layers="re:.*input_layernorm",
+    ),
+    LayerMap(
+        balance_layers=["re:.*up_proj"],
+        smooth_layers="re:.*post_attention_layernorm",
+    ),
+]
+
 # MLP smoothing (post_attention_layernorm) is intentionally omitted for MoE.
 # A single smoothing scale across all experts causes inter-expert imbalance,
 # degrading PPL even with the router gate properly balanced. This matches
@@ -111,7 +125,7 @@ AFMOE_SMOOTHQUANT_MAPPINGS: list[LayerMap] = [
 # Registry of layer mappings for different architectures
 #   Add more mappings here
 MAPPINGS_REGISTRY: dict[str, list[LayerMap]] = {
-    "ArceeForCausalLM": DEFAULT_SMOOTHQUANT_MAPPINGS,
+    "ArceeForCausalLM": ARCEE_SMOOTHQUANT_MAPPINGS,
     "BloomForCausalLM": BLOOM_SMOOTHQUANT_MAPPINGS,
     "ChatGLMForConditionalGeneration": BLOOM_SMOOTHQUANT_MAPPINGS,
     "CohereForCausalLM": COHERE_SMOOTHQUANT_MAPPINGS,

--- a/src/llmcompressor/modifiers/transform/smoothquant/utils.py
+++ b/src/llmcompressor/modifiers/transform/smoothquant/utils.py
@@ -111,6 +111,7 @@ AFMOE_SMOOTHQUANT_MAPPINGS: list[LayerMap] = [
 # Registry of layer mappings for different architectures
 #   Add more mappings here
 MAPPINGS_REGISTRY: dict[str, list[LayerMap]] = {
+    "ArceeForCausalLM": DEFAULT_SMOOTHQUANT_MAPPINGS,
     "BloomForCausalLM": BLOOM_SMOOTHQUANT_MAPPINGS,
     "ChatGLMForConditionalGeneration": BLOOM_SMOOTHQUANT_MAPPINGS,
     "CohereForCausalLM": COHERE_SMOOTHQUANT_MAPPINGS,

--- a/tests/llmcompressor/modifiers/transform/smoothquant/test_utils.py
+++ b/tests/llmcompressor/modifiers/transform/smoothquant/test_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from llmcompressor.modifiers.transform.smoothquant.utils import (
+    ARCEE_SMOOTHQUANT_MAPPINGS,
     COHERE_SMOOTHQUANT_MAPPINGS,
     DEEPSEEK_V2_SMOOTHQUANT_MAPPINGS,
     DEFAULT_SMOOTHQUANT_MAPPINGS,
@@ -69,6 +70,7 @@ def test_new_architecture_mappings_resolve(architecture, expected_mappings):
     [
         ("DeepseekV3ForCausalLM", DEEPSEEK_V2_SMOOTHQUANT_MAPPINGS),
         ("Phi3ForCausalLM", PHI3_VISION_SMOOTHQUANT_MAPPINGS),
+        ("ArceeForCausalLM", ARCEE_SMOOTHQUANT_MAPPINGS),
     ],
 )
 def test_specialized_architecture_overrides_default(architecture, expected_mappings):
@@ -76,3 +78,57 @@ def test_specialized_architecture_overrides_default(architecture, expected_mappi
     resolved = get_layer_mappings_from_architecture(architecture)
     assert resolved is expected_mappings
     assert resolved is not DEFAULT_SMOOTHQUANT_MAPPINGS
+
+
+@pytest.mark.unit
+def test_arcee_mapping_regex_matches_real_module_tree():
+    """Construct ArceeForCausalLM on the meta device with a tiny config
+    and assert ARCEE_SMOOTHQUANT_MAPPINGS' regex matches expected
+    attention + un-gated MLP modules per layer. Arcee's MLP is
+    `down_proj(act_fn(up_proj(x)))` — no gate_proj — so the mapping
+    intentionally omits the gate_proj balance target that
+    DEFAULT_SMOOTHQUANT_MAPPINGS uses.
+    """
+    import re
+
+    import torch
+    from transformers import ArceeConfig, ArceeForCausalLM
+
+    config = ArceeConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=100,
+        bos_token_id=0,
+        eos_token_id=1,
+    )
+    with torch.device("meta"):
+        model = ArceeForCausalLM(config)
+
+    module_names = [name for name, _ in model.named_modules()]
+
+    # ARCEE_SMOOTHQUANT_MAPPINGS must hit every regex; the omitted
+    # gate_proj target is the whole point of the dedicated mapping.
+    for layer_map in ARCEE_SMOOTHQUANT_MAPPINGS:
+        smooth_pat = layer_map.smooth_layers.removeprefix("re:")
+        smooth_re = re.compile(smooth_pat)
+        smooth_hits = [n for n in module_names if smooth_re.search(n)]
+        assert smooth_hits, (
+            f"ArceeForCausalLM: smooth pattern {smooth_pat!r} matched no "
+            f"modules; sample names: {module_names[:20]}"
+        )
+        for balance_pat_raw in layer_map.balance_layers:
+            balance_pat = balance_pat_raw.removeprefix("re:")
+            balance_re = re.compile(balance_pat)
+            balance_hits = [n for n in module_names if balance_re.search(n)]
+            assert balance_hits, (
+                f"ArceeForCausalLM: balance pattern {balance_pat!r} matched "
+                f"no modules; sample names: {module_names[:20]}"
+            )
+
+    # Sanity: gate_proj must NOT exist on Arcee (un-gated MLP). This is
+    # what motivates the ARCEE_SMOOTHQUANT_MAPPINGS variant over
+    # DEFAULT_SMOOTHQUANT_MAPPINGS.
+    assert not any("gate_proj" in n for n in module_names)


### PR DESCRIPTION
SUMMARY:
Adds \`ArceeForCausalLM\` (Arcee AI's open dense decoder — \`arcee-ai/AFM-4.5B-Base\`, \`arcee-ai/Trinity-Nano-Preview\`, etc.) to both the AWQ and SmoothQuant layer-mapping registries. Maps to the existing \`default_mappings\` / \`DEFAULT_SMOOTHQUANT_MAPPINGS\`.

Verified against HF \`transformers/models/arcee/modeling_arcee.py\`:
- attention attrs: \`q_proj\`, \`k_proj\`, \`v_proj\`, \`o_proj\` (separate, not fused)
- norms: \`input_layernorm\`, \`post_attention_layernorm\` — \`RMSNorm\` (parametric)
- MLP attrs: \`gate_proj\`, \`up_proj\`, \`down_proj\`
- no \`q_norm\` / \`k_norm\` (no QK-norm)

Identical shape to the already-registered \`LlamaForCausalLM\` / \`MistralForCausalLM\` / \`Qwen2ForCausalLM\` entries; existing tests for those entries cover the mapping shape.

Part of #1442. Continues the pattern from #2419 / #2609 / #2639 / #2727.

TEST PLAN:
- \`ruff check\` / \`ruff format --check\` clean.
- HF source inspection confirms standard layer naming (q/k/v/o_proj, input/post_attention_layernorm, gate/up/down_proj) — same shape as already-mapped Llama/Mistral/Qwen2.

Diff:
\`\`\`diff
+    "ArceeForCausalLM": default_mappings,                  # awq/mappings.py
+    "ArceeForCausalLM": DEFAULT_SMOOTHQUANT_MAPPINGS,      # smoothquant/utils.py
\`\`\`