### PR TITLE
Remove sparsity-preserving logic from GPTQ quantization

### DIFF
--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -11,7 +11,6 @@ from compressed_tensors.quantization import (
 )
 from loguru import logger
 
-
 GPTQ_PRECISION = torch.float32
 
 __all__ = ["make_empty_hessian", "accumulate_hessian", "quantize_weight"]

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -11,8 +11,6 @@ from compressed_tensors.quantization import (
 )
 from loguru import logger
 
-from llmcompressor.modifiers.utils import SPARSITY_THRESHOLD
-from llmcompressor.pytorch.utils.helpers import tensor_sparsity
 
 GPTQ_PRECISION = torch.float32
 
@@ -139,15 +137,6 @@ def quantize_weight(
         qparams["global_scale"],
     )
 
-    # sparsity mask
-    sparsity = tensor_sparsity(W)
-    preserve_zeros = sparsity >= SPARSITY_THRESHOLD
-    W_nz_mask = (
-        (~torch.isclose(W, torch.zeros(1, device=W.device).float())).float()
-        if preserve_zeros
-        else None
-    )
-
     losses = torch.zeros(num_rows, device=module.weight.device)
 
     # mask dead hessian values
@@ -183,9 +172,6 @@ def quantize_weight(
         Err1 = torch.zeros_like(W1)
         losses1 = torch.zeros_like(W1)
         Hinv1 = Hinv[i1:i2, i1:i2]
-
-        if preserve_zeros:
-            W1_nz_mask = W_nz_mask[:, i1:i2]
 
         for i in range(count):
             w = W1[:, i]
@@ -247,10 +233,7 @@ def quantize_weight(
 
             err1 = (w - q) / d
             w1_err = err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
-            if preserve_zeros:
-                W1[:, i:] -= w1_err * W1_nz_mask[:, i:]
-            else:
-                W1[:, i:] -= w1_err
+            W1[:, i:] -= w1_err
             Err1[:, i] = err1
 
         # propagate block error
@@ -258,10 +241,7 @@ def quantize_weight(
         losses += torch.sum(losses1, 1) / 2
 
         w_err = Err1.matmul(Hinv[i1:i2, i2:])
-        if preserve_zeros:
-            W[:, i2:] -= w_err * W_nz_mask[:, i2:]
-        else:
-            W[:, i2:] -= w_err
+        W[:, i2:] -= w_err
 
     if actorder:
         # restore original permutation

--- a/src/llmcompressor/modifiers/utils/__init__.py
+++ b/src/llmcompressor/modifiers/utils/__init__.py
@@ -1,3 +1,2 @@
 # ruff: noqa
 
-from .constants import *

--- a/src/llmcompressor/modifiers/utils/constants.py
+++ b/src/llmcompressor/modifiers/utils/constants.py
@@ -2,10 +2,6 @@
 Constants for modifier operations and compression thresholds.
 
 This module defines global constants used throughout the compression
-framework for determining sparsity thresholds, pruning criteria, and
-other modifier-specific parameters.
+framework for determining pruning criteria and other modifier-specific
+parameters.
 """
-
-__all__ = ["SPARSITY_THRESHOLD"]
-
-SPARSITY_THRESHOLD: float = 0.05


### PR DESCRIPTION
## Summary
this sparsity stuff makes gptq data dependent and to my knowledge its completely unused 

## Test plan
- [x] `pytest tests/llmcompressor/modifiers/gptq/ -v` — 53 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)