### PR TITLE
[Agents] Add quantization skills: kv-cache, attention, w4a8, autoround, embedding, model-free-ptq

### DIFF
--- a/examples/.claude/skills/attention/SKILL.md
+++ b/examples/.claude/skills/attention/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: attention
+description: >
+  Generate a working attention quantization example script (FP8 attention activations)
+  and save a compressed-tensors checkpoint.
+  Triggers on: "attention quantization", "quantize attention", "fp8 attention", "attention fp8", "qkv quantization".
+allowed-tools: [Read, Write, Glob, Bash(make style), Bash(ls *), Bash(find *)]
+---
+
+# Write Attention Example
+
+Generate a working Python example script that quantizes the attention activations
+of a model to FP8 and saves a compressed-tensors checkpoint.
+
+Attention quantization targets the model's attention module directly (not the
+`Linear` layers), so the target is the **attention class name** for the model
+architecture. It requires calibration data.
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
+2. **Attention module class** — the model-specific attention class to target, e.g.
+   - Llama: `LlamaAttention`
+   - Qwen2 / Qwen2.5: `Qwen2Attention`
+   - Mistral: `MistralAttention`
+   Find it with `print(type(model.model.layers[0].self_attn).__name__)`.
+3. **Model type** — dense, MoE, or multimodal.
+
+Attention quantization always requires a calibration dataset.
+
+## Step 2 — Choose the template
+
+```python
+from compressed_tensors.offload import dispatch_model
+from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+ds = load_dataset("HuggingFaceH4/ultrachat_200k", split=f"train_sft[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {"text": tokenizer.apply_chat_template(example["messages"], tokenize=False)}
+
+
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(preprocess)
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+# Target the attention module class (NOT "Linear"). Replace "<ATTENTION_CLASS>"
+# with the model's attention class, e.g. "LlamaAttention" / "Qwen2Attention".
+recipe = QuantizationModifier(
+    config_groups={
+        "attention": QuantizationScheme(
+            targets=["<ATTENTION_CLASS>"],
+            input_activations=QuantizationArgs(
+                num_bits=8, type="float", strategy="tensor"
+            ),
+        )
+    }
+)
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-attention-fp8"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+## Step 3 — Apply model-type adjustments
+
+### Dense models
+Set `targets` to the model's attention class name (see Step 1).
+
+### Combining with weight/activation or KV-cache quantization
+Add more entries to `config_groups` (e.g. a `Linear` group for FP8 weights, or a
+`kv_cache_scheme`) to quantize attention together with the rest of the model.
+
+### Multimodal (vision / audio)
+Use `AutoProcessor`, and target the language-model attention class (the vision
+tower has its own attention class — usually left in full precision).
+
+## Step 4 — Write the file
+
+Place the file under `examples/quantization_attention/`.
+
+Name the file `{model_name_slug}_attention.py` (e.g. `llama3_attention.py`).
+
+Run `make style` after writing the file.
+
+## Notes
+
+- The target is the **attention module class**, not `Linear` — using `"Linear"`
+  here quantizes the projections, not the attention compute.
+- Attention quantization is most useful combined with KV-cache quantization for
+  long-context serving.
+- The attention class name is architecture-specific; always confirm it from the
+  loaded model rather than assuming.

--- a/examples/.claude/skills/autoround/SKILL.md
+++ b/examples/.claude/skills/autoround/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: autoround
+description: >
+  Generate a working AutoRound quantization example script (learned weight rounding for
+  W4A16 / NVFP4 / MXFP4) and save a compressed-tensors checkpoint.
+  Triggers on: "autoround", "auto-round", "auto round", "learned rounding", "sign-SGD rounding".
+allowed-tools: [Read, Write, Glob, Bash(make style), Bash(ls *), Bash(find *)]
+---
+
+# Write AutoRound Example
+
+Generate a working Python example script that quantizes a model with the AutoRound
+algorithm and saves a compressed-tensors checkpoint.
+
+AutoRound is an alternative weight-quantization algorithm to GPTQ/AWQ: it learns
+per-weight rounding via a short optimization, often improving low-bit accuracy. It
+applies across schemes (W4A16, NVFP4, MXFP4, FP8). Requires the `auto-round`
+package (`pip install auto-round`).
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
+2. **Scheme** — `W4A16` (default), `NVFP4`, or `MXFP4`.
+3. **iters** — AutoRound optimization steps (200 is a good default; higher = more
+   accuracy, slower).
+4. **Model type** — dense, MoE, or multimodal.
+
+AutoRound always requires a calibration dataset.
+
+## Step 2 — Choose the template
+
+AutoRound uses its own aligned calibration dataset via `auto_round.calib_dataset`.
+
+```python
+from auto_round.calib_dataset import get_dataset
+from compressed_tensors.offload import dispatch_model
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.autoround import AutoRoundModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+NUM_CALIBRATION_SAMPLES = 128
+MAX_SEQUENCE_LENGTH = 2048
+
+# AutoRound-aligned calibration dataset.
+ds = get_dataset(
+    tokenizer=tokenizer,
+    seqlen=MAX_SEQUENCE_LENGTH,
+    nsamples=NUM_CALIBRATION_SAMPLES,
+)
+
+# Learned 4-bit weight rounding (group 128). Swap scheme for NVFP4 / MXFP4.
+recipe = AutoRoundModifier(
+    targets="Linear", scheme="W4A16", ignore=["lm_head"], iters=200
+)
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    # disable shuffling to get slightly better MMLU score
+    shuffle_calibration_samples=False,
+)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-W4A16-G128-AutoRound"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+## Step 3 — Apply model-type adjustments
+
+### Dense models
+`ignore=["lm_head"]` is sufficient.
+
+### MoE models
+Add gate/router layers to `ignore` (e.g. Qwen MoE: `"re:.*mlp\.gate$"`). See
+`examples/autoround/ddp/` for a distributed MoE example.
+
+### NVFP4 / MXFP4 with AutoRound
+Set `scheme="NVFP4"` or `scheme="MXFP4"`. See
+`examples/autoround/quantization_w4a4_fp4/` and
+`examples/autoround/quantization_w4a4_mxfp4/`.
+
+### Multimodal (vision / audio)
+Use `AutoProcessor` and the model-specific class; add vision/audio towers to
+`ignore`. See `examples/autoround/quantization_w4a4_fp4/qwen3_vl_example.py`.
+
+## Step 4 — Write the file
+
+Place the file under `examples/autoround/quantization_<scheme>/`
+(e.g. `quantization_w4a16/`, `quantization_w4a4_fp4/`).
+
+Name the file `{model_name_slug}_example.py` (e.g. `llama3_example.py`).
+
+Run `make style` after writing the file.
+
+## Notes
+
+- Requires `pip install auto-round`; calibration uses `auto_round.calib_dataset`.
+- `shuffle_calibration_samples=False` is recommended — AutoRound's aligned dataset
+  scores slightly better unshuffled.
+- AutoRound trades extra calibration time (the `iters` optimization) for better
+  low-bit accuracy than plain RTN; compare against GPTQ/AWQ for your model.

