### PR TITLE
Validate KV-cache scales after calibration

### DIFF
--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -233,11 +233,13 @@ class GPTQModifier(Modifier, QuantizationMixin):
     def on_sequential_epoch_end(
         self, state: State, event: Event, modules: list[torch.nn.Module], **kwargs
     ):
+        validation_modules = modules
         modules = [module for module in modules if is_module_quantized(module)]
         observe(modules, base_name="weight")
         self.sync_obs_act_stats(modules)
         update_qparams(modules, ACTIVATION_OBS, only_update_onload=not is_src())
         self.compress_modules()
+        self.validate_module_calibration(state.model, validation_modules)
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -237,6 +237,9 @@ class GPTQModifier(Modifier, QuantizationMixin):
         observe(modules, base_name="weight")
         self.sync_obs_act_stats(modules)
         update_qparams(modules, ACTIVATION_OBS, only_update_onload=not is_src())
+        self.validate_module_calibration(
+            state.model, modules, (*ACTIVATION_OBS, "weight")
+        )
         self.compress_modules()
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -233,13 +233,11 @@ class GPTQModifier(Modifier, QuantizationMixin):
     def on_sequential_epoch_end(
         self, state: State, event: Event, modules: list[torch.nn.Module], **kwargs
     ):
-        validation_modules = modules
         modules = [module for module in modules if is_module_quantized(module)]
         observe(modules, base_name="weight")
         self.sync_obs_act_stats(modules)
         update_qparams(modules, ACTIVATION_OBS, only_update_onload=not is_src())
         self.compress_modules()
-        self.validate_module_calibration(state.model, validation_modules)
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -86,11 +86,13 @@ class QuantizationModifier(Modifier, QuantizationMixin):
         modules = [module for module in modules if is_module_quantized(module)]
         self.sync_obs_act_stats(modules)
         update_qparams(modules, ACTIVATION_OBS)
+        self.validate_module_calibration(state.model, modules, ACTIVATION_OBS)
 
         ### Not Distributed
         if not is_distributed():
             observe(modules, "weight")
             update_qparams(modules, "weight")
+            self.validate_module_calibration(state.model, modules, "weight")
             return
 
         ### Distributed
@@ -105,8 +107,16 @@ class QuantizationModifier(Modifier, QuantizationMixin):
 
         observe(rank_to_modules[rank], "weight")
         update_qparams(rank_to_modules[rank], "weight")
+<<<<<<< HEAD
         broadcast_qparams_and_cleanup(module_list, module_to_rank, _WEIGHT_Q_PARAMS)
         self.validate_module_calibration(state.model, rank_to_modules[rank])
+=======
+        self.validate_module_calibration(
+            state.model, rank_to_modules[rank], "weight"
+        )
+        dist.barrier()  # wait for async offload updates to finish
+        self._broadcast_qparam_onloads(module_list, module_to_rank)
+>>>>>>> a13c76e1 (Validate calibration observers after sequential epochs)
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -107,16 +107,8 @@ class QuantizationModifier(Modifier, QuantizationMixin):
 
         observe(rank_to_modules[rank], "weight")
         update_qparams(rank_to_modules[rank], "weight")
-<<<<<<< HEAD
         broadcast_qparams_and_cleanup(module_list, module_to_rank, _WEIGHT_Q_PARAMS)
         self.validate_module_calibration(state.model, rank_to_modules[rank])
-=======
-        self.validate_module_calibration(
-            state.model, rank_to_modules[rank], "weight"
-        )
-        dist.barrier()  # wait for async offload updates to finish
-        self._broadcast_qparam_onloads(module_list, module_to_rank)
->>>>>>> a13c76e1 (Validate calibration observers after sequential epochs)
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -83,6 +83,7 @@ class QuantizationModifier(Modifier, QuantizationMixin):
     def on_sequential_epoch_end(
         self, state: State, event: Event, modules: list[torch.nn.Module], **kwargs
     ):
+        validation_modules = modules
         modules = [module for module in modules if is_module_quantized(module)]
         self.sync_obs_act_stats(modules)
         update_qparams(modules, ACTIVATION_OBS)
@@ -91,6 +92,7 @@ class QuantizationModifier(Modifier, QuantizationMixin):
         if not is_distributed():
             observe(modules, "weight")
             update_qparams(modules, "weight")
+            self.validate_module_calibration(state.model, validation_modules)
             return
 
         ### Distributed
@@ -106,6 +108,7 @@ class QuantizationModifier(Modifier, QuantizationMixin):
         observe(rank_to_modules[rank], "weight")
         update_qparams(rank_to_modules[rank], "weight")
         broadcast_qparams_and_cleanup(module_list, module_to_rank, _WEIGHT_Q_PARAMS)
+        self.validate_module_calibration(state.model, rank_to_modules[rank])
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -83,7 +83,6 @@ class QuantizationModifier(Modifier, QuantizationMixin):
     def on_sequential_epoch_end(
         self, state: State, event: Event, modules: list[torch.nn.Module], **kwargs
     ):
-        validation_modules = modules
         modules = [module for module in modules if is_module_quantized(module)]
         self.sync_obs_act_stats(modules)
         update_qparams(modules, ACTIVATION_OBS)
@@ -92,7 +91,6 @@ class QuantizationModifier(Modifier, QuantizationMixin):
         if not is_distributed():
             observe(modules, "weight")
             update_qparams(modules, "weight")
-            self.validate_module_calibration(state.model, validation_modules)
             return
 
         ### Distributed

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -264,10 +264,111 @@ class QuantizationMixin(HooksMixin):
         :param model: model to end calibration for
         """
         self.remove_hooks(self._calibration_hooks)
+        unobserved_kv_cache = self._collect_unobserved_kv_cache_observers(model)
         for _, module in match_named_modules(model, self.resolved_targets, self.ignore):
             freeze_module_quantization(module)  # remove observers
 
+        self._validate_kv_cache_scales(model, unobserved_kv_cache)
         model.apply(enable_quantization)  # keep quantization enabled
+
+    def _collect_unobserved_kv_cache_observers(
+        self, model: torch.nn.Module
+    ) -> list[str]:
+        if self._skip_kv_cache_scale_validation():
+            return []
+
+        unobserved = []
+        for module_name, module in model.named_modules():
+            if not is_attention_module(module) or not hasattr(module, KV_CACHE_ATTR):
+                continue
+
+            for base_name in ("k", "v"):
+                observer = getattr(module, f"{base_name}_observer", None)
+                if observer is None or not observer.has_statistics:
+                    unobserved.append(
+                        self._format_kv_cache_param_name(
+                            module_name, f"{base_name}_observer"
+                        )
+                    )
+
+        return unobserved
+
+    def _validate_kv_cache_scales(
+        self,
+        model: torch.nn.Module,
+        unobserved_kv_cache: list[str],
+    ):
+        if self._skip_kv_cache_scale_validation():
+            return
+
+        invalid_scales = []
+        for module_name, module in model.named_modules():
+            if not is_attention_module(module) or not hasattr(module, KV_CACHE_ATTR):
+                continue
+
+            for base_name in ("k", "v"):
+                param_name = f"{base_name}_scale"
+                scale = getattr(module, param_name, None)
+                invalid_reason = self._get_invalid_scale_reason(scale)
+                if invalid_reason is not None:
+                    invalid_scales.append(
+                        f"{self._format_kv_cache_param_name(module_name, param_name)} "
+                        f"({invalid_reason})"
+                    )
+
+        if not unobserved_kv_cache and not invalid_scales:
+            return
+
+        details = []
+        if unobserved_kv_cache:
+            details.append(
+                "missing or unobserved calibration observers: "
+                f"{', '.join(unobserved_kv_cache)}"
+            )
+        if invalid_scales:
+            details.append(f"invalid scales: {', '.join(invalid_scales)}")
+
+        raise ValueError(
+            "KV cache quantization calibration failed. "
+            "KV cache scales must be observed and finite positive values before "
+            "saving a quantized checkpoint. "
+            f"Found {'; '.join(details)}. "
+            "This usually means the model accessed the KV cache without routing "
+            "key/value tensors through the calibration hooks."
+        )
+
+    def _skip_kv_cache_scale_validation(self) -> bool:
+        kv_cache_scheme = self.resolved_config.kv_cache_scheme
+        if kv_cache_scheme is None:
+            return True
+
+        dynamic = kv_cache_scheme.dynamic
+        return dynamic is True or dynamic == DynamicType.LOCAL
+
+    @staticmethod
+    def _get_invalid_scale_reason(scale: torch.Tensor | None) -> str | None:
+        if scale is None:
+            return "missing"
+
+        scale = scale.detach() if isinstance(scale, torch.Tensor) else torch.as_tensor(
+            scale
+        )
+        if scale.is_meta:
+            return "stored on meta device"
+        if scale.numel() == 0:
+            return "empty"
+
+        scale = scale.to(device="cpu")
+        if not torch.isfinite(scale).all().item():
+            return "non-finite"
+        if (scale <= 0).any().item():
+            return "non-positive"
+
+        return None
+
+    @staticmethod
+    def _format_kv_cache_param_name(module_name: str, param_name: str) -> str:
+        return f"{module_name}.{param_name}" if module_name else param_name
 
     def sync_obs_act_stats(self, modules: Iterator[torch.nn.Module]):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -267,10 +267,11 @@ class QuantizationMixin(HooksMixin):
         """
         self.remove_hooks(self._calibration_hooks)
         unobserved_kv_cache = self._collect_unobserved_kv_cache_observers(model)
+        self._validate_kv_cache_scales(model, unobserved_kv_cache)
+
         for _, module in match_named_modules(model, self.resolved_targets, self.ignore):
             freeze_module_quantization(module)  # remove observers
 
-        self._validate_kv_cache_scales(model, unobserved_kv_cache)
         model.apply(enable_quantization)  # keep quantization enabled
 
     def _iter_kv_cache_modules(

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -329,6 +329,12 @@ class QuantizationMixin(HooksMixin):
         }
         invalid_scales = []
         for module_name, module in kv_cache_modules:
+            if (
+                getattr(module, "quantization_status", None)
+                == QuantizationStatus.FROZEN
+            ):
+                continue
+
             for base_name in ("k", "v"):
                 param_name = f"{base_name}_scale"
                 full_param_name = self._format_kv_cache_param_name(

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -281,9 +281,9 @@ class QuantizationMixin(HooksMixin):
             model, self.resolved_targets, self.ignore
         ):
             if (
-                hasattr(module, "quantization_scheme")
+                getattr(module, "quantization_scheme", None) is not None
                 and is_attention_module(module)
-                and hasattr(module, KV_CACHE_ATTR)
+                and getattr(module, KV_CACHE_ATTR, None) is not None
             ):
                 yield module_name, module
 
@@ -295,7 +295,10 @@ class QuantizationMixin(HooksMixin):
 
         unobserved = []
         for module_name, module in self._iter_kv_cache_modules(model):
-            if module.quantization_status == QuantizationStatus.FROZEN:
+            if (
+                getattr(module, "quantization_status", None)
+                == QuantizationStatus.FROZEN
+            ):
                 continue
 
             for base_name in ("k", "v"):
@@ -522,7 +525,7 @@ class QuantizationMixin(HooksMixin):
         return scheme
 
     def _initialize_observers(self, module: torch.nn.Module):
-        if not hasattr(module, "quantization_scheme"):
+        if getattr(module, "quantization_scheme", None) is None:
             return
 
         scheme: QuantizationScheme = module.quantization_scheme
@@ -555,7 +558,7 @@ class QuantizationMixin(HooksMixin):
 
     def _initialize_hooks(self, module: torch.nn.Module) -> set[RemovableHandle]:
         hooks = set()
-        if not hasattr(module, "quantization_scheme"):
+        if getattr(module, "quantization_scheme", None) is None:
             return hooks
 
         scheme: QuantizationScheme = module.quantization_scheme

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -266,8 +266,11 @@ class QuantizationMixin(HooksMixin):
         :param model: model to end calibration for
         """
         self.remove_hooks(self._calibration_hooks)
-        unobserved_kv_cache = self._collect_unobserved_kv_cache_observers(model)
-        self._validate_kv_cache_scales(model, unobserved_kv_cache)
+        kv_cache_modules = list(self._iter_kv_cache_modules(model))
+        unobserved_kv_cache = self._collect_unobserved_kv_cache_observers(
+            kv_cache_modules
+        )
+        self._validate_kv_cache_scales(kv_cache_modules, unobserved_kv_cache)
 
         for _, module in match_named_modules(model, self.resolved_targets, self.ignore):
             freeze_module_quantization(module)  # remove observers
@@ -288,13 +291,13 @@ class QuantizationMixin(HooksMixin):
                 yield module_name, module
 
     def _collect_unobserved_kv_cache_observers(
-        self, model: torch.nn.Module
+        self, kv_cache_modules: list[tuple[str, torch.nn.Module]]
     ) -> list[str]:
         if self._skip_kv_cache_scale_validation():
             return []
 
         unobserved = []
-        for module_name, module in self._iter_kv_cache_modules(model):
+        for module_name, module in kv_cache_modules:
             if (
                 getattr(module, "quantization_status", None)
                 == QuantizationStatus.FROZEN
@@ -314,23 +317,30 @@ class QuantizationMixin(HooksMixin):
 
     def _validate_kv_cache_scales(
         self,
-        model: torch.nn.Module,
+        kv_cache_modules: list[tuple[str, torch.nn.Module]],
         unobserved_kv_cache: list[str],
     ):
         if self._skip_kv_cache_scale_validation():
             return
 
+        unobserved_scales = {
+            observer_name.removesuffix("_observer") + "_scale"
+            for observer_name in unobserved_kv_cache
+        }
         invalid_scales = []
-        for module_name, module in self._iter_kv_cache_modules(model):
+        for module_name, module in kv_cache_modules:
             for base_name in ("k", "v"):
                 param_name = f"{base_name}_scale"
+                full_param_name = self._format_kv_cache_param_name(
+                    module_name, param_name
+                )
+                if full_param_name in unobserved_scales:
+                    continue
+
                 scale = getattr(module, param_name, None)
                 invalid_reason = self._get_invalid_scale_reason(scale)
                 if invalid_reason is not None:
-                    invalid_scales.append(
-                        f"{self._format_kv_cache_param_name(module_name, param_name)} "
-                        f"({invalid_reason})"
-                    )
+                    invalid_scales.append(f"{full_param_name} ({invalid_reason})")
 
         if not unobserved_kv_cache and not invalid_scales:
             return

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -347,8 +347,7 @@ class QuantizationMixin(HooksMixin):
         if kv_cache_scheme is None:
             return True
 
-        dynamic = kv_cache_scheme.dynamic
-        return dynamic is True or dynamic == DynamicType.LOCAL
+        return bool(kv_cache_scheme.dynamic)
 
     @staticmethod
     def _get_invalid_scale_reason(scale: torch.Tensor | None) -> str | None:

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -43,10 +43,7 @@ from llmcompressor.modifiers.quantization.group_size_validation import (
     validate_group_size_divisibility,
 )
 from llmcompressor.modifiers.quantization.quantization.mixin_helpers import (
-    collect_calibration_modules,
-    format_calibration_error,
-    get_invalid_static_kv_cache_scales,
-    get_unvalidated_calibration_observers,
+    validate_static_kv_cache_scales,
 )
 from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.observers import ACTIVATION_OBS, fuse_weight_observers
@@ -267,50 +264,21 @@ class QuantizationMixin(HooksMixin):
         Remove calibration hooks and observers, and set the model status to frozen.
         Keep quantization enabled for future operations
 
-        :raises ValueError: if calibration observers are unobserved or if static
-            KV cache quantization scales are invalid
+        :raises ValueError: if static KV cache quantization scales are invalid
         :param model: model to end calibration for
         """
         self.remove_hooks(self._calibration_hooks)
