### PR TITLE
[MoE] Support more MoE model architectures

### DIFF
--- a/src/llmcompressor/modeling/moe/conversion_mappings.py
+++ b/src/llmcompressor/modeling/moe/conversion_mappings.py
@@ -10,9 +10,8 @@ from transformers.core_model_loading import (
     WeightRenaming,
     WeightTransform,
 )
-from transformers.models.deepseek_v4.modeling_deepseek_v4 import DeepseekV4Experts
-from transformers.models.qwen2_moe.modeling_qwen2_moe import Qwen2MoeExperts
-from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeExperts
+
+from .helpers import import_or_none
 
 __all__ = [
     "has_linearize_load_mappings",
@@ -20,11 +19,146 @@ __all__ = [
     "set_save_conversion_mapping",
 ]
 
-# TODO: in the future, we can potentially grep the source code for this
-ARCH_TO_EXPERTS_MODULE_CLS = {
-    "deepseek_v4": DeepseekV4Experts,
-    "qwen2_moe": Qwen2MoeExperts,
-    "qwen3_moe": Qwen3MoeExperts,
+ARCH_TO_IMPORT_PATHS: dict[str, tuple[str | list[str], str | list[str]]] = {
+    "afmoe": (
+        "transformers.models.afmoe.configuration_afmoe.AfmoeConfig",
+        "transformers.models.afmoe.modeling_afmoe.AfmoeExperts",
+    ),
+    "cohere2_moe": (
+        "transformers.models.cohere2_moe.configuration_cohere2_moe.Cohere2MoeConfig",
+        "transformers.models.cohere2_moe.modeling_cohere2_moe.Cohere2MoeExperts",
+    ),
+    "deepseek_ocr2": (
+        "transformers.models.deepseek_ocr2.configuration_deepseek_ocr2.DeepseekOcr2TextConfig",
+        "transformers.models.deepseek_ocr2.modeling_deepseek_ocr2.DeepseekOcr2TextExperts",
+    ),
+    "deepseek_v3": (
+        "transformers.models.deepseek_v3.configuration_deepseek_v3.DeepseekV3Config",
+        [
+            "transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3NaiveMoe",
+            "transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3Experts",
+        ],
+    ),
+    "deepseek_v4": (
+        "transformers.models.deepseek_v4.configuration_deepseek_v4.DeepseekV4Config",
+        "transformers.models.deepseek_v4.modeling_deepseek_v4.DeepseekV4Experts",
+    ),
+    "exaone_moe": (
+        "transformers.models.exaone_moe.configuration_exaone_moe.ExaoneMoeConfig",
+        "transformers.models.exaone_moe.modeling_exaone_moe.ExaoneMoeExperts",
+    ),
+    "flex_olmo": (
+        "transformers.models.flex_olmo.configuration_flex_olmo.FlexOlmoConfig",
+        "transformers.models.flex_olmo.modeling_flex_olmo.FlexOlmoExperts",
+    ),
+    "gemma4": (
+        "transformers.models.gemma4.configuration_gemma4.Gemma4TextConfig",
+        "transformers.models.gemma4.modeling_gemma4.Gemma4TextExperts",
+    ),
+    "glm4_moe": (
+        "transformers.models.glm4_moe.configuration_glm4_moe.Glm4MoeConfig",
+        [
+            "transformers.models.glm4_moe.modeling_glm4_moe.Glm4MoeNaiveMoe",
+            "transformers.models.glm4_moe.modeling_glm4_moe.Glm4MoeExperts",
+        ],
+    ),
+    "glm4_moe_lite": (
+        "transformers.models.glm4_moe_lite.configuration_glm4_moe_lite.Glm4MoeLiteConfig",
+        [
+            "transformers.models.glm4_moe_lite.modeling_glm4_moe_lite.Glm4MoeLiteNaiveMoe",
+            "transformers.models.glm4_moe_lite.modeling_glm4_moe_lite.Glm4MoeLiteExperts",
+        ],
+    ),
+    "glm_moe_dsa": (
+        "transformers.models.glm_moe_dsa.configuration_glm_moe_dsa.GlmMoeDsaConfig",
+        [
+            "transformers.models.glm_moe_dsa.modeling_glm_moe_dsa.GlmMoeDsaNaiveMoe",
+            "transformers.models.glm_moe_dsa.modeling_glm_moe_dsa.GlmMoeDsaExperts",
+        ],
+    ),
+    "gpt_oss": (
+        "transformers.models.gpt_oss.configuration_gpt_oss.GptOssConfig",
+        "transformers.models.gpt_oss.modeling_gpt_oss.GptOssExperts",
+    ),
+    "granitemoe": (
+        "transformers.models.granitemoe.configuration_granitemoe.GraniteMoeConfig",
+        [
+            "transformers.models.granitemoe.modeling_granitemoe.GraniteMoeParallelExperts",
+            "transformers.models.granitemoe.modeling_granitemoe.GraniteMoeExperts",
+        ],
+    ),
+    "hy_v3": (
+        "transformers.models.hy_v3.configuration_hy_v3.HYV3Config",
+        "transformers.models.hy_v3.modeling_hy_v3.HYV3Experts",
+    ),
+    "jamba": (
+        "transformers.models.jamba.configuration_jamba.JambaConfig",
+        "transformers.models.jamba.modeling_jamba.JambaExperts",
+    ),
+    "laguna": (
+        "transformers.models.laguna.configuration_laguna.LagunaConfig",
+        "transformers.models.laguna.modeling_laguna.LagunaExperts",
+    ),
+    "lfm2_moe": (
+        "transformers.models.lfm2_moe.configuration_lfm2_moe.Lfm2MoeConfig",
+        "transformers.models.lfm2_moe.modeling_lfm2_moe.Lfm2MoeExperts",
+    ),
+    "llama4": (
+        "transformers.models.llama4.configuration_llama4.Llama4TextConfig",
+        "transformers.models.llama4.modeling_llama4.Llama4TextExperts",
+    ),
+    "mellum": (
+        "transformers.models.mellum.configuration_mellum.MellumConfig",
+        "transformers.models.mellum.modeling_mellum.MellumExperts",
+    ),
+    "minimax": (
+        "transformers.models.minimax.configuration_minimax.MiniMaxConfig",
+        "transformers.models.minimax.modeling_minimax.MiniMaxExperts",
+    ),
+    "minimax_m2": (
+        "transformers.models.minimax_m2.configuration_minimax_m2.MiniMaxM2Config",
+        "transformers.models.minimax_m2.modeling_minimax_m2.MiniMaxM2Experts",
+    ),
+    "mixtral": (
+        "transformers.models.mixtral.configuration_mixtral.MixtralConfig",
+        "transformers.models.mixtral.modeling_mixtral.MixtralExperts",
+    ),
+    "nemotron_h": (
+        "transformers.models.nemotron_h.configuration_nemotron_h.NemotronHConfig",
+        "transformers.models.nemotron_h.modeling_nemotron_h.NemotronHExperts",
+    ),
+    "olmoe": (
+        "transformers.models.olmoe.configuration_olmoe.OlmoeConfig",
+        "transformers.models.olmoe.modeling_olmoe.OlmoeExperts",
+    ),
+    "openai_privacy_filter": (
+        "transformers.models.openai_privacy_filter.configuration_openai_privacy_filter.OpenAIPrivacyFilterConfig",
+        "transformers.models.openai_privacy_filter.modeling_openai_privacy_filter.OpenAIPrivacyFilterExperts",
+    ),
+    "phimoe": (
+        "transformers.models.phimoe.configuration_phimoe.PhimoeConfig",
+        "transformers.models.phimoe.modeling_phimoe.PhimoeExperts",
+    ),
+    "qwen2_moe": (
+        "transformers.models.qwen2_moe.configuration_qwen2_moe.Qwen2MoeConfig",
+        "transformers.models.qwen2_moe.modeling_qwen2_moe.Qwen2MoeExperts",
+    ),
+    "qwen3_5_moe": (
+        "transformers.models.qwen3_5_moe.configuration_qwen3_5_moe.Qwen3_5MoeTextConfig",
+        "transformers.models.qwen3_5_moe.modeling_qwen3_5_moe.Qwen3_5MoeExperts",
+    ),
+    "qwen3_moe": (
+        "transformers.models.qwen3_moe.configuration_qwen3_moe.Qwen3MoeConfig",
+        "transformers.models.qwen3_moe.modeling_qwen3_moe.Qwen3MoeExperts",
+    ),
+    "qwen3_next": (
+        "transformers.models.qwen3_next.configuration_qwen3_next.Qwen3NextConfig",
+        "transformers.models.qwen3_next.modeling_qwen3_next.Qwen3NextExperts",
+    ),
+    "qwen3_vl_moe": (
+        "transformers.models.qwen3_vl_moe.configuration_qwen3_vl_moe.Qwen3VLMoeTextConfig",
+        "transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe.Qwen3VLMoeTextExperts",
+    ),
 }
 
 ARCH_TO_2D_MAPPINGS = {
@@ -54,11 +188,11 @@ ARCH_TO_2D_MAPPINGS = {
             ),
             WeightRenaming(
                 source_patterns=r"^layers\.(\d+)\.mlp\.experts\.(\d+)\.up_proj\.",
-                target_patterns=r"layers.\1.mlp.experts.\2.up_proj.",
+                target_patterns=r"layers.\1.mlp.experts.\2.down_proj.",
             ),
             WeightRenaming(
                 source_patterns=r"^layers\.(\d+)\.mlp\.experts\.(\d+)\.down_proj\.",
-                target_patterns=r"layers.\1.mlp.experts.\2.down_proj.",
+                target_patterns=r"layers.\1.mlp.experts.\2.up_proj.",
             ),
         ],
     ),
@@ -66,18 +200,19 @@ ARCH_TO_2D_MAPPINGS = {
 
 
 def has_linearize_load_mappings(model_type: str) -> bool:
-    model_type = _MODEL_TO_CONVERSION_PATTERN.get(model_type, model_type)
-    return model_type in ARCH_TO_2D_MAPPINGS
+    remapped_type = _MODEL_TO_CONVERSION_PATTERN.get(model_type, model_type)
+    return model_type in ARCH_TO_IMPORT_PATHS and remapped_type in ARCH_TO_2D_MAPPINGS
 
 
 def get_linearize_load_mappings(
     model_type: str,
 ) -> tuple[type[torch.nn.Module], list[WeightTransform], list[WeightTransform]]:
     """ """
-    experts_cls = ARCH_TO_EXPERTS_MODULE_CLS[model_type]
-    model_type = _MODEL_TO_CONVERSION_PATTERN.get(model_type, model_type)
+    _config_paths, expert_paths = ARCH_TO_IMPORT_PATHS[model_type]
+    experts_cls = import_or_none(expert_paths)
 
     mapping: list[WeightTransform] = get_checkpoint_conversion_mapping(model_type)
+    model_type = _MODEL_TO_CONVERSION_PATTERN.get(model_type, model_type)
     remove_targets, new_mappings = ARCH_TO_2D_MAPPINGS[model_type]
 
     # forwards has conversion mappings

--- a/src/llmcompressor/modeling/moe/conversion_mappings.py
+++ b/src/llmcompressor/modeling/moe/conversion_mappings.py
@@ -188,11 +188,11 @@ ARCH_TO_2D_MAPPINGS = {
             ),
             WeightRenaming(
                 source_patterns=r"^layers\.(\d+)\.mlp\.experts\.(\d+)\.up_proj\.",
-                target_patterns=r"layers.\1.mlp.experts.\2.down_proj.",
+                target_patterns=r"layers.\1.mlp.experts.\2.up_proj.",
             ),
             WeightRenaming(
                 source_patterns=r"^layers\.(\d+)\.mlp\.experts\.(\d+)\.down_proj\.",
-                target_patterns=r"layers.\1.mlp.experts.\2.up_proj.",
+                target_patterns=r"layers.\1.mlp.experts.\2.down_proj.",
             ),
         ],
     ),

