### PR TITLE
Add REAP pruning modifier

### DIFF
--- a/examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
+++ b/examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
@@ -1,0 +1,76 @@
+"""
+REAP Expert Pruning: Qwen3-30B-A3B at 25% compression.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=0,1,2,3 uv run python examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
+"""
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+
+# ── Configuration ──────────────────────────────────────────────────────────
+
+MODEL_ID = "/home/eldarkurtic/hf_models/Qwen/Qwen3-30B-A3B-Instruct-2507"
+OUTPUT_DIR = "/home/eldarkurtic/github/eldarkurtic/llm-compressor/output_dir/Qwen3-30B-A3B-Instruct-2507_REAP_sp25"
+COMPRESSION_RATIO = 0.25
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQ_LENGTH = 2048
+DATASET = "open_platypus"
+
+# ── Recipe ─────────────────────────────────────────────────────────────────
+
+RECIPE = """
+pruning_stage:
+  pruning_modifiers:
+    REAPPruningModifier:
+      compression_ratio: 0.25
+"""
+
+# ── Run pruning ────────────────────────────────────────────────────────────
+
+print(f"Model:             {MODEL_ID}")
+print(f"Compression ratio: {COMPRESSION_RATIO}")
+print(f"Output:            {OUTPUT_DIR}")
+print(f"Calibration:       {NUM_CALIBRATION_SAMPLES} samples, {MAX_SEQ_LENGTH} max seq len")
+print()
+
+oneshot(
+    model=MODEL_ID,
+    recipe=RECIPE,
+    dataset=DATASET,
+    output_dir=OUTPUT_DIR,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    max_seq_length=MAX_SEQ_LENGTH,
+)
+
+print(f"\nDone! Pruned model saved to: {OUTPUT_DIR}")
+
+# ── Quick smoke test ───────────────────────────────────────────────────────
+
+print("\nRunning generation smoke test...")
+
+tokenizer = AutoTokenizer.from_pretrained(OUTPUT_DIR)
+model = AutoModelForCausalLM.from_pretrained(
+    OUTPUT_DIR,
+    torch_dtype=torch.bfloat16,
+    device_map="auto",
+)
+model.eval()
+
+prompt = "Write a Python function that checks if a number is prime."
+messages = [{"role": "user", "content": prompt}]
+text = tokenizer.apply_chat_template(
+    messages, tokenize=False, add_generation_prompt=True, enable_thinking=False
+)
+inputs = tokenizer(text, return_tensors="pt").to(model.device)
+
+with torch.no_grad():
+    output_ids = model.generate(**inputs, max_new_tokens=1000, do_sample=False)
+
+new_tokens = output_ids[0][inputs["input_ids"].shape[1] :]
+response = tokenizer.decode(new_tokens, skip_special_tokens=True)
+
+print(f"\nPrompt: {prompt}")
+print(f"Response: {response}")

--- a/examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
+++ b/examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
@@ -1,8 +1,8 @@
 """
-REAP Expert Pruning: Qwen3-30B-A3B at 25% compression.
+REAP Expert Pruning: Qwen3-30B-A3B at 25% sparsity.
 
 Usage:
-    CUDA_VISIBLE_DEVICES=0,1,2,3 uv run python examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
+CUDA_VISIBLE_DEVICES=0,1 python examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
 """
 
 import torch
@@ -10,31 +10,22 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 
-# ── Configuration ──────────────────────────────────────────────────────────
-
-MODEL_ID = "/home/eldarkurtic/hf_models/Qwen/Qwen3-30B-A3B-Instruct-2507"
-OUTPUT_DIR = "/home/eldarkurtic/github/eldarkurtic/llm-compressor/output_dir/Qwen3-30B-A3B-Instruct-2507_REAP_sp25"
-COMPRESSION_RATIO = 0.25
+MDL = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+SPARSITY = 0.25
+BASE_PATH = "/home/eldarkurtic/"
+OUT_PATH = "github/eldarkurtic/llm-compressor/output_dir/"
+MODEL_ID = BASE_PATH + "hf_models/" + MDL
+OUTPUT_DIR = BASE_PATH + OUT_PATH + MDL + "_REAP_sp" + str(int(SPARSITY * 100))
 NUM_CALIBRATION_SAMPLES = 512
 MAX_SEQ_LENGTH = 2048
 DATASET = "open_platypus"
-
-# ── Recipe ─────────────────────────────────────────────────────────────────
 
 RECIPE = """
 pruning_stage:
   pruning_modifiers:
     REAPPruningModifier:
-      compression_ratio: 0.25
-"""
-
-# ── Run pruning ────────────────────────────────────────────────────────────
-
-print(f"Model:             {MODEL_ID}")
-print(f"Compression ratio: {COMPRESSION_RATIO}")
-print(f"Output:            {OUTPUT_DIR}")
-print(f"Calibration:       {NUM_CALIBRATION_SAMPLES} samples, {MAX_SEQ_LENGTH} max seq len")
-print()
+      sparsity: {SPARSITY}
+""".format(SPARSITY=SPARSITY)
 
 oneshot(
     model=MODEL_ID,
@@ -46,9 +37,6 @@ oneshot(
 )
 
 print(f"\nDone! Pruned model saved to: {OUTPUT_DIR}")
-
-# ── Quick smoke test ───────────────────────────────────────────────────────
-
 print("\nRunning generation smoke test...")
 
 tokenizer = AutoTokenizer.from_pretrained(OUTPUT_DIR)

--- a/examples/reap_expert_pruning/reap_qwen3_30b_50pct.py
+++ b/examples/reap_expert_pruning/reap_qwen3_30b_50pct.py
@@ -3,35 +3,29 @@ REAP Expert Pruning: Qwen3-30B-A3B at 25% sparsity.
 
 Usage:
 CUDA_VISIBLE_DEVICES=0,1 python examples/reap_expert_pruning/reap_qwen3_30b_25pct.py
-
-The model is loaded from the Hugging Face Hub by default. Override the source
-model or output location with the MODEL_ID / OUTPUT_DIR environment variables.
 """
-
-import inspect
-import os
 
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 
-MODEL_ID = os.environ.get("MODEL_ID", "Qwen/Qwen3-30B-A3B-Instruct-2507")
-SPARSITY = 0.25
-OUTPUT_DIR = os.environ.get(
-    "OUTPUT_DIR",
-    f"{MODEL_ID.split('/')[-1]}_REAP_sp{int(SPARSITY * 100)}",
-)
+MDL = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+SPARSITY = 0.5
+BASE_PATH = "/home/eldarkurtic/"
+OUT_PATH = "github/eldarkurtic/llm-compressor/output_dir/"
+MODEL_ID = BASE_PATH + "hf_models/" + MDL
+OUTPUT_DIR = BASE_PATH + OUT_PATH + MDL + "_REAP_sp" + str(int(SPARSITY * 100))
 NUM_CALIBRATION_SAMPLES = 512
 MAX_SEQ_LENGTH = 2048
 DATASET = "open_platypus"
 
-RECIPE = f"""
+RECIPE = """
 pruning_stage:
   pruning_modifiers:
     REAPPruningModifier:
       sparsity: {SPARSITY}
