### PR TITLE
Preserve tokenizer truncation/padding across calibration tokenization

### DIFF
--- a/src/llmcompressor/transformers/data/base.py
+++ b/src/llmcompressor/transformers/data/base.py
@@ -52,8 +52,14 @@ def _preserve_tokenizer_state(tokenizer):
     try:
         yield
     finally:
-        backend.no_truncation() if truncation is None else backend.enable_truncation(**truncation)
-        backend.no_padding() if padding is None else backend.enable_padding(**padding)
+        if truncation is None:
+            backend.no_truncation()
+        else:
+            backend.enable_truncation(**truncation)
+        if padding is None:
+            backend.no_padding()
+        else:
+            backend.enable_padding(**padding)
 
 
 class TextGenerationDataset(RegistryMixin):

--- a/src/llmcompressor/transformers/data/base.py
+++ b/src/llmcompressor/transformers/data/base.py
@@ -34,13 +34,14 @@ def _preserve_tokenizer_state(tokenizer):
     """
     Snapshot and restore a fast tokenizer's truncation/padding across tokenization.
 
-    ``transformers>=4.51`` persists the per-call ``truncation``/``max_length`` and ``padding``
-    arguments onto the fast tokenizer's backend. Calibration tokenization therefore leaks these
-    settings into the tokenizer, which is then serialized into ``tokenizer.json`` on save --
-    silently breaking downstream inference. For VLMs this is especially harmful: a large image
-    expands to more placeholder tokens than the leaked ``max_length`` and the request fails with
-    "Mismatch in image token count between text and input_ids". Snapshotting and restoring keeps
-    the saved tokenizer identical to the base model's.
+    ``transformers>=4.51`` persists the per-call ``truncation``/``max_length`` and
+    ``padding`` arguments onto the fast tokenizer's backend. Calibration tokenization
+    therefore leaks these settings into the tokenizer, which is then serialized into
+    ``tokenizer.json`` on save -- silently breaking downstream inference. For VLMs this
+    is especially harmful: a large image expands to more placeholder tokens than the
+    leaked ``max_length`` and the request fails with "Mismatch in image token count
+    between text and input_ids". Snapshotting and restoring keeps the saved tokenizer
+    identical to the base model's.
 
     See https://github.com/vllm-project/llm-compressor/issues/1418
     """
@@ -157,16 +158,19 @@ class TextGenerationDataset(RegistryMixin):
             # tokenize/ process
             dataset = self.filter_tokenizer_args(dataset)
             logger.debug(f"Tokenizer args after filtering: {get_columns(dataset)}")