--- a/src/llmcompressor/modeling/moe/granitemoe.py
+++ b/src/llmcompressor/modeling/moe/granitemoe.py
@@ -1,7 +1,13 @@
+from typing import TYPE_CHECKING
+
 import torch
 from compressed_tensors.offload import get_cache_init_kwargs, offload_module
 from transformers.models.granitemoe.configuration_granitemoe import GraniteMoeConfig
-from transformers.models.granitemoe.modeling_granitemoe import GraniteMoeParallelExperts
+
+if TYPE_CHECKING:
+    from transformers.models.granitemoe.modeling_granitemoe import (
+        GraniteMoeParallelExperts,
+    )
 
 from llmcompressor.modeling.moe.context import get_calibrate_all_experts_flag
 from llmcompressor.modeling.moe.linear_experts import LinearExperts2D
@@ -80,5 +86,12 @@ class GraniteMoeLinearExperts(LinearExperts2D):
         return torch.cat(output_list, dim=0)
 
 
-# register in registry
-LinearExperts2D._registry[GraniteMoeParallelExperts] = GraniteMoeLinearExperts
+# register in registry (for earlier transformers versions)
+try:
+    from transformers.models.granitemoe.modeling_granitemoe import (
+        GraniteMoeParallelExperts,
+    )
+
+    LinearExperts2D._registry[GraniteMoeParallelExperts] = GraniteMoeLinearExperts
+except ImportError:
+    pass

