### PR TITLE
[MoE] [Bugfix] Add missing `moe_calibration_context`

### DIFF
--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -10,6 +10,7 @@ with various pipeline configurations for efficient model optimization.
 from __future__ import annotations
 
 import os
+from contextlib import ExitStack
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
@@ -22,6 +23,7 @@ from llmcompressor.args import parse_args
 from llmcompressor.core.session_functions import active_session
 from llmcompressor.datasets import get_calibration_dataloader
 from llmcompressor.entrypoints.utils import post_process, pre_process
+from llmcompressor.modeling.moe.context import moe_calibration_context
 from llmcompressor.modeling.moe.linearize import get_non_linearized_moes, linearize_moe
 from llmcompressor.modeling.offset_norm import norm_calibration_context
 from llmcompressor.pipelines import CalibrationPipeline
@@ -227,7 +229,11 @@ class Oneshot:
 
         # (Helen INFERENG-661): validate recipe modifiers before initialization
         # Apply calibration contexts for the entire calibration process
-        with norm_calibration_context(self.model):
+        with ExitStack() as stack:
+            stack.enter_context(norm_calibration_context(self.model))
+            if self.dataset_args.moe_calibrate_all_experts:
+                stack.enter_context(moe_calibration_context())
+
             session.initialize(
                 model=self.model,
                 start=-1,

--- a/tests/e2e/e2e_utils.py
+++ b/tests/e2e/e2e_utils.py
@@ -152,7 +152,8 @@ def run_oneshot_single(
     save_compressed: bool = False,
     shuffle_calibration_samples: bool = True,
     data_collator: str | Callable = DefaultDataCollator(),
-):
+    **kwargs,
+) -> torch.nn.Module:
     oneshot_kwargs, loaded_model, processor = prepare_oneshot_kwargs(
         model_id=model,
         model_class=model_class,
@@ -173,9 +174,11 @@ def run_oneshot_single(
     _run_oneshot(**oneshot_kwargs)
 
     logger.info("================= SAVING TO DISK ======================")
-    save_model_and_processor(
-        loaded_model, processor, save_dir, save_compressed, reset_session=True
-    )
+    if save_dir is not None:
+        save_model_and_processor(
+            loaded_model, processor, save_dir, save_compressed, reset_session=True
+        )
+    return loaded_model
 
 
 def run_oneshot_ddp(config: dict, save_compressed: bool = False):

--- a/tests/e2e/moe_configs/w4a16_moe.yaml
+++ b/tests/e2e/moe_configs/w4a16_moe.yaml
@@ -1,0 +1,3 @@
+cadence: "nightly"
+model: Qwen/Qwen3-30B-A3B
+scheme: W4A16

--- a/tests/e2e/test_vllm.py
+++ b/tests/e2e/test_vllm.py
@@ -130,7 +130,7 @@ class TestvLLM:
                     model_class=self.config.model_class,
                     max_memory=self.config.max_memory,
                     num_calibration_samples=self.config.num_calibration_samples,
-                    max_seq_length=2048,
+                    max_seq_length=self.config.max_seq_length,
                     scheme=self.config.scheme,
                     dataset_id=self.config.dataset_id,
                     dataset_config=self.config.dataset_config,

--- a/tests/llmcompressor/modeling/test_linear_experts.py
+++ b/tests/llmcompressor/modeling/test_linear_experts.py
@@ -1,0 +1,106 @@
+import torch
+from transformers import initialization as init
+from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
+from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeExperts
+
+from llmcompressor.modeling.moe.context import moe_calibration_context
+from llmcompressor.modeling.moe.helpers import MoEConfig
+from llmcompressor.modeling.moe.linear_experts import LinearExperts2D
+
+
+@torch.no_grad()
+def test_linear_experts_2d_with_hooks():
+    """
+    Test LinearExperts2D with forward hooks to verify calibration context behavior.
+
+    This test verifies that:
+    1. Outside moe_calibration_context: only selected tokens are sent to each expert
+    2. Inside moe_calibration_context: all tokens are sent to all experts
+    """
+    # Create a Qwen3MoeConfig
+    config = Qwen3MoeConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        num_experts=4,
+        num_experts_per_tok=2,
+    )
+
+    # Get the LinearExperts2D class for Qwen3MoeExperts
+    linear_experts_cls = LinearExperts2D.get_linear_experts_cls(Qwen3MoeExperts)
+
+    # Create LinearExperts2D instance
+    linear_experts = linear_experts_cls(config)
+
+    # Initialize weights to avoid NaN/Inf
+    moe_config = MoEConfig.from_config(config)
+    for expert_idx in range(linear_experts.num_experts):
+        expert = linear_experts[expert_idx]
+        init.normal_(expert.up_proj.weight, mean=0.0, std=config.initializer_range)
+        init.normal_(expert.gate_proj.weight, mean=0.0, std=config.initializer_range)
+        init.normal_(expert.down_proj.weight, mean=0.0, std=config.initializer_range)
+
+    # Create hook counters to track input shapes for each expert
+    expert_num_tokens = dict()
+
+    def make_hook(expert_idx):
+        def hook(module, input, output):
+            num_tokens = input[0].size(0)
+            expert_num_tokens[expert_idx] = num_tokens
+
+        return hook
+
+    # Register hooks on each expert
+    hooks = []
+    for expert_idx in range(linear_experts.num_experts):
+        expert = linear_experts[expert_idx]
+        hook_handle = expert.register_forward_hook(make_hook(expert_idx))
+        hooks.append(hook_handle)
+
+    # Create test inputs
+    num_tokens = 16
+    hidden_states = torch.randn(
+        num_tokens, moe_config.hidden_dim, dtype=moe_config.dtype
+    )
+
+    # Create routing: each token goes to 2 experts (top_k=2)
+    # Make sure not all tokens go to all experts
+    top_k_index = torch.tensor([[0], [1], [2], [3]])
+    top_k_weights = torch.randn(
+        num_tokens, moe_config.num_experts_per_tok, dtype=moe_config.dtype
+    )
+
+    # Test 1: Forward pass WITHOUT calibration context
+    expert_num_tokens = dict()
+    output_normal = linear_experts(hidden_states, top_k_index, top_k_weights)
+
+    # Verify that not all tokens went to all experts (1 token, see top_k_index)
+    for expert_idx in range(moe_config.num_experts):
+        input_size = expert_num_tokens[expert_idx]
+        assert input_size == 1, (
+            f"Without calibration context, expert {expert_idx} should receive "
+            f"exactly 1 token, but received {input_size}"
+        )
+
+    # Test 2: Forward pass WITH calibration context
+    expert_num_tokens = dict()
+    with moe_calibration_context():
+        output_calib = linear_experts(hidden_states, top_k_index, top_k_weights)
+
+    # Verify that all tokens went to all experts
+    for expert_idx in range(moe_config.num_experts):
+        input_size = expert_num_tokens[expert_idx]
+        assert input_size == num_tokens, (
+            f"With calibration context, expert {expert_idx} should receive "
+            f"all {num_tokens} tokens, but received {input_size}"
+        )
+
+    # Test 3: Verify outputs are valid tensors (not checking exact values since
+    # calibration mode changes computation by passing all tokens through experts)
+    assert output_normal.shape == hidden_states.shape
+    assert output_calib.shape == hidden_states.shape
+    assert not torch.isnan(output_normal).any()
+    assert not torch.isnan(output_calib).any()
+
+    # Clean up hooks
+    for hook in hooks:
+        hook.remove()

--- a/tests/llmcompressor/modeling/test_moe_context.py
+++ b/tests/llmcompressor/modeling/test_moe_context.py
@@ -10,7 +10,6 @@ from tests.testing_utils import BaseTestConfig, requires_gpu
 def test_oneshot_integration():
     """
     Tests that moe_calibration_context is called within oneshot
-
     """
     config = BaseTestConfig(
         cadence="commit",

--- a/tests/llmcompressor/modeling/test_moe_context.py
+++ b/tests/llmcompressor/modeling/test_moe_context.py
@@ -1,0 +1,43 @@
+import torch
+from compressed_tensors.offload import disable_onloading
+from compressed_tensors.quantization import QuantizationMetadata
+
+from tests.e2e.e2e_utils import run_oneshot_single
+from tests.testing_utils import BaseTestConfig, requires_gpu
+
+
+@requires_gpu(1)
+def test_oneshot_integration():
+    """
+    Tests that moe_calibration_context is called within oneshot
+
+    """
+    config = BaseTestConfig(
+        cadence="commit",
+        model="nm-testing/tinysmokeqwen3moe",
+        scheme="NVFP4",
+        dataset_id="HuggingFaceH4/ultrachat_200k",
+        dataset_split="train_sft",
+        num_calibration_samples=1,
+        max_seq_length=1,  # not enough tokens to send to all experts w/o context
+    )
+
+    model = run_oneshot_single(**config.model_dump())
+    _test_qparams(model)
+
+
+def _test_qparams(model: torch.nn.Module):
+    all_qparam_names = QuantizationMetadata.all_qparam_names()
+
+    with disable_onloading():
+        all_qparams = [
+            (module_name + "." + qparam_name, getattr(module, qparam_name))
+            for module_name, module in model.named_modules()
+            for qparam_name in all_qparam_names
+            if hasattr(module, qparam_name)
+        ]
+    assert len(all_qparams) > 0, "Model does not have any qparams to test"
+
+    for name, qparam in all_qparams:
+        assert isinstance(qparam, torch.Tensor)
+        assert qparam._version >= 1, f"{name} was never updated after initialization"

--- a/tests/lmeval/test_lmeval.py
+++ b/tests/lmeval/test_lmeval.py
@@ -180,7 +180,7 @@ class TestLMEval:
                     model_class=self.config.model_class,
                     max_memory=self.config.max_memory,
                     num_calibration_samples=self.config.num_calibration_samples,
-                    max_seq_length=2048,
+                    max_seq_length=self.config.max_seq_length,
                     scheme=self.config.scheme,
                     dataset_id=self.config.dataset_id,
                     dataset_config=self.config.dataset_config,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -220,9 +220,8 @@ class BaseTestConfig(BaseModel):
         None,
         description="Dataset split (e.g. 'train_sft', 'train').",
     )
-    num_calibration_samples: int = Field(
-        512, description="Number of calibration samples"
-    )
+    num_calibration_samples: int = Field(512, description="Num of calibration samples")
+    max_seq_length: int = Field(2048, description="Max calibration sequence length")
 
     # -------------------------------------------------------------------------
     # Model / quantization overrides


### PR DESCRIPTION
## Purpose ##
* Fix calibration of all experts
  * Need to enter `moe_calibration_context` during oneshot. In the future, I'd like to add this to `calibration_forward_context` and deprecate the `moe_calibrate_all_experts` argument
  * I'm not sure why this error was never seen by any of the other NVFP4/ GPTQ tests

## Changes ##
* Added `moe_calibration_context` to oneshot call

## Testing ##
* Added `tests/llmcompressor/modeling/test_linear_experts.py` which tests that the `LinearExperts2D` class properly sends all tokens to all experts in context
* Added `tests/llmcompressor/modeling/test_moe_context.py` which asserts that all expert qparams get calibrated after `oneshot` call (finishes in 3.6s)


* Ran `examples/quantization_w4a4_fp4/qwen_30b_a3b.py`
```
========== SAMPLE GENERATION ==============
[transformers] The attention mask is not set and cannot be inferred from input because pad token is same as eos token. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.
Hello my name is John and I'm 30 years old. I'm from the USA. I have a B.S. in computer science. I'm looking for a job in the software industry. I have experience in Java, Python, and C++. I have a few projects that I've worked on. I'm looking for a job in the software industry. I'm looking for a job in the software industry. I'm looking for a job in the software industry. I'm looking for a job in the
==========================================
```