-"""
+""".format(SPARSITY=SPARSITY)
 
 oneshot(
     model=MODEL_ID,
@@ -55,11 +49,9 @@ model.eval()
 
 prompt = "Write a Python function that checks if a number is prime."
 messages = [{"role": "user", "content": prompt}]
-chat_kwargs = {"tokenize": False, "add_generation_prompt": True}
-# enable_thinking is only accepted by some Qwen tokenizers
-if "enable_thinking" in inspect.signature(tokenizer.apply_chat_template).parameters:
-    chat_kwargs["enable_thinking"] = False
-text = tokenizer.apply_chat_template(messages, **chat_kwargs)
+text = tokenizer.apply_chat_template(
+    messages, tokenize=False, add_generation_prompt=True, enable_thinking=False
+)
 inputs = tokenizer(text, return_tensors="pt").to(model.device)
 
 with torch.no_grad():

--- a/src/llmcompressor/modifiers/pruning/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/__init__.py
@@ -2,5 +2,6 @@
 
 from .constant import *
 from .magnitude import *
+from .reap import *
 from .wanda import *
 from .sparsegpt import *

--- a/src/llmcompressor/modifiers/pruning/reap/__init__.py
+++ b/src/llmcompressor/modifiers/pruning/reap/__init__.py
@@ -1,0 +1,3 @@
+# ruff: noqa
+
+from .base import REAPPruningModifier

--- a/src/llmcompressor/modifiers/pruning/reap/base.py
+++ b/src/llmcompressor/modifiers/pruning/reap/base.py
@@ -8,7 +8,6 @@ from functools import partial
 from typing import Any
 
 import torch
-import torch.nn.functional as F
 from loguru import logger
 from pydantic import Field, PrivateAttr, model_validator
 
@@ -17,9 +16,14 @@ from llmcompressor.modifiers import Modifier
 from llmcompressor.modifiers.pruning.reap.utils import (
     MoEModelAttrs,
     REAPSaliencyTracker,
+    assert_routing_feasible,
+    compute_retained_experts,
     detect_moe_attrs,
+    extract_routing,
     find_moe_layers,
     get_num_experts,
+    get_router_num_groups,
+    get_router_topk_group,
     prune_moe_layer,
     update_model_config,
 )
@@ -29,10 +33,30 @@ __all__ = ["REAPPruningModifier"]
 
 class REAPPruningModifier(Modifier):
     """
-    Prunes experts from MoE layers using the REAP saliency metric:
-    S_j = mean(g_j * ||f_j||_2), averaged over tokens routed to expert j.
+    Prunes experts from MoE layers using the REAP saliency metric. For each
+    expert ``j`` the saliency is
 
-    :param sparsity: fraction of experts to remove per layer (0, 1).
+        ``S_j = mean(g_j * ||f_j||_2)``
+
+    averaged over the tokens routed to expert ``j``, where:
+
+    - ``g_j`` is the router gate weight assigned to expert ``j`` (the coefficient
+      that multiplies the expert's output when combining experts), and
+    - ``f_j`` is expert ``j``'s output activation for that token, so
+      ``||f_j||_2`` is its L2 norm.
+
+    The lowest-saliency experts are removed per layer. REAP runs during the
+    sequential calibration pipeline: saliency is accumulated via hooks on the MoE
+    calibration wrappers (which route every token through every expert), the
+    drop decision for a layer is finalized as soon as its calibration subgraph
+    completes (``SEQUENTIAL_EPOCH_END``) so its activation buffers can be freed,
+    and the structural pruning is applied at ``on_finalize`` (after the
+    calibration context has exited and a layer's second error-propagation pass,
+    if any, has run).
+
+    :param sparsity: fraction of experts to remove per layer (0, 1). For
+        group-limited routers (DeepSeek-V3, GLM4, GLM-MoE-DSA) the count is
+        rounded to an equal number per expert group.
     :param ignore: module name patterns to skip during MoE layer detection.
 
     Example recipe::
@@ -50,11 +74,13 @@ class REAPPruningModifier(Modifier):
         default_factory=dict
     )
     _top_k: int = PrivateAttr(default=2)
+    _n_group: int = PrivateAttr(default=1)
     _n_experts_to_drop: int = PrivateAttr(default=0)
+    _prune_decisions: dict[str, list[int]] = PrivateAttr(default_factory=dict)
     _norm_buffers: dict[str, dict[int, torch.Tensor]] = PrivateAttr(
         default_factory=dict
     )
-    _routing_cache: dict = PrivateAttr(default_factory=dict)
+    _routing_cache: dict[str, Any] = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_sparsity(self) -> "REAPPruningModifier":
@@ -68,8 +94,9 @@ class REAPPruningModifier(Modifier):
         self._attrs = detect_moe_attrs(model)
         if self._attrs is None:
             raise ValueError(
-                "Could not detect MoE architecture. Ensure the model is an "
-                "MoE model or specify 'targets' explicitly."
+                "Could not detect a supported MoE architecture. REAP requires an "
+                "MoE model with a calibration wrapper that routes all tokens to "
+                "all experts."
             )
 
         moe_layers = find_moe_layers(model, self._attrs, self.ignore)
@@ -83,6 +110,7 @@ class REAPPruningModifier(Modifier):
 
         sample_module = next(iter(moe_layers.values()))
         num_experts = get_num_experts(sample_module, self._attrs)
+        self._n_group = get_router_num_groups(sample_module, self._attrs)
         self._n_experts_to_drop = int(num_experts * self.sparsity)
 
         if self._n_experts_to_drop == 0:
@@ -91,11 +119,22 @@ class REAPPruningModifier(Modifier):
                 f"experts to drop (out of {num_experts}). No pruning will "
                 "be performed."
             )
+        else:
+            # fail fast (before calibration) if the requested sparsity would
+            # leave the router unable to select top_k experts per token
+            assert_routing_feasible(
+                num_experts,
+                self._n_experts_to_drop,
+                self._n_group,
+                get_router_topk_group(sample_module, self._attrs),
+                self._top_k,
+            )
 
         logger.info(
             f"REAP initialized: {len(moe_layers)} MoE layers, "
             f"{num_experts} experts/layer, will drop "
             f"{self._n_experts_to_drop} ({self.sparsity:.0%})"
+            + (f", n_group={self._n_group}" if self._n_group > 1 else "")
         )
 
         return True
@@ -106,31 +145,44 @@ class REAPPruningModifier(Modifier):
 
         for layer_name in self._moe_layer_names:
             module = model.get_submodule(layer_name)
+
+            if not hasattr(module, "calibrate_all_experts"):
+                raise RuntimeError(
+                    f"REAP requires the MoE block '{layer_name}' "
+                    f"({module.__class__.__name__}) to support all-expert "
+                    "calibration, but it has no 'calibrate_all_experts' attribute. "
+                    "Ensure the model runs inside moe_calibration_context."
+                )
+            module.calibrate_all_experts = True
+
             num_experts = get_num_experts(module, self._attrs)
             self._saliency_trackers[layer_name] = REAPSaliencyTracker(num_experts)
             self._norm_buffers[layer_name] = {}
 
-            if hasattr(module, "calibrate_all_experts"):
-                module.calibrate_all_experts = True
-
+            # capture the router's raw output so routing is read from the model
+            # itself rather than recomputed (correct for every routing scheme)
+            router = getattr(module, self._attrs.router_attr)
             self.register_hook(
-                module,
-                partial(self._moe_pre_hook, layer_name),
-                "forward_pre",
+                router, partial(self._router_hook, layer_name), "forward"
             )
 
+            # one hook per expert to record its per-token output norm
             experts = getattr(module, self._attrs.experts_attr)
+            n_expert_hooks = 0
             for idx, expert in enumerate(experts.children()):
                 self.register_hook(
-                    expert,
-                    partial(self._expert_hook, layer_name, idx),
-                    "forward",
+                    expert, partial(self._expert_hook, layer_name, idx), "forward"
+                )
+                n_expert_hooks += 1
+            if n_expert_hooks == 0:
+                raise RuntimeError(
+                    f"REAP could not register per-expert hooks for '{layer_name}': "
+                    f"the experts module ({experts.__class__.__name__}) has no "
+                    "child modules. Fused experts are not supported."
                 )
 
             self.register_hook(
-                module,
-                partial(self._moe_post_hook, layer_name),
-                "forward",
+                module, partial(self._moe_post_hook, layer_name), "forward"
             )
 
     def on_event(self, state: State, event: Event, **kwargs):
@@ -138,17 +190,26 @@ class REAPPruningModifier(Modifier):
             if not self.started_:
                 self.on_start(state, None)
 
+        if event.type_ == EventType.SEQUENTIAL_EPOCH_END:
+            # a subgraph just finished calibrating: any MoE layer whose saliency
+            # is complete can have its drop decision finalized and its activation
+            # buffers freed now, rather than carrying them until on_finalize
+            self._finalize_decisions()
+
         if event.type_ == EventType.CALIBRATION_EPOCH_END:
             if not self.ended_:
                 self.on_end(state, None)
 
     def on_end(self, state: State, event: Event, **kwargs):
         self.ended_ = True
+        # fallback for pipelines that never fire SEQUENTIAL_EPOCH_END
+        self._finalize_decisions()
         self.remove_hooks()
 
     def on_finalize(self, state: State, **kwargs) -> bool:
-        # Prune in on_finalize (not on_end) so we act on actual modules,
-        # not calibration wrappers that get restored after the context exits.
+        # Apply structural pruning here (after the calibration context has
+        # exited): the decisions were finalized at SEQUENTIAL_EPOCH_END, so this
+        # only mutates module structure -- it does not need calibration data.
         if not self.ended_:
             self.on_end(state, None)
 
@@ -156,51 +217,66 @@ class REAPPruningModifier(Modifier):
             logger.info("REAP: nothing to prune (n_experts_to_drop=0)")
             return True
 
-        model = state.model
-
-        for layer_name in self._moe_layer_names:
-            tracker = self._saliency_trackers[layer_name]
-            saliency = tracker.mean_saliency
-
-            logger.debug(f"REAP saliency for {layer_name}: {saliency.tolist()}")
-
-            prune_moe_layer(
-                model,
-                layer_name,
-                saliency,
-                self._n_experts_to_drop,
-                self._attrs,
+        missing = [n for n in self._moe_layer_names if n not in self._prune_decisions]
+        if missing:
+            raise RuntimeError(
+                f"REAP did not finalize prune decisions for {len(missing)} MoE "
+                f"layers (e.g. {missing[:3]}); no calibration data reached them."
             )
+
+        model = state.model
+        for layer_name, retained in self._prune_decisions.items():
+            logger.debug(
+                f"Pruning {layer_name}: keeping {len(retained)} experts {retained}"
+            )
+            prune_moe_layer(model, layer_name, retained, self._attrs)
 
         sample_module = model.get_submodule(self._moe_layer_names[0])
         new_num_experts = get_num_experts(sample_module, self._attrs)
         update_model_config(model, self._attrs, new_num_experts)
+
+        self._prune_decisions.clear()
         self._saliency_trackers.clear()
+        self._norm_buffers.clear()
+        self._routing_cache.clear()
 
         return True
 
-    def _moe_pre_hook(self, layer_name: str, module: torch.nn.Module, args: tuple):
-        """Run the router (one Linear layer) and cache routing decisions."""
-        hidden_states = args[0]
-        if hidden_states.dim() == 3:
-            hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+    # -- decision finalization ----------------------------------------------
 
-        router = getattr(module, self._attrs.router_attr)
+    def _finalize_decisions(self):
+        """Finalize drop decisions for any tracked layer whose saliency is
+        complete, then release its activation buffers."""
+        if self._n_experts_to_drop == 0:
+            return
 
-        with torch.no_grad():
-            router_output = router(hidden_states)
-            if isinstance(router_output, tuple):
-                router_logits = router_output[-1]
-            else:
-                router_logits = router_output
+        for layer_name, tracker in list(self._saliency_trackers.items()):
+            if layer_name in self._prune_decisions:
+                continue
+            if tracker.total_count <= 0:
+                continue
 
-            routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float32)
-            _, topk_indices = torch.topk(routing_weights, self._top_k, dim=-1)
+            retained = compute_retained_experts(
+                tracker.mean_saliency, self._n_experts_to_drop, self._n_group
+            )
+            self._prune_decisions[layer_name] = retained
 
-        self._routing_cache[layer_name] = {
-            "routing_weights": routing_weights,
-            "topk_indices": topk_indices,
-        }
+            # free this layer's accumulators / buffers now
+            del self._saliency_trackers[layer_name]
+            self._norm_buffers.pop(layer_name, None)
+            self._routing_cache.pop(layer_name, None)
+
+    # -- calibration hooks ---------------------------------------------------
+
+    def _router_hook(
+        self, layer_name: str, module: torch.nn.Module, args: tuple, output: Any
+    ):
+        """Cache the router's raw forward output for this layer/batch."""
+        # hooks stay registered through the pipeline's error-propagation pass,
+        # which re-runs an already-finalized subgraph; ignore those calls
+        if layer_name not in self._saliency_trackers:
+            return
+        self._routing_cache[layer_name] = output
 
     def _expert_hook(
         self,
@@ -210,11 +286,13 @@ class REAPPruningModifier(Modifier):
         args: tuple,
         output: Any,
     ):
-        """Buffer output norms from the calibration forward pass."""
+        """Record expert ``f_j`` output norms for every token this batch."""
+        if layer_name not in self._norm_buffers:
+            return
         if isinstance(output, tuple):
             output = output[0]
         with torch.no_grad():
-            norms = torch.linalg.norm(output.float(), dim=-1)
+            norms = torch.linalg.norm(output.float(), dim=-1).reshape(-1)
         self._norm_buffers[layer_name][expert_idx] = norms
 
     def _moe_post_hook(
@@ -225,24 +303,29 @@ class REAPPruningModifier(Modifier):
         output: Any,
     ):
         """Combine cached routing decisions with buffered expert norms."""
-        cache = self._routing_cache[layer_name]
-        routing_weights = cache["routing_weights"]
-        topk_indices = cache["topk_indices"]
-        tracker = self._saliency_trackers[layer_name]
+        tracker = self._saliency_trackers.get(layer_name)
+        router_output = self._routing_cache.get(layer_name)
+        if tracker is None or router_output is None:
+            return
+
+        norm_buffer = self._norm_buffers[layer_name]
+        if len(norm_buffer) != tracker.num_experts:
+            logger.warning(
+                f"REAP: layer '{layer_name}' saw {len(norm_buffer)}/"
+                f"{tracker.num_experts} experts this batch; skipping update."
+            )
+            self._norm_buffers[layer_name] = {}
+            self._routing_cache[layer_name] = None
+            return
 
         with torch.no_grad():
-            for expert_idx in range(tracker.num_experts):
-                norms = self._norm_buffers[layer_name].get(expert_idx)
-                if norms is None:
-                    continue
+            topk_indices, topk_weights = extract_routing(
+                router_output, module, self._attrs, self._top_k
+            )
+            expert_norms = torch.stack(
+                [norm_buffer[i] for i in range(tracker.num_experts)], dim=1
+            )
+            tracker.update(topk_indices, topk_weights, expert_norms)
 
-                token_mask = (topk_indices == expert_idx).any(dim=-1)
-                if not token_mask.any():
-                    continue
-
-                gate_vals = routing_weights[token_mask, expert_idx]
-                routed_norms = norms[token_mask]
-                tracker.update(expert_idx, gate_vals, routed_norms)
-
-        self._norm_buffers[layer_name].clear()
+        self._norm_buffers[layer_name] = {}
         self._routing_cache[layer_name] = None

--- a/src/llmcompressor/modifiers/pruning/reap/base.py
+++ b/src/llmcompressor/modifiers/pruning/reap/base.py
@@ -1,0 +1,256 @@
+"""
+REAP (Router-weighted Expert Activation Pruning) modifier for MoE models.
+
+See: https://arxiv.org/abs/2510.13999
+"""
+
+from functools import partial
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from loguru import logger
+from pydantic import Field, PrivateAttr, model_validator
+
+from llmcompressor.core import Event, EventType, State
+from llmcompressor.modifiers import Modifier
+from llmcompressor.modifiers.pruning.reap.utils import (
+    MoEModelAttrs,
+    REAPSaliencyTracker,
+    detect_moe_attrs,
+    find_moe_layers,
+    get_num_experts,
+    prune_moe_layer,
+    update_model_config,
+)
+
+__all__ = ["REAPPruningModifier"]
+
+
+class REAPPruningModifier(Modifier):
+    """
+    Prunes experts from MoE layers using the REAP saliency metric:
+    S_j = mean(g_j * ||f_j||_2), averaged over tokens routed to expert j.
+
+    :param compression_ratio: fraction of experts to remove per layer (0, 1).
+    :param ignore: module name patterns to skip during MoE layer detection.
+
+    Example recipe::
+
+        REAPPruningModifier:
+          compression_ratio: 0.5
+    """
+
+    compression_ratio: float = 0.5
+    ignore: list[str] = Field(default_factory=list)
+
+    _attrs: MoEModelAttrs | None = PrivateAttr(default=None)
+    _moe_layer_names: list[str] = PrivateAttr(default_factory=list)
+    _saliency_trackers: dict[str, REAPSaliencyTracker] = PrivateAttr(
+        default_factory=dict
+    )
+    _top_k: int = PrivateAttr(default=2)
+    _n_experts_to_drop: int = PrivateAttr(default=0)
+    _norm_buffers: dict[str, dict[int, torch.Tensor]] = PrivateAttr(
+        default_factory=dict
+    )
+    _routing_cache: dict = PrivateAttr(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_compression_ratio(self) -> "REAPPruningModifier":
+        if not 0.0 < self.compression_ratio < 1.0:
+            raise ValueError(
+                f"compression_ratio must be in (0, 1), got {self.compression_ratio}"
+            )
+        return self
+
+    def on_initialize(self, state: State, **kwargs) -> bool:
+        model = state.model
+
+        self._attrs = detect_moe_attrs(model)
+        if self._attrs is None:
+            raise ValueError(
+                "Could not detect MoE architecture. Ensure the model is an "
+                "MoE model or specify 'targets' explicitly."
+            )
+
+        moe_layers = find_moe_layers(model, self._attrs, self.ignore)
+        if not moe_layers:
+            raise ValueError("No MoE layers found in model.")
+        self._moe_layer_names = list(moe_layers.keys())
+
+        config = model.config
+        text_config = getattr(config, "text_config", config)
+        self._top_k = getattr(text_config, "num_experts_per_tok", 2)
+
+        sample_module = next(iter(moe_layers.values()))
+        num_experts = get_num_experts(sample_module, self._attrs)
+        self._n_experts_to_drop = int(num_experts * self.compression_ratio)
+
+        if self._n_experts_to_drop == 0:
+            logger.warning(
+                f"compression_ratio={self.compression_ratio} results in 0 "
+                f"experts to drop (out of {num_experts}). No pruning will "
+                "be performed."
+            )
+
+        logger.info(
+            f"REAP initialized: {len(moe_layers)} MoE layers, "
+            f"{num_experts} experts/layer, will drop "
+            f"{self._n_experts_to_drop} ({self.compression_ratio:.0%})"
+        )
+
+        return True
+
+    def on_start(self, state: State, event: Event, **kwargs):
+        self.started_ = True
+        model = state.model
+
+        for layer_name in self._moe_layer_names:
+            module = model.get_submodule(layer_name)
+            num_experts = get_num_experts(module, self._attrs)
+            self._saliency_trackers[layer_name] = REAPSaliencyTracker(num_experts)
+            self._norm_buffers[layer_name] = {}
+
+            if hasattr(module, "calibrate_all_experts"):
+                module.calibrate_all_experts = True
+
+            self.register_hook(
+                module,
+                partial(self._moe_pre_hook, layer_name),
+                "forward_pre",
+            )
+
+            experts = getattr(module, self._attrs.experts_attr)
+            for idx, expert in enumerate(experts.children()):
+                self.register_hook(
+                    expert,
+                    partial(self._expert_hook, layer_name, idx),
+                    "forward",
+                )
+
+            self.register_hook(
+                module,
+                partial(self._moe_post_hook, layer_name),
+                "forward",
+            )
+
+    def on_event(self, state: State, event: Event, **kwargs):
+        if event.type_ == EventType.CALIBRATION_EPOCH_START:
+            if not self.started_:
+                self.on_start(state, None)
+
+        if event.type_ == EventType.CALIBRATION_EPOCH_END:
+            if not self.ended_:
+                self.on_end(state, None)
+
+    def on_end(self, state: State, event: Event, **kwargs):
+        self.ended_ = True
+        self.remove_hooks()
+
+    def on_finalize(self, state: State, **kwargs) -> bool:
+        # Prune in on_finalize (not on_end) so we act on actual modules,
+        # not calibration wrappers that get restored after the context exits.
+        if not self.ended_:
+            self.on_end(state, None)
+
+        if self._n_experts_to_drop == 0:
+            logger.info("REAP: nothing to prune (n_experts_to_drop=0)")
+            return True
+
+        model = state.model
+
+        for layer_name in self._moe_layer_names:
+            tracker = self._saliency_trackers[layer_name]
+            saliency = tracker.mean_saliency
+
+            logger.debug(f"REAP saliency for {layer_name}: {saliency.tolist()}")
+
+            prune_moe_layer(
+                model,
+                layer_name,
+                saliency,
+                self._n_experts_to_drop,
+                self._attrs,
+            )
+
+        sample_module = model.get_submodule(self._moe_layer_names[0])
+        new_num_experts = get_num_experts(sample_module, self._attrs)
+        update_model_config(model, self._attrs, new_num_experts)
+        self._saliency_trackers.clear()
+
+        return True
+
+    def _moe_pre_hook(
+        self, layer_name: str, module: torch.nn.Module, args: tuple
+    ):
+        """Run the router (one Linear layer) and cache routing decisions."""
+        hidden_states = args[0]
+        if hidden_states.dim() == 3:
+            hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+
+        router = getattr(module, self._attrs.router_attr)
+
+        with torch.no_grad():
+            router_output = router(hidden_states)
+            if isinstance(router_output, tuple):
+                router_logits = router_output[-1]
+            else:
+                router_logits = router_output
+
+            routing_weights = F.softmax(
+                router_logits, dim=-1, dtype=torch.float32
+            )
+            _, topk_indices = torch.topk(
+                routing_weights, self._top_k, dim=-1
+            )
+
+        self._routing_cache[layer_name] = {
+            "routing_weights": routing_weights,
+            "topk_indices": topk_indices,
+        }
+
+    def _expert_hook(
+        self,
+        layer_name: str,
+        expert_idx: int,
+        module: torch.nn.Module,
+        args: tuple,
+        output: Any,
+    ):
+        """Buffer output norms from the calibration forward pass."""
+        if isinstance(output, tuple):
+            output = output[0]
+        with torch.no_grad():
+            norms = torch.linalg.norm(output.float(), dim=-1)
+        self._norm_buffers[layer_name][expert_idx] = norms
+
+    def _moe_post_hook(
+        self,
+        layer_name: str,
+        module: torch.nn.Module,
+        args: tuple,
+        output: Any,
+    ):
+        """Combine cached routing decisions with buffered expert norms."""
+        cache = self._routing_cache[layer_name]
+        routing_weights = cache["routing_weights"]
+        topk_indices = cache["topk_indices"]
+        tracker = self._saliency_trackers[layer_name]
+
+        with torch.no_grad():
+            for expert_idx in range(tracker.num_experts):
+                norms = self._norm_buffers[layer_name].get(expert_idx)
+                if norms is None:
+                    continue
+
+                token_mask = (topk_indices == expert_idx).any(dim=-1)
+                if not token_mask.any():
+                    continue
+
+                gate_vals = routing_weights[token_mask, expert_idx]
+                routed_norms = norms[token_mask]
+                tracker.update(expert_idx, gate_vals, routed_norms)
+
+        self._norm_buffers[layer_name].clear()
+        self._routing_cache[layer_name] = None

--- a/src/llmcompressor/modifiers/pruning/reap/base.py
+++ b/src/llmcompressor/modifiers/pruning/reap/base.py
@@ -32,16 +32,16 @@ class REAPPruningModifier(Modifier):
     Prunes experts from MoE layers using the REAP saliency metric:
     S_j = mean(g_j * ||f_j||_2), averaged over tokens routed to expert j.
 
-    :param compression_ratio: fraction of experts to remove per layer (0, 1).
+    :param sparsity: fraction of experts to remove per layer (0, 1).
     :param ignore: module name patterns to skip during MoE layer detection.
 
     Example recipe::
 
         REAPPruningModifier:
-          compression_ratio: 0.5
+          sparsity: 0.5
     """
 
-    compression_ratio: float = 0.5
+    sparsity: float
     ignore: list[str] = Field(default_factory=list)
 
     _attrs: MoEModelAttrs | None = PrivateAttr(default=None)
@@ -57,11 +57,9 @@ class REAPPruningModifier(Modifier):
     _routing_cache: dict = PrivateAttr(default_factory=dict)
 
     @model_validator(mode="after")
-    def _validate_compression_ratio(self) -> "REAPPruningModifier":
-        if not 0.0 < self.compression_ratio < 1.0:
-            raise ValueError(
-                f"compression_ratio must be in (0, 1), got {self.compression_ratio}"
-            )
+    def _validate_sparsity(self) -> "REAPPruningModifier":
+        if not 0.0 < self.sparsity < 1.0:
+            raise ValueError(f"sparsity must be in (0, 1), got {self.sparsity}")
         return self
 
     def on_initialize(self, state: State, **kwargs) -> bool:
@@ -85,11 +83,11 @@ class REAPPruningModifier(Modifier):
 
         sample_module = next(iter(moe_layers.values()))
         num_experts = get_num_experts(sample_module, self._attrs)
-        self._n_experts_to_drop = int(num_experts * self.compression_ratio)
+        self._n_experts_to_drop = int(num_experts * self.sparsity)
 
         if self._n_experts_to_drop == 0:
             logger.warning(
-                f"compression_ratio={self.compression_ratio} results in 0 "
+                f"sparsity={self.sparsity} results in 0 "
                 f"experts to drop (out of {num_experts}). No pruning will "
                 "be performed."
             )
@@ -97,7 +95,7 @@ class REAPPruningModifier(Modifier):
         logger.info(
             f"REAP initialized: {len(moe_layers)} MoE layers, "
             f"{num_experts} experts/layer, will drop "
-            f"{self._n_experts_to_drop} ({self.compression_ratio:.0%})"
+            f"{self._n_experts_to_drop} ({self.sparsity:.0%})"
         )
 
         return True
@@ -181,9 +179,7 @@ class REAPPruningModifier(Modifier):
 
         return True
 
-    def _moe_pre_hook(
-        self, layer_name: str, module: torch.nn.Module, args: tuple
-    ):
+    def _moe_pre_hook(self, layer_name: str, module: torch.nn.Module, args: tuple):
         """Run the router (one Linear layer) and cache routing decisions."""
         hidden_states = args[0]
         if hidden_states.dim() == 3:
@@ -198,12 +194,8 @@ class REAPPruningModifier(Modifier):
             else:
                 router_logits = router_output
 
-            routing_weights = F.softmax(
-                router_logits, dim=-1, dtype=torch.float32
-            )
-            _, topk_indices = torch.topk(
-                routing_weights, self._top_k, dim=-1
-            )
+            routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float32)
+            _, topk_indices = torch.topk(routing_weights, self._top_k, dim=-1)
 
         self._routing_cache[layer_name] = {
             "routing_weights": routing_weights,

--- a/src/llmcompressor/modifiers/pruning/reap/utils.py
+++ b/src/llmcompressor/modifiers/pruning/reap/utils.py
@@ -54,12 +54,10 @@ MOE_ATTR_REGISTRY: dict[str, MoEModelAttrs] = {
     "Glm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
     "CalibrationGlm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
     # Llama4
-    "Llama4TextMoe": MoEModelAttrs(
-        "router", "experts", "num_local_experts"    ),
+    "Llama4TextMoe": MoEModelAttrs("router", "experts", "num_local_experts"),
     "SequentialLlama4TextMoe": MoEModelAttrs("router", "experts", "num_local_experts"),
     # Gemma4
-    "Gemma4TextExperts": MoEModelAttrs(
-        "router", "experts", "num_experts"    ),
+    "Gemma4TextExperts": MoEModelAttrs("router", "experts", "num_experts"),
     "SequentialGemma4TextExperts": MoEModelAttrs("router", "experts", "num_experts"),
     # AfMoE
     "AfmoeMoE": MoEModelAttrs("router", "experts", "num_experts"),
@@ -189,7 +187,7 @@ def prune_moe_layer(
     drop_set = set(drop_indices.tolist())
     retained = sorted(i for i in range(num_experts) if i not in drop_set)
 
-    logger.info(
+    logger.debug(
         f"Pruning {layer_name}: dropping experts {sorted(drop_set)}, "
         f"retaining {retained} ({len(retained)}/{num_experts})"
     )
@@ -215,13 +213,9 @@ def prune_moe_layer(
 def _prune_router(router: nn.Module, retained: list[int]):
     retained_t = torch.tensor(retained, dtype=torch.long)
 
-    router.weight = nn.Parameter(
-        router.weight.data[retained_t, :], requires_grad=False
-    )
+    router.weight = nn.Parameter(router.weight.data[retained_t, :], requires_grad=False)
     if router.bias is not None:
-        router.bias = nn.Parameter(
-            router.bias.data[retained_t], requires_grad=False
-        )
+        router.bias = nn.Parameter(router.bias.data[retained_t], requires_grad=False)
     router.out_features = len(retained)
 
 

--- a/src/llmcompressor/modifiers/pruning/reap/utils.py
+++ b/src/llmcompressor/modifiers/pruning/reap/utils.py
@@ -1,5 +1,13 @@
 """
-Utilities for REAP: MoE detection, saliency tracking, and expert pruning.
+Utilities for REAP: MoE detection, routing extraction, saliency tracking, and
+expert pruning.
+
+Supported architectures all share the property that, under
+``moe_calibration_context``, the MoE block is replaced by a calibration wrapper
+that routes *every* token through *every* expert (``calibrate_all_experts``).
+This lets REAP observe each expert's output for all tokens. Each architecture's
+router, however, produces gate weights differently, so the routing math is
+captured per-architecture via ``ROUTING_MODE`` (see ``extract_routing``).
 """
 
 import re
@@ -7,17 +15,34 @@ from dataclasses import dataclass, field
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from compressed_tensors import align_module_device
 from loguru import logger
 
 __all__ = [
     "MoEModelAttrs",
     "REAPSaliencyTracker",
+    "assert_routing_feasible",
+    "compute_retained_experts",
     "detect_moe_attrs",
+    "extract_routing",
     "find_moe_layers",
     "get_num_experts",
+    "get_router_num_groups",
+    "get_router_topk_group",
     "prune_moe_layer",
     "update_model_config",
 ]
+
+
+# Routing modes describe how to turn a router module's raw forward output into
+# ``(topk_indices, topk_weights)`` -- the experts selected per token and the
+# gate weight applied to each. See ``extract_routing``.
+SOFTMAX = "softmax"  # router returns logits [T, E]; softmax + top-k (+ optional norm)
+INDICES_WEIGHTS = "indices_weights"  # router returns (topk_indices, topk_weights)
+WEIGHTS_INDICES = "weights_indices"  # router returns (topk_weights, topk_indices)
+SCORES_LOGITS = "scores_logits"  # router returns (scores [T, E], logits [T, E])
+GLM_DSA = "glm_dsa"  # router returns logits; group-limited sigmoid routing in block
 
 
 @dataclass
@@ -25,54 +50,104 @@ class MoEModelAttrs:
     router_attr: str
     experts_attr: str
     num_experts_config_key: str
+    routing_mode: str = SOFTMAX
 
 
 MOE_ATTR_REGISTRY: dict[str, MoEModelAttrs] = {
-    # Qwen3 family
-    "Qwen3MoeSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    # Qwen3 family (softmax router)
+    "Qwen3MoeSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts", SOFTMAX),
     "CalibrationQwen3MoeSparseMoeBlock": MoEModelAttrs(
-        "gate", "experts", "num_experts"
+        "gate", "experts", "num_experts", SOFTMAX
     ),
-    "Qwen3_5MoeSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "Qwen3_5MoeSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts", SOFTMAX
+    ),
     "SequentialQwen3_5MoeSparseMoeBlock": MoEModelAttrs(
-        "gate", "experts", "num_experts"
+        "gate", "experts", "num_experts", SOFTMAX
     ),
-    "Qwen3NextSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "Qwen3NextSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts", SOFTMAX),
     "CalibrationQwen3NextSparseMoeBlock": MoEModelAttrs(
-        "gate", "experts", "num_experts"
+        "gate", "experts", "num_experts", SOFTMAX
     ),
-    "Qwen3VLMoeTextSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
-    "SequentialQwen3VLMoeTextSparseMoeBlock": MoEModelAttrs(
-        "gate", "experts", "num_experts"
+    "Qwen3VLMoeTextSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts", SOFTMAX
     ),
-    # Mixtral
-    "MixtralSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_local_experts"),
-    # DeepSeek
-    "DeepseekV3MoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
-    "SequentialDeepseekV3MoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
-    # GLM4
-    "Glm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
-    "CalibrationGlm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
-    # Llama4
-    "Llama4TextMoe": MoEModelAttrs("router", "experts", "num_local_experts"),
-    "SequentialLlama4TextMoe": MoEModelAttrs("router", "experts", "num_local_experts"),
-    # Gemma4
-    "Gemma4TextExperts": MoEModelAttrs("router", "experts", "num_experts"),
-    "SequentialGemma4TextExperts": MoEModelAttrs("router", "experts", "num_experts"),
-    # AfMoE
-    "AfmoeMoE": MoEModelAttrs("router", "experts", "num_experts"),
-    "CalibrationAfmoeMoE": MoEModelAttrs("router", "experts", "num_experts"),
+    "CalibrateQwen3VLMoeTextSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts", SOFTMAX
+    ),
+    # DeepSeek-V3 (sigmoid + group-limited top-k router, returns indices+weights)
+    "DeepseekV3MoE": MoEModelAttrs(
+        "gate", "experts", "n_routed_experts", INDICES_WEIGHTS
+    ),
+    "CalibrationDeepseekV3MoE": MoEModelAttrs(
+        "gate", "experts", "n_routed_experts", INDICES_WEIGHTS
+    ),
+    # GLM4 MoE (sigmoid + group-limited top-k router, returns indices+weights)
+    "Glm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts", INDICES_WEIGHTS),
+    "CalibrationGlm4MoeMoE": MoEModelAttrs(
+        "gate", "experts", "n_routed_experts", INDICES_WEIGHTS
+    ),
+    # GLM-MoE-DSA / GLM4-MoE-Lite (group-limited sigmoid routing inside the block)
+    "GlmMoeDsaMoE": MoEModelAttrs("gate", "experts", "n_routed_experts", GLM_DSA),
+    "CalibrationGlmMoeDsaMoE": MoEModelAttrs(
+        "gate", "experts", "n_routed_experts", GLM_DSA
+    ),
+    "Glm4MoeLiteMoE": MoEModelAttrs("gate", "experts", "n_routed_experts", GLM_DSA),
+    "CalibrationGlm4MoeLiteMoE": MoEModelAttrs(
+        "gate", "experts", "n_routed_experts", GLM_DSA
+    ),
+    # Llama4 (router returns sigmoid scores + logits)
+    "Llama4TextMoe": MoEModelAttrs(
+        "router", "experts", "num_local_experts", SCORES_LOGITS
+    ),
+    "SequentialLlama4TextMoe": MoEModelAttrs(
+        "router", "experts", "num_local_experts", SCORES_LOGITS
+    ),
+    # AfMoE (router returns scores + selected experts)
+    "AfmoeMoE": MoEModelAttrs("router", "experts", "num_experts", WEIGHTS_INDICES),
+    "CalibrationAfmoeMoE": MoEModelAttrs(
+        "router", "experts", "num_experts", WEIGHTS_INDICES
+    ),
+}
+
+# Architectures that are intentionally not supported, mapped to the reason.
+# Detected here so REAP can raise a clear error instead of silently
+# mis-calibrating or emitting a broken checkpoint.
+UNSUPPORTED_MOE_BLOCKS: dict[str, str] = {
+    # No calibration wrapper exists, so calibrate_all_experts cannot route every
+    # token through every expert -- REAP's per-expert norms would be incomplete.
+    "MixtralSparseMoeBlock": (
+        "Mixtral has no MoE calibration wrapper, so REAP cannot observe every "
+        "expert on every token."
+    ),
+    # The Gemma4 'experts' block has no router attribute (routing happens in the
+    # parent module and is passed in as arguments), so REAP cannot locate or
+    # prune the router alongside the experts.
+    "Gemma4TextExperts": (
+        "Gemma4 routes outside the experts block; REAP cannot pair a router with "
+        "the experts module."
+    ),
+    "SequentialGemma4TextExperts": (
+        "Gemma4 routes outside the experts block; REAP cannot pair a router with "
+        "the experts module."
+    ),
 }
 
 
 def detect_moe_attrs(model: nn.Module) -> MoEModelAttrs | None:
     for _, module in model.named_modules():
         class_name = module.__class__.__name__
+        if class_name in UNSUPPORTED_MOE_BLOCKS:
+            raise NotImplementedError(
+                f"REAP does not support MoE architecture '{class_name}': "
+                f"{UNSUPPORTED_MOE_BLOCKS[class_name]}"
+            )
         if class_name in MOE_ATTR_REGISTRY:
             attrs = MOE_ATTR_REGISTRY[class_name]
             logger.info(
                 f"Detected MoE architecture: {class_name} "
-                f"(router={attrs.router_attr}, experts={attrs.experts_attr})"
+                f"(router={attrs.router_attr}, experts={attrs.experts_attr}, "
+                f"routing={attrs.routing_mode})"
             )
             return attrs
 
@@ -83,10 +158,11 @@ def detect_moe_attrs(model: nn.Module) -> MoEModelAttrs | None:
                 router_attr=router,
                 experts_attr="experts",
                 num_experts_config_key="num_experts",
+                routing_mode=SOFTMAX,
             )
             logger.info(
                 f"Auto-detected MoE block: {module.__class__.__name__} "
-                f"(router={router})"
+                f"(router={router}, routing={SOFTMAX})"
             )
             return attrs
 
@@ -141,71 +217,332 @@ def get_num_experts(module: nn.Module, attrs: MoEModelAttrs) -> int:
     )
 
 
+def get_router_num_groups(module: nn.Module, attrs: MoEModelAttrs) -> int:
+    """
+    Number of expert groups used by group-limited routers (DeepSeek-V3, GLM4,
+    GLM-MoE-DSA). Returns 1 for routers without grouping. ``n_group`` may live on
+    the router module or on the (calibration) block.
+    """
+    router = getattr(module, attrs.router_attr)
+    for holder in (router, module):
+        n_group = getattr(holder, "n_group", None)
+        if isinstance(n_group, int) and n_group > 0:
+            return n_group
+    return 1
+
+
+def get_router_topk_group(module: nn.Module, attrs: MoEModelAttrs) -> int:
+    """
+    Number of expert groups a token may route into (``topk_group``) for
+    group-limited routers. Defaults to ``n_group`` (all groups) when not set.
+    """
+    router = getattr(module, attrs.router_attr)
+    for holder in (router, module):
+        topk_group = getattr(holder, "topk_group", None)
+        if isinstance(topk_group, int) and topk_group > 0:
+            return topk_group
+    return get_router_num_groups(module, attrs)
+
+
+# ---------------------------------------------------------------------------
+# Routing extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_routing(
+    router_output,
+    block: nn.Module,
+    attrs: MoEModelAttrs,
+    top_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Convert a router module's raw forward output into per-token routing
+    decisions, matching how the architecture actually combines experts.
+
+    :param router_output: the value returned by the router submodule's forward
+    :param block: the MoE block (calibration wrapper) holding routing config
+    :param attrs: architecture descriptor (selects the routing mode)
+    :param top_k: number of experts selected per token
+    :return: ``(topk_indices, topk_weights)`` each shaped ``[num_tokens, top_k]``;
+        ``topk_weights[t, s]`` is the gate weight applied to expert
+        ``topk_indices[t, s]`` for token ``t``
+    """
+    mode = attrs.routing_mode
+
+    if mode == INDICES_WEIGHTS:
+        topk_indices, topk_weights = router_output
+        return topk_indices, topk_weights
+
+    if mode == WEIGHTS_INDICES:
+        topk_weights, topk_indices = router_output
+        return topk_indices, topk_weights
+
+    if mode == SCORES_LOGITS:
+        scores, logits = router_output
+        _, topk_indices = torch.topk(logits, top_k, dim=-1)
+        topk_weights = scores.gather(-1, topk_indices)
+        return topk_indices, topk_weights
+
+    if mode == SOFTMAX:
+        logits = router_output
+        routing_weights = F.softmax(logits, dim=-1, dtype=torch.float32)
+        topk_weights, topk_indices = torch.topk(routing_weights, top_k, dim=-1)
+        if getattr(block, "norm_topk_prob", True):
+            topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+        return topk_indices, topk_weights
+
+    if mode == GLM_DSA:
+        return _route_glm_dsa(router_output, block, attrs, top_k)
+
+    raise ValueError(f"Unknown routing mode '{mode}'")
+
+
+def _route_glm_dsa(
+    router_logits: torch.Tensor,
+    block: nn.Module,
+    attrs: MoEModelAttrs,
+    top_k: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Group-limited sigmoid routing, mirroring
+    ``CalibrationGlmMoeDsaMoE.route_tokens_to_experts``. The score-correction
+    bias and group/scaling parameters live on the block (and its gate).
+    """
+    router = getattr(block, attrs.router_attr)
+    n_group = int(getattr(block, "n_group", getattr(router, "n_group", 1)) or 1)
+    topk_group = int(getattr(block, "topk_group", n_group) or n_group)
+    n_routed = router_logits.shape[-1]
+    norm_topk_prob = getattr(block, "norm_topk_prob", True)
+    routed_scaling_factor = getattr(block, "routed_scaling_factor", 1.0)
+    correction_bias = getattr(router, "e_score_correction_bias", 0.0)
+
+    scores = router_logits.sigmoid()
+    scores_for_choice = scores + correction_bias
+    group_scores = (
+        scores_for_choice.view(-1, n_group, n_routed // n_group)
+        .topk(2, dim=-1)[0]
+        .sum(dim=-1)
+    )
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=False)[1]
+    group_mask = torch.zeros_like(group_scores)
+    group_mask.scatter_(1, group_idx, 1)
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(-1, n_group, n_routed // n_group)
+        .reshape(-1, n_routed)
+    )
+    masked = scores_for_choice.masked_fill(~score_mask.bool(), 0.0)
+    topk_indices = torch.topk(masked, k=top_k, dim=-1, sorted=False)[1]
+    topk_weights = scores.gather(1, topk_indices)
+    if norm_topk_prob:
+        topk_weights = topk_weights / (topk_weights.sum(dim=-1, keepdim=True) + 1e-20)
+    topk_weights = topk_weights * routed_scaling_factor
+    return topk_indices, topk_weights
+
+
+# ---------------------------------------------------------------------------
+# Saliency tracking
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class REAPSaliencyTracker:
-    """Accumulates S_j = mean(g_j * ||f_j||_2) per expert across batches."""
+    """
+    Accumulates the REAP saliency ``S_j = mean(g_j * ||f_j||_2)`` per expert,
+    averaged over the tokens routed to expert ``j``, where ``g_j`` is the router
+    gate weight and ``f_j`` is the expert output.
+
+    Accumulators live on the device of the incoming data (allocated lazily) to
+    avoid a host sync on every update; they are moved to the host only when
+    ``mean_saliency`` is read.
+    """
 
     num_experts: int
-    sum_saliency: torch.Tensor = field(init=False)
-    count: torch.Tensor = field(init=False)
+    sum_saliency: torch.Tensor | None = field(init=False, default=None)
+    count: torch.Tensor | None = field(init=False, default=None)
 
-    def __post_init__(self):
-        self.sum_saliency = torch.zeros(self.num_experts, dtype=torch.float64)
-        self.count = torch.zeros(self.num_experts, dtype=torch.int64)
+    def _ensure(self, device: torch.device):
+        if self.sum_saliency is None:
+            self.sum_saliency = torch.zeros(
+                self.num_experts, dtype=torch.float64, device=device
+            )
+            self.count = torch.zeros(
+                self.num_experts, dtype=torch.float64, device=device
+            )
 
     def update(
         self,
-        expert_idx: int,
-        gate_values: torch.Tensor,
-        output_norms: torch.Tensor,
+        topk_indices: torch.Tensor,
+        topk_weights: torch.Tensor,
+        expert_norms: torch.Tensor,
     ):
-        saliency = (gate_values.float() * output_norms.float()).sum()
-        self.sum_saliency[expert_idx] += saliency.cpu().to(torch.float64)
-        self.count[expert_idx] += gate_values.shape[0]
+        """
+        Vectorized accumulation over one batch.
+
+        :param topk_indices: ``[num_tokens, top_k]`` selected expert ids
+        :param topk_weights: ``[num_tokens, top_k]`` gate weight per selection
+        :param expert_norms: ``[num_tokens, num_experts]`` output norm of every
+            expert for every token (available because all experts see all tokens)
+        """
+        self._ensure(expert_norms.device)
+
+        flat_idx = topk_indices.reshape(-1).to(torch.long)
+        gathered_norms = expert_norms.gather(1, topk_indices.to(torch.long))
+        contrib = topk_weights.to(torch.float64) * gathered_norms.to(torch.float64)
+        self.sum_saliency.index_add_(0, flat_idx, contrib.reshape(-1))
+        self.count.index_add_(
+            0, flat_idx, torch.ones_like(flat_idx, dtype=torch.float64)
+        )
+
+    @property
+    def total_count(self) -> float:
+        if self.count is None:
+            return 0.0
+        return float(self.count.sum().item())
 
     @property
     def mean_saliency(self) -> torch.Tensor:
-        safe_count = self.count.clamp(min=1).to(torch.float64)
-        return self.sum_saliency / safe_count
+        if self.sum_saliency is None:
+            return torch.zeros(self.num_experts, dtype=torch.float64)
+        sum_saliency = self.sum_saliency.detach().to("cpu", torch.float64)
+        count = self.count.detach().to("cpu", torch.float64)
+        return sum_saliency / count.clamp(min=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Pruning
+# ---------------------------------------------------------------------------
+
+
+def compute_retained_experts(
+    saliency: torch.Tensor,
+    n_experts_to_drop: int,
+    n_group: int = 1,
+) -> list[int]:
+    """
+    Select which experts to keep, dropping the lowest-saliency ones.
+
+    For group-limited routers (``n_group > 1``) the experts form ``n_group``
+    contiguous groups and the router requires every group to keep the same
+    number of experts (so ``n_routed_experts`` stays divisible by ``n_group``).
+    We therefore drop an equal number from each group; the requested drop count
+    is rounded to the nearest multiple of ``n_group``.
+    """
+    num_experts = len(saliency)
+    if n_experts_to_drop >= num_experts:
+        raise ValueError(
+            f"Cannot drop {n_experts_to_drop} experts from a layer with only "
+            f"{num_experts} experts"
+        )
+
+    if n_group <= 1:
+        _, drop_idx = torch.topk(saliency, n_experts_to_drop, largest=False)
+        drop_set = set(drop_idx.tolist())
+        return sorted(i for i in range(num_experts) if i not in drop_set)
+
+    if num_experts % n_group != 0:
+        raise ValueError(f"{num_experts} experts not divisible by n_group={n_group}")
+    group_size = num_experts // n_group
+    drop_per_group = _drop_per_group(n_experts_to_drop, n_group, group_size)
+    if drop_per_group == 0:
+        raise ValueError(
+            f"Requested drop of {n_experts_to_drop} experts rounds to 0 per "
+            f"group (n_group={n_group}, group_size={group_size})"
+        )
+    effective = drop_per_group * n_group
+    if effective != n_experts_to_drop:
+        logger.warning(
+            f"REAP: group-limited routing requires an equal drop per group; "
+            f"dropping {effective} experts instead of the requested "
+            f"{n_experts_to_drop} (n_group={n_group})"
+        )
+
+    retained: list[int] = []
+    for g in range(n_group):
+        lo = g * group_size
+        grp = saliency[lo : lo + group_size]
+        _, drop_local = torch.topk(grp, drop_per_group, largest=False)
+        drop_set = {lo + int(i) for i in drop_local.tolist()}
+        retained.extend(i for i in range(lo, lo + group_size) if i not in drop_set)
+    return sorted(retained)
+
+
+def _drop_per_group(n_experts_to_drop: int, n_group: int, group_size: int) -> int:
+    """Per-group drop count for group-limited routing: equal across groups and
+    leaving at least 2 experts per group (group routing does a top-2 per group)."""
+    drop_per_group = round(n_experts_to_drop / n_group)
+    return max(0, min(drop_per_group, group_size - 2))
+
+
+def assert_routing_feasible(
+    num_experts: int,
+    n_experts_to_drop: int,
+    n_group: int,
+    topk_group: int,
+    top_k: int,
+):
+    """
+    Ensure pruning leaves enough experts for the router to still select ``top_k``
+    per token. For group-limited routers a token may only route into
+    ``topk_group`` groups, so the reachable experts after pruning are
+    ``topk_group * retained_per_group``. Raises ``ValueError`` (fail fast, before
+    calibration) when the requested sparsity would make routing infeasible.
+    """
+    if n_group > 1:
+        group_size = num_experts // n_group
+        retained_per_group = group_size - _drop_per_group(
+            n_experts_to_drop, n_group, group_size
+        )
+        available = topk_group * retained_per_group
+    else:
+        available = num_experts - n_experts_to_drop
+
+    if top_k > available:
+        raise ValueError(
+            f"REAP sparsity is too aggressive: the router selects top_k={top_k} "
+            f"experts per token, but only {available} experts would remain "
+            f"reachable after pruning "
+            f"(num_experts={num_experts}, dropping≈{n_experts_to_drop}"
+            + (f", n_group={n_group}, topk_group={topk_group}" if n_group > 1 else "")
+            + "). Reduce the sparsity."
+        )
 
 
 def prune_moe_layer(
     model: nn.Module,
     layer_name: str,
-    saliency: torch.Tensor,
-    n_experts_to_drop: int,
+    retained: list[int],
     attrs: MoEModelAttrs,
 ) -> list[int]:
-    num_experts = len(saliency)
-    if n_experts_to_drop >= num_experts:
-        raise ValueError(
-            f"Cannot drop {n_experts_to_drop} experts from {layer_name} "
-            f"which only has {num_experts} experts"
-        )
-
-    _, drop_indices = torch.topk(saliency, n_experts_to_drop, largest=False)
-    drop_set = set(drop_indices.tolist())
-    retained = sorted(i for i in range(num_experts) if i not in drop_set)
-
-    logger.debug(
-        f"Pruning {layer_name}: dropping experts {sorted(drop_set)}, "
-        f"retaining {retained} ({len(retained)}/{num_experts})"
-    )
-
+    """
+    Structurally prune a MoE block to keep only ``retained`` experts: rebuild the
+    expert ``ModuleList``, shrink the router, and update expert-count attributes.
+    Offload-safe: experts are kept as existing module objects (offload state
+    travels with them) and the small router is resized under
+    ``align_module_device``.
+    """
     moe_block = model.get_submodule(layer_name)
     router = getattr(moe_block, attrs.router_attr)
     experts = getattr(moe_block, attrs.experts_attr)
 
     if isinstance(experts, nn.ModuleList):
+        old_experts = experts
         new_experts = nn.ModuleList([experts[i] for i in retained])
         setattr(moe_block, attrs.experts_attr, new_experts)
+        del old_experts
     else:
         _prune_fused_experts(experts, retained)
 
     _prune_router(router, retained)
 
-    if hasattr(moe_block, "num_experts"):
-        moe_block.num_experts = len(retained)
+    # n_group / topk_group are intentionally left unchanged: per-group-balanced
+    # pruning keeps the same number of equally-sized groups, so n_routed_experts
+    # stays divisible by n_group and the router's grouping stays valid.
+    for holder in (moe_block, router):
+        if isinstance(getattr(holder, "num_experts", None), int):
+            holder.num_experts = len(retained)
+        if isinstance(getattr(holder, "n_routed_experts", None), int):
+            holder.n_routed_experts = len(retained)
 
     return retained
 
@@ -213,21 +550,48 @@ def prune_moe_layer(
 def _prune_router(router: nn.Module, retained: list[int]):
     retained_t = torch.tensor(retained, dtype=torch.long)
 
-    router.weight = nn.Parameter(router.weight.data[retained_t, :], requires_grad=False)
-    if router.bias is not None:
-        router.bias = nn.Parameter(router.bias.data[retained_t], requires_grad=False)
-    router.out_features = len(retained)
+    with align_module_device(router):
+        retained_t = retained_t.to(router.weight.device)
+        new_weight = router.weight.detach()[retained_t].contiguous()
+        new_bias = None
+        if getattr(router, "bias", None) is not None:
+            new_bias = router.bias.detach()[retained_t].contiguous()
+        # group-limited routers (DeepSeek-V3 / GLM4 / GLM-DSA) carry a per-expert
+        # score-correction bias buffer that must be shrunk in lockstep
+        correction = getattr(router, "e_score_correction_bias", None)
+        new_correction = (
+            correction.detach()[retained_t].contiguous()
+            if correction is not None
+            else None
+        )
+
+    # Direct attribute assignment replaces a parameter/buffer with a different
+    # shape and is correct for both offloaded modules (routed through the
+    # OffloadCache, which re-offloads the new shape) and ordinary modules.
+    router.weight = nn.Parameter(new_weight, requires_grad=False)
+    if new_bias is not None:
+        router.bias = nn.Parameter(new_bias, requires_grad=False)
+    if new_correction is not None:
+        router.e_score_correction_bias = new_correction
+
+    if isinstance(getattr(router, "out_features", None), int):
+        router.out_features = len(retained)
 
 
 def _prune_fused_experts(experts: nn.Module, retained: list[int]):
+    """Fallback for fused experts (stacked weight tensors). Defensive: all
+    currently supported calibration wrappers expose experts as a ModuleList."""
     retained_t = torch.tensor(retained, dtype=torch.long)
 
-    for name, param in list(experts.named_parameters(recurse=False)):
-        if param.dim() >= 2:
-            new_param = param.data[retained_t]
-            setattr(experts, name, nn.Parameter(new_param, requires_grad=False))
+    for name, _ in list(experts.named_parameters(recurse=False)):
+        with align_module_device(experts):
+            param = getattr(experts, name)
+            if param.dim() < 2:
+                continue
+            new_param = param.detach()[retained_t.to(param.device)].contiguous()
+        setattr(experts, name, nn.Parameter(new_param, requires_grad=False))
 
-    if hasattr(experts, "num_experts"):
+    if isinstance(getattr(experts, "num_experts", None), int):
         experts.num_experts = len(retained)
 
 
@@ -239,11 +603,16 @@ def update_model_config(
     config = model.config
     attr_name = attrs.num_experts_config_key
 
+    updated = False
     for cfg in (config, getattr(config, "text_config", None)):
         if cfg is not None and hasattr(cfg, attr_name):
             old_val = getattr(cfg, attr_name)
             setattr(cfg, attr_name, new_num_experts)
             logger.info(f"Updated config.{attr_name}: {old_val} -> {new_num_experts}")
-            return
+            updated = True
+            break
 
-    logger.warning(f"Config attribute '{attr_name}' not found, skipping config update")
+    if not updated:
+        logger.warning(
+            f"Config attribute '{attr_name}' not found, skipping config update"
+        )

--- a/src/llmcompressor/modifiers/pruning/reap/utils.py
+++ b/src/llmcompressor/modifiers/pruning/reap/utils.py
@@ -1,0 +1,255 @@
+"""
+Utilities for REAP: MoE detection, saliency tracking, and expert pruning.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+import torch
+import torch.nn as nn
+from loguru import logger
+
+__all__ = [
+    "MoEModelAttrs",
+    "REAPSaliencyTracker",
+    "detect_moe_attrs",
+    "find_moe_layers",
+    "get_num_experts",
+    "prune_moe_layer",
+    "update_model_config",
+]
+
+
+@dataclass
+class MoEModelAttrs:
+    router_attr: str
+    experts_attr: str
+    num_experts_config_key: str
+
+
+MOE_ATTR_REGISTRY: dict[str, MoEModelAttrs] = {
+    # Qwen3 family
+    "Qwen3MoeSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "CalibrationQwen3MoeSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts"
+    ),
+    "Qwen3_5MoeSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "SequentialQwen3_5MoeSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts"
+    ),
+    "Qwen3NextSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "CalibrationQwen3NextSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts"
+    ),
+    "Qwen3VLMoeTextSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_experts"),
+    "SequentialQwen3VLMoeTextSparseMoeBlock": MoEModelAttrs(
+        "gate", "experts", "num_experts"
+    ),
+    # Mixtral
+    "MixtralSparseMoeBlock": MoEModelAttrs("gate", "experts", "num_local_experts"),
+    # DeepSeek
+    "DeepseekV3MoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
+    "SequentialDeepseekV3MoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
+    # GLM4
+    "Glm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
+    "CalibrationGlm4MoeMoE": MoEModelAttrs("gate", "experts", "n_routed_experts"),
+    # Llama4
+    "Llama4TextMoe": MoEModelAttrs(
+        "router", "experts", "num_local_experts"    ),
+    "SequentialLlama4TextMoe": MoEModelAttrs("router", "experts", "num_local_experts"),
+    # Gemma4
+    "Gemma4TextExperts": MoEModelAttrs(
+        "router", "experts", "num_experts"    ),
+    "SequentialGemma4TextExperts": MoEModelAttrs("router", "experts", "num_experts"),
+    # AfMoE
+    "AfmoeMoE": MoEModelAttrs("router", "experts", "num_experts"),
+    "CalibrationAfmoeMoE": MoEModelAttrs("router", "experts", "num_experts"),
+}
+
+
+def detect_moe_attrs(model: nn.Module) -> MoEModelAttrs | None:
+    for _, module in model.named_modules():
+        class_name = module.__class__.__name__
+        if class_name in MOE_ATTR_REGISTRY:
+            attrs = MOE_ATTR_REGISTRY[class_name]
+            logger.info(
+                f"Detected MoE architecture: {class_name} "
+                f"(router={attrs.router_attr}, experts={attrs.experts_attr})"
+            )
+            return attrs
+
+    for _, module in model.named_modules():
+        router = _find_router_attr(module)
+        if router is not None and hasattr(module, "experts"):
+            attrs = MoEModelAttrs(
+                router_attr=router,
+                experts_attr="experts",
+                num_experts_config_key="num_experts",
+            )
+            logger.info(
+                f"Auto-detected MoE block: {module.__class__.__name__} "
+                f"(router={router})"
+            )
+            return attrs
+
+    return None
+
+
+def _find_router_attr(module: nn.Module) -> str | None:
+    for attr_name in ("gate", "router"):
+        val = getattr(module, attr_name, None)
+        if val is not None and isinstance(val, nn.Linear):
+            return attr_name
+    return None
+
+
+def find_moe_layers(
+    model: nn.Module,
+    attrs: MoEModelAttrs,
+    ignore: list[str] | None = None,
+) -> dict[str, nn.Module]:
+    ignore = ignore or []
+    moe_layers = {}
+
+    for name, module in model.named_modules():
+        has_router = hasattr(module, attrs.router_attr)
+        has_experts = hasattr(module, attrs.experts_attr)
+        if not (has_router and has_experts):
+            continue
+        if not isinstance(getattr(module, attrs.router_attr), nn.Module):
+            continue
+        if any(re.search(pattern, name) for pattern in ignore):
+            continue
+        moe_layers[name] = module
+
+    logger.info(f"Found {len(moe_layers)} MoE layers")
+    return moe_layers
+
+
+def get_num_experts(module: nn.Module, attrs: MoEModelAttrs) -> int:
+    experts = getattr(module, attrs.experts_attr)
+    if isinstance(experts, nn.ModuleList):
+        return len(experts)
+
+    if hasattr(experts, "num_experts"):
+        return experts.num_experts
+
+    for _, param in experts.named_parameters(recurse=False):
+        if param.dim() >= 2:
+            return param.shape[0]
+
+    raise ValueError(
+        f"Cannot determine number of experts from {module.__class__.__name__}"
+    )
+
+
+@dataclass
+class REAPSaliencyTracker:
+    """Accumulates S_j = mean(g_j * ||f_j||_2) per expert across batches."""
+
+    num_experts: int
+    sum_saliency: torch.Tensor = field(init=False)
+    count: torch.Tensor = field(init=False)
+
+    def __post_init__(self):
+        self.sum_saliency = torch.zeros(self.num_experts, dtype=torch.float64)
+        self.count = torch.zeros(self.num_experts, dtype=torch.int64)
+
+    def update(
+        self,
+        expert_idx: int,
+        gate_values: torch.Tensor,
+        output_norms: torch.Tensor,
+    ):
+        saliency = (gate_values.float() * output_norms.float()).sum()
+        self.sum_saliency[expert_idx] += saliency.cpu().to(torch.float64)
+        self.count[expert_idx] += gate_values.shape[0]
+
+    @property
+    def mean_saliency(self) -> torch.Tensor:
+        safe_count = self.count.clamp(min=1).to(torch.float64)
+        return self.sum_saliency / safe_count
+
+
+def prune_moe_layer(
+    model: nn.Module,
+    layer_name: str,
+    saliency: torch.Tensor,
+    n_experts_to_drop: int,
+    attrs: MoEModelAttrs,
+) -> list[int]:
+    num_experts = len(saliency)
+    if n_experts_to_drop >= num_experts:
+        raise ValueError(
+            f"Cannot drop {n_experts_to_drop} experts from {layer_name} "
+            f"which only has {num_experts} experts"
+        )
+
+    _, drop_indices = torch.topk(saliency, n_experts_to_drop, largest=False)
+    drop_set = set(drop_indices.tolist())
+    retained = sorted(i for i in range(num_experts) if i not in drop_set)
+
+    logger.info(
+        f"Pruning {layer_name}: dropping experts {sorted(drop_set)}, "
+        f"retaining {retained} ({len(retained)}/{num_experts})"
+    )
+
+    moe_block = model.get_submodule(layer_name)
+    router = getattr(moe_block, attrs.router_attr)
+    experts = getattr(moe_block, attrs.experts_attr)
+
+    if isinstance(experts, nn.ModuleList):
+        new_experts = nn.ModuleList([experts[i] for i in retained])
+        setattr(moe_block, attrs.experts_attr, new_experts)
+    else:
+        _prune_fused_experts(experts, retained)
+
+    _prune_router(router, retained)
+
+    if hasattr(moe_block, "num_experts"):
+        moe_block.num_experts = len(retained)
+
+    return retained
+
+
+def _prune_router(router: nn.Module, retained: list[int]):
+    retained_t = torch.tensor(retained, dtype=torch.long)
+
+    router.weight = nn.Parameter(
+        router.weight.data[retained_t, :], requires_grad=False
+    )
+    if router.bias is not None:
+        router.bias = nn.Parameter(
+            router.bias.data[retained_t], requires_grad=False
+        )
+    router.out_features = len(retained)
+
+
+def _prune_fused_experts(experts: nn.Module, retained: list[int]):
+    retained_t = torch.tensor(retained, dtype=torch.long)
+
+    for name, param in list(experts.named_parameters(recurse=False)):
+        if param.dim() >= 2:
+            new_param = param.data[retained_t]
+            setattr(experts, name, nn.Parameter(new_param, requires_grad=False))
+
+    if hasattr(experts, "num_experts"):
+        experts.num_experts = len(retained)
+
+
+def update_model_config(
+    model: nn.Module,
+    attrs: MoEModelAttrs,
+    new_num_experts: int,
+):
+    config = model.config
+    attr_name = attrs.num_experts_config_key
+
+    for cfg in (config, getattr(config, "text_config", None)):
+        if cfg is not None and hasattr(cfg, attr_name):
+            old_val = getattr(cfg, attr_name)
+            setattr(cfg, attr_name, new_num_experts)
+            logger.info(f"Updated config.{attr_name}: {old_val} -> {new_num_experts}")
+            return
+
+    logger.warning(f"Config attribute '{attr_name}' not found, skipping config update")

