### PR TITLE
fix: widen oneshot() recipe type hint to accept Modifier and Recipe objects

### DIFF
--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -33,6 +33,8 @@ __all__ = ["Oneshot", "oneshot"]
 if TYPE_CHECKING:
     from datasets import Dataset, DatasetDict
 
+    from llmcompressor.recipe import RecipeInput
+
 
 TOKENIZERS_PARALLELISM_ENV = "TOKENIZERS_PARALLELISM"
 
@@ -272,7 +274,7 @@ def oneshot(
     save_compressed: bool = True,
     model_revision: str = "main",
     # Recipe arguments
-    recipe: str | list[str] | None = None,
+    recipe: RecipeInput | None = None,
     recipe_args: list[str] | None = None,
     clear_sparse_session: bool = False,
     stage: str | None = None,
@@ -344,8 +346,8 @@ def oneshot(
         tag, or commit id).
 
     # Recipe arguments
-    :param recipe: Path to a LLM Compressor recipe, or a list of paths
-      to multiple LLM Compressor recipes.
+    :param recipe: A LLM Compressor recipe. Accepts a path (or list of paths)
+      to recipe YAML file(s), a Modifier instance (or list), or a Recipe object.
     :param recipe_args: List of recipe arguments to evaluate, in the
         format "key1=value1", "key2=value2".
     :param clear_sparse_session: Whether to clear CompressionSession/

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -346,8 +346,9 @@ def oneshot(
         tag, or commit id).
 
     # Recipe arguments
-    :param recipe: A LLM Compressor recipe. Accepts a path (or list of paths)
-        to recipe YAML file(s), a Modifier instance (or list), or a Recipe object (or list).
+    :param recipe: A LLM Compressor recipe. Accepts a path (or list
+        of paths) to recipe YAML file(s), a Modifier instance (or
+        list), or a Recipe object (or list).
     :param recipe_args: List of recipe arguments to evaluate, in the
         format "key1=value1", "key2=value2".
     :param clear_sparse_session: Whether to clear CompressionSession/

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -347,7 +347,7 @@ def oneshot(
 
     # Recipe arguments
     :param recipe: A LLM Compressor recipe. Accepts a path (or list of paths)
-      to recipe YAML file(s), a Modifier instance (or list), or a Recipe object.
+        to recipe YAML file(s), a Modifier instance (or list), or a Recipe object (or list).
     :param recipe_args: List of recipe arguments to evaluate, in the
         format "key1=value1", "key2=value2".
     :param clear_sparse_session: Whether to clear CompressionSession/


### PR DESCRIPTION
## Summary
- Widen the `recipe` parameter type on `oneshot()` from `str | list[str] | None` to `RecipeInput | None`
- Update docstring to reflect accepted input types

`RecipeArguments.recipe` is left as `str | None` since `HfArgumentParser` needs primitive types.

Fixes #2837