--- a/src/llmcompressor/modeling/moe/helpers.py
+++ b/src/llmcompressor/modeling/moe/helpers.py
@@ -1,11 +1,8 @@
 import ast
+import importlib
 import inspect
 from dataclasses import dataclass
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-)
+from typing import Any, Callable, ClassVar
 
 import torch
 from loguru import logger
@@ -154,6 +151,21 @@ class MoEConfig:
                 ret.hidden_act = "silu"
 
         return ret
+
+
+def import_or_none(paths: str | list[str]) -> object | None:
+    if isinstance(paths, str):
+        paths = [paths]
+
+    for path in paths:
+        try:
+            module_path, attr_name = path.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            return getattr(module, attr_name)
+        except (ImportError, AttributeError):
+            pass
+
+    return None
 
 
 def _getattr_fallbacks(

--- a/src/llmcompressor/modeling/moe/helpers.py
+++ b/src/llmcompressor/modeling/moe/helpers.py
@@ -136,18 +136,22 @@ class MoEConfig:
             ),
             use_bias=_getattr_fallbacks(config, ["use_bias", "mlp_bias"], False),
             hidden_act=_getattr_fallbacks(
-                config, ["hidden_act", "hidden_activation", "mlp_hidden_act"]
+                config, ["hidden_act", "hidden_activation", "mlp_hidden_act"], None
             ),
             limit=_getattr_fallbacks(config, ["swiglu_limit"], None),
             alpha=None,
             dtype=_getattr_fallbacks(config, ["dtype"]),
         )
 
