### PR TITLE
fix ddp smoke race conditions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ emulated XPU identity on real CUDA hardware:
   3. Local is_accelerator_type patches — accept both "xpu" and "cuda"
 """
 
+import os
 from types import SimpleNamespace
 
 import torch
@@ -51,6 +52,11 @@ def pytest_configure(config):
     compares against the mocked "xpu" and would return False.  This is the known
     trade-off: routing logic is bypassed and must be tested separately (Option 1).
     """
+    # Give each torchrun rank its own basetemp to avoid cleanup race conditions
+    rank = os.environ.get("LOCAL_RANK")
+    if rank is not None and config.option.basetemp is None:
+        config.option.basetemp = f"/tmp/pytest-torchrun-rank{rank}"
+
     if not config.getoption("--emulate-xpu"):
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ emulated XPU identity on real CUDA hardware:
 """
 
 import os
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 
 import torch
@@ -55,7 +57,11 @@ def pytest_configure(config):
     # Give each torchrun rank its own basetemp to avoid cleanup race conditions
     rank = os.environ.get("LOCAL_RANK")
     if rank is not None and config.option.basetemp is None:
-        config.option.basetemp = f"/tmp/pytest-torchrun-rank{rank}"
+        run_id = os.environ.get("TORCHELASTIC_RUN_ID", str(os.getpid()))
+        config.option.basetemp = tempfile.mkdtemp(
+            prefix=f"pytest-torchrun-{run_id}-rank{rank}-",
+            dir=Path(tempfile.gettempdir()),
+        )
 
     if not config.getoption("--emulate-xpu"):
         return

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -462,8 +462,6 @@ def torchrun(world_size: int = 1, init_dist: bool = False):
                     "pytest",
                     f"{file_path}::{func_name}",
                     "-sx",
-                    "--basetemp",
-                    f"/tmp/pytest-torchrun-{func_name}",
                 ]
 
                 # If coverage is enabled (--cov in PYTEST_ADDOPTS), prevent


### PR DESCRIPTION
Summary
Both ranks are trying to clean up the temp dirs causing a race condition

fail:
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/27996125653/job/82858691361


TEST PLAN:
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/28053514637

(no race conditions)