-        self.validate_module_calibration(model)
+        validate_static_kv_cache_scales(
+            model,
+            self.resolved_targets,
+            self.ignore,
+            self.resolved_config.kv_cache_scheme,
+        )
 
         for _, module in match_named_modules(model, self.resolved_targets, self.ignore):
             freeze_module_quantization(module)  # remove observers
 
         model.apply(enable_quantization)  # keep quantization enabled
-
-    def validate_module_calibration(
-        self,
-        model: torch.nn.Module,
-        modules: Iterator[torch.nn.Module] | None = None,
-    ):
-        """
-        Validate that quantized modules were exercised during calibration.
-
-        :raises ValueError: if calibration observers were not invoked or if static
-            KV cache quantization scales are invalid
-        :param model: full model being calibrated
-        :param modules: optional sequential chunk to validate
-        """
-        calibration_modules = collect_calibration_modules(
-            model,
-            self.resolved_targets,
-            self.ignore,
-            modules,
-        )
-        unobserved_observers = get_unvalidated_calibration_observers(
-            calibration_modules,
-            self.resolved_config.kv_cache_scheme,
-        )
-        invalid_scales = get_invalid_static_kv_cache_scales(
-            calibration_modules,
-            self.resolved_config.kv_cache_scheme,
-            unobserved_observers,
-        )
-        if not unobserved_observers and not invalid_scales:
-            return
-
-        raise ValueError(format_calibration_error(unobserved_observers, invalid_scales))
 
     def sync_obs_act_stats(self, modules: Iterator[torch.nn.Module]):
         """
@@ -452,7 +420,7 @@ class QuantizationMixin(HooksMixin):
         return scheme
 
     def _initialize_observers(self, module: torch.nn.Module):
-        if getattr(module, "quantization_scheme", None) is None:
+        if not hasattr(module, "quantization_scheme"):
             return
 
         scheme: QuantizationScheme = module.quantization_scheme
@@ -485,7 +453,7 @@ class QuantizationMixin(HooksMixin):
 
     def _initialize_hooks(self, module: torch.nn.Module) -> set[RemovableHandle]:
         hooks = set()
-        if getattr(module, "quantization_scheme", None) is None:
+        if not hasattr(module, "quantization_scheme"):
             return hooks
 
         scheme: QuantizationScheme = module.quantization_scheme

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -261,6 +261,8 @@ class QuantizationMixin(HooksMixin):
         Remove calibration hooks and observers, and set the model status to frozen.
         Keep quantization enabled for future operations
 
+        :raises ValueError: if static KV cache quantization scales are invalid or
+            unobserved
         :param model: model to end calibration for
         """
         self.remove_hooks(self._calibration_hooks)
@@ -271,6 +273,15 @@ class QuantizationMixin(HooksMixin):
         self._validate_kv_cache_scales(model, unobserved_kv_cache)
         model.apply(enable_quantization)  # keep quantization enabled
 
+    def _iter_kv_cache_modules(
+        self, model: torch.nn.Module
+    ) -> Iterator[tuple[str, torch.nn.Module]]:
+        for module_name, module in match_named_modules(
+            model, self.resolved_targets, self.ignore
+        ):
+            if is_attention_module(module) and hasattr(module, KV_CACHE_ATTR):
+                yield module_name, module
+
     def _collect_unobserved_kv_cache_observers(
         self, model: torch.nn.Module
     ) -> list[str]:
@@ -278,10 +289,7 @@ class QuantizationMixin(HooksMixin):
             return []
 
         unobserved = []
-        for module_name, module in model.named_modules():
-            if not is_attention_module(module) or not hasattr(module, KV_CACHE_ATTR):
-                continue
-
+        for module_name, module in self._iter_kv_cache_modules(model):
             for base_name in ("k", "v"):
                 observer = getattr(module, f"{base_name}_observer", None)
                 if observer is None or not observer.has_statistics:
@@ -302,10 +310,7 @@ class QuantizationMixin(HooksMixin):
             return
 
         invalid_scales = []
-        for module_name, module in model.named_modules():
-            if not is_attention_module(module) or not hasattr(module, KV_CACHE_ATTR):
-                continue
-
+        for module_name, module in self._iter_kv_cache_modules(model):
             for base_name in ("k", "v"):
                 param_name = f"{base_name}_scale"
                 scale = getattr(module, param_name, None)

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -280,7 +280,11 @@ class QuantizationMixin(HooksMixin):
         for module_name, module in match_named_modules(
             model, self.resolved_targets, self.ignore
         ):