--- a/src/llmcompressor/pipelines/registry.py
+++ b/src/llmcompressor/pipelines/registry.py
@@ -64,6 +64,7 @@ class CalibrationPipeline(ABC, RegistryMixin):
                 "AWQModifier",
                 "AutoRoundModifier",
                 "IMatrixGatherer",
+                "REAPPruningModifier",
             ):
                 return True
             elif isinstance(modifier, QuantizationModifier):

--- a/tests/llmcompressor/modifiers/pruning/reap/test_base.py
+++ b/tests/llmcompressor/modifiers/pruning/reap/test_base.py
@@ -7,10 +7,20 @@ from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers.factory import ModifierFactory
 from llmcompressor.modifiers.pruning.reap import REAPPruningModifier
 from llmcompressor.modifiers.pruning.reap.utils import (
+    GLM_DSA,
+    INDICES_WEIGHTS,
+    SCORES_LOGITS,
+    SOFTMAX,
+    WEIGHTS_INDICES,
+    MoEModelAttrs,
     REAPSaliencyTracker,
+    assert_routing_feasible,
+    compute_retained_experts,
     detect_moe_attrs,
+    extract_routing,
     find_moe_layers,
     get_num_experts,
+    get_router_num_groups,
     prune_moe_layer,
 )
 
