### PR TITLE
Add oneshot check for quantized models

### DIFF
--- a/src/llmcompressor/entrypoints/utils.py
+++ b/src/llmcompressor/entrypoints/utils.py
@@ -38,6 +38,20 @@ from llmcompressor.typing import Processor
 from llmcompressor.utils import untie_word_embeddings
 
 
+def raise_if_model_is_quantized(model: PreTrainedModel):
+    quantization_config = getattr(
+        getattr(model, "config", None), "quantization_config", None
+    )
+
+    if quantization_config is not None:
+        raise ValueError(
+            "Attempting to quantize a model that already has a "
+            "`quantization_config` is not supported. Please use a "
+            "full-precision checkpoint, or first dequantize the checkpoint "
+            "using the compressed-tensors `convert_checkpoint` entrypoint."
+        )
+
+
 def pre_process(
     model_args: ModelArguments,
     dataset_args: DatasetArguments,
@@ -61,6 +75,8 @@ def pre_process(
     if isinstance(model_args.model, (str, PosixPath)):
         model = initialize_model_from_path(model_args)
         model_args.model = model
+
+    raise_if_model_is_quantized(model_args.model)
 
     # Initialize processor if dataset provided
     if isinstance(model_args.processor, (str, type(None))):

--- a/tests/llmcompressor/entrypoints/test_utils.py
+++ b/tests/llmcompressor/entrypoints/test_utils.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from llmcompressor.args import DatasetArguments, ModelArguments
+from llmcompressor.entrypoints.utils import pre_process, raise_if_model_is_quantized
+
+
+def test_raise_if_model_is_quantized():
+    model = SimpleNamespace(
+        config=SimpleNamespace(quantization_config={"quant_method": "fp8"})
+    )
+
+    with pytest.raises(ValueError, match="already has a `quantization_config`"):
+        raise_if_model_is_quantized(model)
+
+
+def test_raise_if_model_is_quantized_allows_full_precision_model():
+    model = SimpleNamespace(config=SimpleNamespace())
+
+    raise_if_model_is_quantized(model)
+
+
+def test_pre_process_checks_for_quantized_model_before_processor_init(monkeypatch):
+    model = SimpleNamespace(
+        config=SimpleNamespace(quantization_config={"quant_method": "fp8"})
+    )
+    initialize_processor_from_path = Mock()
+    monkeypatch.setattr(
+        "llmcompressor.entrypoints.utils.initialize_processor_from_path",
+        initialize_processor_from_path,
+    )
+
+    with pytest.raises(ValueError, match="full-precision checkpoint"):
+        pre_process(
+            ModelArguments(model=model),
+            DatasetArguments(),
+            output_dir=None,
+        )
+
+    initialize_processor_from_path.assert_not_called()


### PR DESCRIPTION
## Summary
- add an early `oneshot` pre-processing check for models that already define `quantization_config`
- raise a clear error that points users to a full-precision checkpoint or `convert_checkpoint`
- add unit coverage for the guard and pre-processing order

Fixes #2907.

## Testing
- `python -m py_compile src\llmcompressor\entrypoints\utils.py tests\llmcompressor\entrypoints\test_utils.py`

Could not run `pytest` or `ruff` locally because they are not installed in this environment (`No module named pytest`, `No module named ruff`).