### PR TITLE
fix(gptq): drop non-GROUP actorder for non-grouped strategies (#2805)

### DIFF
--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -174,15 +174,22 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 # Apply modifier-level actorder to already-constructed QuantizationArgs.
                 scheme.weights.actorder = resolve_actorder(scheme.weights.actorder)
 
+                # Activation ordering is only meaningful for grouped strategies;
+                # non-grouped strategies must fall back to actorder=None so the
+                # serialized config reloads cleanly (e.g. in vLLM). This applies
+                # to every ordering value, not just GROUP -- the default STATIC
+                # (alias of WEIGHT) would otherwise be written for channel/tensor
+                # schemes and rejected on reload.
                 if (
-                    scheme.weights.actorder == ActivationOrdering.GROUP
+                    scheme.weights.actorder is not None
                     and strategy not in grouped_strategies
                 ):
-                    logger.warning(
-                        f"ActivationOrdering.GROUP is not compatible with "
-                        f"strategy={strategy}; falling back to actorder=None "
-                        f"for this scheme."
-                    )
+                    if scheme.weights.actorder == ActivationOrdering.GROUP:
+                        logger.warning(
+                            f"ActivationOrdering.GROUP is not compatible with "
+                            f"strategy={strategy}; falling back to actorder=None "
+                            f"for this scheme."
+                        )
                     scheme.weights.actorder = None
         return config
 


### PR DESCRIPTION
## Summary

Fixes #2805.

`GPTQModifier.actorder` defaults to `Sentinel("static")`, which `resolve_actorder` resolves to `ActivationOrdering.STATIC` (an alias of `WEIGHT`) for every scheme whose `actorder` is unset. The fall-back guard in `resolve_quantization_config()` then only reset `actorder` to `None` when it equalled `ActivationOrdering.GROUP`:

```python
if (
    scheme.weights.actorder == ActivationOrdering.GROUP
    and strategy not in grouped_strategies
):
    ...
    scheme.weights.actorder = None
```

So the default `STATIC` (and an explicit `WEIGHT`) **slipped through** for `channel` / `tensor` / `block` strategies and got written into `config.json`. This contradicts the comment right above the block, which already states that non-grouped strategies should *"fall back to None"*.

## Impact

Activation ordering is meaningless without groups to reorder across. compressed-tensors rejects it on non-grouped strategies on reload, so quantizing e.g. `W8A8` (channel) or `FP8` (tensor) produces models that fail to load in vLLM:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
Value error, Must use group or tensor_group quantization strategy in order to
apply activation ordering
```

(reproduced by the reporter on vLLM 0.22.1 + compressed-tensors 0.16.0). `W4A16`/`NVFP4` (grouped) are unaffected and keep serving fine.

## Fix

Reset `actorder` to `None` for non-grouped strategies regardless of the ordering value, matching the comment's stated intent. The `GROUP`-incompatibility warning is preserved for the case where a user *explicitly* requested group ordering on an unsupported strategy; the harmless default `STATIC`/`WEIGHT` is dropped silently.

```python
if (
    scheme.weights.actorder is not None
    and strategy not in grouped_strategies
):
    if scheme.weights.actorder == ActivationOrdering.GROUP:
        logger.warning(...)
    scheme.weights.actorder = None
```

## Scope note

This only touches config **serialization** (`resolve_quantization_config`). The runtime guard in `gptq_quantize.py` is intentionally left unchanged: applying `WEIGHT`/`STATIC` ordering *during calibration* is valid for any strategy (it improves accuracy and restores the original column order without a format change), so it should still run — only the reloaded config must not advertise an ordering the format doesn't carry.

> Note: recent `compressed-tensors` `main` has relaxed its validator to reject only `GROUP` actorder on non-grouped strategies, so the crash above no longer reproduces on bleeding-edge installs. This fix is still warranted: it restores the documented intent, unbreaks the released vLLM + compressed-tensors stack, and stops emitting a meaningless `actorder` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
