### PR TITLE
cleanup: remove stale actorder serialization TODO

### DIFF
--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -122,7 +122,6 @@ class GPTQModifier(Modifier, QuantizationMixin):
     # gptq modifier arguments
     block_size: int = 128
     dampening_frac: float | None = 0.01
-    # TODO: this does not serialize / will be incorrectly written
     actorder: ActivationOrdering | Sentinel | None = Sentinel("static")
     offload_hessians: bool = False
 


### PR DESCRIPTION

## Summary

- Removes the stale `# TODO: this does not serialize / will be incorrectly written` comment on `GPTQModifier.actorder`                                                                          

The TODO was added in #1815 when serialization behavior of the `Sentinel("static")` default was uncertain. It is no longer applicable:

- `test_serialize_actorder` confirms the Sentinel default already serializes correctly as `"static"`
- [compressed-tensors #682](https://github.com/vllm-project/compressed-tensors/pull/682) relaxed the validator to allow `STATIC`/`WEIGHT` actorder on non-grouped strategies, making the serialized value valid
across all strategy types

Context: I ran into this while investigating #2805, which turned out to be a compressed-tensors version issue (fixed in `compressed-tensors==0.16.0`).

## Test plan

- No behavior change — comment-only removal
- Existing `test_serialize_actorder` covers serialization correctness
