### PR TITLE
fix: DDP smoke test improvements and device_map mismatch fix

### DIFF
--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -95,9 +95,10 @@ def _run_single_gpu(
     Returns:
         weights dict if return_model=False, else (weights, model, dataset)
     """
-    model = AutoModelForCausalLM.from_pretrained(
-        model_id, dtype=torch.bfloat16, device_map=device
-    )
+    with load_offloaded_model():
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id, dtype=torch.bfloat16, device_map="auto_offload"
+        )
     ds = _prepare_dataset(model_id, num_samples)
 
     oneshot(
@@ -107,7 +108,6 @@ def _run_single_gpu(
         num_calibration_samples=num_samples,
         max_seq_length=MAX_SEQ_LENGTH,
     )
-
     # Extract quantized weights (exclude common ignored parameters)
     weights = {
         name: param.clone().cpu()
@@ -158,7 +158,6 @@ def _compare_outputs(ref_model, ddp_model, dataset, num_samples: int = 5):
 
     with torch.no_grad():
         for i in range(min(num_samples, len(dataset))):
-            # Get inputs
             sample = dataset[i]
             inputs = {
                 k: v.unsqueeze(0).to("cuda:0")
@@ -166,7 +165,6 @@ def _compare_outputs(ref_model, ddp_model, dataset, num_samples: int = 5):
                 if k == "input_ids"
             }
 
-            # Get outputs
             ref_out = ref_model(**inputs).logits[0].float().cpu()
             ddp_out = ddp_model(**inputs).logits[0].float().cpu()
 
@@ -272,7 +270,6 @@ def _test_ddp_modifier(
         max_seq_length=MAX_SEQ_LENGTH,
         pipeline=pipeline,
     )
-
     # Extract DDP weights (exclude common ignored parameters)
     ddp_weights = {
         name: param.clone().cpu()
@@ -287,6 +284,12 @@ def _test_ddp_modifier(
         # Compare outputs first (primary correctness test)
         max_diff, mean_diff, top1_match_rate = _compare_outputs(
             ref_model, model, ref_dataset, num_samples=5
+        )
+
+        print(
+            f"[Rank {rank}] Results: top1_match={100*top1_match_rate:.1f}%, "
+            f"mean_logit_diff={mean_diff:.6f}, max_logit_diff={max_diff:.6f}",
+            flush=True,
         )
 
         # Primary test: outputs should be very similar
@@ -323,6 +326,44 @@ def _test_ddp_modifier(
     torch.cuda.empty_cache()
     torch.distributed.barrier()
 
+w8a8_static_rtn = {
+    "group_0": QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(
+            num_bits=8,
+            type="int",
+            symmetric=True,
+            strategy="channel",
+        ),
+        input_activations=QuantizationArgs(
+            num_bits=8,
+            type="int",
+            symmetric=True,
+            strategy="tensor",
+            observer="static_minmax",
+        ),
+    )
+}
+
+w8a8_static_mse = {
+    "group_0": QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(
+            num_bits=8,
+            type="int",
+            symmetric=True,
+            strategy="channel",
+            observer="mse",
+        ),
+        input_activations=QuantizationArgs(
+            num_bits=8,
+            type="int",
+            symmetric=True,
+            strategy="tensor",
+            observer="static_minmax",
+        ),
+    )
+}
 
 # ---------------------------------------------------------------------------
 # Individual Test Functions (each gets its own torchrun subprocess)
@@ -347,88 +388,21 @@ def test_ddp_smoke_smoothquant():
 @pytest.mark.multi_gpu
 @requires_gpu(2)
 @torchrun(world_size=2)
-def test_ddp_smoke_rtn_minmax():
+def test_ddp_smoke_imatrix():
     _test_ddp_modifier(
-        "rtn_minmax",
-        lambda: QuantizationModifier(
-            scheme={"W8A8": ["Linear"]},
-            ignore=["lm_head"],
-        ),
-        "independent",
-        None,
-        weight_atol=1e-5,
-    )
-
-
-@pytest.mark.integration
-@pytest.mark.multi_gpu
-@requires_gpu(2)
-@torchrun(world_size=2)
-def test_ddp_smoke_rtn_mse():
-    _test_ddp_modifier(
-        "rtn_mse",
-        lambda: QuantizationModifier(
-            config_groups={
-                "group_0": QuantizationScheme(
-                    targets=["Linear"],
-                    weights=QuantizationArgs(
-                        num_bits=8,
-                        type="int",
-                        symmetric=True,
-                        strategy="channel",
-                        observer="mse",
-                    ),
-                    input_activations=QuantizationArgs(
-                        num_bits=8,
-                        type="int",
-                        symmetric=True,
-                        strategy="tensor",
-                        observer="mse",
-                    ),
-                )
-            },
-            ignore=["lm_head"],
-        ),
-        "independent",
-        None,
-        weight_atol=1e-4,
-        min_top1_match=0.90,
-        max_logit_diff=0.15,
-    )
-
-
-@pytest.mark.integration
-@pytest.mark.multi_gpu
-@requires_gpu(2)
-@torchrun(world_size=2)
-def test_ddp_smoke_rtn_imatrix():
-    _test_ddp_modifier(
-        "rtn_imatrix",
+        "imatrix",
         lambda: [
             IMatrixGatherer(ignore=["lm_head"]),
             QuantizationModifier(
-                config_groups={
-                    "group_0": QuantizationScheme(
-                        targets=["Linear"],
-                        weights=QuantizationArgs(
-                            num_bits=4,
-                            type="int",
-                            symmetric=True,
-                            strategy="group",
-                            group_size=128,
-                            observer="imatrix_mse",
-                        ),
-                        input_activations=None,
-                    )
-                },
+                scheme={"W4A16": ["Linear"]},
                 ignore=["lm_head"],
             ),
         ],
         "independent",
         None,
         weight_atol=5e-3,
-        min_top1_match=0.90,
-        max_logit_diff=0.15,
+        min_top1_match=1.00,
+        max_logit_diff=0.00,
     )
 
 
@@ -436,16 +410,18 @@ def test_ddp_smoke_rtn_imatrix():
 @pytest.mark.multi_gpu
 @requires_gpu(2)
 @torchrun(world_size=2)
-def test_ddp_smoke_rtn_cpu_offload():
+def test_ddp_smoke_mse_cpu_offload():
     _test_ddp_modifier(
-        "rtn_cpu_offload",
+        "mse_cpu_offload",
         lambda: QuantizationModifier(
-            scheme={"W8A8": ["Linear"]},
+            config_groups=w8a8_static_mse,
             ignore=["lm_head"],
         ),
         "independent",
         "cpu",
         weight_atol=1e-5,
+        min_top1_match=1.00,
+        max_logit_diff=0.00,
     )
 
 
@@ -463,12 +439,14 @@ def test_ddp_smoke_rtn_disk_offload():
     _test_ddp_modifier(
         "rtn_disk_offload",
         lambda: QuantizationModifier(
-            scheme={"W8A8": ["Linear"]},
+            config_groups=w8a8_static_rtn,
             ignore=["lm_head"],
         ),
         "independent",
         "disk",
         weight_atol=1e-5,
+        min_top1_match=1.00,
+        max_logit_diff=0.00,
         offload_folder=offload_folder,
     )
 
@@ -490,6 +468,7 @@ def test_ddp_smoke_awq():
         "independent",
         None,
         weight_atol=5e-2,
+        min_top1_match=0.85,
     )
 
 
@@ -508,8 +487,8 @@ def test_ddp_smoke_gptq():
         "independent",
         None,
         weight_atol=1e-1,
-        min_top1_match=0.90,
-        max_logit_diff=0.15,
+        min_top1_match=1.00,
+        max_logit_diff=0.00,
     )
 
 
@@ -529,5 +508,5 @@ def test_ddp_smoke_autoround():
         None,
         weight_atol=1e-1,
         min_top1_match=0.85,
-        max_logit_diff=0.15,
+        max_logit_diff=0.2,
     )

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -177,7 +177,9 @@ def _compare_outputs(ref_model, ddp_model, dataset, num_samples: int = 5):
             )
             kl_divs.append(kl.item())
 
-            top1_matches += (ref_out.argmax(dim=-1) == ddp_out.argmax(dim=-1)).sum().item()
+            top1_matches += (
+                (ref_out.argmax(dim=-1) == ddp_out.argmax(dim=-1)).sum().item()
+            )
             top1_total += ref_out.shape[0]
 
     kl_div = sum(kl_divs) / len(kl_divs)
@@ -303,8 +305,7 @@ def _test_ddp_modifier(
             )
 
         assert not errors, (
-            f"Distributed {test_id} outputs differ significantly:\n"
-            + "\n".join(errors)
+            f"Distributed {test_id} outputs differ significantly:\n" + "\n".join(errors)
         )
 
         # Clean up reference model

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -467,6 +467,7 @@ def test_ddp_smoke_awq():
         None,
         weight_atol=5e-2,
         min_top1_match=0.85,
+        max_kl_div=0.001,
     )
 
 
@@ -486,7 +487,7 @@ def test_ddp_smoke_gptq():
         None,
         weight_atol=1e-1,
         min_top1_match=0.95,
-        max_kl_div=0.15,
+        max_kl_div=0.001,
     )
 
 
@@ -506,5 +507,5 @@ def test_ddp_smoke_autoround():
         None,
         weight_atol=1e-1,
         min_top1_match=0.85,
-        max_kl_div=0.2,
+        max_kl_div=0.01,
     )

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -149,17 +149,17 @@ def _compare_outputs(ref_model, ddp_model, dataset, num_samples: int = 5):
     """
     Compare model outputs between single-GPU and DDP runs.
 
-    Returns tuple of (max_abs_diff, mean_abs_diff, top1_match_rate)
+    Returns tuple of (kl_div, top1_match_rate)
     """
     ref_model.eval()
     ddp_model.eval()
 
-    ref_outputs = []
-    ddp_outputs = []
+    kl_divs = []
+    top1_matches = 0
+    top1_total = 0
 
     with torch.no_grad():
         for i in range(min(num_samples, len(dataset))):
-            # Get inputs
             sample = dataset[i]
             inputs = {
                 k: v.unsqueeze(0).to("cuda:0")
@@ -167,29 +167,23 @@ def _compare_outputs(ref_model, ddp_model, dataset, num_samples: int = 5):
                 if k == "input_ids"
             }
 
-            # Get outputs
             ref_out = ref_model(**inputs).logits[0].float().cpu()
             ddp_out = ddp_model(**inputs).logits[0].float().cpu()
 
-            ref_outputs.append(ref_out)
-            ddp_outputs.append(ddp_out)
+            ref_log_probs = torch.nn.functional.log_softmax(ref_out, dim=-1)
+            ddp_log_probs = torch.nn.functional.log_softmax(ddp_out, dim=-1)
+            kl = torch.nn.functional.kl_div(
+                ddp_log_probs, ref_log_probs, log_target=True, reduction="batchmean"
+            )
+            kl_divs.append(kl.item())
 
-    # Stack and compute differences
-    ref_outputs = torch.stack(ref_outputs)
-    ddp_outputs = torch.stack(ddp_outputs)
+            top1_matches += (ref_out.argmax(dim=-1) == ddp_out.argmax(dim=-1)).sum().item()
+            top1_total += ref_out.shape[0]
 
-    abs_diff = torch.abs(ref_outputs - ddp_outputs)
-    max_abs_diff = abs_diff.max().item()
-    mean_abs_diff = abs_diff.mean().item()
-
-    # Check top-1 predictions
-    ref_top1 = ref_outputs.argmax(dim=-1)
-    ddp_top1 = ddp_outputs.argmax(dim=-1)
-    top1_matches = (ref_top1 == ddp_top1).sum().item()
-    top1_total = ref_top1.numel()
+    kl_div = sum(kl_divs) / len(kl_divs)
     top1_match_rate = top1_matches / top1_total
 
-    return max_abs_diff, mean_abs_diff, top1_match_rate
+    return kl_div, top1_match_rate
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +198,7 @@ def _test_ddp_modifier(
     offload_device,
     weight_atol=1e-4,
     min_top1_match=0.95,
-    max_logit_diff=0.1,
+    max_kl_div=0.1,
     offload_folder=None,
 ):
     """
@@ -224,7 +218,7 @@ def _test_ddp_modifier(
         offload_device: Device to offload model weights (None, "cpu", or "disk")
         weight_atol: Absolute tolerance for weight comparison (default 1e-4)
         min_top1_match: Minimum top-1 prediction match rate (default 0.95 = 95%)
-        max_logit_diff: Maximum allowed mean logit difference (default 0.1)
+        max_kl_div: Maximum allowed mean KL divergence (default 0.1)
         offload_folder: Optional folder for disk offload (default None)
     """
     # Set deterministic seed for reproducibility
@@ -286,13 +280,13 @@ def _test_ddp_modifier(
     # Compare (only rank 0)
     if rank == 0:
         # Compare outputs first (primary correctness test)
-        max_diff, mean_diff, top1_match_rate = _compare_outputs(
+        kl_div, top1_match_rate = _compare_outputs(
             ref_model, model, ref_dataset, num_samples=5
         )
 
         print(
             f"[Rank {rank}] Results: top1_match={100*top1_match_rate:.1f}%, "
-            f"mean_logit_diff={mean_diff:.6f}, max_logit_diff={max_diff:.6f}",
+            f"kl_div={kl_div:.6f}",
             flush=True,
         )
 
@@ -303,15 +297,14 @@ def _test_ddp_modifier(
                 f"  Top-1 match rate: {100*top1_match_rate:.1f}% "
                 f"(expected >= {100*min_top1_match:.0f}%)"
             )
-        if mean_diff > max_logit_diff:
+        if kl_div > max_kl_div:
             errors.append(
-                f"  Mean logit diff: {mean_diff:.6f} (expected <= {max_logit_diff})"
+                f"  Mean KL divergence: {kl_div:.6f} (expected <= {max_kl_div})"
             )
 
         assert not errors, (
             f"Distributed {test_id} outputs differ significantly:\n"
             + "\n".join(errors)
-            + f"\n  (Max logit diff: {max_diff:.6f})"
         )
 
         # Clean up reference model
@@ -407,7 +400,7 @@ def test_ddp_smoke_imatrix():
         None,
         weight_atol=5e-3,
         min_top1_match=1.00,
-        max_logit_diff=0.00,
+        max_kl_div=0.00,
     )
 
 
@@ -426,7 +419,7 @@ def test_ddp_smoke_mse_cpu_offload():
         "cpu",
         weight_atol=1e-5,
         min_top1_match=1.00,
-        max_logit_diff=0.00,
+        max_kl_div=0.00,
     )
 
 
@@ -451,7 +444,7 @@ def test_ddp_smoke_rtn_disk_offload():
         "disk",
         weight_atol=1e-5,
         min_top1_match=1.00,
-        max_logit_diff=0.00,
+        max_kl_div=0.00,
         offload_folder=offload_folder,
     )
 
@@ -493,7 +486,7 @@ def test_ddp_smoke_gptq():
         None,
         weight_atol=1e-1,
         min_top1_match=0.95,
-        max_logit_diff=0.15,
+        max_kl_div=0.15,
     )
 
 
@@ -513,5 +506,5 @@ def test_ddp_smoke_autoround():
         None,
         weight_atol=1e-1,
         min_top1_match=0.85,
-        max_logit_diff=0.2,
+        max_kl_div=0.2,
     )

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -108,6 +108,7 @@ def _run_single_gpu(
         num_calibration_samples=num_samples,
         max_seq_length=MAX_SEQ_LENGTH,
     )
+
     # Extract quantized weights (exclude common ignored parameters)
     weights = {
         name: param.clone().cpu()
@@ -158,6 +159,7 @@ def _compare_outputs(ref_model, ddp_model, dataset, num_samples: int = 5):
 
     with torch.no_grad():
         for i in range(min(num_samples, len(dataset))):
+            # Get inputs
             sample = dataset[i]
             inputs = {
                 k: v.unsqueeze(0).to("cuda:0")
@@ -165,6 +167,7 @@ def _compare_outputs(ref_model, ddp_model, dataset, num_samples: int = 5):
                 if k == "input_ids"
             }
 
+            # Get outputs
             ref_out = ref_model(**inputs).logits[0].float().cpu()
             ddp_out = ddp_model(**inputs).logits[0].float().cpu()
 
@@ -270,6 +273,7 @@ def _test_ddp_modifier(
         max_seq_length=MAX_SEQ_LENGTH,
         pipeline=pipeline,
     )
+
     # Extract DDP weights (exclude common ignored parameters)
     ddp_weights = {
         name: param.clone().cpu()
@@ -325,6 +329,7 @@ def _test_ddp_modifier(
     del model
     torch.cuda.empty_cache()
     torch.distributed.barrier()
+
 
 w8a8_static_rtn = {
     "group_0": QuantizationScheme(

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -492,8 +492,8 @@ def test_ddp_smoke_gptq():
         "independent",
         None,
         weight_atol=1e-1,
-        min_top1_match=1.00,
-        max_logit_diff=0.00,
+        min_top1_match=0.95,
+        max_logit_diff=0.15,
     )
 
 


### PR DESCRIPTION
## Summary
1) I noticed that even when DDP and single gpu models were exactly the same, inference was giving different results because they were dispatched differently (auto offload vs on-device) aligning this makes things a ton more consistent.
2) made all the tests do activation calibration otherwise whats the point. Had to do w8a8 static to test this.
3) made all tests either w8a8 (if they didn't do calibration naturally) or w4a16 (if they would naturally do calibration)
4) got rid of rtn and mse and instead testing rtn/mse while doing the offloading tests
5) changed to kl_div as measure of accuracy.

## Test plan
CI: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/28122621875

local: pytest -vs -rs /home/HDCharles/repos/llm-compressor/tests/llmcompressor/transformers/compression/test_compression_ddp.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)