@@ -116,32 +126,108 @@ class FakeMoEModel(nn.Module):
 
 @pytest.mark.unit
 class TestREAPSaliencyTracker:
-    def test_update_single_expert(self):
+    def test_update_and_mean(self):
         tracker = REAPSaliencyTracker(num_experts=4)
-        gate_vals = torch.tensor([0.5, 0.3])
-        norms = torch.tensor([2.0, 4.0])
+        # 2 tokens, top_k=2, 4 experts; expert 3 is never routed
+        topk_indices = torch.tensor([[0, 1], [0, 2]])
+        topk_weights = torch.tensor([[0.6, 0.4], [0.5, 0.5]])
+        expert_norms = torch.tensor(
+            [
+                [3.0, 2.0, 9.0, 5.0],  # token 0 output norm per expert
+                [1.0, 9.0, 4.0, 5.0],  # token 1
+            ]
+        )
 
-        tracker.update(1, gate_vals, norms)
-
-        expected = 0.5 * 2.0 + 0.3 * 4.0
-        assert tracker.sum_saliency[1].item() == pytest.approx(expected)
-        assert tracker.count[1].item() == 2
-        assert tracker.count[0].item() == 0
-
-    def test_mean_saliency(self):
-        tracker = REAPSaliencyTracker(num_experts=3)
-
-        tracker.update(0, torch.tensor([0.6]), torch.tensor([3.0]))
-        tracker.update(0, torch.tensor([0.4]), torch.tensor([1.0]))
-        tracker.update(1, torch.tensor([0.5, 0.5]), torch.tensor([2.0, 2.0]))
+        tracker.update(topk_indices, topk_weights, expert_norms)
 
         mean = tracker.mean_saliency
