### PR TITLE
fix: Add pre-processing check for model in oneshot API

### DIFF
--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -419,6 +419,15 @@ def oneshot(
 
     :return: The calibrated PreTrainedModel
     """
+    import torch.nn as nn
+
+    if not isinstance(model, (str, nn.Module)):
+        raise TypeError(
+            "The `model` argument must be a string representing a model path/hub ID "
+            f"or a PyTorch `nn.Module`. Got: {type(model).__name__}. "
+            "If you are passing a `vllm.LLM` object, please provide a model path or "
+            "a standard PyTorch model (like `AutoModelForCausalLM`) instead."
+        )
 
     # pass all args directly into Oneshot
     local_args = {


### PR DESCRIPTION
Resolves #2907

<details>

Added a validation check in `oneshot()` to catch if `model` is not a string or `nn.Module` and to raise a clear error message.

</details>

Signed-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>