### PR TITLE
Bump tested transformers upper bound to 5.12.1 (unblocks newer model types, e.g. diffusion_gemma)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         ("tqdm>=4.66.3,<=4.68.2" if BUILD_TYPE == "release" else "tqdm>=4.66.3"),
         ("torch>=2.10.0,<=2.12.0" if BUILD_TYPE == "release" else "torch>=2.10.0"),
         (
-            "transformers>=5.9.0,<=5.10.1"
+            "transformers>=5.9.0,<=5.12.1"
             if BUILD_TYPE == "release"
             else "transformers>=5.9.0"
         ),


### PR DESCRIPTION
## Summary

Bump the **release** upper bound on `transformers` from `<=5.10.1` to `<=5.12.1`.

The current release pin (`setup.py`) caps `transformers>=5.9.0,<=5.10.1`. That upper bound predates several recent HuggingFace model types — notably **`diffusion_gemma`** (DiffusionGemma), which lands in `transformers` 5.12 — so a released `llmcompressor` can't even *load* those models to calibrate them, failing with `Unrecognized configuration class ... DiffusionGemmaConfig` / `model type 'diffusion_gemma' not recognized`.

## Why it's safe

`llmcompressor` 0.12 works with `transformers` 5.12.1 in practice — this isn't a speculative bump:
- `import llmcompressor` and `from llmcompressor import oneshot` succeed under transformers 5.12.1.
- A full `oneshot` calibration of a Gemma-4 MoE (`google/gemma-4-26B-A4B-it`) with an **NVFP4 weight scheme + NVFP4 KV-cache scheme** completed cleanly and produced a servable checkpoint.

The change also just realigns this one pin with the rest of the file: the dev branch is already uncapped (`else "transformers>=5.9.0"`), and the other release pins here track current releases (e.g. `torch<=2.12.0`, `accelerate<=1.13.0`, `datasets<=5.0.0`). This is the same kind of routine "bump the tested ceiling" change.

## Change
```diff
-            "transformers>=5.9.0,<=5.10.1"
+            "transformers>=5.9.0,<=5.12.1"
```

If maintainers prefer a different ceiling (or dropping the upper bound entirely, as some ecosystems do), happy to adjust.
