### PR TITLE
[Calibration] Ensure all experts are calibrated

### DIFF
--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -223,7 +223,10 @@ class Oneshot:
                 "model `with llmcompressor.modeling.moe.linearize.load_quantizable_moe`"
                 " before passing to `oneshot`. Falling back to post-load linearization."
             )
-            linearize_moe(self.model)
+            linearize_moe(
+                self.model,
+                calibrate_all_experts=self.dataset_args.moe_calibrate_all_experts,
+            )
 
         # (Helen INFERENG-661): validate recipe modifiers before initialization
         # Apply calibration contexts for the entire calibration process

--- a/src/llmcompressor/modeling/moe/granitemoe.py
+++ b/src/llmcompressor/modeling/moe/granitemoe.py
@@ -3,7 +3,6 @@ from compressed_tensors.offload import get_cache_init_kwargs, offload_module
 from transformers.models.granitemoe.configuration_granitemoe import GraniteMoeConfig
 from transformers.models.granitemoe.modeling_granitemoe import GraniteMoeParallelExperts
 
-from llmcompressor.modeling.moe.context import get_calibrate_all_experts_flag
 from llmcompressor.modeling.moe.linear_experts import LinearExperts2D
 from llmcompressor.utils.dev import skip_weights_initialize
 
@@ -17,7 +16,10 @@ class GraniteMoeLinearExperts(LinearExperts2D):
     @classmethod
     @torch.no_grad()
     def from_experts_module(
-        cls, experts: "GraniteMoeParallelExperts", config: GraniteMoeConfig
+        cls,
+        experts: "GraniteMoeParallelExperts",
+        config: GraniteMoeConfig,
+        calibrate_all_experts: bool = True,
     ):
         assert experts.num_experts == config.num_local_experts
 
@@ -26,6 +28,7 @@ class GraniteMoeLinearExperts(LinearExperts2D):
                 experts.num_experts, experts.input_size, experts.output_size, config
             )
             self.num_experts = experts.num_experts
+            self.calibrate_all_experts = calibrate_all_experts
 
         # TODO: experiment with copying views, not values
         for i in range(experts.num_experts):
@@ -71,7 +74,7 @@ class GraniteMoeLinearExperts(LinearExperts2D):
         output_list = []
 
         for i in range(self.num_experts):
-            if get_calibrate_all_experts_flag():
+            if self.calibrate_all_experts:
                 expert_out = self[i](inputs).split(expert_size, dim=0)[i]
             else:
                 expert_out = self[i](inputs.split(expert_size, dim=0)[i])

--- a/src/llmcompressor/modeling/moe/linear_experts.py
+++ b/src/llmcompressor/modeling/moe/linear_experts.py
@@ -11,7 +11,6 @@ from transformers.integrations.moe import _default_apply_gate
 
 from llmcompressor.utils.dev import skip_weights_initialize
 
