### PR TITLE
[Bugfix] Fix observer memory leak

### DIFF
--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -97,6 +97,8 @@ class Observer(InternalModule, RegistryMixin):
                     fused_obs(fused_mod.weight)
                 global_absmax = torch.max(global_absmax, -fused_obs.min_vals.min())
                 global_absmax = torch.max(global_absmax, fused_obs.max_vals.max())
+                del fused_obs.min_vals
+                del fused_obs.max_vals
             global_scale = generate_gparam(
                 -global_absmax.reshape(1), global_absmax.reshape(1)
             )

--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -108,6 +108,9 @@ class Observer(InternalModule, RegistryMixin):
             global_scale=global_scale,
         )
 
+        del self.min_vals
+        del self.max_vals
+
         return {"scale": scale, "zero_point": zero_point, "global_scale": global_scale}
 
     @torch.no_grad


### PR DESCRIPTION
## Purpose ##
* Reduce memory usage when quantizing large models

## Changes ##
* Delete statistics after qparams are computed

## Testing ##
* TODO: Show before and after of memory usage