### PR TITLE
fix(oneshot): widen recipe type hint to accept Modifier and Recipe objects

### DIFF
--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -33,6 +33,8 @@ __all__ = ["Oneshot", "oneshot"]
 if TYPE_CHECKING:
     from datasets import Dataset, DatasetDict
 
+    from llmcompressor.recipe import RecipeInput
+
 
 TOKENIZERS_PARALLELISM_ENV = "TOKENIZERS_PARALLELISM"
 
@@ -270,7 +272,7 @@ def oneshot(
     save_compressed: bool = True,
     model_revision: str = "main",
     # Recipe arguments
-    recipe: str | list[str] | None = None,
+    recipe: RecipeInput | None = None,
     recipe_args: list[str] | None = None,
     clear_sparse_session: bool = False,
     stage: str | None = None,
@@ -341,8 +343,9 @@ def oneshot(
         tag, or commit id).
 
     # Recipe arguments
-    :param recipe: Path to a LLM Compressor recipe, or a list of paths
-      to multiple LLM Compressor recipes.
+    :param recipe: A LLM Compressor recipe specifying the modifiers to
+      apply. Accepts a path (or list of paths) to recipe file(s), a
+      ``Modifier`` instance (or list of them), or a ``Recipe`` object.
     :param recipe_args: List of recipe arguments to evaluate, in the
         format "key1=value1", "key2=value2".
     :param clear_sparse_session: Whether to clear CompressionSession/


### PR DESCRIPTION
## Summary

`oneshot()`'s `recipe` parameter was annotated `str | list[str] | None`, but `Recipe.create_instance()` — and the existing `RecipeInput` alias in `llmcompressor/recipe/recipe.py` — also accept `Modifier` / `list[Modifier]` / `Recipe` instances, all of which work at runtime. Passing a modifier directly (e.g. `GPTQModifier`) therefore raised a false type error in Pylance/Pyright:

```
Argument of type "GPTQModifier" cannot be assigned to parameter "recipe" of type "str | list[str] | None"
```

This reuses the already-exported `RecipeInput` alias so the public signature matches what the function actually accepts.

## Why not widen `RecipeArguments.recipe`

The issue also suggested widening `RecipeArguments`. I left it as `str | None` on purpose: `RecipeArguments` is introspected by `HfArgumentParser` in `args/utils.py:parse_args` to build the CLI argument parser, which only supports `Optional[<primitive>]` field types. Annotating that field with the full `RecipeInput` union would break parser construction for every `oneshot()`/`train()` call. The `Modifier` object still flows through correctly at runtime because `parse_dict` assigns values without type coercion — only the public-facing `oneshot()` annotation needed fixing, which is where users hit the type error.

## Changes

- Import `RecipeInput` under `TYPE_CHECKING` (the module already uses `from __future__ import annotations`).
- Annotate `oneshot(recipe=...)` as `RecipeInput | None`.
- Clarify the `recipe` docstring to list the accepted input types.

Fixes #2837

🤖 Generated with [Claude Code](https://claude.com/claude-code)