-        # special case: GptOssConfig has some parameters which are not marked in config
-        if config.model_type == "gpt_oss":
-            ret.use_bias = True
-            ret.limit = 7.0
-            ret.alpha = 1.702
+        # special case: some configs have parameters which are not marked in config
+        match config.model_type:
+            case "gpt_oss" | "openai_privacy_filter":
+                ret.use_bias = True
+                ret.limit = 7.0
+                ret.alpha = 1.702
+                ret.hidden_act = "sigmoid"
+            case "lfm2_moe":
+                ret.hidden_act = "silu"
 
         return ret
 

--- a/src/llmcompressor/modeling/moe/linear_experts.py
+++ b/src/llmcompressor/modeling/moe/linear_experts.py
@@ -3,9 +3,7 @@ from typing import Any, Callable, ClassVar
 
 import torch
 from compressed_tensors.offload import get_cache_init_kwargs, offload_module
-from transformers import (
-    PreTrainedConfig,
-)
+from transformers import PreTrainedConfig
 from transformers.activations import ACT2FN
 from transformers.integrations.moe import _default_apply_gate
 

--- a/tests/llmcompressor/modeling/test_linearize.py
+++ b/tests/llmcompressor/modeling/test_linearize.py
@@ -7,96 +7,19 @@ from compressed_tensors.utils import patch_attr
 from safetensors import safe_open
 from transformers import AutoModelForCausalLM
 from transformers import initialization as init
-from transformers.models.afmoe.configuration_afmoe import AfmoeConfig
-from transformers.models.afmoe.modeling_afmoe import AfmoeExperts
-from transformers.models.cohere2_moe.configuration_cohere2_moe import Cohere2MoeConfig
-from transformers.models.cohere2_moe.modeling_cohere2_moe import Cohere2MoeExperts
-from transformers.models.deepseek_ocr2.configuration_deepseek_ocr2 import (
-    DeepseekOcr2TextConfig,
-)
-from transformers.models.deepseek_ocr2.modeling_deepseek_ocr2 import (
-    DeepseekOcr2TextExperts,
-)
-from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
-from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3NaiveMoe
-from transformers.models.deepseek_v4.configuration_deepseek_v4 import DeepseekV4Config
 from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
-    DeepseekV4Experts,
     DeepseekV4PreTrainedModel,
 )
