### PR TITLE
[Claude] Improve common issues with `create-tiny-model` skill

### DIFF
--- a/.claude/skills/create-tiny-model/scripts/finetune.py
+++ b/.claude/skills/create-tiny-model/scripts/finetune.py
@@ -119,6 +119,22 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model, device_map="auto")
 
+    # Pre-flight NaN check: catch bad weight initialization before training silently fails.
+    # A NaN loss on the first step almost always means weights have NaN/Inf/extreme values
+    # (common with bfloat16 allocation of custom norm layers). Diagnose early.
+    test_ids = tokenizer("hello world", return_tensors="pt").input_ids.to(model.device)
+    with torch.no_grad():
+        test_out = model(input_ids=test_ids, labels=test_ids)
+    if test_out.loss is None or test_out.loss.isnan() or test_out.loss.isinf():
+        raise RuntimeError(
+            f"Pre-flight check failed: loss={test_out.loss}. "
+            "The model likely has uninitialized/extreme weights. "
+            "Re-run save_tiny_model.py (it now includes a weight fixup step) "
+            "or manually reset bad params: norm weights → 1.0, biases → 0.0, "
+            "other params → kaiming_uniform."
+        )
+    print(f"Pre-flight check passed: initial loss={test_out.loss.item():.3f}")
+
     # Set pad token if not set
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token

--- a/.claude/skills/create-tiny-model/scripts/finetune.py
+++ b/.claude/skills/create-tiny-model/scripts/finetune.py
@@ -125,7 +125,7 @@ def main():
     test_ids = tokenizer("hello world", return_tensors="pt").input_ids.to(model.device)
     with torch.no_grad():
         test_out = model(input_ids=test_ids, labels=test_ids)
-    if test_out.loss is None or test_out.loss.isnan() or test_out.loss.isinf():
+    if test_out.loss is None or not torch.isfinite(test_out.loss).item():
         raise RuntimeError(
             f"Pre-flight check failed: loss={test_out.loss}. "
             "The model likely has uninitialized/extreme weights. "

--- a/.claude/skills/create-tiny-model/scripts/save_tiny_model.py
+++ b/.claude/skills/create-tiny-model/scripts/save_tiny_model.py
@@ -1,3 +1,6 @@
+import math
+
+import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from llmcompressor.utils.dev import skip_weights_download
 
@@ -7,6 +10,16 @@ with skip_weights_download(AutoModelForCausalLM):
     model = AutoModelForCausalLM.from_pretrained(model_id, num_hidden_layers=1)
     model.init_weights()
     tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+# Fix initialization of weights which were not properly implemented by `init_weights`
+for name, param in model.named_parameters():
+    if param.isnan().any() or param.isinf().any() or param.abs().max() > 1e6:
+        if "norm" in name.lower() and "weight" in name:
+            param.data.fill_(1.0)
+        elif "bias" in name:
+            param.data.zero_()
+        else:
+            torch.nn.init.kaiming_uniform_(param, a=math.sqrt(5))
 
 num_parameters = model.num_parameters()
 num_parameters_b = num_parameters / 1e9

--- a/.claude/skills/create-tiny-model/scripts/save_tiny_model.py
+++ b/.claude/skills/create-tiny-model/scripts/save_tiny_model.py
@@ -12,14 +12,18 @@ with skip_weights_download(AutoModelForCausalLM):
     tokenizer = AutoTokenizer.from_pretrained(model_id)
 
 # Fix initialization of weights which were not properly implemented by `init_weights`
-for name, param in model.named_parameters():
-    if param.isnan().any() or param.isinf().any() or param.abs().max() > 1e6:
-        if "norm" in name.lower() and "weight" in name:
-            param.data.fill_(1.0)
-        elif "bias" in name:
-            param.data.zero_()
-        else:
-            torch.nn.init.kaiming_uniform_(param, a=math.sqrt(5))
+with torch.no_grad():
+    for name, param in model.named_parameters():
+        if not torch.isfinite(param).all() or param.abs().max() > 1e6:
+            if "norm" in name.lower() and "weight" in name:
+                param.fill_(1.0)
+            elif "bias" in name:
+                param.zero_()
+            else:
+                if param.ndim >= 2:
+                    torch.nn.init.kaiming_uniform_(param, a=math.sqrt(5))
+                else:
+                    torch.nn.init.normal_(param, std=0.02)
 
 num_parameters = model.num_parameters()
 num_parameters_b = num_parameters / 1e9


### PR DESCRIPTION
## Purpose ##
* Make `create-tiny-model` more robust and efficient by fixing common pitfalls

## Changes ##
* Transformers often does a bad job of implementing `model.init_weights()` and other weight initialization logic. This trips up the model basically every time
  * Add a step to initialize weights directly
  * Add a "preflight" check before training