-        # Expert 0: (0.6*3.0 + 0.4*1.0) / 2 = 2.2 / 2 = 1.1
-        assert mean[0].item() == pytest.approx(1.1)
-        # Expert 1: (0.5*2.0 + 0.5*2.0) / 2 = 2.0 / 2 = 1.0
-        assert mean[1].item() == pytest.approx(1.0)
-        # Expert 2: never routed -> 0
-        assert mean[2].item() == pytest.approx(0.0)
+        # expert 0: (0.6*3.0 + 0.5*1.0) / 2 = 2.3 / 2 = 1.15
+        assert mean[0].item() == pytest.approx(1.15)
+        # expert 1: 0.4*2.0 / 1 = 0.8
+        assert mean[1].item() == pytest.approx(0.8)
+        # expert 2: 0.5*4.0 / 1 = 2.0
+        assert mean[2].item() == pytest.approx(2.0)
+        # expert 3: never routed -> 0
+        assert mean[3].item() == pytest.approx(0.0)
+
+    def test_accumulates_across_batches(self):
+        tracker = REAPSaliencyTracker(num_experts=2)
+        idx = torch.tensor([[0]])
+        norms = torch.tensor([[3.0, 0.0]])
+        tracker.update(idx, torch.tensor([[0.6]]), norms)
+        tracker.update(idx, torch.tensor([[0.4]]), torch.tensor([[1.0, 0.0]]))
+        # expert 0: (0.6*3.0 + 0.4*1.0) / 2 = 2.2 / 2 = 1.1
+        assert tracker.mean_saliency[0].item() == pytest.approx(1.1)
+        assert tracker.total_count == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: routing extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRoutingExtraction:
+    def test_softmax_mode(self):
+        torch.manual_seed(0)
+        logits = torch.randn(5, 8)
+        block = nn.Module()
+        block.norm_topk_prob = True
+        attrs = MoEModelAttrs("gate", "experts", "num_experts", SOFTMAX)
+
+        idx, weights = extract_routing(logits, block, attrs, top_k=2)
+
+        rw = F.softmax(logits, dim=-1, dtype=torch.float32)
+        exp_w, exp_idx = torch.topk(rw, 2, dim=-1)
+        exp_w = exp_w / exp_w.sum(dim=-1, keepdim=True)
+        assert torch.equal(idx, exp_idx)
+        torch.testing.assert_close(weights, exp_w)
+
+    def test_indices_weights_mode(self):
+        attrs = MoEModelAttrs("gate", "experts", "n_routed_experts", INDICES_WEIGHTS)
+        topk_indices = torch.tensor([[1, 3], [0, 2]])
+        topk_weights = torch.tensor([[0.7, 0.3], [0.6, 0.4]])
+        idx, w = extract_routing((topk_indices, topk_weights), nn.Module(), attrs, 2)
+        assert torch.equal(idx, topk_indices)
+        torch.testing.assert_close(w, topk_weights)
+
+    def test_weights_indices_mode(self):
+        attrs = MoEModelAttrs("router", "experts", "num_experts", WEIGHTS_INDICES)
+        topk_weights = torch.tensor([[0.7, 0.3]])
+        topk_indices = torch.tensor([[1, 3]])
+        idx, w = extract_routing((topk_weights, topk_indices), nn.Module(), attrs, 2)
+        assert torch.equal(idx, topk_indices)
+        torch.testing.assert_close(w, topk_weights)
+
+    def test_scores_logits_mode(self):
+        attrs = MoEModelAttrs("router", "experts", "num_local_experts", SCORES_LOGITS)
+        scores = torch.tensor([[0.1, 0.9, 0.5, 0.2]])
+        logits = torch.tensor([[1.0, 5.0, 3.0, 0.5]])
+        idx, w = extract_routing((scores, logits), nn.Module(), attrs, 2)
+        # top-2 logits are experts 1 (5.0) and 2 (3.0)
+        assert set(idx[0].tolist()) == {1, 2}
+        # weights are the gathered scores at those experts
+        gathered = scores.gather(-1, idx)
+        torch.testing.assert_close(w, gathered)
+
+    def test_glm_dsa_mode_single_group(self):
+        # with one group, glm_dsa reduces to sigmoid scores + top-k
+        attrs = MoEModelAttrs("gate", "experts", "n_routed_experts", GLM_DSA)
+        block = nn.Module()
+        block.n_group = 1
+        block.topk_group = 1
+        block.norm_topk_prob = False
+        block.routed_scaling_factor = 1.0
+        block.gate = nn.Module()
+        block.gate.e_score_correction_bias = torch.zeros(4)
+
+        logits = torch.tensor([[2.0, -1.0, 0.5, 3.0]])
+        idx, w = extract_routing(logits, block, attrs, top_k=2)
+
+        scores = logits.sigmoid()
+        # highest sigmoid scores are experts 3 and 0
+        assert set(idx[0].tolist()) == {0, 3}
+        torch.testing.assert_close(w, scores.gather(1, idx))
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +245,7 @@ class TestMoEDetection:
         assert attrs is not None
         assert attrs.router_attr == "gate"
         assert attrs.experts_attr == "experts"
