### PR TITLE
fix(observers/imatrix): remove stale gatherer hook on second-pass attach

### DIFF
--- a/src/llmcompressor/observers/imatrix.py
+++ b/src/llmcompressor/observers/imatrix.py
@@ -78,6 +78,16 @@ class IMatrixMSEObserver(Observer):
             self._imatrix_count = module._imatrix_count
             del module._imatrix_sum
             del module._imatrix_count
+            # A gatherer's accumulation hook may still be registered on this
+            # module: its ``detach()`` runs at ``on_calibration_end``, which can
+            # be *after* this second-pass ``attach()`` when the gatherer and the
+            # quantization modifier share a single calibration run (e.g.
+            # ``IMatrixGatherer`` composed with ``GPTQModifier``). Remove it so
+            # it cannot fire against the accumulators we just deleted, otherwise
+            # the next forward raises ``AttributeError`` on ``_imatrix_sum``.
+            if hasattr(module, "_imatrix_hook"):
+                module._imatrix_hook.remove()
+                del module._imatrix_hook
             return
 
         if not hasattr(module, "in_features"):

--- a/tests/llmcompressor/observers/test_imatrix.py
+++ b/tests/llmcompressor/observers/test_imatrix.py
@@ -362,3 +362,46 @@ class TestHookDisabling:
 
         module(torch.randn(2, 8))
         assert module._imatrix_count.item() > 0
+
+
+# ---------------------------------------------------------------------------
+# Second-pass attach must not leave a stale gatherer hook behind
+# ---------------------------------------------------------------------------
+
+
+class TestSecondPassHookRemoval:
+    """
+    Regression test for the ``IMatrixGatherer`` + ``GPTQModifier`` composition.
+
+    When a second observer's ``attach()`` picks up the raw accumulators left by
+    a gatherer pass, it deletes ``_imatrix_sum`` / ``_imatrix_count`` from the
+    module. If the gatherer's forward-pre hook is still registered at that point
+    (its ``detach()`` only runs at ``on_calibration_end``), the next forward
+    fires the hook against the now-deleted accumulators and raises
+    ``AttributeError: 'Linear' object has no attribute '_imatrix_sum'``.
+    """
+
+    def test_second_pass_attach_removes_stale_hook(self):
+        module = torch.nn.Linear(8, 4)
+
+        # First pass (gatherer): registers the accumulation hook + accumulators.
+        _make_observer(module, strategy="channel")
+        assert hasattr(module, "_imatrix_hook")
+        module(torch.randn(2, 8))
+        assert module._imatrix_count.item() > 0
+
+        # Second pass (quantization observer) picks up the accumulators while
+        # the gatherer hook is still live; attach() must remove the hook.
+        _make_observer(module, strategy="channel")
+        assert not hasattr(module, "_imatrix_sum")
+        assert not hasattr(module, "_imatrix_hook")
+
+    def test_forward_after_second_pass_does_not_raise(self):
+        module = torch.nn.Linear(8, 4)
+
+        _make_observer(module, strategy="channel")
+        module(torch.randn(2, 8))
+        _make_observer(module, strategy="channel")
+
+        # Must not raise AttributeError on the deleted ``_imatrix_sum``.
+        module(torch.randn(2, 8))


### PR DESCRIPTION
## Summary

`IMatrixMSEObserver.attach()` can leave a **stale forward-pre hook** on a module, which then crashes on the next forward with:

```text
AttributeError: 'Linear' object has no attribute '_imatrix_sum'
```

Reported in #2914 (triggered by `IMatrixGatherer` → `GPTQModifier` with `pipeline="sequential"`).

## Root cause

The iMatrix lifecycle spans two passes:

1. **`IMatrixGatherer`** — `on_initialize` calls `observer.attach(module)`, which creates `module._imatrix_sum` / `module._imatrix_count` and registers `module._imatrix_hook` (a forward-pre hook that accumulates `E[x²]`). The gatherer's `on_calibration_end` later calls `observer.detach(module)`, which **removes the hook but intentionally leaves the accumulators** on the module.
2. **Quantization modifier** (`GPTQModifier` / `QuantizationModifier`) — its `imatrix_mse` observer's `attach()` hits the second-pass branch, **steals the accumulators and `del`s them** from the module, then returns.

When the two modifiers share a single calibration run, the quantization observer's `attach()` (step 2) runs **before** the gatherer's `detach()` (`on_calibration_end`). So the accumulators get deleted while the gatherer's `_imatrix_hook` is **still registered**. The next forward fires that hook, which dereferences the now-deleted `mod._imatrix_sum` → `AttributeError`.

## Fix

When the second-pass `attach()` steals and deletes the accumulators, also remove any lingering `_imatrix_hook` so it can't fire against deleted state. The removal is guarded by `hasattr`, so it's a no-op on the normal path where `detach()` already removed the hook — no behavior change for the happy path.

## Test

Adds a CPU-only regression test (`TestSecondPassHookRemoval`) that reproduces the exact failure: attach → forward → second attach (steals accumulators) → forward. Without the fix the final forward raises the reported `AttributeError`; with it, the hook is removed and the forward is a clean no-op.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