-from .context import get_calibrate_all_experts_flag
 from .helpers import (
     FusedExpertsProtocol,
     MoEConfig,
@@ -192,10 +191,13 @@ class LinearExperts2D(torch.nn.ModuleList):
     @classmethod
     @torch.no_grad()
     def from_experts_module(
-        cls, experts: FusedExpertsProtocol, config: PreTrainedConfig
+        cls,
+        experts: FusedExpertsProtocol,
+        config: PreTrainedConfig,
+        calibrate_all_experts: bool = True,
     ):
         with skip_weights_initialize():
-            self = cls(config)
+            self = cls(config, calibrate_all_experts=calibrate_all_experts)
 
         for index in range(self.num_experts):
             expert: ExpertMLP = self[index]
@@ -208,7 +210,14 @@ class LinearExperts2D(torch.nn.ModuleList):
 
         return self
 
-    def __init__(self, config: PreTrainedConfig, *args, **kwargs):
+    def __init__(
+        self,
+        config: PreTrainedConfig,
+        calibrate_all_experts: bool = True,
+        *args,
+        **kwargs,
+    ):
+        self.calibrate_all_experts = calibrate_all_experts
         moe_config = MoEConfig.from_config(config)
 
         # store num_experts before appending `act_fn` to module list
@@ -254,7 +263,7 @@ class LinearExperts2D(torch.nn.ModuleList):
 
             # apply expert
             expert = self[expert_index]
-            if get_calibrate_all_experts_flag():
+            if self.calibrate_all_experts:
                 expert_output = expert(hidden_states)[token_indices]
             else:
                 expert_output = expert(hidden_states[token_indices])

--- a/src/llmcompressor/modeling/moe/linearize.py
+++ b/src/llmcompressor/modeling/moe/linearize.py
@@ -27,7 +27,10 @@ from .linear_experts import LinearExperts2D
 
 
 @contextlib.contextmanager
-def load_quantizable_moe(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
+def load_quantizable_moe(
+    model_cls: Type[PreTrainedModel] = AutoModelForCausalLM,
+    calibrate_all_experts: bool = True,
+):
     """
     Context manager for loading MoE models with linearized experts for
     efficient calibration and quantization.
@@ -62,7 +65,7 @@ def load_quantizable_moe(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM
         # fall back to post-load conversion
         if not has_linearize_load_mappings(model_type):
             model = original_from_pretrained(*args, **kwargs)
-            linearize_moe(model)
+            linearize_moe(model, calibrate_all_experts=calibrate_all_experts)
             return model
 
         # prepare to load linearized weights
@@ -93,7 +96,7 @@ def load_quantizable_moe(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM
                 )
 
 
-def linearize_moe(model: PreTrainedModel):
+def linearize_moe(model: PreTrainedModel, calibrate_all_experts: bool = True):
     """
     Linearize a mixture-of-experts model after it has been loaded. For more
     runtime-efficient loading, please see `load_quantizable_moe`.
@@ -104,6 +107,9 @@ def linearize_moe(model: PreTrainedModel):
     (as designated by the `use_experts_implementation` decorator)
 
     :param model: model containing MoE layers to linearize
+    :param calibrate_all_experts: whether all experts should process all tokens
+        during calibration, ensuring proper quantization statistics for experts
+        that are rarely routed to
     """
     non_linearized_moes = get_non_linearized_moes(model)
 
@@ -121,7 +127,9 @@ def linearize_moe(model: PreTrainedModel):
     for name, module in tqdm.tqdm(non_linearized_moes, desc="Linearizing experts"):
         config = getattr(module, "config", model.config)
         linear_experts_cls = LinearExperts2D.get_linear_experts_cls(module.__class__)
-        linear_moe = linear_experts_cls.from_experts_module(module, config)
+        linear_moe = linear_experts_cls.from_experts_module(
+            module, config, calibrate_all_experts=calibrate_all_experts
+        )
         model.set_submodule(name, linear_moe)
 
 

--- a/src/llmcompressor/modeling/moe/linearize.py
+++ b/src/llmcompressor/modeling/moe/linearize.py
@@ -77,6 +77,10 @@ def load_quantizable_moe(
         # load model
         model: PreTrainedModel = original_from_pretrained(*args, **kwargs)
 
+        for module in model.modules():
+            if isinstance(module, LinearExperts2D):
+                module.calibrate_all_experts = calibrate_all_experts
+
         # prepare for saving to be called later
         clear_patch_mapping()
         set_save_conversion_mapping(model, save_map)

--- a/src/llmcompressor/modeling/moe/llama4.py
+++ b/src/llmcompressor/modeling/moe/llama4.py
@@ -7,7 +7,6 @@ from transformers.models.llama4.configuration_llama4 import (
 )
 from transformers.models.llama4.modeling_llama4 import Llama4TextExperts
 
-from llmcompressor.modeling.moe.context import get_calibrate_all_experts_flag
 from llmcompressor.modeling.moe.linear_experts import ExpertMLPWithGate, LinearExperts2D
 from llmcompressor.utils.dev import skip_weights_initialize
 
@@ -25,7 +24,12 @@ class Llama4LinearExperts(LinearExperts2D):
 
     @classmethod
     @torch.no_grad()
-    def from_experts_module(cls, experts: "Llama4TextExperts", config: Llama4Config):
+    def from_experts_module(
+        cls,
+        experts: "Llama4TextExperts",
+        config: Llama4Config,
+        calibrate_all_experts: bool = True,
+    ):
         config: Llama4TextConfig = config.text_config
         assert experts.num_experts == config.num_local_experts
         experts.is_concatenated = cls.is_concatenated
@@ -41,6 +45,7 @@ class Llama4LinearExperts(LinearExperts2D):
                 config,
             )
             self.num_experts = experts.num_experts
+            self.calibrate_all_experts = calibrate_all_experts
 
         # Extract individual expert weights from the batched parameters
         for index in range(experts.num_experts):
@@ -101,7 +106,7 @@ class Llama4LinearExperts(LinearExperts2D):
         output_list = []
         for i in range(self.num_experts):
             expert = self[i]
-            if get_calibrate_all_experts_flag():
+            if self.calibrate_all_experts:
                 expert_output = expert(hidden_states).view(*expert_view)[i]
             else:
                 expert_output = expert(hidden_states.view(*expert_view)[i])


### PR DESCRIPTION
## Summary

**Problem:** `moe_calibrate_all_experts` (default `True`) was accepted as a parameter in `DatasetArguments` and `oneshot()` but was never wired up — `get_calibrate_all_experts_flag()` always returned `False`. As a result, MoE experts only received their routed tokens during calibration. Experts that were never activated by the calibration dataset produced NaN `input_global_scale` values (empty activation statistics → undefined max → NaN scale), causing corrupted quantization for those experts.

**Fix:** Replaced the unused global flag mechanism with a `calibrate_all_experts` attribute stored directly on each `LinearExperts2D` module. The flag is now threaded from `DatasetArguments.moe_calibrate_all_experts` → `linearize_moe()` → `from_experts_module()` → `self.calibrate_all_experts`, and read in each module's `forward()`. This ensures the flag is correctly set at linearization time and requires no global mutable state.

**Changes:**
- `linear_experts.py`: `LinearExperts2D.__init__` and `from_experts_module` accept `calibrate_all_experts`; `forward` uses `self.calibrate_all_experts` instead of the global flag
- `granitemoe.py` / `llama4.py`: Same treatment for their `from_experts_module` overrides and `forward` methods; removed `get_calibrate_all_experts_flag` imports
- `linearize.py`: `linearize_moe` and `load_quantizable_moe` accept and thread `calibrate_all_experts` through to `from_experts_module`
- `oneshot.py`: Passes `self.dataset_args.moe_calibrate_all_experts` to `linearize_moe`

**Validation:** Re-ran W4A4 FP4 quantization on Qwen3.6-35B-A3B. Before this fix, 255 of 30,880 `input_global_scale` tensors were NaN (83 unactivated MoE experts × 3 projections). After this fix, all 30,880 `input_global_scale` tensors are valid (range: 5.16–4544, no NaNs, zeros, or Infs).