-from transformers.models.exaone_moe.configuration_exaone_moe import ExaoneMoeConfig
-from transformers.models.exaone_moe.modeling_exaone_moe import ExaoneMoeExperts
-from transformers.models.flex_olmo.configuration_flex_olmo import FlexOlmoConfig
-from transformers.models.flex_olmo.modeling_flex_olmo import FlexOlmoExperts
-from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
-from transformers.models.gemma4.modeling_gemma4 import Gemma4TextExperts
-from transformers.models.glm4_moe.configuration_glm4_moe import Glm4MoeConfig
-from transformers.models.glm4_moe.modeling_glm4_moe import Glm4MoeNaiveMoe
-from transformers.models.glm4_moe_lite.configuration_glm4_moe_lite import (
-    Glm4MoeLiteConfig,
-)
-from transformers.models.glm4_moe_lite.modeling_glm4_moe_lite import Glm4MoeLiteNaiveMoe
-from transformers.models.glm_moe_dsa.configuration_glm_moe_dsa import GlmMoeDsaConfig
-from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import GlmMoeDsaNaiveMoe
-from transformers.models.gpt_oss.configuration_gpt_oss import GptOssConfig
-from transformers.models.gpt_oss.modeling_gpt_oss import GptOssExperts
-from transformers.models.granitemoe.configuration_granitemoe import GraniteMoeConfig
-from transformers.models.granitemoe.modeling_granitemoe import GraniteMoeParallelExperts
-from transformers.models.hy_v3.configuration_hy_v3 import HYV3Config
-from transformers.models.hy_v3.modeling_hy_v3 import HYV3Experts
-from transformers.models.jamba.configuration_jamba import JambaConfig
-from transformers.models.jamba.modeling_jamba import JambaExperts
-from transformers.models.laguna.configuration_laguna import LagunaConfig
-from transformers.models.laguna.modeling_laguna import LagunaExperts
-from transformers.models.lfm2_moe.configuration_lfm2_moe import Lfm2MoeConfig
-from transformers.models.lfm2_moe.modeling_lfm2_moe import Lfm2MoeExperts
-from transformers.models.llama4.configuration_llama4 import (
-    Llama4Config,
-    Llama4TextConfig,
-)
-from transformers.models.llama4.modeling_llama4 import Llama4TextExperts
-from transformers.models.mellum.configuration_mellum import MellumConfig
-from transformers.models.mellum.modeling_mellum import MellumExperts
-from transformers.models.minimax.configuration_minimax import MiniMaxConfig
-from transformers.models.minimax.modeling_minimax import MiniMaxExperts
-from transformers.models.minimax_m2.configuration_minimax_m2 import MiniMaxM2Config
-from transformers.models.minimax_m2.modeling_minimax_m2 import MiniMaxM2Experts
-from transformers.models.mixtral.configuration_mixtral import MixtralConfig
-from transformers.models.mixtral.modeling_mixtral import MixtralExperts
-from transformers.models.nemotron_h.configuration_nemotron_h import NemotronHConfig
-from transformers.models.nemotron_h.modeling_nemotron_h import NemotronHExperts
-from transformers.models.olmoe.configuration_olmoe import OlmoeConfig
-from transformers.models.olmoe.modeling_olmoe import OlmoeExperts
-from transformers.models.openai_privacy_filter.configuration_openai_privacy_filter import (  # noqa: E501
-    OpenAIPrivacyFilterConfig,
-)
-from transformers.models.openai_privacy_filter.modeling_openai_privacy_filter import (
-    OpenAIPrivacyFilterExperts,
-)
-from transformers.models.phimoe.configuration_phimoe import PhimoeConfig
-from transformers.models.phimoe.modeling_phimoe import PhimoeExperts
-from transformers.models.qwen2_moe.configuration_qwen2_moe import Qwen2MoeConfig
-from transformers.models.qwen2_moe.modeling_qwen2_moe import Qwen2MoeExperts
-from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import (
-    Qwen3_5MoeTextConfig,
-)
-from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeExperts
-from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
-from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeExperts
-from transformers.models.qwen3_next.configuration_qwen3_next import Qwen3NextConfig
-from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextExperts
-from transformers.models.qwen3_vl_moe.configuration_qwen3_vl_moe import (
-    Qwen3VLMoeTextConfig,
-)
-from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import Qwen3VLMoeTextExperts
 
 from llmcompressor.modeling.moe.context import (
     moe_calibration_context,
 )
+from llmcompressor.modeling.moe.conversion_mappings import ARCH_TO_IMPORT_PATHS
 from llmcompressor.modeling.moe.helpers import (
     FusedExpertsProtocol,
     MoEConfig,
     _getattr_fallbacks,
+    import_or_none,
 )
 from llmcompressor.modeling.moe.linearize import linearize_moe, load_quantizable_moe
 from tests.testing_utils import requires_gpu
@@ -104,6 +27,16 @@ from tests.testing_utils import requires_gpu
 NUM_TEST_TOKENS = 64
 MODEL_MSE = 1e-2
 MODULE_MSE = 1e-10
+CONFIG_OVERRIDES = {
+    "deepseek_ocr2": {"num_experts_per_tok": 16},
+    "deepseek_v3": {"hidden_size": 512, "moe_intermediate_size": 1024},
+    "cohere2_moe": {"hidden_size": 256, "intermediate_size": 256},
+    "gemma4": {"num_experts": 16, "top_k_experts": 4, "moe_intermediate_size": 2304},
+    "glm_moe_dsa": {"hidden_size": 512},
+    "hy_v3": {"hidden_size": 256, "moe_intermediate_size": 256, "num_experts": 16},
+    "jamba": {"hidden_size": 256, "intermediate_size": 256, "num_experts": 16},
+    "nemotron_h": {"hidden_size": 32, "moe_intermediate_size": 64},
+}
 
 
 @pytest.fixture
@@ -140,6 +73,14 @@ def patch_deepseek_fp32_modules():
                 "model.layers.2.mlp.experts.1.down_proj.weight",
             ],
         ),
