### PR TITLE
Allow requests 2.32.5+ versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
             else "numpy>=2.0.0"
         ),
         (
-            "requests>=2.32.2,<=2.32.5"
+            "requests>=2.32.2,<=2.34.2"
             if BUILD_TYPE == "release"
             else "requests>=2.32.2"
         ),


### PR DESCRIPTION
SUMMARY:
Bump up requests upper bound to allow CVE fixes.


TEST PLAN:
Kicked off weekly tests here: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/28102941232/job/83209697233

Compared with older 0.9.0.3 release run: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/25321500228/job/74231607820, the only new failure was the one in the example test https://github.com/neuralmagic/llm-compressor-testing/actions/runs/28102941232/job/83209697310 with :

`tests/examples/test_quantization_w8a8_fp8.py::TestQuantizationW8A8_FP8::test_example_scripts[fp8_block_example.py] FAILED

RuntimeError: Expected all tensors to be on the same device, but got index is on cuda:0, different from other tensors on cpu (when checking argument in method wrapper_CUDA__index_select)`
