### PR TITLE
Remove all device movement from pipelines

### DIFF
--- a/src/llmcompressor/pipelines/basic/pipeline.py
+++ b/src/llmcompressor/pipelines/basic/pipeline.py
@@ -3,7 +3,8 @@ from typing import TYPE_CHECKING, Union
 
 import torch
 import tqdm
-from compressed_tensors.offload import dispatch_model, get_execution_device
+from compressed_tensors.offload import get_execution_device
+from loguru import logger
 from torch.utils.data.dataloader import DataLoader
 
 from llmcompressor.core import LifecycleCallbacks, active_session
@@ -39,8 +40,12 @@ class BasicPipeline(CalibrationPipeline):
         :param dataset_args: dataset arguments relevant to pipelines
         """
         session = active_session()
-        dispatch_model(model)  # basic dispatch is identical to generation
         model_device = get_execution_device(model)
+        if model_device == torch.device("cpu"):
+            logger.warning(
+                "Attempting to calibrate on CPU. Consider loading your model with"
+                " `device_map='auto'`"
+            )
         use_loss_mask = (
             getattr(dataset_args, "use_loss_mask", False) if dataset_args else False
         )

--- a/src/llmcompressor/pipelines/data_free/pipeline.py
+++ b/src/llmcompressor/pipelines/data_free/pipeline.py
@@ -1,11 +1,12 @@
 from typing import TYPE_CHECKING, Optional
 
 import torch
-from compressed_tensors.offload import dispatch_model
+from compressed_tensors.offload import set_onload_device
 from torch.utils.data.dataloader import DataLoader
 
 from llmcompressor.core.session_functions import LifecycleCallbacks
 from llmcompressor.pipelines.registry import CalibrationPipeline
+from llmcompressor.utils.dev import get_main_device
 
 if TYPE_CHECKING:
     from llmcompressor.args.dataset_arguments import DatasetArguments
@@ -30,7 +31,8 @@ class DataFreePipeline(CalibrationPipeline):
         """
         # some ops are still performed on the model by modifiers
         # we want those ops to occur on the GPU
-        dispatch_model(model)
+        onload_device = get_main_device()
+        set_onload_device(model, onload_device)
 
         LifecycleCallbacks.calibration_start()
         LifecycleCallbacks.sequential_epoch_end(list(model.modules()))


### PR DESCRIPTION
## Background ##
As of the introduction of `load_offloaded_model` via https://github.com/vllm-project/llm-compressor/pull/2148 and https://github.com/vllm-project/llm-compressor/pull/2373, users are encouraged to load models as offloaded. This allows for distributed dispatches, disk offloading etc. This means that pipelines are no longer responsible for dispatching models. This makes sense, as pipelines never had the information necessary to make the dispatch decision (don't know memory requirements, incur excess device movement if the load dispatch doesn't match the pipeline dispatch).

## Purpose ##
* Avoid excess device movement and OOM errors by not having `datafree` and `basic` pipelines dispatch models