+        assert attrs.routing_mode == SOFTMAX
 
     def test_find_moe_layers(self):
         model = FakeMoEModel(num_layers=3)
@@ -180,42 +267,138 @@ class TestMoEDetection:
         for module in layers.values():
             assert get_num_experts(module, attrs) == 8
 
+    def test_get_router_num_groups_default(self):
+        model = FakeMoEModel()
+        attrs = detect_moe_attrs(model)
+        module = next(iter(find_moe_layers(model, attrs).values()))
+        assert get_router_num_groups(module, attrs) == 1
+
+    def test_unsupported_arch_raises(self):
+        class MixtralSparseMoeBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate = nn.Linear(8, 4, bias=False)
+                self.experts = nn.ModuleList([nn.Linear(8, 8) for _ in range(4)])
+
+        model = nn.Module()
+        model.block = MixtralSparseMoeBlock()
+        with pytest.raises(NotImplementedError, match="Mixtral"):
+            detect_moe_attrs(model)
+
+
+# ---------------------------------------------------------------------------
+# Tests: pruning
+# ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestPruning:
+    def test_compute_retained_global(self):
+        saliency = torch.tensor(
+            [0.1, 0.5, 0.8, 0.3, 0.7, 0.2, 0.9, 0.4], dtype=torch.float64
+        )
+        retained = compute_retained_experts(saliency, n_experts_to_drop=3, n_group=1)
+        # drop the 3 lowest: experts 0 (0.1), 5 (0.2), 3 (0.3)
+        assert retained == [1, 2, 4, 6, 7]
+
+    def test_compute_retained_per_group(self):
+        # 2 groups of 4; drop 2 -> 1 per group (lowest within each group)
+        saliency = torch.tensor(
+            [0.1, 0.9, 0.8, 0.7, 0.6, 0.2, 0.5, 0.4], dtype=torch.float64
+        )
+        retained = compute_retained_experts(saliency, n_experts_to_drop=2, n_group=2)
+        # group 0 [0,1,2,3]: drop expert 0 (0.1) -> keep 1,2,3
+        # group 1 [4,5,6,7]: drop expert 5 (0.2) -> keep 4,6,7
+        assert retained == [1, 2, 3, 4, 6, 7]
+
+    def test_compute_retained_too_many_raises(self):
+        saliency = torch.arange(4, dtype=torch.float64)
+        with pytest.raises(ValueError, match="Cannot drop"):
+            compute_retained_experts(saliency, n_experts_to_drop=4, n_group=1)
+
+    def test_routing_feasible_ok(self):
+        # non-group: 8 experts, drop 4 -> 4 remain, top_k=2 fits
+        assert_routing_feasible(
+            num_experts=8, n_experts_to_drop=4, n_group=1, topk_group=1, top_k=2
+        )
+        # group: 16 experts, 4 groups, topk_group=4 -> 2/group*4 = 8 reachable
+        assert_routing_feasible(
+            num_experts=16, n_experts_to_drop=8, n_group=4, topk_group=4, top_k=8
+        )
+
+    def test_routing_feasible_too_aggressive_raises(self):
+        # group: 16 experts, 4 groups, only topk_group=1 group reachable, 2/group
+        # remain -> only 2 reachable, but top_k=3 requested
+        with pytest.raises(ValueError, match="too aggressive"):
+            assert_routing_feasible(
+                num_experts=16, n_experts_to_drop=8, n_group=4, topk_group=1, top_k=3
+            )
+
+    def test_routing_feasible_non_group_too_aggressive_raises(self):
+        # 8 experts, drop 7 -> 1 remains, top_k=2 cannot be satisfied
+        with pytest.raises(ValueError, match="too aggressive"):
+            assert_routing_feasible(
+                num_experts=8, n_experts_to_drop=7, n_group=1, topk_group=1, top_k=2
+            )
+
     def test_prune_moe_layer(self):
         model = FakeMoEModel(num_experts=8)
         attrs = detect_moe_attrs(model)
         layers = find_moe_layers(model, attrs)
-        layer_name = list(layers.keys())[0]
+        layer_name = next(iter(layers.keys()))
         moe_block = model.get_submodule(layer_name)
         original_experts = list(moe_block.experts)
         original_gate = moe_block.gate.weight.detach().clone()
 
-        saliency = torch.tensor(
-            [0.1, 0.5, 0.8, 0.3, 0.7, 0.2, 0.9, 0.4], dtype=torch.float64
-        )
-        retained = prune_moe_layer(model, layer_name, saliency, 3, attrs)
+        retained = [1, 2, 4, 6, 7]
+        result = prune_moe_layer(model, layer_name, retained, attrs)
 