-            # `self.tokenize` calls the processor with truncation=True; preserve the tokenizer's
-            # truncation/padding state so it is not leaked into the saved tokenizer (#1418).
+            # `self.tokenize` calls the processor with truncation=True; preserve the
+            # tokenizer's truncation/padding state so it is not leaked into the saved
+            # tokenizer (#1418).
             with _preserve_tokenizer_state(self.tokenizer):
                 dataset = self.map(
                     dataset,
                     self.tokenize,
-                    batched=False,  # batching is not well supported for vision processors
-                    keep_in_memory=True,  # bug occurs when not batched and not in memory,
+                    # batching is not well supported for vision processors
+                    batched=False,
+                    # bug occurs when not batched and not in memory;
                     # subsequent ds.map calls are always batched,
                     # regardless of `batched` argument
+                    keep_in_memory=True,
                     remove_columns=get_columns(dataset),  # assumes that input names
                     # and output names are disjoint
                     num_proc=self.dataset_args.preprocessing_num_workers,

--- a/src/llmcompressor/transformers/data/base.py
+++ b/src/llmcompressor/transformers/data/base.py
@@ -8,6 +8,7 @@ for fine-tuning workflows.
 """
 
 import inspect
+from contextlib import contextmanager
 from functools import cached_property
 from inspect import _ParameterKind as Kind
 from typing import Any, Callable
@@ -26,6 +27,33 @@ from llmcompressor.transformers.data.data_helpers import (
 )
 from llmcompressor.typing import DatasetType, Processor
 from llmcompressor.utils import import_from_path
+
+
+@contextmanager
+def _preserve_tokenizer_state(tokenizer):
+    """
+    Snapshot and restore a fast tokenizer's truncation/padding across tokenization.
+
+    ``transformers>=4.51`` persists the per-call ``truncation``/``max_length`` and ``padding``
+    arguments onto the fast tokenizer's backend. Calibration tokenization therefore leaks these
+    settings into the tokenizer, which is then serialized into ``tokenizer.json`` on save --
+    silently breaking downstream inference. For VLMs this is especially harmful: a large image
+    expands to more placeholder tokens than the leaked ``max_length`` and the request fails with
+    "Mismatch in image token count between text and input_ids". Snapshotting and restoring keeps
+    the saved tokenizer identical to the base model's.
+
+    See https://github.com/vllm-project/llm-compressor/issues/1418
+    """
+    backend = getattr(tokenizer, "backend_tokenizer", None)
+    if backend is None:  # slow tokenizer or no tokenizer -- nothing to leak
+        yield
+        return
+    truncation, padding = backend.truncation, backend.padding
+    try:
+        yield
+    finally:
+        backend.no_truncation() if truncation is None else backend.enable_truncation(**truncation)
+        backend.no_padding() if padding is None else backend.enable_padding(**padding)
 
 
 class TextGenerationDataset(RegistryMixin):
@@ -123,19 +151,22 @@ class TextGenerationDataset(RegistryMixin):
             # tokenize/ process
             dataset = self.filter_tokenizer_args(dataset)
             logger.debug(f"Tokenizer args after filtering: {get_columns(dataset)}")
-            dataset = self.map(
-                dataset,
-                self.tokenize,
-                batched=False,  # batching is not well supported for vision processors
-                keep_in_memory=True,  # bug occurs when not batched and not in memory,
-                # subsequent ds.map calls are always batched,
-                # regardless of `batched` argument
-                remove_columns=get_columns(dataset),  # assumes that input names
-                # and output names are disjoint
-                num_proc=self.dataset_args.preprocessing_num_workers,
-                load_from_cache_file=not self.dataset_args.overwrite_cache,
-                desc="Tokenizing",
-            )
+            # `self.tokenize` calls the processor with truncation=True; preserve the tokenizer's
+            # truncation/padding state so it is not leaked into the saved tokenizer (#1418).
+            with _preserve_tokenizer_state(self.tokenizer):
+                dataset = self.map(
+                    dataset,
+                    self.tokenize,
+                    batched=False,  # batching is not well supported for vision processors
+                    keep_in_memory=True,  # bug occurs when not batched and not in memory,
+                    # subsequent ds.map calls are always batched,
+                    # regardless of `batched` argument
+                    remove_columns=get_columns(dataset),  # assumes that input names
+                    # and output names are disjoint
+                    num_proc=self.dataset_args.preprocessing_num_workers,
+                    load_from_cache_file=not self.dataset_args.overwrite_cache,
+                    desc="Tokenizing",
+                )
             logger.debug(f"Model kwargs after tokenizing: {get_columns(dataset)}")
 
         if self.dataset_args.concatenate_data:

--- a/tests/llmcompressor/transformers/data/test_dataset_loading.py
+++ b/tests/llmcompressor/transformers/data/test_dataset_loading.py
@@ -7,6 +7,29 @@ from llmcompressor.transformers import TextGenerationDataset
 
 
 @pytest.mark.unit
+def test_tokenizer_truncation_not_leaked(tiny_llama_tokenizer):
+    # Regression test for #1418. Calibration tokenization passes truncation=True/max_length,
+    # which transformers>=4.51 persists onto the fast tokenizer's backend. That state would then
+    # be serialized into tokenizer.json on save and silently break downstream inference (for VLMs,
+    # a large image expands past max_length -> "Mismatch in image token count"). The saved
+    # tokenizer must match the base model, so calibration must not leave truncation/padding behind.
+    backend = tiny_llama_tokenizer.backend_tokenizer
+    truncation_before = backend.truncation
+    padding_before = backend.padding
+
+    manager = TextGenerationDataset.load_from_registry(
+        "open_platypus",
+        dataset_args=DatasetArguments(dataset="open_platypus", max_seq_length=64),
+        split="train[:5%]",
+        processor=tiny_llama_tokenizer,
+    )
+    manager()  # tokenizes calibration data; without the fix this leaks truncation state
+
+    assert backend.truncation == truncation_before
+    assert backend.padding == padding_before
+
+
+@pytest.mark.unit
 def test_concatenation_tokenization(tiny_llama_tokenizer):
     dataset_args = DatasetArguments(
         dataset="wikitext",

--- a/tests/llmcompressor/transformers/data/test_dataset_loading.py
+++ b/tests/llmcompressor/transformers/data/test_dataset_loading.py
@@ -8,11 +8,13 @@ from llmcompressor.transformers import TextGenerationDataset
 
 @pytest.mark.unit
 def test_tokenizer_truncation_not_leaked(tiny_llama_tokenizer):
-    # Regression test for #1418. Calibration tokenization passes truncation=True/max_length,
-    # which transformers>=4.51 persists onto the fast tokenizer's backend. That state would then
-    # be serialized into tokenizer.json on save and silently break downstream inference (for VLMs,
-    # a large image expands past max_length -> "Mismatch in image token count"). The saved
-    # tokenizer must match the base model, so calibration must not leave truncation/padding behind.
+    # Regression test for #1418. Calibration tokenization passes
+    # truncation=True/max_length, which transformers>=4.51 persists onto the fast
+    # tokenizer's backend. That state would then be serialized into tokenizer.json
+    # on save and silently break downstream inference (for VLMs, a large image
+    # expands past max_length -> "Mismatch in image token count"). The saved
+    # tokenizer must match the base model, so calibration must not leave
+    # truncation/padding behind.
     backend = tiny_llama_tokenizer.backend_tokenizer
     truncation_before = backend.truncation
     padding_before = backend.padding


### PR DESCRIPTION
## Summary

`TextGenerationDataset.tokenize()` calls the processor with `truncation=True` and `max_length` for calibration. Since **transformers>=4.51** this per-call truncation (and padding) is **persisted onto the fast tokenizer's backend**, and then serialized into `tokenizer.json` when the processor is saved. The saved tokenizer diverges from the base model:

```diff
- "truncation": null
+ "truncation": {"direction": "Right", "max_length": <max_seq_length>, "strategy": "LongestFirst", "stride": 0}
```

This **silently breaks downstream inference**. For VLMs it's especially harmful: a large image expands to more image-placeholder tokens than the leaked `max_length`, so the request fails with:

```
ValueError: Mismatch in image token count between text and `input_ids`.
Got ids=[4095] and text=[10902]. Likely due to `truncation='max_length'`.
```

Small images stay under the cap, so it only surfaces on large documents/high-resolution inputs — and in vLLM the underlying error is often masked (e.g. `Failed to apply Qwen3VLProcessor`), making it hard to trace back to the tokenizer.

Fixes #1418 (closed without a fix; multiple "same error" reports, and the workaround there is to pin `transformers==4.49`). This affects real published NVFP4/W4A16 VLM checkpoints today.

## Fix

Snapshot the fast tokenizer's `truncation`/`padding` before the tokenize `map` and restore it afterward (via a small `_preserve_tokenizer_state` context manager), so calibration doesn't leave state on the saved tokenizer. No-op for slow tokenizers (`backend_tokenizer is None`), and version-agnostic — it restores whatever the tokenizer had before, so it's correct whether or not transformers persists the state.

## Test

Adds `test_tokenizer_truncation_not_leaked` — runs the real calibration path over `open_platypus` and asserts the tokenizer's `truncation`/`padding` are unchanged afterward.

Also verified the snapshot/restore mechanism directly on a fast tokenizer: the `truncation=True` call reproduces the leak, the restore returns it to `None`, and the non-`None` round-trip (`enable_truncation(**backend.truncation)`) works without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)