### PR TITLE
[Distributed] Add `suspend_distributed_timeout` to enable large model saving

### DIFF
--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -208,8 +208,8 @@ def update_and_save_recipe(model_stub: str, save_directory: str):
 
 @contextmanager
 def suspend_distributed_timeout(
-    current_group: dist.ProcessGroup | None = None,
     timeout: datetime.timedelta = datetime.timedelta(hours=3),
+    current_group: dist.ProcessGroup | None = None,
 ):
     """
     Context manager that extends the timeout for distributed operations.
@@ -219,10 +219,10 @@ def suspend_distributed_timeout(
     distributed training environments. The context manager synchronizes all
     processes before and after the operation using barriers.
 
-    :param current_group: The current process group to synchronize. If None,
-        defaults to dist.group.WORLD
     :param timeout: The extended timeout for the temporary process group.
         Defaults to 3 hours
+    :param current_group: The current process group to synchronize. If None,
+        defaults to dist.group.WORLD
     """
     if not dist.is_initialized():
         yield
@@ -238,3 +238,4 @@ def suspend_distributed_timeout(
     finally:
         dist.barrier(group=suspend_group)
         dist.barrier(group=current_group)
+        dist.destroy_process_group(group=suspend_group)

--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -1,5 +1,7 @@
+import datetime
 import os
 import weakref
+from contextlib import contextmanager
 from functools import wraps
 
 import torch
@@ -81,22 +83,22 @@ def modify_save_pretrained(model: PreTrainedModel):
             # convert to accelerate offloaded for optimal saving with transformers
             to_accelerate(model)
 
-            if is_source_process():
-                # save model structure
-                original_save_fn.__get__(model, model_class)(save_directory, **kwargs)
+            with suspend_distributed_timeout():
+                if is_source_process():
+                    # save model structure
+                    original_save_fn.__get__(model, model_class)(
+                        save_directory, **kwargs
+                    )
 
-                # update config to reflect quantization
-                compressor.update_config(save_directory)
+                    # update config to reflect quantization
+                    compressor.update_config(save_directory)
 
-                # update existing recipe
-                update_and_save_recipe(model.name_or_path, save_directory)
+                    # update existing recipe
+                    update_and_save_recipe(model.name_or_path, save_directory)
 
-                # copy python files from cache dir to save_path if any
-                copy_python_files_from_model_cache(model, save_directory)
+                    # copy python files from cache dir to save_path if any
+                    copy_python_files_from_model_cache(model, save_directory)
 
-            # synchronize before converting back from accelerate
-            if dist.is_initialized():
-                dist.barrier()
             # convert back from accelerate to restore model to original form
             from_accelerate(model)
 
@@ -202,3 +204,37 @@ def update_and_save_recipe(model_stub: str, save_directory: str):
 
     recipe_path = os.path.join(save_directory, RECIPE_FILE_NAME)
     recipe.yaml(file_path=recipe_path, existing_recipe_path=existing_recipe)
+
+
+@contextmanager
+def suspend_distributed_timeout(
+    current_group: dist.ProcessGroup | None = None,
+    timeout: datetime.timedelta = datetime.timedelta(hours=3),
+):
+    """
+    Context manager that extends the timeout for distributed operations.
+
+    Creates a temporary process group with an extended timeout to prevent
+    timeout errors during long-running operations (e.g., model saving) in
+    distributed training environments. The context manager synchronizes all
+    processes before and after the operation using barriers.
+
+    :param current_group: The current process group to synchronize. If None,
+        defaults to dist.group.WORLD
+    :param timeout: The extended timeout for the temporary process group.
+        Defaults to 3 hours
+    """
+    if not dist.is_initialized():
+        yield
+        return
+
+    if current_group is None:
+        current_group = dist.group.WORLD
+    suspend_group = dist.new_group(backend="gloo", timeout=timeout)
+
+    try:
+        dist.barrier(group=current_group)
+        yield
+    finally:
+        dist.barrier(group=suspend_group)
+        dist.barrier(group=current_group)

--- a/tests/llmcompressor/transformers/compression/test_compress_tensor_utils.py
+++ b/tests/llmcompressor/transformers/compression/test_compress_tensor_utils.py
@@ -1,8 +1,14 @@
+import datetime
+import os
+import time
+
 import pytest
 import torch
+import torch.distributed as dist
 from accelerate import dispatch_model
 from accelerate.accelerator import get_state_dict_offloaded_model
 from compressed_tensors.compressors.format import infer_model_format
+from compressed_tensors.distributed import is_source_process
 from compressed_tensors.quantization import (
     QuantizationConfig,
     QuantizationStatus,
@@ -14,9 +20,10 @@ from transformers import AutoModelForCausalLM
 from llmcompressor import oneshot
 from llmcompressor.transformers.compression.compressed_tensors_utils import (
     modify_save_pretrained,
+    suspend_distributed_timeout,
 )
 from llmcompressor.utils import untie_word_embeddings
-from tests.testing_utils import requires_gpu
+from tests.testing_utils import requires_gpu, torchrun
 
 
 @requires_gpu
@@ -263,3 +270,26 @@ def test_correct_compressor_inferred(
     model.linear.quantization_status = QuantizationStatus.FROZEN
 
     assert infer_model_format(model) == expected_format
+
+
+@requires_gpu(2)
+@torchrun(world_size=2, init_dist=False)
+def test_suspend_distributed_timeout():
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    device = torch.device(f"cuda:{local_rank}")
+
+    dist.init_process_group(
+        backend="nccl",
+        init_method="env://",
+        rank=rank,
+        world_size=world_size,
+        device_id=device,
+        timeout=datetime.timedelta(seconds=10),
+    )
+    dist.barrier()
+
+    with suspend_distributed_timeout(datetime.timedelta(seconds=30)):
+        if is_source_process():
+            time.sleep(20)


### PR DESCRIPTION
## Purpose ##
* Support saving models which take more than 10 minutes to save
  * Longer save times can be exacerbated by very large models and disk/cpu offloading

## Changes ##
* Add `suspend_distributed_timeout`

## Testing ##
* Add `test_suspend_distributed_timeout`
* Now able to save models which take +20min to save