-            if is_attention_module(module) and hasattr(module, KV_CACHE_ATTR):
+            if (
+                hasattr(module, "quantization_scheme")
+                and is_attention_module(module)
+                and hasattr(module, KV_CACHE_ATTR)
+            ):
                 yield module_name, module
 
     def _collect_unobserved_kv_cache_observers(
@@ -291,6 +295,9 @@ class QuantizationMixin(HooksMixin):
 
         unobserved = []
         for module_name, module in self._iter_kv_cache_modules(model):
+            if module.quantization_status == QuantizationStatus.FROZEN:
+                continue
+
             for base_name in ("k", "v"):
                 observer = getattr(module, f"{base_name}_observer", None)
                 if observer is None or not observer.has_statistics:

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 import torch
@@ -43,7 +43,10 @@ from llmcompressor.modifiers.quantization.group_size_validation import (
     validate_group_size_divisibility,
 )
 from llmcompressor.modifiers.quantization.quantization.mixin_helpers import (
-    validate_static_kv_cache_scales,
+    CALIBRATION_OBSERVER_BASE_NAMES,
+)
+from llmcompressor.modifiers.quantization.quantization.mixin_helpers import (
+    validate_module_calibration as _validate_module_calibration,
 )
 from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.observers import ACTIVATION_OBS, fuse_weight_observers
@@ -264,21 +267,29 @@ class QuantizationMixin(HooksMixin):
         Remove calibration hooks and observers, and set the model status to frozen.
         Keep quantization enabled for future operations
 
-        :raises ValueError: if static KV cache quantization scales are invalid
         :param model: model to end calibration for
         """
         self.remove_hooks(self._calibration_hooks)
-        validate_static_kv_cache_scales(
-            model,
-            self.resolved_targets,
-            self.ignore,
-            self.resolved_config.kv_cache_scheme,
-        )
 
         for _, module in match_named_modules(model, self.resolved_targets, self.ignore):
             freeze_module_quantization(module)  # remove observers
 
         model.apply(enable_quantization)  # keep quantization enabled
+
+    def validate_module_calibration(
+        self,
+        model: torch.nn.Module,
+        modules: torch.nn.Module | Iterable[torch.nn.Module],
+        base_names: str | Iterable[str] = CALIBRATION_OBSERVER_BASE_NAMES,
+    ):
+        """
+        Validate that calibration observers on a sequential chunk were called.
+
+        :param model: full model, used for module names in error messages
+        :param modules: modules from the current sequential chunk
+        :param base_names: observer base names to validate
+        """
+        _validate_module_calibration(model, modules, base_names)
 
     def sync_obs_act_stats(self, modules: Iterator[torch.nn.Module]):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -42,6 +42,12 @@ from llmcompressor.modifiers.quantization.calibration import (
 from llmcompressor.modifiers.quantization.group_size_validation import (
     validate_group_size_divisibility,
 )
+from llmcompressor.modifiers.quantization.quantization.mixin_helpers import (
+    collect_calibration_modules,
+    format_calibration_error,
+    get_invalid_static_kv_cache_scales,
+    get_unvalidated_calibration_observers,
+)
 from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.observers import ACTIVATION_OBS, fuse_weight_observers
 from llmcompressor.utils import (
@@ -261,145 +267,50 @@ class QuantizationMixin(HooksMixin):
         Remove calibration hooks and observers, and set the model status to frozen.
         Keep quantization enabled for future operations
 
-        :raises ValueError: if static KV cache quantization scales are invalid or
-            unobserved
+        :raises ValueError: if calibration observers are unobserved or if static
+            KV cache quantization scales are invalid
         :param model: model to end calibration for
         """
         self.remove_hooks(self._calibration_hooks)
-        kv_cache_modules = list(self._iter_kv_cache_modules(model))
-        unobserved_kv_cache = self._collect_unobserved_kv_cache_observers(
-            kv_cache_modules
-        )
-        self._validate_kv_cache_scales(kv_cache_modules, unobserved_kv_cache)
+        self.validate_module_calibration(model)
 
         for _, module in match_named_modules(model, self.resolved_targets, self.ignore):
             freeze_module_quantization(module)  # remove observers
 
         model.apply(enable_quantization)  # keep quantization enabled
 
-    def _iter_kv_cache_modules(
-        self, model: torch.nn.Module
-    ) -> Iterator[tuple[str, torch.nn.Module]]:
-        for module_name, module in match_named_modules(
-            model, self.resolved_targets, self.ignore
-        ):
-            if (
-                getattr(module, "quantization_scheme", None) is not None
-                and is_attention_module(module)
-                and getattr(module, KV_CACHE_ATTR, None) is not None
-            ):
-                yield module_name, module
-
-    def _collect_unobserved_kv_cache_observers(
-        self, kv_cache_modules: list[tuple[str, torch.nn.Module]]
-    ) -> list[str]:
-        if self._skip_kv_cache_scale_validation():
-            return []
-
-        unobserved = []
-        for module_name, module in kv_cache_modules:
-            if (
-                getattr(module, "quantization_status", None)
-                == QuantizationStatus.FROZEN
-            ):
-                continue
-
-            for base_name in ("k", "v"):
-                observer = getattr(module, f"{base_name}_observer", None)
-                if observer is None or not observer.has_statistics:
-                    unobserved.append(
-                        self._format_kv_cache_param_name(
-                            module_name, f"{base_name}_observer"
-                        )
-                    )
-
-        return unobserved
-
-    def _validate_kv_cache_scales(
+    def validate_module_calibration(
         self,
-        kv_cache_modules: list[tuple[str, torch.nn.Module]],
-        unobserved_kv_cache: list[str],
+        model: torch.nn.Module,
+        modules: Iterator[torch.nn.Module] | None = None,
     ):
-        if self._skip_kv_cache_scale_validation():
+        """
+        Validate that quantized modules were exercised during calibration.
+
+        :raises ValueError: if calibration observers were not invoked or if static
+            KV cache quantization scales are invalid
+        :param model: full model being calibrated
+        :param modules: optional sequential chunk to validate
+        """
+        calibration_modules = collect_calibration_modules(
+            model,
+            self.resolved_targets,
+            self.ignore,
+            modules,
+        )
+        unobserved_observers = get_unvalidated_calibration_observers(
+            calibration_modules,
+            self.resolved_config.kv_cache_scheme,
+        )
+        invalid_scales = get_invalid_static_kv_cache_scales(
+            calibration_modules,
+            self.resolved_config.kv_cache_scheme,
+            unobserved_observers,
+        )
+        if not unobserved_observers and not invalid_scales:
             return
 
-        unobserved_scales = {
-            observer_name.removesuffix("_observer") + "_scale"
-            for observer_name in unobserved_kv_cache
-        }
-        invalid_scales = []
-        for module_name, module in kv_cache_modules:
-            if (
-                getattr(module, "quantization_status", None)
-                == QuantizationStatus.FROZEN
-            ):
-                continue
-
-            for base_name in ("k", "v"):
-                param_name = f"{base_name}_scale"
-                full_param_name = self._format_kv_cache_param_name(
-                    module_name, param_name
-                )
-                if full_param_name in unobserved_scales:
-                    continue
-
-                scale = getattr(module, param_name, None)
-                invalid_reason = self._get_invalid_scale_reason(scale)
-                if invalid_reason is not None:
-                    invalid_scales.append(f"{full_param_name} ({invalid_reason})")
-
-        if not unobserved_kv_cache and not invalid_scales:
-            return
-
-        details = []
-        if unobserved_kv_cache:
-            details.append(
-                "missing or unobserved calibration observers: "
-                f"{', '.join(unobserved_kv_cache)}"
-            )
-        if invalid_scales:
-            details.append(f"invalid scales: {', '.join(invalid_scales)}")
-
-        raise ValueError(
-            "KV cache quantization calibration failed. "
-            "KV cache scales must be observed and finite positive values before "
-            "saving a quantized checkpoint. "
-            f"Found {'; '.join(details)}. "
-            "This usually means the model accessed the KV cache without routing "
-            "key/value tensors through the calibration hooks."
-        )
-
-    def _skip_kv_cache_scale_validation(self) -> bool:
-        kv_cache_scheme = self.resolved_config.kv_cache_scheme
-        if kv_cache_scheme is None:
-            return True
-
-        return bool(kv_cache_scheme.dynamic)
-
-    @staticmethod
-    def _get_invalid_scale_reason(scale: torch.Tensor | None) -> str | None:
-        if scale is None:
-            return "missing"
-
-        scale = scale.detach() if isinstance(scale, torch.Tensor) else torch.as_tensor(
-            scale
-        )
-        if scale.is_meta:
-            return "stored on meta device"
-        if scale.numel() == 0:
-            return "empty"
-
-        scale = scale.to(device="cpu")
-        if not torch.isfinite(scale).all().item():
-            return "non-finite"
-        if (scale <= 0).any().item():
-            return "non-positive"
-
-        return None
-
-    @staticmethod
-    def _format_kv_cache_param_name(module_name: str, param_name: str) -> str:
-        return f"{module_name}.{param_name}" if module_name else param_name
+        raise ValueError(format_calibration_error(unobserved_observers, invalid_scales))
 
     def sync_obs_act_stats(self, modules: Iterator[torch.nn.Module]):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
@@ -25,37 +25,15 @@ def validate_static_kv_cache_scales(
     if _skip_static_kv_cache_validation(kv_cache_scheme):
         return
 
-    unobserved_observers: list[str] = []
-    invalid_scales: list[str] = []
-    for module_name, module in _iter_static_kv_cache_modules(model, targets, ignore):
-        if _is_frozen(module):
-            continue
-
-        for base_name in _KV_CACHE_BASE_NAMES:
-            observer_name = f"{base_name}_observer"
-            scale_name = f"{base_name}_scale"
-            observer = getattr(module, observer_name, None)
-            if observer is None or not getattr(observer, "has_statistics", False):
-                unobserved_observers.append(
-                    _format_module_attr(module_name, observer_name)
-                )
-                continue
-
-            invalid_reason = _get_invalid_scale_reason(
-                getattr(module, scale_name, None)
-            )
-            if invalid_reason is not None:
-                invalid_scales.append(
-                    f"{_format_module_attr(module_name, scale_name)} "
-                    f"({invalid_reason})"
-                )
-
-    if not unobserved_observers and not invalid_scales:
-        return
-
-    raise ValueError(
-        _format_static_kv_cache_error(unobserved_observers, invalid_scales)
-    )
+    failures = [
+        failure
+        for module_name, module in _iter_static_kv_cache_modules(model, targets, ignore)
+        if not _is_frozen(module)
+        for base_name in _KV_CACHE_BASE_NAMES
+        if (failure := _kv_cache_scale_failure(module_name, module, base_name))
+    ]
+    if failures:
+        raise ValueError(_format_static_kv_cache_error(failures))
 
 
 def _iter_static_kv_cache_modules(
@@ -64,12 +42,16 @@ def _iter_static_kv_cache_modules(
     ignore: list[str],
 ) -> Iterable[tuple[str, Module]]:
     for module_name, module in match_named_modules(model, targets, ignore):
-        if (
-            getattr(module, "quantization_scheme", None) is not None
-            and is_attention_module(module)
-            and getattr(module, KV_CACHE_ATTR, None) is not None
-        ):
+        if _is_kv_cache_module(module):
             yield module_name, module
+
+
+def _is_kv_cache_module(module: Module) -> bool:
+    return (
+        getattr(module, "quantization_scheme", None) is not None
+        and is_attention_module(module)
+        and getattr(module, KV_CACHE_ATTR, None) is not None
+    )
 
 
 def _skip_static_kv_cache_validation(kv_cache_scheme: QuantizationArgs | None) -> bool:
@@ -83,24 +65,29 @@ def _is_frozen(module: Module) -> bool:
     return getattr(module, "quantization_status", None) == QuantizationStatus.FROZEN
 
 
-def _format_static_kv_cache_error(
-    unobserved_observers: list[str], invalid_scales: list[str]
-) -> str:
-    details = []
-    if unobserved_observers:
-        details.append(
-            "missing or unobserved KV-cache calibration observers: "
-            f"{', '.join(unobserved_observers)}"
-        )
-    if invalid_scales:
-        details.append(
-            "invalid static KV-cache scales: " f"{', '.join(invalid_scales)}"
-        )
+def _kv_cache_scale_failure(
+    module_name: str,
+    module: Module,
+    base_name: str,
+) -> str | None:
+    observer_name = f"{base_name}_observer"
+    scale_name = f"{base_name}_scale"
+    observer = getattr(module, observer_name, None)
+    if observer is None or not getattr(observer, "has_statistics", False):
+        return f"{_format_module_attr(module_name, observer_name)} (missing/unobserved)"
 
+    invalid_reason = _get_invalid_scale_reason(getattr(module, scale_name, None))
+    if invalid_reason is None:
+        return None
+
+    return f"{_format_module_attr(module_name, scale_name)} ({invalid_reason})"
+
+
+def _format_static_kv_cache_error(failures: list[str]) -> str:
     return (
         "KV-cache quantization calibration failed. Static KV-cache scales must "
         "be finite positive values before saving a quantized checkpoint. Found "
-        f"{'; '.join(details)}. This usually means K/V tensors were not "
+        f"{', '.join(failures)}. This usually means K/V tensors were not "
         "observed during calibration. That can happen when a model bypasses the "
         "standard cache update(...) API; in that case, update the model upstream "
         "to route KV-cache writes through the standard cache update path."

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
@@ -1,119 +1,79 @@
 from collections.abc import Iterable
 
-import torch
-from compressed_tensors.modeling import KV_CACHE_ATTR
-from compressed_tensors.quantization import (
-    QuantizationArgs,
-    QuantizationStatus,
-    is_attention_module,
-)
-from compressed_tensors.utils import match_named_modules
+from compressed_tensors.quantization import QuantizationStatus
 from torch.nn import Module
 
-__all__ = ["validate_static_kv_cache_scales"]
+__all__ = ["CALIBRATION_OBSERVER_BASE_NAMES", "validate_module_calibration"]
 
-_STATIC_DYNAMICS = (False, None)
-_KV_CACHE_BASE_NAMES = ("k", "v")
+CALIBRATION_OBSERVER_BASE_NAMES = ("input", "weight", "output", "q", "k", "v")
 
 
-def validate_static_kv_cache_scales(
+def validate_module_calibration(
     model: Module,
-    targets: set[str],
-    ignore: list[str],
-    kv_cache_scheme: QuantizationArgs | None,
+    modules: Module | Iterable[Module],
+    base_names: str | Iterable[str] = CALIBRATION_OBSERVER_BASE_NAMES,
 ) -> None:
-    if _skip_static_kv_cache_validation(kv_cache_scheme):
-        return
-
-    failures = [
-        failure
-        for module_name, module in _iter_static_kv_cache_modules(model, targets, ignore)
-        if not _is_frozen(module)
-        for base_name in _KV_CACHE_BASE_NAMES
-        if (failure := _kv_cache_scale_failure(module_name, module, base_name))
-    ]
-    if failures:
-        raise ValueError(_format_static_kv_cache_error(failures))
-
-
-def _iter_static_kv_cache_modules(
-    model: Module,
-    targets: set[str],
-    ignore: list[str],
-) -> Iterable[tuple[str, Module]]:
-    for module_name, module in match_named_modules(model, targets, ignore):
-        if _is_kv_cache_module(module):
-            yield module_name, module
-
-
-def _is_kv_cache_module(module: Module) -> bool:
-    return (
-        getattr(module, "quantization_scheme", None) is not None
-        and is_attention_module(module)
-        and getattr(module, KV_CACHE_ATTR, None) is not None
+    module_names = {id(module): name for name, module in model.named_modules()}
+    observer_base_names = _normalize_base_names(base_names)
+    failures = list(
+        _iter_unobserved_observers(modules, observer_base_names, module_names)
     )
+    if failures:
+        raise ValueError(_format_calibration_error(failures))
 
 
-def _skip_static_kv_cache_validation(kv_cache_scheme: QuantizationArgs | None) -> bool:
-    if kv_cache_scheme is None:
-        return True
+def _normalize_base_names(base_names: str | Iterable[str]) -> tuple[str, ...]:
+    if isinstance(base_names, str):
+        return (base_names,)
 
-    return getattr(kv_cache_scheme, "dynamic", None) not in _STATIC_DYNAMICS
+    return tuple(base_names)
+
+
+def _iter_unobserved_observers(
+    modules: Module | Iterable[Module],
+    base_names: tuple[str, ...],
+    module_names: dict[int, str],
+) -> Iterable[str]:
+    for module in _iter_unique_modules(modules):
+        if _is_frozen(module):
+            continue
+        for base_name in base_names:
+            observer_name = f"{base_name}_observer"
+            observer = getattr(module, observer_name, None)
+            if observer is None:
+                continue
+            if getattr(observer, "num_observations", 0) == 0:
+                yield _format_module_attr(module, observer_name, module_names)
+
+
+def _iter_unique_modules(modules: Module | Iterable[Module]) -> Iterable[Module]:
+    modules = (modules,) if isinstance(modules, Module) else modules
+    seen = set()
+    for module in modules:
+        for submodule in module.modules():
+            if id(submodule) in seen:
+                continue
+            seen.add(id(submodule))
+            yield submodule
 
 
 def _is_frozen(module: Module) -> bool:
     return getattr(module, "quantization_status", None) == QuantizationStatus.FROZEN
 
 
-def _kv_cache_scale_failure(
-    module_name: str,
+def _format_module_attr(
     module: Module,
-    base_name: str,
-) -> str | None:
-    observer_name = f"{base_name}_observer"
-    scale_name = f"{base_name}_scale"
-    observer = getattr(module, observer_name, None)
-    if observer is None or not getattr(observer, "has_statistics", False):
-        return f"{_format_module_attr(module_name, observer_name)} (missing/unobserved)"
-
-    invalid_reason = _get_invalid_scale_reason(getattr(module, scale_name, None))
-    if invalid_reason is None:
-        return None
-
-    return f"{_format_module_attr(module_name, scale_name)} ({invalid_reason})"
-
-
-def _format_static_kv_cache_error(failures: list[str]) -> str:
-    return (
-        "KV-cache quantization calibration failed. Static KV-cache scales must "
-        "be finite positive values before saving a quantized checkpoint. Found "
-        f"{', '.join(failures)}. This usually means K/V tensors were not "
-        "observed during calibration. That can happen when a model bypasses the "
-        "standard cache update(...) API; in that case, update the model upstream "
-        "to route KV-cache writes through the standard cache update path."
-    )
-
-
-def _format_module_attr(module_name: str, attr_name: str) -> str:
+    attr_name: str,
+    module_names: dict[int, str],
+) -> str:
+    module_name = module_names.get(id(module), module.__class__.__name__)
     return f"{module_name}.{attr_name}" if module_name else attr_name
 
 
-def _get_invalid_scale_reason(scale: torch.Tensor | None) -> str | None:
-    if scale is None:
-        return "missing"
-
-    scale = (
-        scale.detach() if isinstance(scale, torch.Tensor) else torch.as_tensor(scale)
+def _format_calibration_error(failures: list[str]) -> str:
+    return (
+        "Quantization calibration failed. The following observers were never "
+        f"called: {', '.join(failures)}. This usually means the calibration data "
+        "did not execute these quantized modules, or the model did not route "
+        "tensors through their calibration hooks."
     )
-    if scale.is_meta:
-        return "stored on meta device"
-    if scale.numel() == 0:
-        return "empty"
-
-    scale = scale.to(device="cpu")
-    if not torch.isfinite(scale).all().item():
-        return "non-finite"
-    if (scale <= 0).any().item():
-        return "non-positive"
-
-    return None

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
@@ -151,7 +151,7 @@ def _observer_enabled(args: QuantizationArgs | None, is_input: bool) -> bool:
         return False
 
     dynamic = getattr(args, "dynamic", None)
-    if input:
+    if is_input:
         return dynamic in _OBSERVED_INPUT_DYNAMICS
 
     return dynamic in _STATIC_DYNAMICS

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
@@ -3,171 +3,73 @@ from collections.abc import Iterable
 import torch
 from compressed_tensors.modeling import KV_CACHE_ATTR
 from compressed_tensors.quantization import (
-    DynamicType,
     QuantizationArgs,
     QuantizationStatus,
     is_attention_module,
 )
 from compressed_tensors.utils import match_named_modules
-from torch.nn import Embedding, Linear, Module
+from torch.nn import Module
 
-__all__ = [
-    "collect_calibration_modules",
-    "format_calibration_error",
-    "get_unvalidated_calibration_observers",
-    "get_invalid_static_kv_cache_scales",
-]
+__all__ = ["validate_static_kv_cache_scales"]
 
-_OBSERVED_INPUT_DYNAMICS = (False, None, DynamicType.LOCAL, "local")
 _STATIC_DYNAMICS = (False, None)
-_SUPPORTED_CALIBRATION_MODULES = (Linear, Embedding)
+_KV_CACHE_BASE_NAMES = ("k", "v")
 
 
-def collect_calibration_modules(
+def validate_static_kv_cache_scales(
     model: Module,
     targets: set[str],
     ignore: list[str],
-    modules: Iterable[Module] | None = None,
-) -> list[tuple[str, Module]]:
-    named_modules = list(match_named_modules(model, targets, ignore))
-    if modules is None:
-        return named_modules
-
-    module_ids = _module_tree_ids(modules)
-    return [
-        (name, module) for name, module in named_modules if id(module) in module_ids
-    ]
-
-
-def get_unvalidated_calibration_observers(
-    named_modules: list[tuple[str, Module]],
     kv_cache_scheme: QuantizationArgs | None,
-) -> list[str]:
-    unobserved = []
-    for module_name, module in named_modules:
-        for base_name in _expected_observer_base_names(module, kv_cache_scheme):
-            observer = getattr(module, f"{base_name}_observer", None)
-            if _observer_num_observations(observer) <= 0:
-                unobserved.append(
-                    format_module_attr(module_name, f"{base_name}_observer")
-                )
-
-    return unobserved
-
-
-def get_invalid_static_kv_cache_scales(
-    named_modules: list[tuple[str, Module]],
-    kv_cache_scheme: QuantizationArgs | None,
-    unobserved_observers: list[str],
-) -> list[str]:
+) -> None:
     if _skip_static_kv_cache_validation(kv_cache_scheme):
-        return []
+        return
 
-    unobserved_scales = {
-        observer_name.removesuffix("_observer") + "_scale"
-        for observer_name in unobserved_observers
-    }
-    invalid_scales = []
-    for module_name, module in named_modules:
-        if _module_is_frozen(module) or not _is_static_kv_cache_module(
-            module, kv_cache_scheme
-        ):
+    unobserved_observers: list[str] = []
+    invalid_scales: list[str] = []
+    for module_name, module in _iter_static_kv_cache_modules(model, targets, ignore):
+        if _is_frozen(module):
             continue
 
-        for base_name in ("k", "v"):
-            param_name = f"{base_name}_scale"
-            full_param_name = format_module_attr(module_name, param_name)
-            if full_param_name in unobserved_scales:
+        for base_name in _KV_CACHE_BASE_NAMES:
+            observer_name = f"{base_name}_observer"
+            scale_name = f"{base_name}_scale"
+            observer = getattr(module, observer_name, None)
+            if observer is None or not getattr(observer, "has_statistics", False):
+                unobserved_observers.append(
+                    _format_module_attr(module_name, observer_name)
+                )
                 continue
 
             invalid_reason = _get_invalid_scale_reason(
-                getattr(module, param_name, None)
+                getattr(module, scale_name, None)
             )
             if invalid_reason is not None:
-                invalid_scales.append(f"{full_param_name} ({invalid_reason})")
+                invalid_scales.append(
+                    f"{_format_module_attr(module_name, scale_name)} "
+                    f"({invalid_reason})"
+                )
 
-    return invalid_scales
+    if not unobserved_observers and not invalid_scales:
+        return
 
-
-def format_calibration_error(
-    unobserved_observers: list[str], invalid_scales: list[str]
-) -> str:
-    details = []
-    if unobserved_observers:
-        details.append(
-            "missing or unobserved calibration observers: "
-            f"{', '.join(unobserved_observers)}"
-        )
-    if invalid_scales:
-        details.append(f"invalid static KV-cache scales: {', '.join(invalid_scales)}")
-
-    return (
-        "Quantization calibration failed. Calibration observers must be invoked "
-        "before qparams are frozen, and static KV-cache scales must be finite "
-        f"positive values. Found {'; '.join(details)}. This usually means one "
-        "or more targeted modules were not executed during calibration."
+    raise ValueError(
+        _format_static_kv_cache_error(unobserved_observers, invalid_scales)
     )
 
 
-def format_module_attr(module_name: str, attr_name: str) -> str:
-    return f"{module_name}.{attr_name}" if module_name else attr_name
-
-
-def _module_tree_ids(modules: Iterable[Module]) -> set[int]:
-    module_ids = set()
-    for module in modules:
-        module_ids.update(id(child) for child in module.modules())
-    return module_ids
-
-
-def _expected_observer_base_names(
-    module: Module, kv_cache_scheme: QuantizationArgs | None
-) -> Iterable[str]:
-    scheme = getattr(module, "quantization_scheme", None)
-    if scheme is None or _module_is_frozen(module):
-        return ()
-
-    if _is_static_kv_cache_module(module, kv_cache_scheme):
-        return ("k", "v")
-
-    if is_attention_module(module) or not isinstance(
-        module, _SUPPORTED_CALIBRATION_MODULES
-    ):
-        return ()
-
-    observer_names = []
-    if _observer_enabled(getattr(scheme, "input_activations", None), is_input=True):
-        observer_names.append("input")
-    if getattr(scheme, "weights", None) is not None:
-        observer_names.append("weight")
-    if _observer_enabled(getattr(scheme, "output_activations", None), is_input=False):
-        observer_names.append("output")
-
-    return tuple(observer_names)
-
-
-def _observer_enabled(args: QuantizationArgs | None, is_input: bool) -> bool:
-    if args is None:
-        return False
-
-    dynamic = getattr(args, "dynamic", None)
-    if is_input:
-        return dynamic in _OBSERVED_INPUT_DYNAMICS
-
-    return dynamic in _STATIC_DYNAMICS
-
-
-def _is_static_kv_cache_module(
-    module: Module, kv_cache_scheme: QuantizationArgs | None
-) -> bool:
-    if _skip_static_kv_cache_validation(kv_cache_scheme):
-        return False
-
-    return (
-        getattr(module, "quantization_scheme", None) is not None
-        and is_attention_module(module)
-        and getattr(module, KV_CACHE_ATTR, None) is not None
-    )
+def _iter_static_kv_cache_modules(
+    model: Module,
+    targets: set[str],
+    ignore: list[str],
+) -> Iterable[tuple[str, Module]]:
+    for module_name, module in match_named_modules(model, targets, ignore):
+        if (
+            getattr(module, "quantization_scheme", None) is not None
+            and is_attention_module(module)
+            and getattr(module, KV_CACHE_ATTR, None) is not None
+        ):
+            yield module_name, module
 
 
 def _skip_static_kv_cache_validation(kv_cache_scheme: QuantizationArgs | None) -> bool:
@@ -177,12 +79,36 @@ def _skip_static_kv_cache_validation(kv_cache_scheme: QuantizationArgs | None) -
     return getattr(kv_cache_scheme, "dynamic", None) not in _STATIC_DYNAMICS
 
 
-def _module_is_frozen(module: Module) -> bool:
+def _is_frozen(module: Module) -> bool:
     return getattr(module, "quantization_status", None) == QuantizationStatus.FROZEN
 
 
-def _observer_num_observations(observer: Module | None) -> int:
-    return int(getattr(observer, "num_observations", 0) or 0)
+def _format_static_kv_cache_error(
+    unobserved_observers: list[str], invalid_scales: list[str]
+) -> str:
+    details = []
+    if unobserved_observers:
+        details.append(
+            "missing or unobserved KV-cache calibration observers: "
+            f"{', '.join(unobserved_observers)}"
+        )
+    if invalid_scales:
+        details.append(
+            "invalid static KV-cache scales: " f"{', '.join(invalid_scales)}"
+        )
+
+    return (
+        "KV-cache quantization calibration failed. Static KV-cache scales must "
+        "be finite positive values before saving a quantized checkpoint. Found "
+        f"{'; '.join(details)}. This usually means K/V tensors were not "
+        "observed during calibration. That can happen when a model bypasses the "
+        "standard cache update(...) API; in that case, update the model upstream "
+        "to route KV-cache writes through the standard cache update path."
+    )
+
+
+def _format_module_attr(module_name: str, attr_name: str) -> str:
+    return f"{module_name}.{attr_name}" if module_name else attr_name
 
 
 def _get_invalid_scale_reason(scale: torch.Tensor | None) -> str | None:

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin_helpers.py
@@ -1,0 +1,206 @@
+from collections.abc import Iterable
+
+import torch
+from compressed_tensors.modeling import KV_CACHE_ATTR
+from compressed_tensors.quantization import (
+    DynamicType,
+    QuantizationArgs,
+    QuantizationStatus,
+    is_attention_module,
+)
+from compressed_tensors.utils import match_named_modules
+from torch.nn import Embedding, Linear, Module
+
+__all__ = [
+    "collect_calibration_modules",
+    "format_calibration_error",
+    "get_unvalidated_calibration_observers",
+    "get_invalid_static_kv_cache_scales",
+]
+
+_OBSERVED_INPUT_DYNAMICS = (False, None, DynamicType.LOCAL, "local")
+_STATIC_DYNAMICS = (False, None)
+_SUPPORTED_CALIBRATION_MODULES = (Linear, Embedding)
+
+
+def collect_calibration_modules(
+    model: Module,
+    targets: set[str],
+    ignore: list[str],
+    modules: Iterable[Module] | None = None,
+) -> list[tuple[str, Module]]:
+    named_modules = list(match_named_modules(model, targets, ignore))
+    if modules is None:
+        return named_modules
+
+    module_ids = _module_tree_ids(modules)
+    return [
+        (name, module) for name, module in named_modules if id(module) in module_ids
+    ]
+
+
+def get_unvalidated_calibration_observers(
+    named_modules: list[tuple[str, Module]],
+    kv_cache_scheme: QuantizationArgs | None,
+) -> list[str]:
+    unobserved = []
+    for module_name, module in named_modules:
+        for base_name in _expected_observer_base_names(module, kv_cache_scheme):
+            observer = getattr(module, f"{base_name}_observer", None)
+            if _observer_num_observations(observer) <= 0:
+                unobserved.append(
+                    format_module_attr(module_name, f"{base_name}_observer")
+                )
+
+    return unobserved
+
+
+def get_invalid_static_kv_cache_scales(
+    named_modules: list[tuple[str, Module]],
+    kv_cache_scheme: QuantizationArgs | None,
+    unobserved_observers: list[str],
+) -> list[str]:
+    if _skip_static_kv_cache_validation(kv_cache_scheme):
+        return []
+
+    unobserved_scales = {
+        observer_name.removesuffix("_observer") + "_scale"
+        for observer_name in unobserved_observers
+    }
+    invalid_scales = []
+    for module_name, module in named_modules:
+        if _module_is_frozen(module) or not _is_static_kv_cache_module(
+            module, kv_cache_scheme
+        ):
+            continue
+
+        for base_name in ("k", "v"):
+            param_name = f"{base_name}_scale"
+            full_param_name = format_module_attr(module_name, param_name)
+            if full_param_name in unobserved_scales:
+                continue
+
+            invalid_reason = _get_invalid_scale_reason(
+                getattr(module, param_name, None)
+            )
+            if invalid_reason is not None:
+                invalid_scales.append(f"{full_param_name} ({invalid_reason})")
+
+    return invalid_scales
+
+
+def format_calibration_error(
+    unobserved_observers: list[str], invalid_scales: list[str]
+) -> str:
+    details = []
+    if unobserved_observers:
+        details.append(
+            "missing or unobserved calibration observers: "
+            f"{', '.join(unobserved_observers)}"
+        )
+    if invalid_scales:
+        details.append(f"invalid static KV-cache scales: {', '.join(invalid_scales)}")
+
+    return (
+        "Quantization calibration failed. Calibration observers must be invoked "
+        "before qparams are frozen, and static KV-cache scales must be finite "
+        f"positive values. Found {'; '.join(details)}. This usually means one "
+        "or more targeted modules were not executed during calibration."
+    )
+
+
+def format_module_attr(module_name: str, attr_name: str) -> str:
+    return f"{module_name}.{attr_name}" if module_name else attr_name
+
+
+def _module_tree_ids(modules: Iterable[Module]) -> set[int]:
+    module_ids = set()
+    for module in modules:
+        module_ids.update(id(child) for child in module.modules())
+    return module_ids
+
+
+def _expected_observer_base_names(
+    module: Module, kv_cache_scheme: QuantizationArgs | None
+) -> Iterable[str]:
+    scheme = getattr(module, "quantization_scheme", None)
+    if scheme is None or _module_is_frozen(module):
+        return ()
+
+    if _is_static_kv_cache_module(module, kv_cache_scheme):
+        return ("k", "v")
+
+    if is_attention_module(module) or not isinstance(
+        module, _SUPPORTED_CALIBRATION_MODULES
+    ):
+        return ()
+
+    observer_names = []
+    if _observer_enabled(getattr(scheme, "input_activations", None), is_input=True):
+        observer_names.append("input")
+    if getattr(scheme, "weights", None) is not None:
+        observer_names.append("weight")
+    if _observer_enabled(getattr(scheme, "output_activations", None), is_input=False):
+        observer_names.append("output")
+
+    return tuple(observer_names)
+
+
+def _observer_enabled(args: QuantizationArgs | None, is_input: bool) -> bool:
+    if args is None:
+        return False
+
+    dynamic = getattr(args, "dynamic", None)
+    if input:
+        return dynamic in _OBSERVED_INPUT_DYNAMICS
+
+    return dynamic in _STATIC_DYNAMICS
+
+
+def _is_static_kv_cache_module(
+    module: Module, kv_cache_scheme: QuantizationArgs | None
+) -> bool:
+    if _skip_static_kv_cache_validation(kv_cache_scheme):
+        return False
+
+    return (
+        getattr(module, "quantization_scheme", None) is not None
+        and is_attention_module(module)
+        and getattr(module, KV_CACHE_ATTR, None) is not None
+    )
+
+
+def _skip_static_kv_cache_validation(kv_cache_scheme: QuantizationArgs | None) -> bool:
+    if kv_cache_scheme is None:
+        return True
+
+    return getattr(kv_cache_scheme, "dynamic", None) not in _STATIC_DYNAMICS
+
+
+def _module_is_frozen(module: Module) -> bool:
+    return getattr(module, "quantization_status", None) == QuantizationStatus.FROZEN
+
+
+def _observer_num_observations(observer: Module | None) -> int:
+    return int(getattr(observer, "num_observations", 0) or 0)
+
+
+def _get_invalid_scale_reason(scale: torch.Tensor | None) -> str | None:
+    if scale is None:
+        return "missing"
+
+    scale = (
+        scale.detach() if isinstance(scale, torch.Tensor) else torch.as_tensor(scale)
+    )
+    if scale.is_meta:
+        return "stored on meta device"
+    if scale.numel() == 0:
+        return "empty"
+
+    scale = scale.to(device="cpu")
+    if not torch.isfinite(scale).all().item():
+        return "non-finite"
+    if (scale <= 0).any().item():
+        return "non-positive"
+
+    return None

--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -55,11 +55,14 @@ class Observer(InternalModule, RegistryMixin):
         self.args.observer_kwargs = self.args.observer_kwargs or {}
         self.args.observer_kwargs.update(observer_kwargs)
 
+        self.num_observations = 0
         self.fusion_handler = FusionHandler(self)
 
     @property
     def has_statistics(self) -> bool:
-        return all(hasattr(self, attr) for attr in self._stats_attrs)
+        return self.num_observations > 0 and all(
+            hasattr(self, attr) for attr in self._stats_attrs
+        )
 
     @property
     def is_weight_obs(self) -> bool:
@@ -139,9 +142,8 @@ class Observer(InternalModule, RegistryMixin):
 
         observed = flatten_for_calibration(observed, self.base_name, self.args)
         self.update_statistics_from_observed(observed)
-
+        self.num_observations += 1
         self.fusion_handler.get_fused_statistics()
-
         return self
 
     def sync_activation_stats(self) -> List[dist.Work]:

--- a/src/llmcompressor/observers/base.py
+++ b/src/llmcompressor/observers/base.py
@@ -60,9 +60,7 @@ class Observer(InternalModule, RegistryMixin):
 
     @property
     def has_statistics(self) -> bool:
-        return self.num_observations > 0 and all(
-            hasattr(self, attr) for attr in self._stats_attrs
-        )
+        return all(hasattr(self, attr) for attr in self._stats_attrs)
 
     @property
     def is_weight_obs(self) -> bool:

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -1,10 +1,10 @@
 """
-Tests for KV cache calibration on attention modules.
+Tests for calibration validation on quantized modules.
 
 KV cache quantization relies on key/value observers collecting calibration
 statistics before the final k_scale/v_scale values are frozen. These tests use
-small CPU-only attention stubs so the calibration lifecycle can be validated
-without downloading a model.
+small CPU-only stubs so the calibration lifecycle can be validated without
+downloading a model.
 """
 
 import pytest
@@ -12,14 +12,17 @@ import torch
 import torch.nn as nn
 from compressed_tensors.quantization import (
     QuantizationArgs,
+    QuantizationScheme,
     QuantizationStatus,
     apply_quantization_config,
     is_attention_module,
 )
 from transformers import PretrainedConfig
 
-from llmcompressor.modifiers.quantization.calibration import update_qparams
+from llmcompressor.core import Event, EventType, State
+from llmcompressor.modifiers.quantization.calibration import observe, update_qparams
 from llmcompressor.modifiers.quantization.quantization import QuantizationModifier
+from llmcompressor.observers.min_max import StaticMinMaxObserver
 
 
 class _StubAttention(nn.Module):
@@ -68,21 +71,56 @@ class _StubModel(nn.Module):
         return x
 
 
-def _kv_cache_modifier(dynamic: bool | str = False, ignore: list[str] | None = None):
+class _EmbeddingModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed = nn.Embedding(8, 4)
+
+    def forward(self, input_ids):
+        return self.embed(input_ids)
+
+
+def _quant_args(dynamic: bool | str = False):
     strategy = "tensor_group" if dynamic == "local" else "tensor"
     group_size = 16 if dynamic == "local" else None
 
+    return QuantizationArgs(
+        num_bits=8,
+        type="float",
+        strategy=strategy,
+        group_size=group_size,
+        dynamic=dynamic,
+        symmetric=True,
+    )
+
+
+def _kv_cache_modifier(dynamic: bool | str = False, ignore: list[str] | None = None):
     return QuantizationModifier(
         targets=["Linear"],
         ignore=ignore or [],
-        kv_cache_scheme=QuantizationArgs(
-            num_bits=8,
-            type="float",
-            strategy=strategy,
-            group_size=group_size,
-            dynamic=dynamic,
-            symmetric=True,
-        ),
+        kv_cache_scheme=_quant_args(dynamic=dynamic),
+    )
+
+
+def _linear_modifier():
+    args = QuantizationArgs(num_bits=8, type="int", symmetric=True, strategy="tensor")
+    return QuantizationModifier(
+        config_groups={
+            "group_0": QuantizationScheme(
+                targets=["Linear"],
+                weights=args,
+                input_activations=args,
+            )
+        }
+    )
+
+
+def _embedding_modifier():
+    args = QuantizationArgs(num_bits=8, type="int", symmetric=True, strategy="tensor")
+    return QuantizationModifier(
+        config_groups={
+            "group_0": QuantizationScheme(targets=["Embedding"], weights=args)
+        }
     )
 
 
@@ -106,6 +144,13 @@ def _prepare_model(
     return model, modifier, attn_modules
 
 
+def _observe_weight_observers(model):
+    for module in model.modules():
+        if getattr(module, "weight_observer", None) is not None:
+            observe(module, "weight")
+            update_qparams(module, "weight")
+
+
 def _observe_kv_cache(attn_modules, dim: int = 16):
     key_states = torch.ones(1, 1, 1, dim)
     value_states = torch.full((1, 1, 1, dim), 2.0)
@@ -114,6 +159,24 @@ def _observe_kv_cache(attn_modules, dim: int = 16):
         module.k_observer(key_states)
         module.v_observer(value_states)
         update_qparams(module, ("k", "v"))
+
+
+def test_observer_tracks_num_observations():
+    args = QuantizationArgs(num_bits=8, type="int", symmetric=True, strategy="tensor")
+    observer = StaticMinMaxObserver(base_name="input", args=args)
+
+    assert observer.num_observations == 0
+    assert not observer.has_statistics
+
+    observer(torch.empty(0))
+    assert observer.num_observations == 0
+
+    observer(torch.ones(2, 4))
+    assert observer.num_observations == 1
+    assert observer.has_statistics
+
+    observer(torch.full((2, 4), 2.0))
+    assert observer.num_observations == 2
 
 
 def test_attention_module_not_named_self_attn_gets_calibrated():
@@ -136,6 +199,7 @@ def test_attention_module_not_named_self_attn_gets_calibrated():
         "Expected calibration hooks to be registered"
     )
 
+    _observe_weight_observers(model)
     _observe_kv_cache(attn_modules)
     modifier.end_calibration(model)
 
@@ -147,15 +211,16 @@ def test_attention_module_not_named_self_attn_gets_calibrated():
 
 def test_kv_cache_calibration_requires_observed_scales():
     model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+    _observe_weight_observers(model)
 
     with pytest.raises(ValueError) as exc_info:
         modifier.end_calibration(model)
 
     error_message = str(exc_info.value)
-    assert "KV cache quantization calibration failed" in error_message
+    assert "Quantization calibration failed" in error_message
     assert "layers.0.attention.k_observer" in error_message
     assert "layers.0.attention.v_observer" in error_message
-    assert "invalid scales" not in error_message
+    assert "invalid static KV-cache scales" not in error_message
 
     attention = attn_modules[0][1]
     assert attention.quantization_status == QuantizationStatus.CALIBRATION
@@ -163,10 +228,12 @@ def test_kv_cache_calibration_requires_observed_scales():
     assert hasattr(attention, "v_observer")
 
 
-def test_kv_cache_calibration_rejects_zero_scales():
+def test_kv_cache_calibration_rejects_zero_and_non_finite_scales():
     model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+    _observe_weight_observers(model)
     _observe_kv_cache(attn_modules)
     attn_modules[0][1].k_scale.data.zero_()
+    attn_modules[0][1].v_scale.data.fill_(float("nan"))
 
     with pytest.raises(ValueError) as exc_info:
         modifier.end_calibration(model)
@@ -174,6 +241,8 @@ def test_kv_cache_calibration_rejects_zero_scales():
     error_message = str(exc_info.value)
     assert "layers.0.attention.k_scale" in error_message
     assert "non-positive" in error_message
+    assert "layers.0.attention.v_scale" in error_message
+    assert "non-finite" in error_message
 
     attention = attn_modules[0][1]
     assert attention.quantization_status == QuantizationStatus.CALIBRATION
@@ -187,6 +256,7 @@ def test_kv_cache_calibration_respects_ignore_list():
         num_layers=2,
         ignore=["layers.1.attention"],
     )
+    _observe_weight_observers(model)
     _observe_kv_cache([attn_modules[0]])
     attn_modules[1][1].k_scale.data.zero_()
     attn_modules[1][1].v_scale.data.zero_()
@@ -196,18 +266,21 @@ def test_kv_cache_calibration_respects_ignore_list():
 
 def test_dynamic_kv_cache_calibration_skips_static_scale_validation():
     model, modifier, _ = _prepare_model(dim=16, num_layers=1, dynamic=True)
+    _observe_weight_observers(model)
 
     modifier.end_calibration(model)
 
 
 def test_local_dynamic_kv_cache_calibration_skips_static_scale_validation():
     model, modifier, _ = _prepare_model(dim=16, num_layers=1, dynamic="local")
+    _observe_weight_observers(model)
 
     modifier.end_calibration(model)
 
 
 def test_end_calibration_can_run_after_kv_cache_is_frozen():
     model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+    _observe_weight_observers(model)
     _observe_kv_cache(attn_modules)
 
     modifier.end_calibration(model)
@@ -220,5 +293,44 @@ def test_end_calibration_can_run_after_kv_cache_is_frozen():
 def test_kv_cache_validation_skips_modules_without_quantization_scheme():
     model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
     delattr(attn_modules[0][1], "quantization_scheme")
+    _observe_weight_observers(model)
 
     modifier.end_calibration(model)
+
+
+def test_sequential_epoch_end_validates_current_linear_chunk():
+    model = nn.Sequential(nn.Linear(4, 4))
+    modifier = _linear_modifier()
+    state = State(model=model)
+
+    modifier.on_initialize(state)
+    modifier.on_calibration_start(state, None)
+
+    with pytest.raises(ValueError) as exc_info:
+        modifier.on_sequential_epoch_end(
+            state,
+            Event(type_=EventType.SEQUENTIAL_EPOCH_END),
+            modules=list(model.modules()),
+        )
+
+    error_message = str(exc_info.value)
+    assert "0.input_observer" in error_message
+    assert "0.weight_observer" not in error_message
+
+
+def test_embedding_weight_observer_is_validated():
+    model = _EmbeddingModel()
+    modifier = _embedding_modifier()
+    state = State(model=model)
+
+    modifier.on_initialize(state)
+    modifier.on_calibration_start(state, None)
+
+    with pytest.raises(ValueError) as exc_info:
+        modifier.validate_module_calibration(model)
+
+    assert "embed.weight_observer" in str(exc_info.value)
+
+    observe(model.embed, "weight")
+    update_qparams(model.embed, "weight")
+    modifier.validate_module_calibration(model)

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -202,6 +202,41 @@ def test_static_kv_cache_calibration_uses_observer_counts():
     assert attention.v_observer.num_observations == 1
 
 
+def test_generic_calibration_validator_requires_linear_and_embedding_observation():
+    model = nn.ModuleDict(
+        {
+            "embedding": nn.Embedding(8, 4),
+            "linear": nn.Linear(4, 4),
+        }
+    )
+    weight_args = QuantizationArgs(
+        num_bits=8, type="int", symmetric=True, strategy="tensor"
+    )
+    modifier = QuantizationModifier(
+        config_groups={
+            "group_0": QuantizationScheme(
+                targets=["Linear", "Embedding"],
+                weights=weight_args,
+            )
+        }
+    )
+    state = State(model=model)
+
+    modifier.on_initialize(state)
+    modifier.on_calibration_start(state, None)
+
+    with pytest.raises(ValueError) as exc_info:
+        modifier.validate_module_calibration(
+            state.model,
+            list(model.modules()),
+            "weight",
+        )
+
+    error_message = str(exc_info.value)
+    assert "embedding.weight_observer" in error_message
+    assert "linear.weight_observer" in error_message
+
+
 def test_static_kv_cache_calibration_respects_ignore_list():
     model, modifier, state, attn_modules = _prepare_kv_model(
         dim=16,

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -318,6 +318,41 @@ def test_sequential_epoch_end_validates_current_linear_chunk():
     assert "0.weight_observer" not in error_message
 
 
+def test_local_dynamic_output_activation_observer_is_not_required():
+    model = nn.Sequential(nn.Linear(16, 16))
+    weight_args = QuantizationArgs(
+        num_bits=8,
+        type="int",
+        symmetric=True,
+        strategy="tensor",
+    )
+    output_args = QuantizationArgs(
+        num_bits=8,
+        type="float",
+        symmetric=True,
+        strategy="tensor_group",
+        group_size=16,
+        dynamic="local",
+    )
+    modifier = QuantizationModifier(
+        config_groups={
+            "group_0": QuantizationScheme(
+                targets=["Linear"],
+                weights=weight_args,
+                output_activations=output_args,
+            )
+        }
+    )
+    state = State(model=model)
+
+    modifier.on_initialize(state)
+    modifier.on_calibration_start(state, None)
+
+    assert not hasattr(model[0], "output_observer")
+    observe(model[0], "weight")
+    update_qparams(model[0], "weight")
+    modifier.validate_module_calibration(model)
+
 def test_embedding_weight_observer_is_validated():
     model = _EmbeddingModel()
     modifier = _embedding_modifier()

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -146,7 +146,7 @@ def test_attention_module_not_named_self_attn_gets_calibrated():
 
 
 def test_kv_cache_calibration_requires_observed_scales():
-    model, modifier, _ = _prepare_model(dim=16, num_layers=1)
+    model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
 
     with pytest.raises(ValueError) as exc_info:
         modifier.end_calibration(model)
@@ -155,6 +155,11 @@ def test_kv_cache_calibration_requires_observed_scales():
     assert "KV cache quantization calibration failed" in error_message
     assert "layers.0.attention.k_observer" in error_message
     assert "layers.0.attention.v_observer" in error_message
+
+    attention = attn_modules[0][1]
+    assert attention.quantization_status == QuantizationStatus.CALIBRATION
+    assert hasattr(attention, "k_observer")
+    assert hasattr(attention, "v_observer")
 
 
 def test_kv_cache_calibration_rejects_zero_scales():
@@ -168,6 +173,11 @@ def test_kv_cache_calibration_rejects_zero_scales():
     error_message = str(exc_info.value)
     assert "layers.0.attention.k_scale" in error_message
     assert "non-positive" in error_message
+
+    attention = attn_modules[0][1]
+    assert attention.quantization_status == QuantizationStatus.CALIBRATION
+    assert hasattr(attention, "k_observer")
+    assert hasattr(attention, "v_observer")
 
 
 def test_kv_cache_calibration_respects_ignore_list():

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -211,6 +211,7 @@ def test_end_calibration_can_run_after_kv_cache_is_frozen():
     _observe_kv_cache(attn_modules)
 
     modifier.end_calibration(model)
+    attn_modules[0][1].k_scale.data.zero_()
     modifier.end_calibration(model)
 
     assert attn_modules[0][1].quantization_status == QuantizationStatus.FROZEN

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -1,9 +1,10 @@
 """
-Tests for static KV-cache calibration scale validation.
+Tests for KV-cache calibration observer validation.
 
 KV-cache quantization relies on key/value observers collecting calibration
-statistics before k_scale/v_scale are saved. These tests use small CPU-only
-stubs so the calibration lifecycle can be validated without downloading a model.
+statistics before quantization parameters are updated. These tests use small
+CPU-only stubs so the calibration lifecycle can be validated without downloading
+a model.
 """
 
 import pytest
@@ -11,13 +12,13 @@ import torch
 import torch.nn as nn
 from compressed_tensors.quantization import (
     QuantizationArgs,
+    QuantizationScheme,
     QuantizationStatus,
-    apply_quantization_config,
     is_attention_module,
 )
 from transformers import PretrainedConfig
 
-from llmcompressor.modifiers.quantization.calibration import observe, update_qparams
+from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers.quantization.quantization import QuantizationModifier
 
 
@@ -26,13 +27,16 @@ class _StubAttention(nn.Module):
 
     def __init__(self, dim: int = 16):
         super().__init__()
-        self.q_proj = nn.Linear(dim, dim, bias=False)
-        self.k_proj = nn.Linear(dim, dim, bias=False)
-        self.v_proj = nn.Linear(dim, dim, bias=False)
-        self.o_proj = nn.Linear(dim, dim, bias=False)
+        self.k_proj = nn.Linear(dim, dim)
+        self.v_proj = nn.Linear(dim, dim)
+        self.config = PretrainedConfig(
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            hidden_size=dim,
+        )
 
     def forward(self, x):
-        return self.o_proj(self.q_proj(x) + self.k_proj(x) + self.v_proj(x))
+        return x
 
 
 class _StubBlock(nn.Module):
@@ -56,11 +60,24 @@ class _StubModel(nn.Module):
             hidden_size=dim,
         )
         self.layers = nn.ModuleList([_StubBlock(dim) for _ in range(num_layers)])
+        self.lm_head = nn.Linear(dim, dim)
+
+    def get_input_embeddings(self):
+        return None
+
+    def set_input_embeddings(self, value):
+        pass
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, value):
+        self.lm_head = value
 
     def forward(self, x):
         for layer in self.layers:
             x = layer(x)
-        return x
+        return self.lm_head(x)
 
 
 def _quant_args(dynamic: bool | str = False):
@@ -97,19 +114,13 @@ def _prepare_kv_model(
 ):
     model = _StubModel(dim=dim, num_layers=num_layers)
     modifier = _kv_cache_modifier(dynamic=dynamic, ignore=ignore)
+    state = State(model=model)
     attn_modules = _attention_modules(model)
 
-    apply_quantization_config(model, modifier.resolved_config)
-    modifier.start_calibration(model)
+    modifier.on_initialize(state)
+    modifier.on_calibration_start(state, None)
 
-    return model, modifier, attn_modules
-
-
-def _observe_weight_observers(model):
-    for module in model.modules():
-        if getattr(module, "weight_observer", None) is not None:
-            observe(module, "weight")
-            update_qparams(module, "weight")
+    return model, modifier, state, attn_modules
 
 
 def _observe_kv_cache(attn_modules, dim: int = 16):
@@ -119,12 +130,19 @@ def _observe_kv_cache(attn_modules, dim: int = 16):
     for _, module in attn_modules:
         module.k_observer(key_states)
         module.v_observer(value_states)
-        update_qparams(module, ("k", "v"))
+
+
+def _sequential_epoch_end(modifier, state, model):
+    modifier.on_sequential_epoch_end(
+        state,
+        Event(type_=EventType.SEQUENTIAL_EPOCH_END),
+        modules=list(model.modules()),
+    )
 
 
 def test_attention_module_not_named_self_attn_gets_calibrated():
     """Attention modules named 'attention' should still get KV observers/hooks."""
-    model, modifier, attn_modules = _prepare_kv_model(dim=16)
+    model, modifier, state, attn_modules = _prepare_kv_model(dim=16)
 
     assert len(attn_modules) == 2, "Expected 2 attention modules in _StubModel"
     for name, module in attn_modules:
@@ -137,13 +155,15 @@ def test_attention_module_not_named_self_attn_gets_calibrated():
             f"Attention module '{name}' was not calibrated "
             f"(status={module.quantization_status})"
         )
+        assert hasattr(module, "k_observer")
+        assert hasattr(module, "v_observer")
 
     assert len(modifier._calibration_hooks) > 0, (
         "Expected calibration hooks to be registered"
     )
 
-    _observe_weight_observers(model)
     _observe_kv_cache(attn_modules)
+    _sequential_epoch_end(modifier, state, model)
     modifier.end_calibration(model)
 
     for name, module in attn_modules:
@@ -153,17 +173,15 @@ def test_attention_module_not_named_self_attn_gets_calibrated():
 
 
 def test_static_kv_cache_calibration_requires_observed_kv_tensors():
-    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
-    _observe_weight_observers(model)
+    model, modifier, state, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
 
     with pytest.raises(ValueError) as exc_info:
-        modifier.end_calibration(model)
+        _sequential_epoch_end(modifier, state, model)
 
     error_message = str(exc_info.value)
-    assert "KV-cache quantization calibration failed" in error_message
+    assert "Quantization calibration failed" in error_message
     assert "layers.0.attention.k_observer" in error_message
     assert "layers.0.attention.v_observer" in error_message
-    assert "update(...) API" in error_message
 
     attention = attn_modules[0][1]
     assert attention.quantization_status == QuantizationStatus.CALIBRATION
@@ -171,96 +189,61 @@ def test_static_kv_cache_calibration_requires_observed_kv_tensors():
     assert hasattr(attention, "v_observer")
 
 
-@pytest.mark.parametrize("scale_name", ["k_scale", "v_scale"])
-def test_static_kv_cache_calibration_rejects_zero_scales(scale_name):
-    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
-    _observe_weight_observers(model)
+def test_static_kv_cache_calibration_uses_observer_counts():
+    _, _, _, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
+    attention = attn_modules[0][1]
+
+    assert attention.k_observer.num_observations == 0
+    assert attention.v_observer.num_observations == 0
+
     _observe_kv_cache(attn_modules)
-    getattr(attn_modules[0][1], scale_name).data.zero_()
 
-    with pytest.raises(ValueError) as exc_info:
-        modifier.end_calibration(model)
-
-    error_message = str(exc_info.value)
-    assert f"layers.0.attention.{scale_name}" in error_message
-    assert "non-positive" in error_message
-
-
-@pytest.mark.parametrize("scale_name", ["k_scale", "v_scale"])
-def test_static_kv_cache_calibration_rejects_missing_scales(scale_name):
-    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
-    _observe_weight_observers(model)
-    _observe_kv_cache(attn_modules)
-    delattr(attn_modules[0][1], scale_name)
-
-    with pytest.raises(ValueError) as exc_info:
-        modifier.end_calibration(model)
-
-    error_message = str(exc_info.value)
-    assert f"layers.0.attention.{scale_name}" in error_message
-    assert "missing" in error_message
-
-
-def test_static_kv_cache_calibration_rejects_non_finite_scales():
-    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
-    _observe_weight_observers(model)
-    _observe_kv_cache(attn_modules)
-    attn_modules[0][1].v_scale.data.fill_(float("nan"))
-
-    with pytest.raises(ValueError) as exc_info:
-        modifier.end_calibration(model)
-
-    error_message = str(exc_info.value)
-    assert "layers.0.attention.v_scale" in error_message
-    assert "non-finite" in error_message
+    assert attention.k_observer.num_observations == 1
+    assert attention.v_observer.num_observations == 1
 
 
 def test_static_kv_cache_calibration_respects_ignore_list():
-    model, modifier, attn_modules = _prepare_kv_model(
+    model, modifier, state, attn_modules = _prepare_kv_model(
         dim=16,
         num_layers=2,
         ignore=["layers.1.attention"],
     )
-    _observe_weight_observers(model)
     _observe_kv_cache([attn_modules[0]])
-    attn_modules[1][1].k_scale.data.zero_()
-    attn_modules[1][1].v_scale.data.zero_()
 
-    modifier.end_calibration(model)
+    assert not hasattr(attn_modules[1][1], "k_observer")
+    assert not hasattr(attn_modules[1][1], "v_observer")
 
-
-def test_dynamic_kv_cache_calibration_skips_static_scale_validation():
-    model, modifier, _ = _prepare_kv_model(dim=16, num_layers=1, dynamic=True)
-    _observe_weight_observers(model)
-
-    modifier.end_calibration(model)
+    _sequential_epoch_end(modifier, state, model)
 
 
-def test_local_dynamic_kv_cache_calibration_skips_static_scale_validation():
-    model, modifier, _ = _prepare_kv_model(dim=16, num_layers=1, dynamic="local")
-    _observe_weight_observers(model)
+def test_dynamic_kv_cache_calibration_without_static_observers_passes():
+    model, modifier, state, attn_modules = _prepare_kv_model(
+        dim=16,
+        num_layers=1,
+        dynamic=True,
+    )
 
-    modifier.end_calibration(model)
+    assert not hasattr(attn_modules[0][1], "k_observer")
+    assert not hasattr(attn_modules[0][1], "v_observer")
 
-
-def test_end_calibration_can_run_after_static_kv_cache_is_frozen():
-    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
-    _observe_weight_observers(model)
-    _observe_kv_cache(attn_modules)
-
-    modifier.end_calibration(model)
-    attn_modules[0][1].k_scale.data.zero_()
-    modifier.end_calibration(model)
-
-    assert attn_modules[0][1].quantization_status == QuantizationStatus.FROZEN
+    _sequential_epoch_end(modifier, state, model)
 
 
-def test_non_kv_quantization_flow_is_not_validated():
+def test_non_kv_quantization_flow_is_validated_and_frozen():
     model = nn.Sequential(nn.Linear(4, 4))
-    modifier = QuantizationModifier(targets=["Linear"])
+    weight_args = QuantizationArgs(
+        num_bits=8, type="int", symmetric=True, strategy="tensor"
+    )
+    modifier = QuantizationModifier(
+        config_groups={
+            "group_0": QuantizationScheme(targets=["Linear"], weights=weight_args)
+        }
+    )
+    state = State(model=model)
 
-    apply_quantization_config(model, modifier.resolved_config)
-    modifier.start_calibration(model)
+    modifier.on_initialize(state)
+    modifier.on_calibration_start(state, None)
+    _sequential_epoch_end(modifier, state, model)
     modifier.end_calibration(model)
 
     assert model[0].quantization_status == QuantizationStatus.FROZEN

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -68,14 +68,18 @@ class _StubModel(nn.Module):
         return x
 
 
-def _kv_cache_modifier(dynamic: bool = False, ignore: list[str] | None = None):
+def _kv_cache_modifier(dynamic: bool | str = False, ignore: list[str] | None = None):
+    strategy = "tensor_group" if dynamic == "local" else "tensor"
+    group_size = 16 if dynamic == "local" else None
+
     return QuantizationModifier(
         targets=["Linear"],
         ignore=ignore or [],
         kv_cache_scheme=QuantizationArgs(
             num_bits=8,
             type="float",
-            strategy="tensor",
+            strategy=strategy,
+            group_size=group_size,
             dynamic=dynamic,
             symmetric=True,
         ),
@@ -89,7 +93,7 @@ def _attention_modules(model):
 def _prepare_model(
     dim: int = 16,
     num_layers: int = 2,
-    dynamic: bool = False,
+    dynamic: bool | str = False,
     ignore: list[str] | None = None,
 ):
     model = _StubModel(dim=dim, num_layers=num_layers)
@@ -181,5 +185,11 @@ def test_kv_cache_calibration_respects_ignore_list():
 
 def test_dynamic_kv_cache_calibration_skips_static_scale_validation():
     model, modifier, _ = _prepare_model(dim=16, num_layers=1, dynamic=True)
+
+    modifier.end_calibration(model)
+
+
+def test_local_dynamic_kv_cache_calibration_skips_static_scale_validation():
+    model, modifier, _ = _prepare_model(dim=16, num_layers=1, dynamic="local")
 
     modifier.end_calibration(model)

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -203,3 +203,20 @@ def test_local_dynamic_kv_cache_calibration_skips_static_scale_validation():
     model, modifier, _ = _prepare_model(dim=16, num_layers=1, dynamic="local")
 
     modifier.end_calibration(model)
+
+
+def test_end_calibration_can_run_after_kv_cache_is_frozen():
+    model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+    _observe_kv_cache(attn_modules)
+
+    modifier.end_calibration(model)
+    modifier.end_calibration(model)
+
+    assert attn_modules[0][1].quantization_status == QuantizationStatus.FROZEN
+
+
+def test_kv_cache_validation_skips_modules_without_quantization_scheme():
+    model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+    delattr(attn_modules[0][1], "quantization_scheme")
+
+    modifier.end_calibration(model)

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -155,6 +155,7 @@ def test_kv_cache_calibration_requires_observed_scales():
     assert "KV cache quantization calibration failed" in error_message
     assert "layers.0.attention.k_observer" in error_message
     assert "layers.0.attention.v_observer" in error_message
+    assert "invalid scales" not in error_message
 
     attention = attn_modules[0][1]
     assert attention.quantization_status == QuantizationStatus.CALIBRATION

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -1,14 +1,14 @@
 """
-Test that start_calibration initializes KV cache observers on attention modules
-regardless of their name in the module tree.
+Tests for KV cache calibration on attention modules.
 
-compressed_tensors' _apply_kv_cache_scheme discovers attention modules via
-is_attention_module() (name-agnostic), but QuantizationMixin.start_calibration
-previously relied on resolved_targets which includes "re:.*self_attn$". This
-regex fails for models that name their attention differently (e.g. "attention",
-"self_attention"). The fix adds an is_attention_module() fallback pass.
+KV cache quantization relies on key/value observers collecting calibration
+statistics before the final k_scale/v_scale values are frozen. These tests use
+small CPU-only attention stubs so the calibration lifecycle can be validated
+without downloading a model.
 """
 
+import pytest
+import torch
 import torch.nn as nn
 from compressed_tensors.quantization import (
     QuantizationArgs,
@@ -18,6 +18,7 @@ from compressed_tensors.quantization import (
 )
 from transformers import PretrainedConfig
 
+from llmcompressor.modifiers.quantization.calibration import update_qparams
 from llmcompressor.modifiers.quantization.quantization import QuantizationModifier
 
 
@@ -42,8 +43,8 @@ class _StubAttention(nn.Module):
 class _StubBlock(nn.Module):
     def __init__(self, dim: int = 16):
         super().__init__()
-        # Named "attention" instead of "self_attn" — does NOT match
-        # the "re:.*self_attn$" regex in resolved_targets.
+        # Named "attention" instead of "self_attn" to exercise name-agnostic
+        # attention module discovery.
         self.attention = _StubAttention(dim)
         self.mlp = nn.Linear(dim, dim)
 
@@ -67,60 +68,93 @@ class _StubModel(nn.Module):
         return x
 
 
-def test_attention_module_not_named_self_attn_gets_calibrated():
-    """Attention modules named 'attention' (not 'self_attn') must still
-    get observers and hooks initialized when kv_cache_scheme is set."""
-    model = _StubModel(dim=16)
-    modifier = QuantizationModifier(
+def _kv_cache_modifier(dynamic: bool = False):
+    return QuantizationModifier(
         targets=["Linear"],
         kv_cache_scheme=QuantizationArgs(
             num_bits=8,
             type="float",
             strategy="tensor",
-            dynamic=False,
+            dynamic=dynamic,
             symmetric=True,
         ),
     )
 
-    # Verify our stub is recognized as attention
-    attn_modules = [
-        (name, m) for name, m in model.named_modules() if is_attention_module(m)
-    ]
-    assert len(attn_modules) == 2, "Expected 2 attention modules in _StubModel"
 
-    # Verify none of them match the self_attn regex
-    for name, _ in attn_modules:
-        assert "self_attn" not in name, f"{name} unexpectedly matches self_attn"
+def _attention_modules(model):
+    return [(name, m) for name, m in model.named_modules() if is_attention_module(m)]
 
-    # Apply quantization config (this uses is_attention_module and WILL set scheme)
+
+def _prepare_model(dim: int = 16, num_layers: int = 2):
+    model = _StubModel(dim=dim, num_layers=num_layers)
+    modifier = _kv_cache_modifier()
+    attn_modules = _attention_modules(model)
+
     apply_quantization_config(model, modifier.resolved_config)
-
-    # Verify schemes were applied to attention modules by _apply_kv_cache_scheme
-    for _, m in attn_modules:
-        assert hasattr(m, "quantization_scheme"), (
-            "apply_quantization_config should set "
-            "quantization_scheme on attention modules"
-        )
-
-    # Now run start_calibration — this is what we're testing
     modifier.start_calibration(model)
 
-    # Verify attention modules got calibration status
-    for name, m in attn_modules:
-        assert m.quantization_status == QuantizationStatus.CALIBRATION, (
-            f"Attention module '{name}' was not calibrated — "
-            f"start_calibration missed it (status={m.quantization_status})"
+    return model, modifier, attn_modules
+
+
+def _observe_kv_cache(attn_modules, dim: int = 16):
+    key_states = torch.ones(1, 1, 1, dim)
+    value_states = torch.full((1, 1, 1, dim), 2.0)
+
+    for _, module in attn_modules:
+        module.k_observer(key_states)
+        module.v_observer(value_states)
+        update_qparams(module, ("k", "v"))
+
+
+def test_attention_module_not_named_self_attn_gets_calibrated():
+    """Attention modules named 'attention' should still get KV observers/hooks."""
+    model, modifier, attn_modules = _prepare_model(dim=16)
+
+    assert len(attn_modules) == 2, "Expected 2 attention modules in _StubModel"
+    for name, module in attn_modules:
+        assert "self_attn" not in name, f"{name} unexpectedly matches self_attn"
+        assert hasattr(module, "quantization_scheme"), (
+            "apply_quantization_config should set quantization_scheme on attention "
+            "modules"
+        )
+        assert module.quantization_status == QuantizationStatus.CALIBRATION, (
+            f"Attention module '{name}' was not calibrated "
+            f"(status={module.quantization_status})"
         )
 
-    # Verify hooks were registered for KV cache calibration
-    assert (
-        len(modifier._calibration_hooks) > 0
-    ), "Expected calibration hooks to be registered"
+    assert len(modifier._calibration_hooks) > 0, (
+        "Expected calibration hooks to be registered"
+    )
 
-    # Clean up
+    _observe_kv_cache(attn_modules)
     modifier.end_calibration(model)
 
-    for name, m in attn_modules:
-        assert (
-            m.quantization_status == QuantizationStatus.FROZEN
-        ), f"Attention module '{name}' was not frozen after end_calibration"
+    for name, module in attn_modules:
+        assert module.quantization_status == QuantizationStatus.FROZEN, (
+            f"Attention module '{name}' was not frozen after end_calibration"
+        )
+
+
+def test_kv_cache_calibration_requires_observed_scales():
+    model, modifier, _ = _prepare_model(dim=16, num_layers=1)
+
+    with pytest.raises(ValueError) as exc_info:
+        modifier.end_calibration(model)
+
+    error_message = str(exc_info.value)
+    assert "KV cache quantization calibration failed" in error_message
+    assert "layers.0.attention.k_observer" in error_message
+    assert "layers.0.attention.v_observer" in error_message
+
+
+def test_kv_cache_calibration_rejects_zero_scales():
+    model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+    _observe_kv_cache(attn_modules)
+    attn_modules[0][1].k_scale.data.zero_()
+
+    with pytest.raises(ValueError) as exc_info:
+        modifier.end_calibration(model)
+
+    error_message = str(exc_info.value)
+    assert "layers.0.attention.k_scale" in error_message
+    assert "non-positive" in error_message

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -1,10 +1,9 @@
 """
-Tests for calibration validation on quantized modules.
+Tests for static KV-cache calibration scale validation.
 
-KV cache quantization relies on key/value observers collecting calibration
-statistics before the final k_scale/v_scale values are frozen. These tests use
-small CPU-only stubs so the calibration lifecycle can be validated without
-downloading a model.
+KV-cache quantization relies on key/value observers collecting calibration
+statistics before k_scale/v_scale are saved. These tests use small CPU-only
+stubs so the calibration lifecycle can be validated without downloading a model.
 """
 
 import pytest
@@ -12,25 +11,18 @@ import torch
 import torch.nn as nn
 from compressed_tensors.quantization import (
     QuantizationArgs,
-    QuantizationScheme,
     QuantizationStatus,
     apply_quantization_config,
     is_attention_module,
 )
 from transformers import PretrainedConfig
 
-from llmcompressor.core import Event, EventType, State
 from llmcompressor.modifiers.quantization.calibration import observe, update_qparams
 from llmcompressor.modifiers.quantization.quantization import QuantizationModifier
-from llmcompressor.observers.min_max import StaticMinMaxObserver
 
 
 class _StubAttention(nn.Module):
-    """Minimal attention module recognized by is_attention_module().
-
-    is_attention_module checks: "attention" in class name (lowercase) and
-    hasattr(k_proj) or hasattr(v_proj).
-    """
+    """Minimal attention module recognized by is_attention_module()."""
 
     def __init__(self, dim: int = 16):
         super().__init__()
@@ -71,15 +63,6 @@ class _StubModel(nn.Module):
         return x
 
 
-class _EmbeddingModel(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.embed = nn.Embedding(8, 4)
-
-    def forward(self, input_ids):
-        return self.embed(input_ids)
-
-
 def _quant_args(dynamic: bool | str = False):
     strategy = "tensor_group" if dynamic == "local" else "tensor"
     group_size = 16 if dynamic == "local" else None
@@ -102,33 +85,11 @@ def _kv_cache_modifier(dynamic: bool | str = False, ignore: list[str] | None = N
     )
 
 
-def _linear_modifier():
-    args = QuantizationArgs(num_bits=8, type="int", symmetric=True, strategy="tensor")
-    return QuantizationModifier(
-        config_groups={
-            "group_0": QuantizationScheme(
-                targets=["Linear"],
-                weights=args,
-                input_activations=args,
-            )
-        }
-    )
-
-
-def _embedding_modifier():
-    args = QuantizationArgs(num_bits=8, type="int", symmetric=True, strategy="tensor")
-    return QuantizationModifier(
-        config_groups={
-            "group_0": QuantizationScheme(targets=["Embedding"], weights=args)
-        }
-    )
-
-
 def _attention_modules(model):
     return [(name, m) for name, m in model.named_modules() if is_attention_module(m)]
 
 
-def _prepare_model(
+def _prepare_kv_model(
     dim: int = 16,
     num_layers: int = 2,
     dynamic: bool | str = False,
@@ -161,27 +122,9 @@ def _observe_kv_cache(attn_modules, dim: int = 16):
         update_qparams(module, ("k", "v"))
 
 
-def test_observer_tracks_num_observations():
-    args = QuantizationArgs(num_bits=8, type="int", symmetric=True, strategy="tensor")
-    observer = StaticMinMaxObserver(base_name="input", args=args)
-
-    assert observer.num_observations == 0
-    assert not observer.has_statistics
-
-    observer(torch.empty(0))
-    assert observer.num_observations == 0
-
-    observer(torch.ones(2, 4))
-    assert observer.num_observations == 1
-    assert observer.has_statistics
-
-    observer(torch.full((2, 4), 2.0))
-    assert observer.num_observations == 2
-
-
 def test_attention_module_not_named_self_attn_gets_calibrated():
     """Attention modules named 'attention' should still get KV observers/hooks."""
-    model, modifier, attn_modules = _prepare_model(dim=16)
+    model, modifier, attn_modules = _prepare_kv_model(dim=16)
 
     assert len(attn_modules) == 2, "Expected 2 attention modules in _StubModel"
     for name, module in attn_modules:
@@ -209,18 +152,18 @@ def test_attention_module_not_named_self_attn_gets_calibrated():
         )
 
 
-def test_kv_cache_calibration_requires_observed_scales():
-    model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+def test_static_kv_cache_calibration_requires_observed_kv_tensors():
+    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
     _observe_weight_observers(model)
 
     with pytest.raises(ValueError) as exc_info:
         modifier.end_calibration(model)
 
     error_message = str(exc_info.value)
-    assert "Quantization calibration failed" in error_message
+    assert "KV-cache quantization calibration failed" in error_message
     assert "layers.0.attention.k_observer" in error_message
     assert "layers.0.attention.v_observer" in error_message
-    assert "invalid static KV-cache scales" not in error_message
+    assert "update(...) API" in error_message
 
     attention = attn_modules[0][1]
     assert attention.quantization_status == QuantizationStatus.CALIBRATION
@@ -228,30 +171,52 @@ def test_kv_cache_calibration_requires_observed_scales():
     assert hasattr(attention, "v_observer")
 
 
-def test_kv_cache_calibration_rejects_zero_and_non_finite_scales():
-    model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+@pytest.mark.parametrize("scale_name", ["k_scale", "v_scale"])
+def test_static_kv_cache_calibration_rejects_zero_scales(scale_name):
+    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
     _observe_weight_observers(model)
     _observe_kv_cache(attn_modules)
-    attn_modules[0][1].k_scale.data.zero_()
+    getattr(attn_modules[0][1], scale_name).data.zero_()
+
+    with pytest.raises(ValueError) as exc_info:
+        modifier.end_calibration(model)
+
+    error_message = str(exc_info.value)
+    assert f"layers.0.attention.{scale_name}" in error_message
+    assert "non-positive" in error_message
+
+
+@pytest.mark.parametrize("scale_name", ["k_scale", "v_scale"])
+def test_static_kv_cache_calibration_rejects_missing_scales(scale_name):
+    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
+    _observe_weight_observers(model)
+    _observe_kv_cache(attn_modules)
+    delattr(attn_modules[0][1], scale_name)
+
+    with pytest.raises(ValueError) as exc_info:
+        modifier.end_calibration(model)
+
+    error_message = str(exc_info.value)
+    assert f"layers.0.attention.{scale_name}" in error_message
+    assert "missing" in error_message
+
+
+def test_static_kv_cache_calibration_rejects_non_finite_scales():
+    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
+    _observe_weight_observers(model)
+    _observe_kv_cache(attn_modules)
     attn_modules[0][1].v_scale.data.fill_(float("nan"))
 
     with pytest.raises(ValueError) as exc_info:
         modifier.end_calibration(model)
 
     error_message = str(exc_info.value)
-    assert "layers.0.attention.k_scale" in error_message
-    assert "non-positive" in error_message
     assert "layers.0.attention.v_scale" in error_message
     assert "non-finite" in error_message
 
-    attention = attn_modules[0][1]
-    assert attention.quantization_status == QuantizationStatus.CALIBRATION
-    assert hasattr(attention, "k_observer")
-    assert hasattr(attention, "v_observer")
 
-
-def test_kv_cache_calibration_respects_ignore_list():
-    model, modifier, attn_modules = _prepare_model(
+def test_static_kv_cache_calibration_respects_ignore_list():
+    model, modifier, attn_modules = _prepare_kv_model(
         dim=16,
         num_layers=2,
         ignore=["layers.1.attention"],
@@ -265,21 +230,21 @@ def test_kv_cache_calibration_respects_ignore_list():
 
 
 def test_dynamic_kv_cache_calibration_skips_static_scale_validation():
-    model, modifier, _ = _prepare_model(dim=16, num_layers=1, dynamic=True)
+    model, modifier, _ = _prepare_kv_model(dim=16, num_layers=1, dynamic=True)
     _observe_weight_observers(model)
 
     modifier.end_calibration(model)
 
 
 def test_local_dynamic_kv_cache_calibration_skips_static_scale_validation():
-    model, modifier, _ = _prepare_model(dim=16, num_layers=1, dynamic="local")
+    model, modifier, _ = _prepare_kv_model(dim=16, num_layers=1, dynamic="local")
     _observe_weight_observers(model)
 
     modifier.end_calibration(model)
 
 
-def test_end_calibration_can_run_after_kv_cache_is_frozen():
-    model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
+def test_end_calibration_can_run_after_static_kv_cache_is_frozen():
+    model, modifier, attn_modules = _prepare_kv_model(dim=16, num_layers=1)
     _observe_weight_observers(model)
     _observe_kv_cache(attn_modules)
 
@@ -290,82 +255,12 @@ def test_end_calibration_can_run_after_kv_cache_is_frozen():
     assert attn_modules[0][1].quantization_status == QuantizationStatus.FROZEN
 
 
-def test_kv_cache_validation_skips_modules_without_quantization_scheme():
-    model, modifier, attn_modules = _prepare_model(dim=16, num_layers=1)
-    delattr(attn_modules[0][1], "quantization_scheme")
-    _observe_weight_observers(model)
+def test_non_kv_quantization_flow_is_not_validated():
+    model = nn.Sequential(nn.Linear(4, 4))
+    modifier = QuantizationModifier(targets=["Linear"])
 
+    apply_quantization_config(model, modifier.resolved_config)
+    modifier.start_calibration(model)
     modifier.end_calibration(model)
 
-
-def test_sequential_epoch_end_validates_current_linear_chunk():
-    model = nn.Sequential(nn.Linear(4, 4))
-    modifier = _linear_modifier()
-    state = State(model=model)
-
-    modifier.on_initialize(state)
-    modifier.on_calibration_start(state, None)
-
-    with pytest.raises(ValueError) as exc_info:
-        modifier.on_sequential_epoch_end(
-            state,
-            Event(type_=EventType.SEQUENTIAL_EPOCH_END),
-            modules=list(model.modules()),
-        )
-
-    error_message = str(exc_info.value)
-    assert "0.input_observer" in error_message
-    assert "0.weight_observer" not in error_message
-
-
-def test_local_dynamic_output_activation_observer_is_not_required():
-    model = nn.Sequential(nn.Linear(16, 16))
-    weight_args = QuantizationArgs(
-        num_bits=8,
-        type="int",
-        symmetric=True,
-        strategy="tensor",
-    )
-    output_args = QuantizationArgs(
-        num_bits=8,
-        type="float",
-        symmetric=True,
-        strategy="tensor_group",
-        group_size=16,
-        dynamic="local",
-    )
-    modifier = QuantizationModifier(
-        config_groups={
-            "group_0": QuantizationScheme(
-                targets=["Linear"],
-                weights=weight_args,
-                output_activations=output_args,
-            )
-        }
-    )
-    state = State(model=model)
-
-    modifier.on_initialize(state)
-    modifier.on_calibration_start(state, None)
-
-    assert not hasattr(model[0], "output_observer")
-    observe(model[0], "weight")
-    update_qparams(model[0], "weight")
-    modifier.validate_module_calibration(model)
-
-def test_embedding_weight_observer_is_validated():
-    model = _EmbeddingModel()
-    modifier = _embedding_modifier()
-    state = State(model=model)
-
-    modifier.on_initialize(state)
-    modifier.on_calibration_start(state, None)
-
-    with pytest.raises(ValueError) as exc_info:
-        modifier.validate_module_calibration(model)
-
-    assert "embed.weight_observer" in str(exc_info.value)
-
-    observe(model.embed, "weight")
-    update_qparams(model.embed, "weight")
-    modifier.validate_module_calibration(model)
+    assert model[0].quantization_status == QuantizationStatus.FROZEN

--- a/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
+++ b/tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
@@ -68,9 +68,10 @@ class _StubModel(nn.Module):
         return x
 
 
-def _kv_cache_modifier(dynamic: bool = False):
+def _kv_cache_modifier(dynamic: bool = False, ignore: list[str] | None = None):
     return QuantizationModifier(
         targets=["Linear"],
+        ignore=ignore or [],
         kv_cache_scheme=QuantizationArgs(
             num_bits=8,
             type="float",
@@ -85,9 +86,14 @@ def _attention_modules(model):
     return [(name, m) for name, m in model.named_modules() if is_attention_module(m)]
 
 
-def _prepare_model(dim: int = 16, num_layers: int = 2):
+def _prepare_model(
+    dim: int = 16,
+    num_layers: int = 2,
+    dynamic: bool = False,
+    ignore: list[str] | None = None,
+):
     model = _StubModel(dim=dim, num_layers=num_layers)
-    modifier = _kv_cache_modifier()
+    modifier = _kv_cache_modifier(dynamic=dynamic, ignore=ignore)
     attn_modules = _attention_modules(model)
 
     apply_quantization_config(model, modifier.resolved_config)
@@ -158,3 +164,22 @@ def test_kv_cache_calibration_rejects_zero_scales():
     error_message = str(exc_info.value)
     assert "layers.0.attention.k_scale" in error_message
     assert "non-positive" in error_message
+
+
+def test_kv_cache_calibration_respects_ignore_list():
+    model, modifier, attn_modules = _prepare_model(
+        dim=16,
+        num_layers=2,
+        ignore=["layers.1.attention"],
+    )
+    _observe_kv_cache([attn_modules[0]])
+    attn_modules[1][1].k_scale.data.zero_()
+    attn_modules[1][1].v_scale.data.zero_()
+
+    modifier.end_calibration(model)
+
+
+def test_dynamic_kv_cache_calibration_skips_static_scale_validation():
+    model, modifier, _ = _prepare_model(dim=16, num_layers=1, dynamic=True)
+
+    modifier.end_calibration(model)

--- a/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
+++ b/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
 
+import pytest
 import torch
 from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationScheme,
+    QuantizationStatus,
     initialize_module_for_quantization,
 )
 from torch import nn
@@ -21,6 +23,16 @@ class _FakeDecoderLayer(nn.Module):
         self.v_proj = nn.Linear(64, 64)
 
 
+def _observe_activation_observers(module: nn.Linear):
+    input_observer = getattr(module, "input_observer", None)
+    if input_observer is not None:
+        input_observer(torch.randn(2, module.in_features))
+
+    output_observer = getattr(module, "output_observer", None)
+    if output_observer is not None:
+        output_observer(torch.randn(2, module.out_features))
+
+
 def test_sequential_epoch_end_only_observes_passed_modules():
     """Verify only subgraph modules observed, not all model weights."""
     model = nn.Sequential(nn.Linear(10, 10), nn.Linear(10, 10), nn.Linear(10, 10))
@@ -34,6 +46,7 @@ def test_sequential_epoch_end_only_observes_passed_modules():
     state = State(model=model)
     modifier.on_initialize(state)
     modifier.on_calibration_start(state, None)
+    _observe_activation_observers(model[0])
 
     # Wrap update_statistics_from_observed to track which observers are called
     with patch.object(
@@ -64,11 +77,12 @@ def test_sequential_activation_qparams_only_updated_once_per_module():
             layer, QuantizationScheme(targets=[], input_activations=act_args)
         )
         initialize_observer(layer, "input")
-        layer.input_observer(layer.weight)  # Trigger observer to have statistics
     modifier = QuantizationModifier(targets="Linear", scheme="W8A8")
     state = State(model=model)
     modifier.on_initialize(state)
     modifier.on_calibration_start(state, None)
+    for layer in model:
+        _observe_activation_observers(layer)
 
     # Patch get_qparams and sync_activation_stats to track calls
     with patch.object(
@@ -119,9 +133,37 @@ def test_sequential_activation_qparams_only_updated_once_per_module():
         assert sync_mock2.call_count == 1
 
 
+def test_sequential_epoch_end_validates_unobserved_activation_observers():
+    model = nn.Sequential(nn.Linear(4, 4))
+    act_args = QuantizationArgs(
+        num_bits=8, type="int", symmetric=True, strategy="tensor"
+    )
+    modifier = QuantizationModifier(
+        config_groups={
+            "group_0": QuantizationScheme(
+                targets=["Linear"],
+                input_activations=act_args,
+            )
+        }
+    )
+    state = State(model=model)
+    modifier.on_initialize(state)
+    modifier.on_calibration_start(state, None)
+
+    with pytest.raises(ValueError) as exc_info:
+        modifier.on_sequential_epoch_end(
+            state,
+            Event(type_=EventType.SEQUENTIAL_EPOCH_END),
+            modules=list(model[0].modules()),
+        )
+
+    assert "0.input_observer" in str(exc_info.value)
+    assert model[0].quantization_status == QuantizationStatus.CALIBRATION
+
+
 def test_nested_parent_modules_produce_valid_global_scale():
     """When SEQUENTIAL_EPOCH_END receives parent modules (as the pipeline does),
-    child Linear layers must get finite, positive global_scale values —
+    child Linear layers must get finite, positive global_scale values -
     not uninitialized torch.empty garbage."""
     model = nn.Sequential(_FakeDecoderLayer())
     tg = QuantizationArgs(

--- a/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
+++ b/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
@@ -34,21 +34,14 @@ def test_sequential_epoch_end_only_observes_passed_modules():
     state = State(model=model)
     modifier.on_initialize(state)
     modifier.on_calibration_start(state, None)
-    model[0].input_observer(torch.randn(1, 10))
 
     # Wrap update_statistics_from_observed to track which observers are called
     with patch.object(
-        model[0].weight_observer,
-        "update_statistics_from_observed",
-        wraps=model[0].weight_observer.update_statistics_from_observed,
+        model[0].weight_observer, "update_statistics_from_observed"
     ) as mock0, patch.object(
-        model[1].weight_observer,
-        "update_statistics_from_observed",
-        wraps=model[1].weight_observer.update_statistics_from_observed,
+        model[1].weight_observer, "update_statistics_from_observed"
     ) as mock1, patch.object(
-        model[2].weight_observer,
-        "update_statistics_from_observed",
-        wraps=model[2].weight_observer.update_statistics_from_observed,
+        model[2].weight_observer, "update_statistics_from_observed"
     ) as mock2:
         modifier.on_sequential_epoch_end(
             state,
@@ -128,7 +121,7 @@ def test_sequential_activation_qparams_only_updated_once_per_module():
 
 def test_nested_parent_modules_produce_valid_global_scale():
     """When SEQUENTIAL_EPOCH_END receives parent modules (as the pipeline does),
-    child Linear layers must get finite, positive global_scale values -
+    child Linear layers must get finite, positive global_scale values —
     not uninitialized torch.empty garbage."""
     model = nn.Sequential(_FakeDecoderLayer())
     tg = QuantizationArgs(

--- a/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
+++ b/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
@@ -34,6 +34,7 @@ def test_sequential_epoch_end_only_observes_passed_modules():
     state = State(model=model)
     modifier.on_initialize(state)
     modifier.on_calibration_start(state, None)
+    model[0].input_observer(torch.randn(1, 10))
 
     # Wrap update_statistics_from_observed to track which observers are called
     with patch.object(
@@ -127,7 +128,7 @@ def test_sequential_activation_qparams_only_updated_once_per_module():
 
 def test_nested_parent_modules_produce_valid_global_scale():
     """When SEQUENTIAL_EPOCH_END receives parent modules (as the pipeline does),
-    child Linear layers must get finite, positive global_scale values —
+    child Linear layers must get finite, positive global_scale values -
     not uninitialized torch.empty garbage."""
     model = nn.Sequential(_FakeDecoderLayer())
     tg = QuantizationArgs(

--- a/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
+++ b/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
@@ -50,11 +50,17 @@ def test_sequential_epoch_end_only_observes_passed_modules():
 
     # Wrap update_statistics_from_observed to track which observers are called
     with patch.object(
-        model[0].weight_observer, "update_statistics_from_observed"
+        model[0].weight_observer,
+        "update_statistics_from_observed",
+        wraps=model[0].weight_observer.update_statistics_from_observed,
     ) as mock0, patch.object(
-        model[1].weight_observer, "update_statistics_from_observed"
+        model[1].weight_observer,
+        "update_statistics_from_observed",
+        wraps=model[1].weight_observer.update_statistics_from_observed,
     ) as mock1, patch.object(
-        model[2].weight_observer, "update_statistics_from_observed"
+        model[2].weight_observer,
+        "update_statistics_from_observed",
+        wraps=model[2].weight_observer.update_statistics_from_observed,
     ) as mock2:
         modifier.on_sequential_epoch_end(
             state,


### PR DESCRIPTION
Fixes #2853

This PR adds a post-calibration guard for static KV-cache quantization. It fails loudly when key/value cache scales are missing, unobserved, non-finite, or non-positive, instead of saving a checkpoint with invalid zero scales.

Tests:
- python -m ruff check src\llmcompressor\modifiers\quantization\quantization\mixin.py tests\llmcompressor\modifiers\quantization\test_kv_cache_calibration.py
- python -m pytest -p no:cacheprovider tests\llmcompressor\modifiers\quantization\test_kv_cache_calibration.py -q