+        (
+            "inference-optimization/GLM-5.2-0.8B-A0.8B",
+            [
+                "model.layers.2.mlp.experts.2.up_proj.weight",
+                "model.layers.3.mlp.experts.0.gate_proj.weight",
+                "model.layers.4.mlp.experts.1.down_proj.weight",
+            ],
+        ),
     ],
 )
 def test_load_quantizable_moe(
@@ -165,10 +106,10 @@ def test_load_quantizable_moe(
     save_dir = tmp_path / "save_path"
     os.mkdir(save_dir)
     model2.save_pretrained(save_dir)
-    assert keys_exist(save_dir, exp_keys)
+    assert_keys_exist(save_dir, exp_keys)
 
 
-def keys_exist(model_path: Path, keys: list[str]) -> bool:
+def assert_keys_exist(model_path: Path, keys: list[str]):
     """
     Utility to check that expected expert keys exist in a saved model.
 
@@ -187,7 +128,7 @@ def keys_exist(model_path: Path, keys: list[str]) -> bool:
         with safe_open(st_file, framework="pt", device="cpu") as f:
             all_keys.update(f.keys())
 
-    return keys <= all_keys
+    assert keys <= all_keys, all_keys
 
 
 class DummyModel(torch.nn.Module):
@@ -203,66 +144,18 @@ class DummyModel(torch.nn.Module):
 @torch.no_grad()
 @requires_gpu
 @pytest.mark.parametrize(
-    "config_cls,experts_cls,kwargs",
-    [
-        (AfmoeConfig, AfmoeExperts, {}),
-        (
-            Cohere2MoeConfig,
-            Cohere2MoeExperts,
-            {"hidden_size": 256, "intermediate_size": 256},
-        ),
-        (DeepseekOcr2TextConfig, DeepseekOcr2TextExperts, {"num_experts_per_tok": 16}),
-        (
-            DeepseekV3Config,
-            DeepseekV3NaiveMoe,
-            {"hidden_size": 512, "moe_intermediate_size": 1024},
-        ),
-        (DeepseekV4Config, DeepseekV4Experts, {}),
-        (ExaoneMoeConfig, ExaoneMoeExperts, {}),
-        (FlexOlmoConfig, FlexOlmoExperts, {}),
-        (
-            Gemma4TextConfig,
-            Gemma4TextExperts,
-            {"num_experts": 16, "top_k_experts": 4, "moe_intermediate_size": 2304},
-        ),
-        (Glm4MoeConfig, Glm4MoeNaiveMoe, {}),
-        (Glm4MoeLiteConfig, Glm4MoeLiteNaiveMoe, {}),
-        (GlmMoeDsaConfig, GlmMoeDsaNaiveMoe, {"hidden_size": 512}),
-        (GptOssConfig, GptOssExperts, {}),
-        (
-            HYV3Config,
-            HYV3Experts,
-            {"hidden_size": 256, "moe_intermediate_size": 256, "num_experts": 16},
-        ),
-        (
-            JambaConfig,
-            JambaExperts,
-            {"hidden_size": 256, "intermediate_size": 256, "num_experts": 16},
-        ),
-        (LagunaConfig, LagunaExperts, {}),
-        (Lfm2MoeConfig, Lfm2MoeExperts, {}),
-        (MellumConfig, MellumExperts, {}),
-        (MiniMaxConfig, MiniMaxExperts, {}),
-        (MiniMaxM2Config, MiniMaxM2Experts, {}),
-        (MixtralConfig, MixtralExperts, {}),
-        (
-            NemotronHConfig,
-            NemotronHExperts,
-            {"hidden_size": 32, "moe_intermediate_size": 64},
-        ),
-        (OlmoeConfig, OlmoeExperts, {}),
-        (OpenAIPrivacyFilterConfig, OpenAIPrivacyFilterExperts, {}),
-        (PhimoeConfig, PhimoeExperts, {}),
-        (Qwen2MoeConfig, Qwen2MoeExperts, {}),
-        (Qwen3_5MoeTextConfig, Qwen3_5MoeExperts, {}),
-        (Qwen3MoeConfig, Qwen3MoeExperts, {}),
-        (Qwen3NextConfig, Qwen3NextExperts, {}),
-        (Qwen3VLMoeTextConfig, Qwen3VLMoeTextExperts, {}),
-    ],
+    "model_type", list(ARCH_TO_IMPORT_PATHS.keys() - {"llama4", "granitemoe"})
 )
-def test_linearize_moe(config_cls, experts_cls, kwargs):
+def test_linearize_moe(model_type):
+    config_path, experts_path = ARCH_TO_IMPORT_PATHS[model_type]
+    config_cls = import_or_none(config_path)
+    experts_cls = import_or_none(experts_path)
+
+    assert config_cls is not None, f"Could not import config for {model_type}"
+    assert experts_cls is not None, f"Could not import experts for {model_type}"
+
     with torch.device("cuda"):
-        config = config_cls(**kwargs)
+        config = config_cls(**CONFIG_OVERRIDES.get(model_type, {}))
         experts = experts_cls(config)
         assert isinstance(experts, FusedExpertsProtocol)
         up_proj = _getattr_fallbacks(experts, ["gate_up_proj", "up_proj"])
@@ -296,6 +189,16 @@ def test_linearize_moe(config_cls, experts_cls, kwargs):
 
 
 def test_linearize_moe_granite():
+    try:
+        from transformers.models.granitemoe.configuration_granitemoe import (
+            GraniteMoeConfig,
+        )
+        from transformers.models.granitemoe.modeling_granitemoe import (
+            GraniteMoeParallelExperts,
+        )
+    except ImportError:
+        pytest.skip("GraniteMoeParallelExperts has been removed")
+
     config = GraniteMoeConfig(hidden_size=512, intermediate_size=1024)
     experts = GraniteMoeParallelExperts(
         config.num_local_experts, config.hidden_size, config.intermediate_size
@@ -323,6 +226,12 @@ def test_linearize_moe_granite():
 
 
 def test_linearize_moe_llama4():
+    from transformers.models.llama4.configuration_llama4 import (
+        Llama4Config,
+        Llama4TextConfig,
+    )
+    from transformers.models.llama4.modeling_llama4 import Llama4TextExperts
+
     text_config = Llama4TextConfig(hidden_size=512, intermediate_size=1024)
     config = Llama4Config(text_config=text_config)
     experts = Llama4TextExperts(config.text_config)

--- a/tests/llmcompressor/modeling/test_linearize.py
+++ b/tests/llmcompressor/modeling/test_linearize.py
@@ -11,9 +11,7 @@ from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
     DeepseekV4PreTrainedModel,
 )
 
-from llmcompressor.modeling.moe.context import (
-    moe_calibration_context,
-)
+from llmcompressor.modeling.moe.context import moe_calibration_context
 from llmcompressor.modeling.moe.conversion_mappings import ARCH_TO_IMPORT_PATHS
 from llmcompressor.modeling.moe.helpers import (
     FusedExpertsProtocol,

--- a/tests/llmcompressor/modeling/test_linearize.py
+++ b/tests/llmcompressor/modeling/test_linearize.py
@@ -9,6 +9,14 @@ from transformers import AutoModelForCausalLM
 from transformers import initialization as init
 from transformers.models.afmoe.configuration_afmoe import AfmoeConfig
 from transformers.models.afmoe.modeling_afmoe import AfmoeExperts
+from transformers.models.cohere2_moe.configuration_cohere2_moe import Cohere2MoeConfig
+from transformers.models.cohere2_moe.modeling_cohere2_moe import Cohere2MoeExperts
+from transformers.models.deepseek_ocr2.configuration_deepseek_ocr2 import (
+    DeepseekOcr2TextConfig,
+)
+from transformers.models.deepseek_ocr2.modeling_deepseek_ocr2 import (
+    DeepseekOcr2TextExperts,
+)
 from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
 from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3NaiveMoe
 from transformers.models.deepseek_v4.configuration_deepseek_v4 import DeepseekV4Config
@@ -16,6 +24,10 @@ from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
     DeepseekV4Experts,
     DeepseekV4PreTrainedModel,
 )
+from transformers.models.exaone_moe.configuration_exaone_moe import ExaoneMoeConfig
+from transformers.models.exaone_moe.modeling_exaone_moe import ExaoneMoeExperts
+from transformers.models.flex_olmo.configuration_flex_olmo import FlexOlmoConfig
+from transformers.models.flex_olmo.modeling_flex_olmo import FlexOlmoExperts
 from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
 from transformers.models.gemma4.modeling_gemma4 import Gemma4TextExperts
 from transformers.models.glm4_moe.configuration_glm4_moe import Glm4MoeConfig
@@ -32,13 +44,39 @@ from transformers.models.granitemoe.configuration_granitemoe import GraniteMoeCo
 from transformers.models.granitemoe.modeling_granitemoe import GraniteMoeParallelExperts
 from transformers.models.hy_v3.configuration_hy_v3 import HYV3Config
 from transformers.models.hy_v3.modeling_hy_v3 import HYV3Experts
+from transformers.models.jamba.configuration_jamba import JambaConfig
+from transformers.models.jamba.modeling_jamba import JambaExperts
+from transformers.models.laguna.configuration_laguna import LagunaConfig
+from transformers.models.laguna.modeling_laguna import LagunaExperts
+from transformers.models.lfm2_moe.configuration_lfm2_moe import Lfm2MoeConfig
+from transformers.models.lfm2_moe.modeling_lfm2_moe import Lfm2MoeExperts
 from transformers.models.llama4.configuration_llama4 import (
     Llama4Config,
     Llama4TextConfig,
 )
 from transformers.models.llama4.modeling_llama4 import Llama4TextExperts
+from transformers.models.mellum.configuration_mellum import MellumConfig
+from transformers.models.mellum.modeling_mellum import MellumExperts
+from transformers.models.minimax.configuration_minimax import MiniMaxConfig
+from transformers.models.minimax.modeling_minimax import MiniMaxExperts
+from transformers.models.minimax_m2.configuration_minimax_m2 import MiniMaxM2Config
+from transformers.models.minimax_m2.modeling_minimax_m2 import MiniMaxM2Experts
+from transformers.models.mixtral.configuration_mixtral import MixtralConfig
+from transformers.models.mixtral.modeling_mixtral import MixtralExperts
 from transformers.models.nemotron_h.configuration_nemotron_h import NemotronHConfig
 from transformers.models.nemotron_h.modeling_nemotron_h import NemotronHExperts
+from transformers.models.olmoe.configuration_olmoe import OlmoeConfig
+from transformers.models.olmoe.modeling_olmoe import OlmoeExperts
+from transformers.models.openai_privacy_filter.configuration_openai_privacy_filter import (  # noqa: E501
+    OpenAIPrivacyFilterConfig,
+)
+from transformers.models.openai_privacy_filter.modeling_openai_privacy_filter import (
+    OpenAIPrivacyFilterExperts,
+)
+from transformers.models.phimoe.configuration_phimoe import PhimoeConfig
+from transformers.models.phimoe.modeling_phimoe import PhimoeExperts
+from transformers.models.qwen2_moe.configuration_qwen2_moe import Qwen2MoeConfig
+from transformers.models.qwen2_moe.modeling_qwen2_moe import Qwen2MoeExperts
 from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import (
     Qwen3_5MoeTextConfig,
 )
@@ -169,11 +207,19 @@ class DummyModel(torch.nn.Module):
     [
         (AfmoeConfig, AfmoeExperts, {}),
         (
+            Cohere2MoeConfig,
+            Cohere2MoeExperts,
+            {"hidden_size": 256, "intermediate_size": 256},
+        ),
+        (DeepseekOcr2TextConfig, DeepseekOcr2TextExperts, {"num_experts_per_tok": 16}),
+        (
             DeepseekV3Config,
             DeepseekV3NaiveMoe,
             {"hidden_size": 512, "moe_intermediate_size": 1024},
         ),
         (DeepseekV4Config, DeepseekV4Experts, {}),
+        (ExaoneMoeConfig, ExaoneMoeExperts, {}),
+        (FlexOlmoConfig, FlexOlmoExperts, {}),
         (
             Gemma4TextConfig,
             Gemma4TextExperts,
@@ -182,17 +228,36 @@ class DummyModel(torch.nn.Module):
         (Glm4MoeConfig, Glm4MoeNaiveMoe, {}),
         (Glm4MoeLiteConfig, Glm4MoeLiteNaiveMoe, {}),
         (GlmMoeDsaConfig, GlmMoeDsaNaiveMoe, {"hidden_size": 512}),
-        (Qwen3_5MoeTextConfig, Qwen3_5MoeExperts, {}),
-        (Qwen3MoeConfig, Qwen3MoeExperts, {}),
-        (Qwen3NextConfig, Qwen3NextExperts, {}),
-        (Qwen3VLMoeTextConfig, Qwen3VLMoeTextExperts, {}),
         (GptOssConfig, GptOssExperts, {}),
-        (HYV3Config, HYV3Experts, {}),
+        (
+            HYV3Config,
+            HYV3Experts,
+            {"hidden_size": 256, "moe_intermediate_size": 256, "num_experts": 16},
+        ),
+        (
+            JambaConfig,
+            JambaExperts,
+            {"hidden_size": 256, "intermediate_size": 256, "num_experts": 16},
+        ),
+        (LagunaConfig, LagunaExperts, {}),
+        (Lfm2MoeConfig, Lfm2MoeExperts, {}),
+        (MellumConfig, MellumExperts, {}),
+        (MiniMaxConfig, MiniMaxExperts, {}),
+        (MiniMaxM2Config, MiniMaxM2Experts, {}),
+        (MixtralConfig, MixtralExperts, {}),
         (
             NemotronHConfig,
             NemotronHExperts,
             {"hidden_size": 32, "moe_intermediate_size": 64},
         ),
+        (OlmoeConfig, OlmoeExperts, {}),
+        (OpenAIPrivacyFilterConfig, OpenAIPrivacyFilterExperts, {}),
+        (PhimoeConfig, PhimoeExperts, {}),
+        (Qwen2MoeConfig, Qwen2MoeExperts, {}),
+        (Qwen3_5MoeTextConfig, Qwen3_5MoeExperts, {}),
+        (Qwen3MoeConfig, Qwen3MoeExperts, {}),
+        (Qwen3NextConfig, Qwen3NextExperts, {}),
+        (Qwen3VLMoeTextConfig, Qwen3VLMoeTextExperts, {}),
     ],
 )
 def test_linearize_moe(config_cls, experts_cls, kwargs):


### PR DESCRIPTION
## Purpose ##
* Support optimal loading for a larger variety of MoEs, including those from transformers [v5.13.0](https://github.com/huggingface/transformers/releases/tag/v5.13.0)
* Expand testing for a larger variety of MoEs
* Move to an MoE import pattern which supports backwards compatibility & siloed imports
* Fixes #2883

## Changes ##
* Populate `ARCH_TO_IMPORT_PATHS` with import paths used by MoE architectures
  * All of these import paths have test coverage in `test_linearize.py`
  * Use these mappings to create linearize load mappings

## Testing ##
* Passes CI (which uses older transformers version)
* Passes locally with newer (unreleased) transformers version