### PR TITLE
Add Buildkite pipeline to migrate GPU test workflows from GHA

### DIFF
--- a/.buildkite/gpu-tests/gpu-tests-H100.yml
+++ b/.buildkite/gpu-tests/gpu-tests-H100.yml
@@ -1,0 +1,100 @@
+steps:
+  - group: ":test_tube: Base Tests (H100)"
+    key: "base-tests"
+    steps:
+      - label: ":python: Base Tests py{{matrix.python}}"
+        agents:
+          queue: RedHat-H100-WDC
+
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 3
+            - exit_status: 255
+              limit: 3
+            - signal_reason: agent_stop
+              limit: 3
+
+        plugins:
+          - kubernetes:
+              podSpec:
+                serviceAccountName: buildkite-anyuid
+                securityContext:
+                  fsGroup: 0
+                  runAsUser: 0
+                  runAsGroup: 0
+                nodeSelector:
+                  vllm.ci/gpu-pool: upstream-ci-h100
+
+                containers:
+                  - name: tests
+                    image: buildkite/agent:3-ubuntu
+                    command:
+                      - chmod +x .buildkite/gpu-tests/scripts/run-tests.sh
+                      - .buildkite/gpu-tests/scripts/run-tests.sh base
+
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 1
+
+                    volumeMounts:
+                      - name: model-cache
+                        mountPath: /model-cache
+                        readOnly: false
+                      - name: devshm
+                        mountPath: /dev/shm
+
+                    env:
+                      - name: PYTHON_VERSION
+                        value: "{{matrix.python}}"
+                      - name: HF_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: hf-token-secret
+                            key: token
+
+                volumes:
+                  - name: model-cache
+                    hostPath:
+                      path: /var/mnt/model-cache
+                      type: DirectoryOrCreate
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+
+        matrix:
+          setup:
+            python: ["3.10", "3.13"]
+
+  - label: ":bar_chart: Combine Coverage"
+    depends_on: "base-tests"
+    allow_dependency_failure: true
+    agents:
+      queue: RedHat-ModelOpt-Util
+    command:
+      - chmod +x .buildkite/gpu-tests/scripts/combine-coverage.sh
+      - .buildkite/gpu-tests/scripts/combine-coverage.sh
+
+  - label: ":mag: Detect changes for Transformers Tests"
+    agents:
+      queue: RedHat-ModelOpt-Util
+    command: |
+      if [ "$${BUILDKITE_PULL_REQUEST}" = "false" ]; then
+        echo "Push to branch — uploading transformers tests"
+        buildkite-agent pipeline upload .buildkite/gpu-tests/transformers-tests-H100.yml
+      else
+        git fetch --unshallow 2>/dev/null || true
+        git fetch origin "$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        CHANGED=$$(git diff --name-only "origin/$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD" \
+          | grep -E '^(src/|tests/|setup\.py$$|MANIFEST\.in$$|\.buildkite/)' \
+          | grep -vE '^tests/(e2e|lmeval|examples)/' \
+          | grep -vE '\.md$$' \
+          || true)
+        if [ -n "$${CHANGED}" ]; then
+          echo "Relevant changes detected:"
+          echo "$${CHANGED}"
+          buildkite-agent pipeline upload .buildkite/gpu-tests/transformers-tests-H100.yml
+        else
+          echo "No relevant changes — skipping transformers tests"
+        fi
+      fi

--- a/.buildkite/gpu-tests/gpu-tests-H100.yml
+++ b/.buildkite/gpu-tests/gpu-tests-H100.yml
@@ -38,7 +38,7 @@ steps:
                         nvidia.com/gpu: 1
 
                     volumeMounts:
-                      - name: model-cache
+                      - name: ci-cache
                         mountPath: /model-cache
                         readOnly: false
                       - name: devshm
@@ -54,9 +54,9 @@ steps:
                             key: token
 
                 volumes:
-                  - name: model-cache
+                  - name: ci-cache
                     hostPath:
-                      path: /var/mnt/model-cache
+                      path: /var/mnt/ci-cache
                       type: DirectoryOrCreate
                   - name: devshm
                     emptyDir:
@@ -86,7 +86,7 @@ steps:
         git fetch --unshallow 2>/dev/null || true
         git fetch origin "$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
         CHANGED=$$(git diff --name-only "origin/$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD" \
-          | grep -E '^(src/|tests/|setup\.py$$|MANIFEST\.in$$|\.buildkite/)' \
+          | grep -E '^(src/|tests/|setup\.py$$|MANIFEST\.in$$|\.buildkite/gpu-tests/transformers-tests-|\.buildkite/gpu-tests/scripts/run-tests\.sh$$)' \
           | grep -vE '^tests/(e2e|lmeval|examples)/' \
           | grep -vE '\.md$$' \
           || true)