-        assert retained == [1, 2, 4, 6, 7]
+        assert result == retained
         assert len(moe_block.experts) == 5
         assert moe_block.gate.weight.shape[0] == 5
         assert moe_block.gate.out_features == 5
+        assert moe_block.num_experts == 5
         assert all(
             expert is original_experts[original_idx]
-            for expert, original_idx in zip(moe_block.experts, retained)
+            for expert, original_idx in zip(moe_block.experts, retained, strict=True)
         )
         torch.testing.assert_close(moe_block.gate.weight, original_gate[retained])
 
-    def test_prune_too_many_raises(self):
-        model = FakeMoEModel(num_experts=4)
-        attrs = detect_moe_attrs(model)
-        layers = find_moe_layers(model, attrs)
-        layer_name = list(layers.keys())[0]
+    def test_prune_resizes_correction_bias(self):
+        # group-limited routers carry a per-expert score-correction bias buffer
+        class GroupRouter(nn.Module):
+            def __init__(self, num_experts, hidden):
+                super().__init__()
+                self.weight = nn.Parameter(torch.randn(num_experts, hidden))
+                self.register_buffer(
+                    "e_score_correction_bias", torch.arange(num_experts).float()
+                )
+                self.n_group = 2
 
-        saliency = torch.arange(4, dtype=torch.float64)
-        with pytest.raises(ValueError, match="Cannot drop"):
-            prune_moe_layer(model, layer_name, saliency, 4, attrs)
+        class GroupMoE(nn.Module):
+            def __init__(self, num_experts, hidden):
+                super().__init__()
+                self.gate = GroupRouter(num_experts, hidden)
+                self.experts = nn.ModuleList(
+                    [nn.Linear(hidden, hidden) for _ in range(num_experts)]
+                )
+                self.n_routed_experts = num_experts
+
+        model = nn.Module()
+        model.block = GroupMoE(8, 16)
+        attrs = MoEModelAttrs("gate", "experts", "n_routed_experts", INDICES_WEIGHTS)
+
+        retained = [1, 2, 3, 5, 6, 7]
+        prune_moe_layer(model, "block", retained, attrs)
+
+        block = model.block
+        assert block.gate.weight.shape[0] == 6
+        assert block.gate.e_score_correction_bias.shape[0] == 6
+        torch.testing.assert_close(
+            block.gate.e_score_correction_bias,
+            torch.tensor(retained, dtype=torch.float32),
+        )
+        assert block.n_routed_experts == 6
 
 
 # ---------------------------------------------------------------------------
@@ -250,9 +433,66 @@ def test_reap_validation():
         REAPPruningModifier(sparsity=-0.1)
 
 
+def _make_state(model):
+    return State(
+        model=model,
+        teacher_model=None,
+        optimizer=None,
+        optim_wrapped=False,
+        loss=None,
+        batch_data=None,
+    )
+
+
+@pytest.mark.unit
+def test_reap_sequential_epoch_end_finalizes_decision():
+    """Decisions are finalized (and buffers freed) at SEQUENTIAL_EPOCH_END."""
+    torch.manual_seed(0)
+    hidden_dim = 16
+    model = FakeMoEModel(hidden_dim=hidden_dim, num_experts=8, top_k=2)
+    model.eval()
+
+    modifier = REAPPruningModifier(sparsity=0.5)
+    state = _make_state(model)
+    modifier.initialize(state)
+
+    modifier.update_event(state, Event(type_=EventType.CALIBRATION_EPOCH_START))
+    assert modifier.started_
+    assert len(modifier._saliency_trackers) == 2
+
+    with torch.no_grad():
+        for _ in range(3):
+            model(torch.randn(2, 8, hidden_dim))
+
+    # before the epoch end, nothing is decided yet
+    assert modifier._prune_decisions == {}
+
+    modifier.update_event(state, Event(type_=EventType.SEQUENTIAL_EPOCH_END))
+
+    # both layers' decisions are finalized and their trackers/buffers freed
+    assert len(modifier._prune_decisions) == 2
+    assert all(len(r) == 4 for r in modifier._prune_decisions.values())
+    assert modifier._saliency_trackers == {}
+    assert modifier._norm_buffers == {}
+
+    decisions_after_epoch = {k: list(v) for k, v in modifier._prune_decisions.items()}
+
+    # the sequential pipeline re-runs a finalized subgraph (propagate_error)
+    # with hooks still registered; this must not crash or change decisions
+    with torch.no_grad():
+        model(torch.randn(2, 8, hidden_dim))
+    assert modifier._saliency_trackers == {}
+    assert modifier._prune_decisions == decisions_after_epoch
+
+    modifier.finalize(state)
+    assert model.config.num_experts == 4
+
+
 @pytest.mark.unit
 def test_reap_full_lifecycle():
-    """End-to-end test: initialize, calibrate, finalize, verify pruning."""
+    """End-to-end test: initialize, calibrate, finalize, verify pruning.
+
+    Uses no SEQUENTIAL_EPOCH_END, exercising the on_end fallback path."""
     torch.manual_seed(42)
 
     hidden_dim = 16
@@ -262,42 +502,26 @@ def test_reap_full_lifecycle():
     model.eval()
 
     modifier = REAPPruningModifier(sparsity=0.5)
+    state = _make_state(model)
 
-    # Create a minimal State
-    state = State(
-        model=model,
-        teacher_model=None,
-        optimizer=None,
-        optim_wrapped=False,
-        loss=None,
-        batch_data=None,
-    )
-
-    # Initialize
     modifier.initialize(state)
     assert modifier.initialized_
     assert modifier._n_experts_to_drop == 4
 
-    # Simulate calibration: manually trigger start, run data, trigger end
-    start_event = Event(type_=EventType.CALIBRATION_EPOCH_START)
-    modifier.update_event(state, start_event)
+    modifier.update_event(state, Event(type_=EventType.CALIBRATION_EPOCH_START))
     assert modifier.started_
 
-    # Run calibration data (forward passes through model trigger hooks)
     with torch.no_grad():
         for _ in range(5):
             x = torch.randn(2, 8, hidden_dim)
             model(x)
 
-    end_event = Event(type_=EventType.CALIBRATION_EPOCH_END)
-    modifier.update_event(state, end_event)
+    modifier.update_event(state, Event(type_=EventType.CALIBRATION_EPOCH_END))
     assert modifier.ended_
 
-    # Verify saliency was accumulated
-    for tracker in modifier._saliency_trackers.values():
-        assert tracker.count.sum().item() > 0
+    # decisions finalized via the on_end fallback
+    assert len(modifier._prune_decisions) == 2
 
-    # Finalize (triggers pruning)
     modifier.finalize(state)
     assert modifier.finalized_
 

