### PR TITLE
[Fix] Recipe.dict() shadows builtin dict — unimportable on Python 3.14 (#2778)

### DIFF
--- a/src/llmcompressor/recipe/recipe.py
+++ b/src/llmcompressor/recipe/recipe.py
@@ -229,7 +229,7 @@ class Recipe(BaseModel):
 
         return model
 
-    def dict(self, *args, **kwargs) -> dict[str, Any]:
+    def to_dict(self, *args, **kwargs) -> dict[str, Any]:
         """
         :return: A dictionary representation of the recipe
         """

--- a/src/llmcompressor/recipe/recipe.py
+++ b/src/llmcompressor/recipe/recipe.py
@@ -232,7 +232,7 @@ class Recipe(BaseModel):
 
         return model
 
-    def dict(self, *args, **kwargs) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         :return: A dictionary representation of the recipe
         """

--- a/tests/llmcompressor/recipe/test_recipe.py
+++ b/tests/llmcompressor/recipe/test_recipe.py
@@ -33,8 +33,8 @@ def test_serialization(recipe_str):
     serialized_recipe = recipe_instance.yaml()
     recipe_from_serialized = Recipe.create_instance(serialized_recipe)
 
-    expected_dict = recipe_instance.dict()
-    actual_dict = recipe_from_serialized.dict()
+    expected_dict = recipe_instance.to_dict()
+    actual_dict = recipe_from_serialized.to_dict()
 
     assert expected_dict == actual_dict
 

--- a/tests/llmcompressor/recipe/test_recipe.py
+++ b/tests/llmcompressor/recipe/test_recipe.py
@@ -39,8 +39,8 @@ def test_serialization(recipe_str):
     serialized_recipe = recipe_instance.yaml()
     recipe_from_serialized = Recipe.create_instance(serialized_recipe)
 
-    expected_dict = recipe_instance.dict()
-    actual_dict = recipe_from_serialized.dict()
+    expected_dict = recipe_instance.to_dict()
+    actual_dict = recipe_from_serialized.to_dict()
 
     assert expected_dict == actual_dict
 


### PR DESCRIPTION
## Motivation

`llmcompressor` is unimportable on Python 3.14 — importing it raises `TypeError: 'function' object is not subscriptable` (#2778).

## Root cause

In `src/llmcompressor/recipe/recipe.py`, `class Recipe(BaseModel)` declares the field `args: dict[str, Any]` **and** defines a method `def dict(self, ...)` that shadows the builtin `dict`. On Python 3.14 (PEP 649 lazy annotations), pydantic's `eval_type_backport` evaluates the string annotation `"dict[str, Any]"` against the class namespace, finds the `dict` *method* instead of the builtin, and raises `TypeError: 'function' object is not subscriptable` at class-creation/import time.

## Modifications

Rename the shadowing method `Recipe.dict()` → `Recipe.to_dict()` (it is a deprecated pydantic-v1-style alias; the canonical `BaseModel` method is `model_dump`). This unshadows the builtin so the `args: dict[str, Any]` annotation resolves correctly. The method is referenced only in tests, so the two call sites in `tests/llmcompressor/recipe/test_recipe.py` are updated accordingly. No production code calls `Recipe.dict()`.

## Duplicate-check

- Track A — enumerated all open PRs (`pulls?state=open&per_page=100 --paginate`) and grepped bodies for `2778`; the only hit (#2821) is a `[not for land] testing` PR where `2778` appears coincidentally as a perplexity number — it touches only `examples/pack_quantized_rtn/*` and does not fix this.
- Track B — issue #2778 (state OPEN) has one maintainer question and no "opened a PR / working on this / taking this" claim.