--- a/examples/.claude/skills/embedding/SKILL.md
+++ b/examples/.claude/skills/embedding/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: embedding
+description: >
+  Generate a working embedding quantization example script (weight-only int4/int8 of the
+  embedding table) and save a compressed-tensors checkpoint.
+  Triggers on: "embedding quantization", "quantize embedding", "embed_tokens", "embedding table", "quantize embeddings".
+allowed-tools: [Read, Write, Glob, Bash(make style), Bash(ls *), Bash(find *)]
+---
+
+# Write Embedding Example
+
+Generate a working Python example script that quantizes a model's input embedding
+table (weight-only) and saves a compressed-tensors checkpoint.
+
+Embedding quantization shrinks the lookup table, which is a large share of
+parameters in small/medium models. It is weight-only (a lookup has no
+activations), so it is **data-free** — no calibration dataset is required.
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
+2. **Bit width / group size** — e.g. int4 group 64 (default), or int8.
+3. **Pair with Linear quantization?** — embeddings are often quantized alongside
+   a W4A16 / W8A8 scheme on the `Linear` layers (add a second config group).
+4. **Model type** — dense, MoE, or multimodal.
+
+## Step 2 — Choose the template
+
+The target is the **`Embedding` module class** (not a name regex), which keeps the
+recipe portable across architectures regardless of the module's name
+(`model.embed_tokens`, `gpt_neox.embed_in`, ...).
+
+```python
+from compressed_tensors.offload import dispatch_model
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+# Quantize the input embedding table to int4, group size 64. Weight-only, so this
+# is data-free.
+recipe = QuantizationModifier(
+    config_groups={
+        "embedding": {
+            "targets": ["Embedding"],
+            "weights": {
+                "num_bits": 4,
+                "type": "int",
+                "symmetric": True,
+                "strategy": "group",
+                "group_size": 64,
+            },
+        }
+    }
+)
+
+oneshot(model=model, recipe=recipe)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-embedding-W4A16-G64"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+## Step 3 — Apply model-type adjustments
+
+### Pair with Linear-layer quantization
+Add a second config group targeting `Linear` to quantize weights too, e.g.:
+
+```python
+recipe = QuantizationModifier(
+    config_groups={
+        "embedding": {
+            "targets": ["Embedding"],
+            "weights": {"num_bits": 4, "type": "int", "symmetric": True,
+                        "strategy": "group", "group_size": 64},
+        },
+        "linear": {
+            "targets": ["Linear"],
+            "weights": {"num_bits": 4, "type": "int", "symmetric": True,
+                        "strategy": "group", "group_size": 128},
+        },
+    },
+    ignore=["lm_head"],
+)
+```
+
+### MoE / multimodal
+Embedding quantization targets the `Embedding` class directly, so MoE routers and
+vision/audio towers are unaffected. Use `AutoProcessor` for multimodal models.
+
+## Step 4 — Write the file
+
+Place the file under `examples/quantization_embedding/`.
+
+Name the file `{model_name_slug}_example.py` (e.g. `llama3_example.py`).
+
+Run `make style` after writing the file.
+
+## Notes
+
+- Embedding quantization is **data-free** — `oneshot(model=model, recipe=recipe)`
+  with no `dataset` is correct.
+- Target the `Embedding` **class**, not a module-name regex, for portability.
+- Most impactful on models where the embedding/`lm_head` is a large fraction of
+  parameters (small models, large vocabularies).

--- a/examples/.claude/skills/kv-cache/SKILL.md
+++ b/examples/.claude/skills/kv-cache/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: kv-cache
+description: >
+  Generate a working KV cache quantization example script (FP8 KV cache, optionally
+  combined with FP8 weights/activations) and save a compressed-tensors checkpoint.
+  Triggers on: "kv cache", "kv-cache", "fp8 kv", "quantize kv cache", "kv cache quantization", "per-head kv".
+allowed-tools: [Read, Write, Glob, Bash(make style), Bash(ls *), Bash(find *)]
+---
+
+# Write KV Cache Example
+
+Generate a working Python example script that quantizes a model's KV cache to FP8
+(optionally alongside FP8 weights and activations) and saves a compressed-tensors
+checkpoint.
+
+KV cache quantization shrinks the per-token cache, which is the dominant memory
+cost at long context / large batch. It requires calibration data to fit the KV
+scales.
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
+2. **Scope** — choose one:
+   - **KV cache only** — leave weights/activations in full precision, quantize
+     just the cache.
+   - **FP8 weights + activations + KV cache** — full FP8 (recommended for serving).
+3. **Strategy** — `tensor` (per-tensor scales, default) or `tensor_group` /
+   per-head for finer granularity.
+4. **Model type** — dense, MoE, or multimodal.
+
+KV cache quantization always requires a calibration dataset.
+
+## Step 2 — Choose the template
+
+### FP8 weights + activations + FP8 KV cache (recommended)
+
+```python
+from compressed_tensors.offload import dispatch_model
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+ds = load_dataset("HuggingFaceH4/ultrachat_200k", split=f"train_sft[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def process_and_tokenize(example):
+    text = tokenizer.apply_chat_template(example["messages"], tokenize=False)
+    return tokenizer(
+        text,
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(process_and_tokenize, remove_columns=ds.column_names)
+
+# The `kv_cache_scheme` block is what quantizes the cache. Here it is paired with
+# FP8 weights + activations; drop the `config_groups` block to quantize the cache
+# only.
+recipe = """
+quant_stage:
+    quant_modifiers:
+        QuantizationModifier:
+            ignore: ["lm_head"]
+            config_groups:
+                group_0:
+                    weights:
+                        num_bits: 8
+                        type: float
+                        strategy: tensor
+                        dynamic: false
+                        symmetric: true
+                    input_activations:
+                        num_bits: 8
+                        type: float
+                        strategy: tensor
+                        dynamic: false
+                        symmetric: true
+                    targets: ["Linear"]
+            kv_cache_scheme:
+                num_bits: 8
+                type: float
+                strategy: tensor
+                dynamic: false
+                symmetric: true
+"""
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-FP8-KV"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+### KV cache only
+
+Remove the `config_groups` block from the recipe and keep just `kv_cache_scheme`
+under `QuantizationModifier`. Weights and activations stay in full precision.
+
+### Per-head KV scales
+
+For finer granularity, set `strategy: tensor_group` (per-head) in
+`kv_cache_scheme`. See `examples/quantization_kv_cache/llama3_fp8_head_kv_example.py`.
+
+## Step 3 — Apply model-type adjustments
+
+### Dense models
+`ignore=["lm_head"]` is sufficient.
+
+### MoE models
+Add gate/router layers to `ignore` (e.g. Qwen MoE: `"re:.*mlp\.gate$"`,
+`"re:.*shared_expert_gate.*"`).
+
+### Multimodal (vision / audio)
+- Use `AutoProcessor` instead of `AutoTokenizer`
+- Add the vision/audio towers to `ignore`
+  (`"re:.*vision_tower.*"`, `"re:.*audio_tower.*"`)
+
+## Step 4 — Write the file
+
+Place the file under `examples/quantization_kv_cache/`.
+
+Name the file `{model_name_slug}_fp8_kv_example.py` (e.g. `llama3_fp8_kv_example.py`).
+
+Run `make style` after writing the file.
+
+## Notes
+
+- KV cache quantization requires calibration; `oneshot` with no `dataset` will not
+  fit the cache scales.
+- Pairing FP8 KV with FP8 weights+activations is the common serving config; the
+  cache can also be quantized on its own.
+- Per-head (`tensor_group`) scales can recover accuracy on models sensitive to a
+  single per-tensor cache scale.

--- a/examples/.claude/skills/model-free-ptq/SKILL.md
+++ b/examples/.claude/skills/model-free-ptq/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: model-free-ptq
+description: >
+  Generate a working model_free_ptq example script for data-free quantization of very large
+  models (FP8, NVFP4A16, MXFP4A16) directly from safetensors, without a transformers model definition.
+  Triggers on: "model_free_ptq", "model free ptq", "data-free ptq", "quantize huge model", "no model definition", "kimi", "deepseek large".
+allowed-tools: [Read, Write, Glob, Bash(make style), Bash(ls *), Bash(find *)]
+---
+
+# Write model_free_ptq Example
+
+Generate a working Python example script that quantizes a model with
+`model_free_ptq` and saves a compressed-tensors checkpoint.
+
+`model_free_ptq` works directly on the checkpoint safetensors — it does **not**
+load the model through transformers. Use it when:
+
+1. the model has **no transformers model definition** (e.g. a brand-new arch), or
+2. the model is **very large** (e.g. Kimi-K2, DeepSeek) and `oneshot` runs into
+   memory issues.
+
+It supports **data-free schemes only** (no calibration): FP8 dynamic/block and the
+weight-only microscale schemes (NVFP4A16 / MXFP4A16).
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace stub or local path (passed directly, not loaded
+   through transformers).
+2. **Scheme** — a data-free scheme: `FP8_DYNAMIC`, `FP8_BLOCK`, `NVFP4A16`, or
+   `MXFP4A16`.
+3. **ignore list** — modules to keep in full precision (`lm_head`,
+   `model.embed_tokens`, MoE gates, and any blocks incompatible with the scheme's
+   block size).
+4. **device** / **max_workers** — e.g. `device="cuda:0"`, `max_workers=15`.
+
+## Step 2 — Choose the template
+
+### FP8 (FP8_DYNAMIC / FP8_BLOCK)
+
+```python
+from llmcompressor import model_free_ptq
+
+MODEL_ID = "<MODEL_ID>"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-FP8-BLOCK"
+
+model_free_ptq(
+    model_stub=MODEL_ID,
+    save_directory=SAVE_DIR,
+    scheme="FP8_BLOCK",  # or FP8_DYNAMIC
+    ignore=[
+        "model.embed_tokens",
+        "lm_head",
+        # add MoE gates / block-size-incompatible layers per model — see Step 3
+    ],
+    max_workers=15,
+    device="cuda:0",
+)
+```
+
+### Microscale (NVFP4A16 / MXFP4A16) — requires a reindex step
+
+Microscale schemes fuse global scales across fused modules (qkv, gate_up), so the
+safetensors must first be reindexed to put fused modules in the same file:
+
+```bash
+llmcompressor.reindex_fused_weights \
+    <MODEL_ID> <MODEL_ID_slug>-reindexed --num_workers=10
+```
+
+Then run `model_free_ptq` on the reindexed files:
+
+```python
+from llmcompressor import model_free_ptq
+
+model_free_ptq(
+    model_stub="<MODEL_ID_slug>-reindexed",
+    save_directory="<MODEL_ID_slug>-NVFP4A16",
+    scheme="NVFP4A16",  # or MXFP4A16
+    ignore=["lm_head", "re:.*gate$", "model.embed_tokens"],
+    max_workers=15,
+    device="cuda:0",
+)
+```
+
+## Step 3 — Apply model-type adjustments
+
+### Dense models
+`ignore=["model.embed_tokens", "lm_head"]` is usually sufficient.
+
+### MoE models
+Add the router/gate and any block-size-incompatible projections to `ignore`, e.g.
+for DeepSeek/Kimi-style models:
+`"re:.*gate$"`, `"re:.*kv_a_proj_with_mqa$"`, `"re:.*q_a_proj$"`. See the Kimi-K2
+and DeepSeek examples under `examples/model_free_ptq/`.
+
+### FP8_BLOCK note
+Block quantization needs dimensions divisible by the block (commonly 128); ignore
+layers that are not (the example ignore lists show the common ones per model).
+
+## Step 4 — Write the file
+
+Place the file under `examples/model_free_ptq/`.
+
+Name the file `{model_name_slug}_{scheme_slug}.py`
+(e.g. `qwen3_fp8_block.py`, `kimi_k2_thinking_nvfp4a16.py`).
+
+Run `make style` after writing the file.
+
+## Notes
+
+- Data-free schemes only — `model_free_ptq` does not take a calibration dataset.
+- The model stub is passed **directly** (not loaded through transformers); this is
+  what lets it handle models without a transformers definition.
+- For microscale schemes, the `llmcompressor.reindex_fused_weights` step is
+  required before quantizing.
+- This is the recommended path for the largest models (Kimi-K2, DeepSeek,
+  Mistral-Large); for normal-sized models prefer `oneshot`.

--- a/examples/.claude/skills/w4a8/SKILL.md
+++ b/examples/.claude/skills/w4a8/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: w4a8
+description: >
+  Generate a working W4A8 quantization example script (4-bit weights + 8-bit activations,
+  W4AFP8 or W4A8) and save a compressed-tensors checkpoint.
+  Triggers on: "w4a8", "W4A8", "W4AFP8", "w4afp8", "int4 fp8", "int4 int8", "4-bit weight 8-bit activation".
+allowed-tools: [Read, Write, Glob, Bash(make style), Bash(ls *), Bash(find *)]
+---
+
+# Write W4A8 Example
+
+Generate a working Python example script that quantizes a model to a 4-bit-weight
+/ 8-bit-activation scheme and saves a compressed-tensors checkpoint. This pairs
+aggressive weight compression with 8-bit activation throughput.
+
+## Step 1 — Gather information
+
+Ask the user (or infer from context) for:
+
+1. **MODEL_ID** — HuggingFace model ID (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`)
+2. **Scheme** — choose one (both use **dynamic** per-token activations):
+   - `W4AFP8` — int4 weights (group 128) + **FP8** dynamic activations. Best on
+     FP8-capable hardware (Ada/Hopper/Blackwell).
+   - `W4A8` — int4 weights + **INT8** dynamic activations. For INT8 throughput
+     paths (Ampere+).
+3. **Algorithm** — choose one (this is what decides calibration, *not* the scheme):
+   - `GPTQModifier` — learned weight rounding. **Requires a calibration dataset.**
+     Best accuracy at 4-bit; the W4AFP8 example uses this.
+   - `QuantizationModifier` (RTN) — round-to-nearest weights. **Data-free** (the
+     activations are dynamic, so no dataset is needed); the GPT-OSS W4A8 example
+     uses this.
+4. **Model type** — dense, MoE, or multimodal.
+
+## Step 2 — Choose the template
+
+### W4AFP8 with GPTQ (calibration required)
+
+```python
+from compressed_tensors.offload import dispatch_model
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.gptq import GPTQModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+ds = load_dataset("HuggingFaceH4/ultrachat_200k", split=f"train_sft[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {"text": tokenizer.apply_chat_template(example["messages"], tokenize=False)}
+
+
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(preprocess)
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+# int4 weights (group 128) + FP8 dynamic per-token activations.
+recipe = GPTQModifier(targets="Linear", scheme="W4AFP8", ignore=["lm_head"])
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+)
+
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================")
+
+# Use quantization_format="pack-quantized" for vLLM compatibility.
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-W4AFP8"
+model.save_pretrained(
+    SAVE_DIR, save_compressed=True, quantization_format="pack-quantized"
+)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+### W4A8 with QuantizationModifier (data-free, RTN)
+
+Because the activations are dynamic, this path needs **no calibration dataset**.
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+
+MODEL_ID = "<MODEL_ID>"
+
+# Load model.
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+# int4 weights + INT8 dynamic per-token activations. No dataset needed.
+recipe = QuantizationModifier(targets="Linear", scheme="W4A8", ignore=["lm_head"])
+
+oneshot(model=model, recipe=recipe)
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-W4A8"
+model.save_pretrained(
+    SAVE_DIR, save_compressed=True, quantization_format="pack-quantized"
+)
+tokenizer.save_pretrained(SAVE_DIR)
+```
+
+For a channelwise-weight / asymmetric-activation variant and a large-MoE load
+path, see `examples/quantization_w4a8/gpt_oss_20b_example.py`, which builds the
+scheme explicitly with `config_groups` instead of the preset string. To improve
+4-bit accuracy, swap `QuantizationModifier` for `GPTQModifier` (and add the
+calibration dataset from the W4AFP8 template).
+
+## Step 3 — Apply model-type adjustments
+
+### Dense models
+`ignore=["lm_head"]` is sufficient.
+
+### MoE models
+Add gate/router layers to `ignore`:
+- Qwen MoE: `"re:.*mlp\.gate$"`, `"re:.*shared_expert_gate.*"`
+- General: `"re:.*mlp\.router.*"`
+
+For very large MoE models, see
+`examples/quantization_w4a8/gpt_oss_20b_example.py` (the GPT-OSS model), which
+also wraps loading in `load_context()`.
+
+### Multimodal (vision / audio)
+- Use `AutoProcessor` instead of `AutoTokenizer`
+- Add the vision/audio towers to `ignore`
+  (`"re:.*vision_tower.*"`, `"re:.*audio_tower.*"`)
+
+## Step 4 — Write the file
+
+Place the file under `examples/quantization_w4a8_fp8/` (W4AFP8) or
+`examples/quantization_w4a8/` (W4A8).
+
+Name the file `{model_name_slug}_example.py` (e.g. `llama3_example.py`).
+
+Run `make style` after writing the file.
+
+## Notes
+
+- Both schemes use **dynamic** activations, so calibration is driven by the
+  **algorithm**: GPTQ needs a dataset, RTN (`QuantizationModifier`) is data-free.
+- `W4AFP8` keeps activations in FP8 (best on FP8-capable GPUs); `W4A8` uses INT8
+  activations.
+- Save with `quantization_format="pack-quantized"` so vLLM loads the packed int4
+  weights.
+- GPTQ trades calibration time for better 4-bit weight accuracy; start with RTN
+  if you want a fast, data-free baseline.


### PR DESCRIPTION
SUMMARY:

Adds agent skills under `examples/.claude/skills/`, following the same template as the `fp8` / `int` / `mxfp4` / `nvfp4` skills in #2851, covering quantization capabilities that set doesn't yet:

- **kv-cache** — FP8 KV cache (optionally with FP8 weights/activations), incl. per-head note
- **attention** — FP8 attention-activation quantization (targets the attention module class)
- **w4a8** — `W4AFP8` (GPTQ, calibrated) and `W4A8` (RTN, data-free) as two distinct templates
- **autoround** — AutoRound learned weight rounding (W4A16 / NVFP4 / MXFP4)
- **embedding** — weight-only int4/int8 of the `Embedding` table (data-free)
- **model-free-ptq** — data-free PTQ for very large models directly from safetensors (FP8 / NVFP4A16 / MXFP4A16), incl. the `reindex_fused_weights` step

Each mirrors the corresponding `examples/` script and uses current APIs. The skill directories are independent of #2851's, so this complements that PR.

TEST PLAN:

Smoke-tested every template end-to-end on an RTX 5090 (Blackwell, sm_120; llmcompressor 0.12.0) with `Qwen/Qwen2.5-0.5B-Instruct` and reduced calibration samples. Each ran and saved a valid compressed-tensors checkpoint:

| Skill | Result | Format |
|---|---|---|
| kv-cache | ✅ | `float-quantized` + `kv_cache_scheme` |
| attention | ✅ | attention `input_activations` quantized |
| w4a8 (W4AFP8, GPTQ) | ✅ | `pack-quantized` |
| w4a8 (W4A8, data-free RTN) | ✅ | `pack-quantized` |
| autoround (W4A16) | ✅ | `pack-quantized` |
| embedding (int4 group64) | ✅ | `pack-quantized` |
| model-free-ptq (FP8_DYNAMIC) | ✅ | `float-quantized` |
