### PR TITLE
[Bugfix] Fix KV cache tests with transformers v5

### DIFF
--- a/tests/llmcompressor/transformers/kv_cache/test_kv_cache.py
+++ b/tests/llmcompressor/transformers/kv_cache/test_kv_cache.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 import pytest
-from accelerate import init_empty_weights
 from compressed_tensors.quantization import is_attention_module
 from datasets import load_dataset
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
@@ -155,9 +154,8 @@ def test_kv_cache_config_format(oneshot_fixture, tmp_path):
 
 def test_kv_cache_model_state_dict_attr(oneshot_fixture, tmp_path):
     model, used_args = next(oneshot_fixture(tmp_path))
-    output_dir = used_args["output_dir"]
-    with init_empty_weights():
-        model = AutoModelForCausalLM.from_pretrained(str(output_dir))
+    output_dir = str(used_args["output_dir"])
+    model = AutoModelForCausalLM.from_pretrained(output_dir, device_map="meta")
 
     counts = 0
     for name, submodule in model.named_modules():
@@ -195,8 +193,7 @@ def test_kv_cache_gptq_config_format(kv_cache_fixture, tmp_path):
     assert kv_cache_scheme["dynamic"] == used_args["dynamic"]
     assert kv_cache_scheme["symmetric"] == used_args["symmetric"]
 
-    with init_empty_weights():
-        model = AutoModelForCausalLM.from_pretrained(output_dir)
+    model = AutoModelForCausalLM.from_pretrained(output_dir, device_map="meta")
 
     counts = 0
     for name, submodule in model.named_modules():


### PR DESCRIPTION
## Purpose ##
* Fix KV Cache tests when using `init_empty_weights` with `accelerate==1.6.0` and `transformers>=5.9.0`
  * Newer versions of transformers attach an attribute `_is_hf_initialized` to parameters. However, `accelerate::init_empty_weights` treats this as a class constructor param. When it tries to reconstruct the parameter with this argument, the constructor fails.
  * This is [fixed by upstream accelerate](https://github.com/huggingface/accelerate/pull/3955), but we can avoid bumping versions by instead just not using `init_empty_weights` and instead loading on the meta device instead.

## Changes ##
* Remove all uses of `init_empty_weights`, instead load on meta device