--- a/tests/llmcompressor/modifiers/pruning/reap/test_base.py
+++ b/tests/llmcompressor/modifiers/pruning/reap/test_base.py
@@ -1,0 +1,364 @@
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from llmcompressor.core import Event, EventType, State
+from llmcompressor.modifiers.factory import ModifierFactory
+from llmcompressor.modifiers.pruning.reap import REAPPruningModifier
+from llmcompressor.modifiers.pruning.reap.utils import (
+    MoEModelAttrs,
+    REAPSaliencyTracker,
+    detect_moe_attrs,
+    find_moe_layers,
+    get_num_experts,
+    prune_moe_layer,
+    update_model_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers: tiny synthetic MoE model for testing
+# ---------------------------------------------------------------------------
+
+
+class FakeExpert(nn.Module):
+    """A simple feedforward expert."""
+
+    def __init__(self, hidden_dim: int, intermediate_dim: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_dim, intermediate_dim, bias=False)
+        self.up_proj = nn.Linear(hidden_dim, intermediate_dim, bias=False)
+        self.down_proj = nn.Linear(intermediate_dim, hidden_dim, bias=False)
+
+    def forward(self, x):
+        return self.down_proj(F.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class FakeMoEBlock(nn.Module):
+    """A minimal MoE block with a gate router and expert ModuleList."""
+
+    calibrate_all_experts = True
+
+    def __init__(self, hidden_dim: int, num_experts: int, top_k: int):
+        super().__init__()
+        self.gate = nn.Linear(hidden_dim, num_experts, bias=False)
+        self.experts = nn.ModuleList(
+            [FakeExpert(hidden_dim, hidden_dim * 2) for _ in range(num_experts)]
+        )
+        self.num_experts = num_experts
+        self.top_k = top_k
+
+    def forward(self, hidden_states):
+        batch_size, seq_len, hidden_dim = hidden_states.shape
+        flat = hidden_states.view(-1, hidden_dim)
+
+        router_logits = self.gate(flat)
+        routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float32)
+        topk_weights, topk_indices = torch.topk(routing_weights, self.top_k, dim=-1)
+
+        final = torch.zeros_like(flat)
+        expert_mask = F.one_hot(topk_indices, self.num_experts).permute(2, 1, 0)
+
+        for expert_idx, expert in enumerate(self.experts):
+            idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
+            out = expert(flat)
+            if len(top_x) > 0:
+                weighted = out[top_x] * topk_weights[top_x, idx, None]
+                final.index_add_(0, top_x, weighted.to(flat.dtype))
+
+        return final.view(batch_size, seq_len, hidden_dim), router_logits
+
+
+class FakeDecoderLayer(nn.Module):
+    def __init__(self, hidden_dim, num_experts, top_k):
+        super().__init__()
+        self.mlp = FakeMoEBlock(hidden_dim, num_experts, top_k)
+
+    def forward(self, x):
+        out, _ = self.mlp(x)
+        return x + out
+
+
+class FakeConfig:
+    def __init__(self, num_experts, top_k):
+        self.num_experts = num_experts
+        self.num_experts_per_tok = top_k
+
+
+class FakeMoEModel(nn.Module):
+    """A tiny 2-layer MoE model for testing."""
+
+    def __init__(
+        self,
+        hidden_dim: int = 32,
+        num_experts: int = 8,
+        top_k: int = 2,
+        num_layers: int = 2,
+    ):
+        super().__init__()
+        self.config = FakeConfig(num_experts, top_k)
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList(
+            [
+                FakeDecoderLayer(hidden_dim, num_experts, top_k)
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(self, x):
+        for layer in self.model.layers:
+            x = layer(x)
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Tests: REAPSaliencyTracker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestREAPSaliencyTracker:
+    def test_initial_state(self):
+        tracker = REAPSaliencyTracker(num_experts=4)
+        assert tracker.sum_saliency.shape == (4,)
+        assert tracker.count.shape == (4,)
+        assert (tracker.sum_saliency == 0).all()
+        assert (tracker.count == 0).all()
+
+    def test_update_single_expert(self):
+        tracker = REAPSaliencyTracker(num_experts=4)
+        gate_vals = torch.tensor([0.5, 0.3])
+        norms = torch.tensor([2.0, 4.0])
+
+        tracker.update(1, gate_vals, norms)
+
+        expected = 0.5 * 2.0 + 0.3 * 4.0
+        assert tracker.sum_saliency[1].item() == pytest.approx(expected)
+        assert tracker.count[1].item() == 2
+        assert tracker.count[0].item() == 0
+
+    def test_mean_saliency(self):
+        tracker = REAPSaliencyTracker(num_experts=3)
+
+        tracker.update(0, torch.tensor([0.6]), torch.tensor([3.0]))
+        tracker.update(0, torch.tensor([0.4]), torch.tensor([1.0]))
+        tracker.update(1, torch.tensor([0.5, 0.5]), torch.tensor([2.0, 2.0]))
+
+        mean = tracker.mean_saliency
+        # Expert 0: (0.6*3.0 + 0.4*1.0) / 2 = 2.2 / 2 = 1.1
+        assert mean[0].item() == pytest.approx(1.1)
+        # Expert 1: (0.5*2.0 + 0.5*2.0) / 2 = 2.0 / 2 = 1.0
+        assert mean[1].item() == pytest.approx(1.0)
+        # Expert 2: never routed -> 0
+        assert mean[2].item() == pytest.approx(0.0)
+
+    def test_zero_count_no_nan(self):
+        tracker = REAPSaliencyTracker(num_experts=2)
+        mean = tracker.mean_saliency
+        assert not torch.isnan(mean).any()
+        assert (mean == 0).all()
+
+
+# ---------------------------------------------------------------------------
+# Tests: MoE detection and pruning utilities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMoEDetection:
+    def test_detect_moe_attrs(self):
+        model = FakeMoEModel()
+        attrs = detect_moe_attrs(model)
+        # FakeMoEBlock is not in the registry, but auto-detection should
+        # find it via the "gate" + "experts" heuristic
+        assert attrs is not None
+        assert attrs.router_attr == "gate"
+        assert attrs.experts_attr == "experts"
+
+    def test_find_moe_layers(self):
+        model = FakeMoEModel(num_layers=3)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        assert len(layers) == 3
+
+    def test_find_moe_layers_with_ignore(self):
+        model = FakeMoEModel(num_layers=3)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs, ignore=["layers.1"])
+        assert len(layers) == 2
+        assert all("layers.1" not in name for name in layers)
+
+    def test_get_num_experts(self):
+        model = FakeMoEModel(num_experts=8)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        for module in layers.values():
+            assert get_num_experts(module, attrs) == 8
+
+
+@pytest.mark.unit
+class TestPruning:
+    def test_prune_moe_layer(self):
+        model = FakeMoEModel(num_experts=8)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        layer_name = list(layers.keys())[0]
+
+        # Give expert 0 the lowest saliency
+        saliency = torch.tensor(
+            [0.1, 0.5, 0.8, 0.3, 0.7, 0.2, 0.9, 0.4], dtype=torch.float64
+        )
+        retained = prune_moe_layer(model, layer_name, saliency, 3, attrs)
+
+        # Should drop experts 0, 3, 5 (indices with lowest saliency)
+        # Actually: sorted saliency: 0(0.1), 5(0.2), 3(0.3), 7(0.4), 1(0.5), ...
+        # Drop 3 lowest: experts 0, 5, 3
+        assert len(retained) == 5
+
+        # Verify the module was updated
+        moe_block = model.get_submodule(layer_name)
+        assert len(moe_block.experts) == 5
+        assert moe_block.gate.weight.shape[0] == 5
+
+    def test_prune_router_out_features(self):
+        model = FakeMoEModel(num_experts=6)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        layer_name = list(layers.keys())[0]
+
+        saliency = torch.arange(6, dtype=torch.float64)
+        prune_moe_layer(model, layer_name, saliency, 2, attrs)
+
+        moe_block = model.get_submodule(layer_name)
+        assert moe_block.gate.out_features == 4
+
+    def test_prune_too_many_raises(self):
+        model = FakeMoEModel(num_experts=4)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+        layer_name = list(layers.keys())[0]
+
+        saliency = torch.arange(4, dtype=torch.float64)
+        with pytest.raises(ValueError, match="Cannot drop"):
+            prune_moe_layer(model, layer_name, saliency, 4, attrs)
+
+    def test_update_model_config(self):
+        model = FakeMoEModel(num_experts=8)
+        attrs = MoEModelAttrs("gate", "experts", "num_experts")
+        update_model_config(model, attrs, 4)
+        assert model.config.num_experts == 4
+
+    def test_model_still_runs_after_pruning(self):
+        """Verify the model produces output after experts are pruned."""
+        model = FakeMoEModel(hidden_dim=16, num_experts=8, top_k=2)
+        attrs = detect_moe_attrs(model)
+        layers = find_moe_layers(model, attrs)
+
+        # Prune all layers
+        saliency = torch.arange(8, dtype=torch.float64)
+        for layer_name in layers:
+            prune_moe_layer(model, layer_name, saliency, 4, attrs)
+
+        update_model_config(model, attrs, 4)
+
+        # Model should still produce valid output
+        x = torch.randn(2, 4, 16)
+        out = model(x)
+        assert out.shape == (2, 4, 16)
+        assert not torch.isnan(out).any()
+
+
+# ---------------------------------------------------------------------------
+# Tests: REAPPruningModifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.usefixtures("setup_modifier_factory")
+def test_reap_is_registered():
+    modifier = ModifierFactory.create(
+        type_="REAPPruningModifier",
+        allow_experimental=False,
+        allow_registered=True,
+        compression_ratio=0.5,
+    )
+    assert isinstance(modifier, REAPPruningModifier)
+
+
+@pytest.mark.unit
+def test_reap_validation():
+    with pytest.raises(ValueError, match="compression_ratio"):
+        REAPPruningModifier(compression_ratio=0.0)
+
+    with pytest.raises(ValueError, match="compression_ratio"):
+        REAPPruningModifier(compression_ratio=1.0)
+
+    with pytest.raises(ValueError, match="compression_ratio"):
+        REAPPruningModifier(compression_ratio=-0.1)
+
+
+@pytest.mark.unit
+def test_reap_full_lifecycle():
+    """End-to-end test: initialize, calibrate, finalize, verify pruning."""
+    torch.manual_seed(42)
+
+    hidden_dim = 16
+    num_experts = 8
+    top_k = 2
+    model = FakeMoEModel(hidden_dim=hidden_dim, num_experts=num_experts, top_k=top_k)
+    model.eval()
+
+    modifier = REAPPruningModifier(compression_ratio=0.5)
+
+    # Create a minimal State
+    state = State(
+        model=model,
+        teacher_model=None,
+        optimizer=None,
+        optim_wrapped=False,
+        loss=None,
+        batch_data=None,
+    )
+
+    # Initialize
+    modifier.initialize(state)
+    assert modifier.initialized_
+    assert modifier._n_experts_to_drop == 4
+
+    # Simulate calibration: manually trigger start, run data, trigger end
+    start_event = Event(type_=EventType.CALIBRATION_EPOCH_START)
+    modifier.update_event(state, start_event)
+    assert modifier.started_
+
+    # Run calibration data (forward passes through model trigger hooks)
+    with torch.no_grad():
+        for _ in range(5):
+            x = torch.randn(2, 8, hidden_dim)
+            model(x)
+
+    end_event = Event(type_=EventType.CALIBRATION_EPOCH_END)
+    modifier.update_event(state, end_event)
+    assert modifier.ended_
+
+    # Verify saliency was accumulated
+    for tracker in modifier._saliency_trackers.values():
+        assert tracker.count.sum().item() > 0
+
+    # Finalize (triggers pruning)
+    modifier.finalize(state)
+    assert modifier.finalized_
+
+    # Verify pruning results
+    assert model.config.num_experts == 4
+
+    for layer in model.model.layers:
+        assert len(layer.mlp.experts) == 4
+        assert layer.mlp.gate.weight.shape[0] == 4
+        assert layer.mlp.gate.out_features == 4
+
+    # Verify model still runs
+    with torch.no_grad():
+        x = torch.randn(2, 4, hidden_dim)
+        out = model(x)
+        assert out.shape == (2, 4, hidden_dim)
+        assert not torch.isnan(out).any()

--- a/tests/llmcompressor/modifiers/pruning/reap/test_base.py
+++ b/tests/llmcompressor/modifiers/pruning/reap/test_base.py
@@ -7,13 +7,11 @@ from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers.factory import ModifierFactory
 from llmcompressor.modifiers.pruning.reap import REAPPruningModifier
 from llmcompressor.modifiers.pruning.reap.utils import (
-    MoEModelAttrs,
     REAPSaliencyTracker,
     detect_moe_attrs,
     find_moe_layers,
     get_num_experts,
     prune_moe_layer,
-    update_model_config,
 )
 
 # ---------------------------------------------------------------------------
@@ -118,13 +116,6 @@ class FakeMoEModel(nn.Module):
 
 @pytest.mark.unit
 class TestREAPSaliencyTracker:
-    def test_initial_state(self):
-        tracker = REAPSaliencyTracker(num_experts=4)
-        assert tracker.sum_saliency.shape == (4,)
-        assert tracker.count.shape == (4,)
-        assert (tracker.sum_saliency == 0).all()
-        assert (tracker.count == 0).all()
-
     def test_update_single_expert(self):
         tracker = REAPSaliencyTracker(num_experts=4)
         gate_vals = torch.tensor([0.5, 0.3])
@@ -151,12 +142,6 @@ class TestREAPSaliencyTracker:
         assert mean[1].item() == pytest.approx(1.0)
         # Expert 2: never routed -> 0
         assert mean[2].item() == pytest.approx(0.0)
-
-    def test_zero_count_no_nan(self):
-        tracker = REAPSaliencyTracker(num_experts=2)
-        mean = tracker.mean_saliency
-        assert not torch.isnan(mean).any()
-        assert (mean == 0).all()
 
 
 # ---------------------------------------------------------------------------
@@ -203,34 +188,24 @@ class TestPruning:
         attrs = detect_moe_attrs(model)
         layers = find_moe_layers(model, attrs)
         layer_name = list(layers.keys())[0]
+        moe_block = model.get_submodule(layer_name)
+        original_experts = list(moe_block.experts)
+        original_gate = moe_block.gate.weight.detach().clone()
 
-        # Give expert 0 the lowest saliency
         saliency = torch.tensor(
             [0.1, 0.5, 0.8, 0.3, 0.7, 0.2, 0.9, 0.4], dtype=torch.float64
         )
         retained = prune_moe_layer(model, layer_name, saliency, 3, attrs)
 
-        # Should drop experts 0, 3, 5 (indices with lowest saliency)
-        # Actually: sorted saliency: 0(0.1), 5(0.2), 3(0.3), 7(0.4), 1(0.5), ...
-        # Drop 3 lowest: experts 0, 5, 3
-        assert len(retained) == 5
-
-        # Verify the module was updated
-        moe_block = model.get_submodule(layer_name)
+        assert retained == [1, 2, 4, 6, 7]
         assert len(moe_block.experts) == 5
         assert moe_block.gate.weight.shape[0] == 5
-
-    def test_prune_router_out_features(self):
-        model = FakeMoEModel(num_experts=6)
-        attrs = detect_moe_attrs(model)
-        layers = find_moe_layers(model, attrs)
-        layer_name = list(layers.keys())[0]
-
-        saliency = torch.arange(6, dtype=torch.float64)
-        prune_moe_layer(model, layer_name, saliency, 2, attrs)
-
-        moe_block = model.get_submodule(layer_name)
-        assert moe_block.gate.out_features == 4
+        assert moe_block.gate.out_features == 5
+        assert all(
+            expert is original_experts[original_idx]
+            for expert, original_idx in zip(moe_block.experts, retained)
+        )
+        torch.testing.assert_close(moe_block.gate.weight, original_gate[retained])
 
     def test_prune_too_many_raises(self):
         model = FakeMoEModel(num_experts=4)
@@ -241,31 +216,6 @@ class TestPruning:
         saliency = torch.arange(4, dtype=torch.float64)
         with pytest.raises(ValueError, match="Cannot drop"):
             prune_moe_layer(model, layer_name, saliency, 4, attrs)
-
-    def test_update_model_config(self):
-        model = FakeMoEModel(num_experts=8)
-        attrs = MoEModelAttrs("gate", "experts", "num_experts")
-        update_model_config(model, attrs, 4)
-        assert model.config.num_experts == 4
-
-    def test_model_still_runs_after_pruning(self):
-        """Verify the model produces output after experts are pruned."""
-        model = FakeMoEModel(hidden_dim=16, num_experts=8, top_k=2)
-        attrs = detect_moe_attrs(model)
-        layers = find_moe_layers(model, attrs)
-
-        # Prune all layers
-        saliency = torch.arange(8, dtype=torch.float64)
-        for layer_name in layers:
-            prune_moe_layer(model, layer_name, saliency, 4, attrs)
-
-        update_model_config(model, attrs, 4)
-
-        # Model should still produce valid output
-        x = torch.randn(2, 4, 16)
-        out = model(x)
-        assert out.shape == (2, 4, 16)
-        assert not torch.isnan(out).any()
 
 
 # ---------------------------------------------------------------------------
@@ -280,21 +230,24 @@ def test_reap_is_registered():
         type_="REAPPruningModifier",
         allow_experimental=False,
         allow_registered=True,
-        compression_ratio=0.5,
+        sparsity=0.5,
     )
     assert isinstance(modifier, REAPPruningModifier)
 
 
 @pytest.mark.unit
 def test_reap_validation():
-    with pytest.raises(ValueError, match="compression_ratio"):
-        REAPPruningModifier(compression_ratio=0.0)
+    with pytest.raises(ValueError, match="sparsity"):
+        REAPPruningModifier()
 
-    with pytest.raises(ValueError, match="compression_ratio"):
-        REAPPruningModifier(compression_ratio=1.0)
+    with pytest.raises(ValueError, match="sparsity"):
+        REAPPruningModifier(sparsity=0.0)
 
-    with pytest.raises(ValueError, match="compression_ratio"):
-        REAPPruningModifier(compression_ratio=-0.1)
+    with pytest.raises(ValueError, match="sparsity"):
+        REAPPruningModifier(sparsity=1.0)
+
+    with pytest.raises(ValueError, match="sparsity"):
+        REAPPruningModifier(sparsity=-0.1)
 
 
 @pytest.mark.unit
@@ -308,7 +261,7 @@ def test_reap_full_lifecycle():
     model = FakeMoEModel(hidden_dim=hidden_dim, num_experts=num_experts, top_k=top_k)
     model.eval()
 
-    modifier = REAPPruningModifier(compression_ratio=0.5)
+    modifier = REAPPruningModifier(sparsity=0.5)
 
     # Create a minimal State
     state = State(


### PR DESCRIPTION
This PR addresses @HDCharles comments from https://github.com/vllm-project/llm-compressor/pull/2703 but I am opening a new branch because of forced push made a lot of mess in the original PR: https://github.com/vllm-project/llm-compressor/pull/2703

@Ryfernandes I will close that branch, and please feel free to take over upgrade to transformers v5 from this branch.

New changes (relative to the old PR):
- Lifecycle: collect saliency during sequential calibration, finalize the
  drop decision per layer at SEQUENTIAL_EPOCH_END (and free that layer's
  activations then), apply the structural prune at on_finalize. Works for both
  "permanent" and "restored" MoE calibration wrappers and survives the pipeline's
  error-propagation second pass.
- Correct routing per architecture: read the router's actual output instead of
  assuming softmax. Modes: softmax (Qwen3 family), tuple indices/weights
  (DeepSeek-V3, GLM4), group-limited sigmoid (GLM-MoE-DSA / GLM4-MoE-Lite),
  scores+logits (Llama4), scores+experts (AfMoE).
- Group-limited routers (DeepSeek/GLM): prune equally per group so routing stays
  valid, resize e_score_correction_bias, update n_routed_experts on router+config.
- Fail fast if the requested sparsity leaves fewer experts than top_k.
- Offload-safe pruning; vectorized, on-device saliency (no per-step CPU syncs).
- Reject unsupported archs with a clear error: Mixtral (no calibration wrapper),
  Gemma4 (router lives outside the experts block).

Tested: GSM8k, 5-shot, vLLM; calib = 512 OpenPlatypus samples, seq 2048.
```
  Model                         Config        flexible   strict
  ----------------------------  ------------  --------   ------
  Qwen3-30B-A3B (softmax,128e)  baseline       0.8802    0.8741
                                REAP 25% ->96  0.8999    0.8923
                                REAP 50% ->64  0.8711    0.8643
  Moonlight-16B-A3B (DeepSeek   baseline       0.7627    0.7566
  -V3 arch, sigmoid, 64e)       REAP 25% ->48  0.6869    0.6831
                                REAP 50% ->32  0.2449    0.2426
```

- Qwen3-30B matches the originally reported numbers at both sparsities -> no
  regression in the softmax path; full lifecycle works end-to-end on a real 30B.
- Moonlight validates the new sigmoid/top-k path (incl. correction-bias resize).
  Smooth monotonic degradation (0.76 -> 0.69 @25% -> 0.24 @50%) = correctly
  working pruner; the steep 50% drop is genuine sparsity-sensitivity of a small
  MoE (few experts, little redundancy), not a bug.
- Practical range: ~25% sparsity is comfortable across families; 50% is fine on
  large expert-rich MoEs (Qwen3) but too aggressive for small ones (Moonlight).