--- a/.buildkite/gpu-tests/gpu-tests-H100.yml
+++ b/.buildkite/gpu-tests/gpu-tests-H100.yml
@@ -85,7 +85,8 @@ steps:
       else
         git fetch --unshallow 2>/dev/null || true
         git fetch origin "$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
-        CHANGED=$$(git diff --name-only "origin/$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD" \
+        DIFF_FILES=$$(git diff --name-only "origin/$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD")
+        CHANGED=$$(echo "$${DIFF_FILES}" \
           | grep -E '^(src/|tests/|setup\.py$$|MANIFEST\.in$$|\.buildkite/gpu-tests/transformers-tests-|\.buildkite/gpu-tests/scripts/run-tests\.sh$$)' \
           | grep -vE '^tests/(e2e|lmeval|examples)/' \
           | grep -vE '\.md$$' \

--- a/.buildkite/gpu-tests/gpu-tests-L4.yml
+++ b/.buildkite/gpu-tests/gpu-tests-L4.yml
@@ -79,7 +79,8 @@ steps:
       else
         git fetch --unshallow 2>/dev/null || true
         git fetch origin "$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
-        CHANGED=$$(git diff --name-only "origin/$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD" \
+        DIFF_FILES=$$(git diff --name-only "origin/$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD")
+        CHANGED=$$(echo "$${DIFF_FILES}" \
           | grep -E '^(src/|tests/|setup\.py$$|MANIFEST\.in$$|\.buildkite/gpu-tests/transformers-tests-|\.buildkite/gpu-tests/scripts/run-tests\.sh$$)' \
           | grep -vE '^tests/(e2e|lmeval|examples)/' \
           | grep -vE '\.md$$' \

--- a/.buildkite/gpu-tests/gpu-tests-L4.yml
+++ b/.buildkite/gpu-tests/gpu-tests-L4.yml
@@ -80,7 +80,7 @@ steps:
         git fetch --unshallow 2>/dev/null || true
         git fetch origin "$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
         CHANGED=$$(git diff --name-only "origin/$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD" \
-          | grep -E '^(src/|tests/|setup\.py$$|MANIFEST\.in$$|\.buildkite/)' \
+          | grep -E '^(src/|tests/|setup\.py$$|MANIFEST\.in$$|\.buildkite/gpu-tests/transformers-tests-|\.buildkite/gpu-tests/scripts/run-tests\.sh$$)' \
           | grep -vE '^tests/(e2e|lmeval|examples)/' \
           | grep -vE '\.md$$' \
           || true)

--- a/.buildkite/gpu-tests/gpu-tests-L4.yml
+++ b/.buildkite/gpu-tests/gpu-tests-L4.yml
@@ -1,0 +1,94 @@
+# NOTE: Multi-GPU tests exist (e.g. test_quantization_ddp.py with @requires_gpu(2),
+# example scripts with torchrun --nproc_per_node=2) but are skipped with 1 GPU.
+# tests/examples/ and tests/sparsity/ are also excluded from the base test suite.
+# To run multi-GPU tests, add a separate group requesting nvidia.com/gpu: 2.
+
+steps:
+  - group: ":test_tube: Base Tests (L4)"
+    key: "base-tests"
+    steps:
+      - label: ":python: Base Tests py{{matrix.python}}"
+        agents:
+          queue: RedHat-L4-GCP
+
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 3
+            - exit_status: 255
+              limit: 3
+            - signal_reason: agent_stop
+              limit: 3
+
+        plugins:
+          - kubernetes:
+              podSpec:
+                nodeSelector:
+                  pool: L4solo
+
+                containers:
+                  - name: tests
+                    image: buildkite/agent:3-ubuntu
+                    command:
+                      - chmod +x .buildkite/gpu-tests/scripts/run-tests.sh
+                      - .buildkite/gpu-tests/scripts/run-tests.sh base
+
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 1
+
+                    volumeMounts:
+                      - name: model-cache
+                        mountPath: /model-cache
+                        readOnly: false
+                      - name: devshm
+                        mountPath: /dev/shm
+
+                    env:
+                      - name: PYTHON_VERSION
+                        value: "{{matrix.python}}"
+
+                volumes:
+                  - name: model-cache
+                    persistentVolumeClaim:
+                      claimName: buildkite-podpvc-ssd-blue
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+
+        matrix:
+          setup:
+            python: ["3.10", "3.13"]
+
+  - label: ":bar_chart: Combine Coverage"
+    depends_on: "base-tests"
+    allow_dependency_failure: true
+    agents:
+      queue: RedHat-ModelOpt-Util
+    command:
+      - chmod +x .buildkite/gpu-tests/scripts/combine-coverage.sh
+      - .buildkite/gpu-tests/scripts/combine-coverage.sh
+
+  - label: ":mag: Detect changes for Transformers Tests"
+    agents:
+      queue: RedHat-ModelOpt-Util
+    command: |
+      if [ "$${BUILDKITE_PULL_REQUEST}" = "false" ]; then
+        echo "Push to branch — uploading transformers tests"
+        buildkite-agent pipeline upload .buildkite/gpu-tests/transformers-tests-L4.yml
+      else
+        git fetch --unshallow 2>/dev/null || true
+        git fetch origin "$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        CHANGED=$$(git diff --name-only "origin/$${BUILDKITE_PULL_REQUEST_BASE_BRANCH}...HEAD" \
+          | grep -E '^(src/|tests/|setup\.py$$|MANIFEST\.in$$|\.buildkite/)' \
+          | grep -vE '^tests/(e2e|lmeval|examples)/' \
+          | grep -vE '\.md$$' \
+          || true)
+        if [ -n "$${CHANGED}" ]; then
+          echo "Relevant changes detected:"
+          echo "$${CHANGED}"
+          buildkite-agent pipeline upload .buildkite/gpu-tests/transformers-tests-L4.yml
+        else
+          echo "No relevant changes — skipping transformers tests"
+        fi
+      fi

--- a/.buildkite/gpu-tests/scripts/combine-coverage.sh
+++ b/.buildkite/gpu-tests/scripts/combine-coverage.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CODE_COVERAGE=$(buildkite-agent meta-data get "code-coverage" --default "false" 2>/dev/null || echo "false")
+if [ "${CODE_COVERAGE}" != "true" ]; then
+  echo "Code coverage not enabled — skipping combine step"
+  exit 0
+fi
+
+git fetch --tags --unshallow 2>/dev/null || git fetch --tags
+
+apt-get update && apt-get install -y curl make python3-dev
+
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+uv venv covenv --python "3.12"
+source covenv/bin/activate
+
+export UV_TORCH_BACKEND=cu130
+uv pip install -U setuptools
+uv pip install coverage setuptools-scm
+make build
+
+buildkite-agent artifact download ".coverage.*" .
+buildkite-agent artifact download "coverage-html/**" . || true
+buildkite-agent artifact download "coverage.json" . || true
+
+cat << 'EOF' > .coveragerc
+[paths]
+source =
+    src/
+    */site-packages/
+EOF
+
+coverage combine
+coverage report --skip-empty --format=markdown
+coverage html --directory coverage-html
+coverage json -o coverage.json
+
+buildkite-agent artifact upload ".coverage;coverage-html/**;coverage.json"

--- a/.buildkite/gpu-tests/scripts/combine-coverage.sh
+++ b/.buildkite/gpu-tests/scripts/combine-coverage.sh
@@ -17,7 +17,7 @@ export PATH="$HOME/.local/bin:$PATH"
 uv venv covenv --python "3.12"
 source covenv/bin/activate
 
-export UV_TORCH_BACKEND=cu130
+export UV_TORCH_BACKEND=auto
 uv pip install -U setuptools
 uv pip install coverage setuptools-scm
 make build

--- a/.buildkite/gpu-tests/scripts/run-tests.sh
+++ b/.buildkite/gpu-tests/scripts/run-tests.sh
@@ -3,28 +3,34 @@ set -euo pipefail
 
 TEST_TYPE="${1:?Usage: run-tests.sh <base|transformers>}"
 
+echo "~~~ System info"
 cat /etc/issue
 
+echo "--- Installing system packages"
 git fetch --tags --unshallow 2>/dev/null || git fetch --tags
-
-apt-get update && apt-get install -y curl g++ gcc make python3-dev
-
+apt-get update -qq && apt-get install -y -qq curl g++ gcc make python3-dev
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 export LD_LIBRARY_PATH=/usr/local/nvidia/lib64
 export PATH="$HOME/.local/bin:/usr/local/nvidia/bin:$PATH"
+
+echo "~~~ GPU info"
 nvidia-smi
 
+echo "--- Setting up Python environment"
+export UV_NO_PROGRESS=1
+export UV_CACHE_DIR="$PWD/.uv-cache"
 uv venv testvenv --python "${PYTHON_VERSION}"
 source testvenv/bin/activate
 
 export CADENCE=commit
-export UV_TORCH_BACKEND=cu130
+export UV_TORCH_BACKEND=auto
 export HF_HOME=/model-cache
 uv pip install .[dev]
 
 CODE_COVERAGE=$(buildkite-agent meta-data get "code-coverage" --default "false" 2>/dev/null || echo "false")
 if [ "${CODE_COVERAGE}" = "true" ]; then
+  echo "--- Setting up code coverage"
   export COVERAGE_FILE=".coverage.${TEST_TYPE}.${PYTHON_VERSION}"
   uv pip install coverage pytest-cov https://github.com/neuralmagic/pytest-nm-releng/archive/v0.4.0.tar.gz
   FLAGS_FILE="coverage_flags.sh"
@@ -34,7 +40,8 @@ if [ "${CODE_COVERAGE}" = "true" ]; then
   export PYTEST_ADDOPTS
 fi
 
-git clone https://github.com/vllm-project/compressed-tensors.git
+echo "--- Installing compressed-tensors (nightly)"
+git clone --quiet https://github.com/vllm-project/compressed-tensors.git
 uv pip uninstall compressed-tensors
 export GIT_CEILING_DIRECTORIES="$(pwd)"
 cd compressed-tensors
@@ -42,15 +49,18 @@ BUILD_TYPE=nightly uv pip install .
 cd ..
 rm -rf compressed-tensors/
 
+echo "--- Installed packages"
 uv pip list
 
 TEST_EXIT_CODE=0
 if [ "${TEST_TYPE}" = "base" ]; then
+  echo "+++ Running base tests"
   make test || TEST_EXIT_CODE=$?
 elif [ "${TEST_TYPE}" = "transformers" ]; then
+  echo "+++ Running transformers tests"
   COV_APPEND=""
   for test_file in $(find tests/llmcompressor/transformers -name "test_*.py" | sort); do
-    echo "--- Running: ${test_file} ---"
+    echo "--- Running: ${test_file}"
     pytest -vra ${COV_APPEND} "${test_file}" || TEST_EXIT_CODE=$?
     if [ "${CODE_COVERAGE}" = "true" ]; then
       COV_APPEND="--cov-append"
@@ -63,6 +73,7 @@ else
 fi
 
 if [ "${CODE_COVERAGE}" = "true" ]; then
+  echo "--- Coverage report"
   coverage report --data-file="${COVERAGE_FILE}" --skip-empty --format=markdown || true
   buildkite-agent artifact upload "${COVERAGE_FILE};coverage-html/**;coverage.json" || true
 fi

--- a/.buildkite/gpu-tests/scripts/run-tests.sh
+++ b/.buildkite/gpu-tests/scripts/run-tests.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_TYPE="${1:?Usage: run-tests.sh <base|transformers>}"
+
+cat /etc/issue
+
+git fetch --tags --unshallow 2>/dev/null || git fetch --tags
+
+apt-get update && apt-get install -y curl g++ gcc make python3-dev
+
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+export LD_LIBRARY_PATH=/usr/local/nvidia/lib64
+export PATH="$HOME/.local/bin:/usr/local/nvidia/bin:$PATH"
+nvidia-smi
+
+uv venv testvenv --python "${PYTHON_VERSION}"
+source testvenv/bin/activate
+
+export CADENCE=commit
+export UV_TORCH_BACKEND=cu130
+export HF_HOME=/model-cache
+uv pip install .[dev]
+
+CODE_COVERAGE=$(buildkite-agent meta-data get "code-coverage" --default "false" 2>/dev/null || echo "false")
+if [ "${CODE_COVERAGE}" = "true" ]; then
+  export COVERAGE_FILE=".coverage.${TEST_TYPE}.${PYTHON_VERSION}"
+  uv pip install coverage pytest-cov https://github.com/neuralmagic/pytest-nm-releng/archive/v0.4.0.tar.gz
+  FLAGS_FILE="coverage_flags.sh"
+  nmre-generate-coverage-flags --package "llmcompressor" --output-file "${FLAGS_FILE}"
+  source "${FLAGS_FILE}"
+  rm "${FLAGS_FILE}"
+  export PYTEST_ADDOPTS
+fi
+
+git clone https://github.com/vllm-project/compressed-tensors.git
+uv pip uninstall compressed-tensors
+export GIT_CEILING_DIRECTORIES="$(pwd)"
+cd compressed-tensors
+BUILD_TYPE=nightly uv pip install .
+cd ..
+rm -rf compressed-tensors/
+
+uv pip list
+
+TEST_EXIT_CODE=0
+if [ "${TEST_TYPE}" = "base" ]; then
+  make test || TEST_EXIT_CODE=$?
+elif [ "${TEST_TYPE}" = "transformers" ]; then
+  COV_APPEND=""
+  for test_file in $(find tests/llmcompressor/transformers -name "test_*.py" | sort); do
+    echo "--- Running: ${test_file} ---"
+    pytest -vra ${COV_APPEND} "${test_file}" || TEST_EXIT_CODE=$?
+    if [ "${CODE_COVERAGE}" = "true" ]; then
+      COV_APPEND="--cov-append"
+    fi
+  done
+else
+  echo "Unknown test type: ${TEST_TYPE}"
+  echo "Usage: run-tests.sh <base|transformers>"
+  exit 1
+fi
+
+if [ "${CODE_COVERAGE}" = "true" ]; then
+  coverage report --data-file="${COVERAGE_FILE}" --skip-empty --format=markdown || true
+  buildkite-agent artifact upload "${COVERAGE_FILE};coverage-html/**;coverage.json" || true
+fi
+
+exit ${TEST_EXIT_CODE}

--- a/.buildkite/gpu-tests/transformers-tests-H100.yml
+++ b/.buildkite/gpu-tests/transformers-tests-H100.yml
@@ -37,7 +37,7 @@ steps:
                         nvidia.com/gpu: 1
 
                     volumeMounts:
-                      - name: model-cache
+                      - name: ci-cache
                         mountPath: /model-cache
                         readOnly: false
                       - name: devshm
@@ -53,9 +53,9 @@ steps:
                             key: token
 
                 volumes:
-                  - name: model-cache
+                  - name: ci-cache
                     hostPath:
-                      path: /var/mnt/model-cache
+                      path: /var/mnt/ci-cache
                       type: DirectoryOrCreate
                   - name: devshm
                     emptyDir:

--- a/.buildkite/gpu-tests/transformers-tests-H100.yml
+++ b/.buildkite/gpu-tests/transformers-tests-H100.yml
@@ -1,0 +1,66 @@
+steps:
+  - group: ":test_tube: Transformers Tests (H100)"
+    steps:
+      - label: ":python: Transformers Tests py{{matrix.python}}"
+        agents:
+          queue: RedHat-H100-WDC
+
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 3
+            - exit_status: 255
+              limit: 3
+            - signal_reason: agent_stop
+              limit: 3
+
+        plugins:
+          - kubernetes:
+              podSpec:
+                serviceAccountName: buildkite-anyuid
+                securityContext:
+                  fsGroup: 0
+                  runAsUser: 0
+                  runAsGroup: 0
+                nodeSelector:
+                  vllm.ci/gpu-pool: upstream-ci-h100
+
+                containers:
+                  - name: tests
+                    image: buildkite/agent:3-ubuntu
+                    command:
+                      - chmod +x .buildkite/gpu-tests/scripts/run-tests.sh
+                      - .buildkite/gpu-tests/scripts/run-tests.sh transformers
+
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 1
+
+                    volumeMounts:
+                      - name: model-cache
+                        mountPath: /model-cache
+                        readOnly: false
+                      - name: devshm
+                        mountPath: /dev/shm
+
+                    env:
+                      - name: PYTHON_VERSION
+                        value: "{{matrix.python}}"
+                      - name: HF_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: hf-token-secret
+                            key: token
+
+                volumes:
+                  - name: model-cache
+                    hostPath:
+                      path: /var/mnt/model-cache
+                      type: DirectoryOrCreate
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+
+        matrix:
+          setup:
+            python: ["3.12"]

--- a/.buildkite/gpu-tests/transformers-tests-L4.yml
+++ b/.buildkite/gpu-tests/transformers-tests-L4.yml
@@ -1,0 +1,55 @@
+steps:
+  - group: ":test_tube: Transformers Tests (L4)"
+    steps:
+      - label: ":python: Transformers Tests py{{matrix.python}}"
+        agents:
+          queue: RedHat-L4-GCP
+
+        retry:
+          automatic:
+            - exit_status: -1
+              limit: 3
+            - exit_status: 255
+              limit: 3
+            - signal_reason: agent_stop
+              limit: 3
+
+        plugins:
+          - kubernetes:
+              podSpec:
+                nodeSelector:
+                  pool: L4solo
+
+                containers:
+                  - name: tests
+                    image: buildkite/agent:3-ubuntu
+                    command:
+                      - chmod +x .buildkite/gpu-tests/scripts/run-tests.sh
+                      - .buildkite/gpu-tests/scripts/run-tests.sh transformers
+
+                    resources:
+                      limits:
+                        nvidia.com/gpu: 1
+
+                    volumeMounts:
+                      - name: model-cache
+                        mountPath: /model-cache
+                        readOnly: false
+                      - name: devshm
+                        mountPath: /dev/shm
+
+                    env:
+                      - name: PYTHON_VERSION
+                        value: "{{matrix.python}}"
+
+                volumes:
+                  - name: model-cache
+                    persistentVolumeClaim:
+                      claimName: buildkite-podpvc-ssd-blue
+                  - name: devshm
+                    emptyDir:
+                      medium: Memory
+
+        matrix:
+          setup:
+            python: ["3.12"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,15 @@
+steps:
+  - label: ":gear: llm-compressor GPU Tests"
+    command: |
+      RUNNER=$$(buildkite-agent meta-data get "test-runner" --default "H100")
+      echo "╔══════════════════════════════════════════╗"
+      echo "║          BUILD SUMMARY                   ║"
+      echo "╠══════════════════════════════════════════╣"
+      echo "║ Triggered by : $${BUILDKITE_BUILD_CREATOR}"
+      echo "║ Source        : $${BUILDKITE_SOURCE}"
+      echo "║ Branch        : $${BUILDKITE_BRANCH}"
+      echo "║ Commit        : $${BUILDKITE_COMMIT:0:8}"
+      echo "║ PR            : $${BUILDKITE_PULL_REQUEST:-none}"
+      echo "║ GPU Runner    : $${RUNNER}"
+      echo "╚══════════════════════════════════════════╝"
+      buildkite-agent pipeline upload .buildkite/gpu-tests/gpu-tests-$${RUNNER}.yml


### PR DESCRIPTION
## Summary

Migrate GPU test workflows (`test-check.yaml` and `test-check-transformers.yaml`) from GitHub Actions to Buildkite using the dispatcher pattern.

- **Base tests**: Python 3.10/3.13 matrix, runs `make test`
- **Transformers tests**: Python 3.12, per-file pytest loop, gated on file change detection via `RedHat-ModelOpt-Util` step
- **Runner support**: H100 (WDC) and L4 (GCP) via meta-data selection, defaulting to H100
- **Code coverage**: Optional, triggered via `code-coverage` meta-data on manual builds, with per-job artifact upload and a combine-coverage step
- **compressed-tensors**: Installed from source (nightly) to match GHA behavior

### Pipeline structure
.buildkite/
├── pipeline.yml                           # Dispatcher
└── gpu-tests/
├── gpu-tests-H100.yml                 # Base tests + detect-changes + combine-coverage
├── gpu-tests-L4.yml                      # Base tests + detect-changes + combine-coverage
├── transformers-tests-H100.yml        # Uploaded conditionally by detect-changes
├── transformers-tests-L4.yml          # Uploaded conditionally by detect-changes
└── scripts/
├── run-tests.sh                   # Shared: accepts "base" or "transformers"
└── combine-coverage.sh            # Downloads artifacts, runs coverage combine



### Buildkite UI configuration required
- **Filter condition**: `build.source == "ui" || build.branch == "main" || build.branch =~ /^release/ || build.pull_request.labels includes "ready"`

### What stays in GHA
CPU-only workflows: quality-check, linkcheck, stale, ready-label-check, set-comment

### Known limitations
- Multi-GPU tests (`test_quantization_ddp.py`, `test_smoothquant_distributed.py`, etc.) are skipped — pods request 1 GPU, matching current GHA behavior
- Code coverage is not triggered on automated builds (manual only via meta-data)

## Test plan
- [ ] Buildkite pipeline created in UI with filter condition and input fields
- [ ] Automatic build on this branch with H100 runner — base tests pass
- [ ] Manual build on this branch with L4 runner — base tests pass
- [ ] Verify detect-changes step skips transformers tests when only docs changed
- [ ] Verify detect-changes step uploads transformers tests when `src/` or `tests/` changed
- [ ] Manual build with `code-coverage: true` — coverage artifacts uploaded and combined