### PR TITLE
fix imatrix + awq

### DIFF
--- a/src/llmcompressor/observers/imatrix.py
+++ b/src/llmcompressor/observers/imatrix.py
@@ -88,7 +88,10 @@ class IMatrixMSEObserver(Observer):
         module._imatrix_count = torch.tensor(0, dtype=torch.int64)
 
         def _hook(mod, args):
-            if HooksMixin._HOOKS_DISABLED:
+            if (
+                HooksMixin._HOOKS_DISABLED
+                and getattr(mod, "_imatrix_hook", None) not in HooksMixin._HOOKS_KEEP_ENABLED
+            ):
                 return
             x = args[0] if isinstance(args, tuple) else args
             if isinstance(x, tuple):

--- a/src/llmcompressor/observers/imatrix.py
+++ b/src/llmcompressor/observers/imatrix.py
@@ -90,7 +90,8 @@ class IMatrixMSEObserver(Observer):
         def _hook(mod, args):
             if (
                 HooksMixin._HOOKS_DISABLED
-                and getattr(mod, "_imatrix_hook", None) not in HooksMixin._HOOKS_KEEP_ENABLED
+                and getattr(mod, "_imatrix_hook", None)
+                not in HooksMixin._HOOKS_KEEP_ENABLED
             ):
                 return
             x = args[0] if isinstance(args, tuple) else args

--- a/src/llmcompressor/observers/imatrix.py
+++ b/src/llmcompressor/observers/imatrix.py
@@ -9,6 +9,7 @@ from compressed_tensors.utils import patch_attr
 from loguru import logger
 from torch import distributed as dist
 
+from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.observers.base import MinMaxTuple, Observer
 from llmcompressor.observers.helpers import flatten_for_calibration
 
@@ -87,6 +88,8 @@ class IMatrixMSEObserver(Observer):
         module._imatrix_count = torch.tensor(0, dtype=torch.int64)
 
         def _hook(mod, args):
+            if HooksMixin._HOOKS_DISABLED:
+                return
             x = args[0] if isinstance(args, tuple) else args
             if isinstance(x, tuple):
                 x = x[0]

--- a/tests/llmcompressor/observers/test_imatrix.py
+++ b/tests/llmcompressor/observers/test_imatrix.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 from compressed_tensors.quantization.quant_args import QuantizationArgs
 
+from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.observers.base import Observer
 
 # ---------------------------------------------------------------------------
@@ -325,3 +326,37 @@ class TestValidation:
         observer.attach(module)
         with pytest.raises(NotImplementedError, match="TENSOR strategy"):
             observer(module.weight).get_qparams()
+
+
+# ---------------------------------------------------------------------------
+# Hook disabled during HooksMixin.disable_hooks()
+# ---------------------------------------------------------------------------
+
+
+class TestHookDisabling:
+    """The iMatrix hook must not accumulate when HooksMixin.disable_hooks() is active."""
+
+    def test_hook_skipped_under_disable_hooks(self):
+        module = torch.nn.Linear(8, 4)
+        observer = _make_observer(module, strategy="channel")
+
+        x = torch.randn(2, 8)
+        module(x)
+        assert module._imatrix_count.item() > 0
+        count_before = module._imatrix_count.item()
+
+        with HooksMixin.disable_hooks():
+            module(torch.randn(2, 8))
+
+        assert module._imatrix_count.item() == count_before
+
+    def test_hook_resumes_after_disable_hooks(self):
+        module = torch.nn.Linear(8, 4)
+        _make_observer(module, strategy="channel")
+
+        with HooksMixin.disable_hooks():
+            module(torch.randn(2, 8))
+        assert module._imatrix_count.item() == 0
+
+        module(torch.randn(2, 8))
+        assert module._imatrix_count.item() > 0

--- a/tests/llmcompressor/observers/test_imatrix.py
+++ b/tests/llmcompressor/observers/test_imatrix.py
@@ -334,11 +334,13 @@ class TestValidation:
 
 
 class TestHookDisabling:
-    """The iMatrix hook must not accumulate when HooksMixin.disable_hooks() is active."""
+    """
+    The iMatrix hook must not accumulate when HooksMixin.disable_hooks() is active.
+    """
 
     def test_hook_skipped_under_disable_hooks(self):
         module = torch.nn.Linear(8, 4)
-        observer = _make_observer(module, strategy="channel")
+        _make_observer(module, strategy="channel")
 
         x = torch.randn(2, 8)
         module(x)


### PR DESCRIPTION
Summary:

imatrix creates its hook differently from hooks_mixin so it wasn'te respecting this

kind of hacky but we're going to rewrite this anyway when we get rid of imatrixgatherer

TEST PLAN:
pytest /home/HDCharles/repos/llm-compressor/tests/llmcompressor/observers -k test_hook
