### PR TITLE
[Autoround] add custom dataset support

### DIFF
--- a/examples/autoround/README.md
+++ b/examples/autoround/README.md
@@ -65,6 +65,7 @@ The accuracy of the quantized model is configured by tuning-related parameters. 
 | ------------------- | ------------------------------------------------------------------------- | ------------------------------------- |
 | `wNa16`             | [llama3_example](./quantization_w4a16/llama3_example.py)                  |                                       |
 | `wNa16`             | [qwen3_example](./quantization_w4a16/qwen3_example.py)                    | Multiple cards for `Qwen3-235B-A22B`  |
+| `wNa16`             | [qwen3_example_custom_dataset.py](./quantization_w4a16/qwen3_example_custom_dataset.py)| Using custom calibration datasets |
 | `wNa16` + `FP8KV`   | [llama3_example](./quantization_kv_cache/llama3_example.py)               |                                       |
 | `W8A8-FP8` Static   | [llama4_example](./quantization_w8a8_fp8/llama4_static_quant_example.py) |                                       |
 | `W8A8-FP8` Dynamic  | [llama4_example](./quantization_w8a8_fp8/llama4_dynamic_quant_example.py)  |                                       |

--- a/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
+++ b/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
@@ -1,0 +1,75 @@
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.autoround import AutoRoundModifier, fix_batch_if_needed
+from llmcompressor.utils import dispatch_for_generation
+
+MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
+MODEL_ID = "/mnt/disk1/yiliu7/Qwen/Qwen3-8B"
+MODEL_ID = "/mnt/disk1/yiliu7/Qwen/Qwen3-0.6B"
+DATASET_ID = "HuggingFaceH4/ultrachat_200k"
+DATASET_SPLIT = "train_sft"
+NUM_CALIBRATION_SAMPLES = 128
+MAX_SEQUENCE_LENGTH = 512
+
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+tokenizer.pad_token = tokenizer.eos_token
+
+dataset = load_dataset(
+    DATASET_ID,
+    split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]",
+).shuffle(seed=42)
+
+
+def preprocess(example):
+    return {
+        "text": tokenizer.apply_chat_template(
+            example["messages"],
+            tokenize=False,
+        )
+    }
+
+
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding="max_length",
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+        return_attention_mask=True,
+    )
+
+
+dataset = dataset.map(preprocess)
+dataset = dataset.map(tokenize, remove_columns=dataset.column_names)
+dataset = dataset.map(fix_batch_if_needed)
+
+recipe = AutoRoundModifier(
+    targets="Linear",
+    scheme="W4A16",
+    ignore=["lm_head"],
+    iters=10,
+)
+
+oneshot(
+    model=model,
+    dataset=dataset,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+print("\n\n========== SAMPLE GENERATION ==============")
+dispatch_for_generation(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================\n\n")
+
+save_dir = MODEL_ID.rstrip("/").split("/")[-1] + "-W4A16-G128-AutoRound-Ultrachat200k"
+model.save_pretrained(save_dir, save_compressed=True)
+tokenizer.save_pretrained(save_dir)

--- a/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
+++ b/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
@@ -17,10 +17,10 @@ tokenizer.pad_token = tokenizer.eos_token
 
 dataset = load_dataset(
     DATASET_ID,
-    split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]",
-).shuffle(seed=42)
-
-
+dataset = load_dataset(
+    DATASET_ID,
+    split=DATASET_SPLIT,
+).shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))
 def preprocess(example):
     return {
         "text": tokenizer.apply_chat_template(

--- a/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
+++ b/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
@@ -6,13 +6,13 @@ from llmcompressor.modifiers.autoround import AutoRoundModifier, fix_batch_if_ne
 from llmcompressor.utils import dispatch_for_generation
 
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
-MODEL_ID = "/mnt/disk1/yiliu7/Qwen/Qwen3-8B"
-MODEL_ID = "/mnt/disk1/yiliu7/Qwen/Qwen3-0.6B"
+MODEL_ID = "Qwen/Qwen3-8B"
+MODEL_ID = "Qwen/Qwen3-0.6B"
 DATASET_ID = "HuggingFaceH4/ultrachat_200k"
 DATASET_SPLIT = "train_sft"
 NUM_CALIBRATION_SAMPLES = 128
 MAX_SEQUENCE_LENGTH = 512
-
+ITERS = 10
 model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 tokenizer.pad_token = tokenizer.eos_token
@@ -51,7 +51,7 @@ recipe = AutoRoundModifier(
     targets="Linear",
     scheme="W4A16",
     ignore=["lm_head"],
-    iters=10,
+    iters=ITERS,
 )
 
 oneshot(

--- a/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
+++ b/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
@@ -7,12 +7,12 @@ from llmcompressor.utils import dispatch_for_generation
 
 MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
 MODEL_ID = "Qwen/Qwen3-8B"
-MODEL_ID = "Qwen/Qwen3-0.6B"
+# MODEL_ID = "Qwen/Qwen3-0.6B"
 DATASET_ID = "HuggingFaceH4/ultrachat_200k"
 DATASET_SPLIT = "train_sft"
 NUM_CALIBRATION_SAMPLES = 128
-MAX_SEQUENCE_LENGTH = 512
-ITERS = 10
+MAX_SEQUENCE_LENGTH = 2048
+ITERS = 200
 model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 tokenizer.pad_token = tokenizer.eos_token

--- a/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
+++ b/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
@@ -14,10 +14,15 @@ ITERS = 200
 model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 
-dataset = load_dataset(
-    DATASET_ID,
-    split=DATASET_SPLIT,
-).shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))
+dataset = (
+    load_dataset(
+        DATASET_ID,
+        split=DATASET_SPLIT,
+    )
+    .shuffle(seed=42)
+    .select(range(NUM_CALIBRATION_SAMPLES))
+)
+
 
 def preprocess(example):
     return {

--- a/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
+++ b/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
@@ -13,14 +13,12 @@ MAX_SEQUENCE_LENGTH = 2048
 ITERS = 200
 model = AutoModelForCausalLM.from_pretrained(MODEL_ID, torch_dtype="auto")
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
-tokenizer.pad_token = tokenizer.eos_token
 
-dataset = load_dataset(
-    DATASET_ID,
 dataset = load_dataset(
     DATASET_ID,
     split=DATASET_SPLIT,
 ).shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))
+
 def preprocess(example):
     return {
         "text": tokenizer.apply_chat_template(

--- a/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
+++ b/examples/autoround/quantization_w4a16/qwen3_example_custom_dataset.py
@@ -5,9 +5,7 @@ from llmcompressor import oneshot
 from llmcompressor.modifiers.autoround import AutoRoundModifier, fix_batch_if_needed
 from llmcompressor.utils import dispatch_for_generation
 
-MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
 MODEL_ID = "Qwen/Qwen3-8B"
-# MODEL_ID = "Qwen/Qwen3-0.6B"
 DATASET_ID = "HuggingFaceH4/ultrachat_200k"
 DATASET_SPLIT = "train_sft"
 NUM_CALIBRATION_SAMPLES = 128

--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -307,7 +307,7 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
             device = first_param.device
             cur_inputs = self._all_module_input[decoding_layer._tmp_name]
             ar_inputs = [((args, kwargs),) for args, kwargs in cur_inputs]
-            self._set_attention_masks(ar, cur_inputs)
+            self._set_attention_masks(ar, decoding_layer, cur_inputs)
             decoding_layer.tuning_device = device
             # Leave offload for LLMC to handle if `device_ids` is not set
             auto_offload = False

--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -616,12 +616,18 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
     def _set_attention_masks(
         self,
         autoround: AutoRound,
+        block: torch.nn.Module,
         captured_inputs: list[tuple[tuple, dict]],
     ):
-        attention_masks = [
-            fix_attention_mask(kwargs["attention_mask"])
-            for _, kwargs in captured_inputs
-            if kwargs.get("attention_mask") is not None
-        ]
+        import inspect
+
+        sig = inspect.signature(block.forward)
+        attention_masks = []
+        for args, kwargs in captured_inputs:
+            bound = sig.bind_partial(*args, **kwargs)
+            mask = bound.arguments.get("attention_mask")
+            if mask is not None:
+                attention_masks.append(fix_attention_mask(mask))
+
         if attention_masks:
             autoround.attention_mask = attention_masks

--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -624,8 +624,11 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
         sig = inspect.signature(block.forward)
         attention_masks = []
         for args, kwargs in captured_inputs:
-            bound = sig.bind_partial(*args, **kwargs)
-            mask = bound.arguments.get("attention_mask")
+            try:
+                bound = sig.bind_partial(*args, **kwargs)
+                mask = bound.arguments.get("attention_mask")
+            except TypeError:
+                mask = kwargs.get("attention_mask")
             if mask is not None:
                 attention_masks.append(fix_attention_mask(mask))
 

--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -207,7 +207,7 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
 
         model.apply(enable_quantization)  # quantize at the same time as calibrate
 
-    def input_capture_hook(self, module, *args, **kwargs):
+    def input_capture_hook(self, module, args, kwargs):
         if module._tmp_name not in self._all_module_input:
             self._all_module_input[module._tmp_name] = []
         self._all_module_input[module._tmp_name].append((args, kwargs))
@@ -306,6 +306,7 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
             first_param = next(decoding_layer.parameters())
             device = first_param.device
             cur_inputs = self._all_module_input[decoding_layer._tmp_name]
+            ar_inputs = [((args, kwargs),) for args, kwargs in cur_inputs]
             self._set_attention_masks(ar, cur_inputs)
             decoding_layer.tuning_device = device
             # Leave offload for LLMC to handle if `device_ids` is not set
@@ -318,7 +319,7 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
 
             q_input, _ = ar.quantize_block(
                 block=decoding_layer,
-                inputs=cur_inputs,
+                inputs=ar_inputs,
                 q_input=self._q_input,
                 device=str(device),
                 auto_offload=auto_offload,

--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -21,12 +21,13 @@ from pydantic import PrivateAttr
 
 from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers import Modifier
+from llmcompressor.modifiers.autoround.utils import fix_attention_mask
 from llmcompressor.modifiers.quantization.calibration import apply_calibration_status
 from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.utils import targets_embeddings, untie_word_embeddings
 from llmcompressor.utils.pytorch import infer_sequential_targets
 
-__all__ = ["AutoRoundModifier"]
+__all__ = ["AutoRoundModifier", "fix_batch_if_needed"]
 
 
 class _LLModelWrapper(torch.nn.Module):
@@ -55,6 +56,20 @@ def _wrap_decoding_layer(layer: torch.nn.Module) -> _PretrainModelWrapper:
     first_param = next(layer.parameters())
     wrapped_model.dtype = first_param.dtype
     return wrapped_model
+
+
+def fix_batch_if_needed(
+    batch: dict[str, list[int] | list[list[int]]],
+) -> dict[str, list[int] | list[list[int]]]:
+    """
+    Normalize custom calibration batches so their attention masks work with AutoRound.
+    """
+    attention_mask = batch.get("attention_mask")
+    if attention_mask is None:
+        return batch
+
+    batch["attention_mask"] = fix_attention_mask(attention_mask).tolist()
+    return batch
 
 
 @contextmanager
@@ -291,6 +306,7 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
             first_param = next(decoding_layer.parameters())
             device = first_param.device
             cur_inputs = self._all_module_input[decoding_layer._tmp_name]
+            self._set_attention_masks(ar, cur_inputs)
             decoding_layer.tuning_device = device
             # Leave offload for LLMC to handle if `device_ids` is not set
             auto_offload = False
@@ -595,3 +611,16 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
             act_data_type=act_data_type,
         )
         return ar_quant_scheme
+
+    def _set_attention_masks(
+        self,
+        autoround: AutoRound,
+        captured_inputs: list[tuple[tuple, dict]],
+    ):
+        attention_masks = [
+            fix_attention_mask(kwargs["attention_mask"])
+            for _, kwargs in captured_inputs
+            if kwargs.get("attention_mask") is not None
+        ]
+        if attention_masks:
+            autoround.attention_mask = attention_masks

--- a/src/llmcompressor/modifiers/autoround/utils.py
+++ b/src/llmcompressor/modifiers/autoround/utils.py
@@ -1,0 +1,66 @@
+import torch
+
+__all__ = ["fix_attention_mask"]
+
+
+def _collapse_causal_attention_mask(mask: torch.Tensor) -> torch.Tensor:
+    """
+    Reduce causal attention masks to the per-token validity mask AutoRound expects.
+
+    AutoRound uses attention masks only to exclude padded query positions from the
+    reconstruction loss, so higher-rank causal masks need to be collapsed to a
+    `[batch, seq_len]` mask first.
+    """
+    if mask.ndim == 4:
+        mask = mask.squeeze(1)
+    if mask.ndim != 3:
+        raise ValueError(
+            "Unsupported causal attention mask shape for AutoRound: "
+            f"{tuple(mask.shape)}"
+        )
+
+    if mask.numel() == 0:
+        return mask
+
+    if mask.dtype == torch.bool:
+        return mask.any(dim=-1)
+
+    if torch.all(mask == 0):
+        return torch.ones(mask.shape[:-1], dtype=torch.long, device=mask.device)
+
+    global_min = mask.amin()
+    return (mask.amax(dim=-1) > global_min).to(torch.long)
+
+
+def fix_attention_mask(
+    mask: torch.Tensor | list[int] | list[list[int]],
+) -> torch.Tensor:
+    """
+    Normalize attention masks for AutoRound custom datasets.
+
+    AutoRound expects at least one masked position when the calibration mask is fully
+    dense. When every token is marked valid, set the final position to 0 while
+    preserving the original dtype and shape.
+    """
+    normalized_mask = torch.as_tensor(mask).clone()
+    if normalized_mask.shape[-1] == 0:
+        return normalized_mask
+
+    if normalized_mask.ndim in (3, 4):
+        normalized_mask = _collapse_causal_attention_mask(normalized_mask)
+
+    if normalized_mask.ndim == 1:
+        if torch.all(normalized_mask == 1):
+            normalized_mask[-1] = 0
+        return normalized_mask
+
+    if normalized_mask.ndim == 2:
+        all_ones_rows = torch.all(normalized_mask == 1, dim=1)
+        if torch.any(all_ones_rows):
+            normalized_mask[all_ones_rows, -1] = 0
+        return normalized_mask
+
+    raise ValueError(
+        "Unsupported attention mask shape for AutoRound: "
+        f"{tuple(normalized_mask.shape)}"
+    )

--- a/src/llmcompressor/modifiers/autoround/utils.py
+++ b/src/llmcompressor/modifiers/autoround/utils.py
@@ -43,6 +43,7 @@ def fix_attention_mask(
     AutoRound expects at least one masked position when the calibration mask is fully
     dense. When every token is marked valid, set the final position to 0 while
     preserving the original dtype and shape.
+    More details can be found here: https://github.com/intel/auto-round/blob/50ee58c9e176e9da2a744dbe6ed220f26e80eccd/auto_round/calibration/llm.py#L315-L355
     """
     normalized_mask = torch.as_tensor(mask).clone()
     if normalized_mask.shape[-1] == 0:

--- a/src/llmcompressor/modifiers/autoround/utils.py
+++ b/src/llmcompressor/modifiers/autoround/utils.py
@@ -19,13 +19,10 @@ def _collapse_causal_attention_mask(mask: torch.Tensor) -> torch.Tensor:
             f"{tuple(mask.shape)}"
         )
 
-    if mask.numel() == 0:
-        return mask
-
     if mask.dtype == torch.bool:
         return mask.any(dim=-1)
 
-    if torch.all(mask == 0):
+    if mask.numel() == 0 or torch.all(mask == 0):
         raise ValueError(
             "Invalid causal attention mask for AutoRound: all positions are masked"
         )
@@ -48,6 +45,13 @@ def fix_attention_mask(
     normalized_mask = torch.as_tensor(mask).clone()
     if normalized_mask.shape[-1] == 0:
         return normalized_mask
+
+    if (
+        normalized_mask.ndim == 4
+        and normalized_mask.shape[1] == 1
+        and normalized_mask.shape[2] == 1
+    ):
+        normalized_mask = normalized_mask.squeeze(2).squeeze(1)
 
     if normalized_mask.ndim in (3, 4):
         normalized_mask = _collapse_causal_attention_mask(normalized_mask)

--- a/src/llmcompressor/modifiers/autoround/utils.py
+++ b/src/llmcompressor/modifiers/autoround/utils.py
@@ -26,7 +26,9 @@ def _collapse_causal_attention_mask(mask: torch.Tensor) -> torch.Tensor:
         return mask.any(dim=-1)
 
     if torch.all(mask == 0):
-        return torch.ones(mask.shape[:-1], dtype=torch.long, device=mask.device)
+        raise ValueError(
+            "Invalid causal attention mask for AutoRound: all positions are masked"
+        )
 
     global_min = mask.amin()
     return (mask.amax(dim=-1) > global_min).to(torch.long)

--- a/src/llmcompressor/modifiers/autoround/utils.py
+++ b/src/llmcompressor/modifiers/autoround/utils.py
@@ -12,7 +12,7 @@ def _collapse_causal_attention_mask(mask: torch.Tensor) -> torch.Tensor:
     `[batch, seq_len]` mask first.
     """
     if mask.ndim == 4:
-        mask = mask.squeeze(1)
+        mask = mask[:, 0]
     if mask.ndim != 3:
         raise ValueError(
             "Unsupported causal attention mask shape for AutoRound: "


### PR DESCRIPTION
```bash
vllm ({'pretrained': 'Qwen3-8B-W4A16-G128-AutoRound-Ultrachat200k/', 'tensor_parallel_size': 1, 'max_model_len': 8192, 'max_num_batched_tokens': 32768, 'max_num_seqs': 128, 'add_bos_token': True, 'gpu_memory_utilization': 0.8, 'dtype': 'bfloat16', 'max_gen_toks': 2048, 'enable_prefix_caching': False}), gen_kwargs: ({}), limit: None, num_fewshot: None, batch_size: 128
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8832|±  |0.0088|
|     |       |strict-match    |     5|exact_match|↑  |0.8832|±  |0.0088|
```

https://huggingface.co/Yi30/Qwen3-8B-W4A16-G128-AutoRound-Ultrachat200k

TEST PLAN:
"please outline how the changes were tested"
