### PR TITLE
fix: remove is_module_quantized filter that made AutoRound a no-op

### DIFF
--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -15,7 +15,6 @@ from compressed_tensors.quantization import (
     QuantizationStrategy,
     enable_quantization,
 )
-from compressed_tensors.quantization.utils import is_module_quantized
 from compressed_tensors.utils import align_module_device, match_named_modules
 from loguru import logger
 from pydantic import PrivateAttr
@@ -227,7 +226,6 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
     def on_sequential_epoch_end(
         self, state: State, event: Event, modules: list[torch.nn.Module], **kwargs
     ):
-        modules = [module for module in modules if is_module_quantized(module)]
         self.apply_autoround(state, modules)
         self.post_autoround_cleanup()
 

--- a/tests/llmcompressor/modifiers/autoround/test_base.py
+++ b/tests/llmcompressor/modifiers/autoround/test_base.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import torch
 from torch import nn
 
 from llmcompressor.core import Event, EventType, State
@@ -27,9 +26,7 @@ def test_on_sequential_epoch_end_passes_all_modules():
     event = Event(type_=EventType.SEQUENTIAL_EPOCH_END)
     modules = [_FakeDecoderLayer(), nn.Linear(64, 64)]
 
-    with patch.object(
-        AutoRoundModifier, "apply_autoround"
-    ) as mock_apply, patch.object(
+    with patch.object(AutoRoundModifier, "apply_autoround") as mock_apply, patch.object(
         AutoRoundModifier, "post_autoround_cleanup"
     ):
         modifier.on_sequential_epoch_end(state, event, modules=modules)

--- a/tests/llmcompressor/modifiers/autoround/test_base.py
+++ b/tests/llmcompressor/modifiers/autoround/test_base.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch import nn
+
+from llmcompressor.core import Event, EventType, State
+from llmcompressor.modifiers.autoround import AutoRoundModifier
+
+
+class _FakeDecoderLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(64, 64)
+        self.k_proj = nn.Linear(64, 64)
+
+
+def test_on_sequential_epoch_end_passes_all_modules():
+    """Verify that on_sequential_epoch_end passes all modules to apply_autoround
+    without filtering. Regression test for a bug where an is_module_quantized
+    filter silently dropped decoder layers, causing autoround to be a no-op."""
+    modifier = AutoRoundModifier(
+        ignore=["lm_head"],
+        iters=10,
+        scheme="W4A16",
+    )
+    state = MagicMock(spec=State)
+    event = Event(type_=EventType.SEQUENTIAL_EPOCH_END)
+    modules = [_FakeDecoderLayer(), nn.Linear(64, 64)]
+
+    with patch.object(
+        AutoRoundModifier, "apply_autoround"
+    ) as mock_apply, patch.object(
+        AutoRoundModifier, "post_autoround_cleanup"
+    ):
+        modifier.on_sequential_epoch_end(state, event, modules=modules)
+        mock_apply.assert_called_once_with(state, modules)

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -517,10 +517,6 @@ def test_ddp_smoke_gptq():
 @pytest.mark.multi_gpu
 @requires_gpu(2)
 @torchrun(world_size=2)
-@pytest.mark.skip(
-    reason="AutoRound DDP gradient sync is broken upstream (auto_round "
-    "setup_ddp_if_needed_ discards the DDP-wrapped block)"
-)
 def test_ddp_smoke_autoround():
     _test_ddp_modifier(
         "autoround",
@@ -533,5 +529,5 @@ def test_ddp_smoke_autoround():
         None,
         weight_atol=1e-1,
         min_top1_match=0.85,
-        max_logit_diff=0.2,
+        max_logit_diff=0.15,
     )


### PR DESCRIPTION
## Summary
when we [updated the lifecycle](https://github.com/vllm-project/llm-compressor/pull/2784) autoround was broken because apply autoround expects a decoder_layer specifically and we added a filter to only pass the quantized linear layers instead (like all the other modifiers) removing this filter fixes the issue.

we can now also re-enable the DDP smoke tests for autoround.

also added an autoround unit test to catch this in the future

## Test plan
`pytest -vs -rs tests/llmcompressor/transformers/compression/test_compression_ddp.py`

`pytest -vs -rs tests/llmcompressor/modifiers/autoround/test_base.py`

PR made with claude