### PR TITLE
Fix recipe merge with pre-numbered stages

### DIFF
--- a/src/llmcompressor/recipe/utils.py
+++ b/src/llmcompressor/recipe/utils.py
@@ -119,6 +119,13 @@ def append_recipe_dict(d1: dict, d2: dict) -> dict:
     Always starts numbering from 0 even for the first occurrence.
     """
     result = dict(d1)
+
+    def next_stage_key(base_key: str, start: int = 0) -> str:
+        index = start
+        while f"{base_key}_{index}" in result:
+            index += 1
+        return f"{base_key}_{index}"
+
     for key, val in d2.items():
         if key not in result:
             result[key] = val
@@ -128,12 +135,15 @@ def append_recipe_dict(d1: dict, d2: dict) -> dict:
 
             # Rename original if not yet renamed
             if key == base_key:
-                result[f"{base_key}_0"] = result.pop(key)
-                result[f"{base_key}_1"] = val
+                original_key = next_stage_key(base_key)
+                result = {
+                    (
+                        original_key if existing_key == key else existing_key
+                    ): existing_val
+                    for existing_key, existing_val in result.items()
+                }
+                result[next_stage_key(base_key)] = val
             else:
                 # Key was already suffixed, find next free index
-                i = 1
-                while f"{base_key}_{i}" in result:
-                    i += 1
-                result[f"{base_key}_{i}"] = val
+                result[next_stage_key(base_key, start=1)] = val
     return result

--- a/tests/llmcompressor/recipe/test_utils.py
+++ b/tests/llmcompressor/recipe/test_utils.py
@@ -1,0 +1,30 @@
+from llmcompressor.recipe.utils import append_recipe_dict
+
+
+def test_append_recipe_dict_numbers_duplicate_stages():
+    first = {"test_stage": {"first": {}}}
+    second = {"test_stage": {"second": {}}}
+
+    result = append_recipe_dict(first, second)
+
+    assert result == {
+        "test_stage_0": {"first": {}},
+        "test_stage_1": {"second": {}},
+    }
+
+
+def test_append_recipe_dict_preserves_existing_numbered_stage():
+    first = {
+        "test_stage": {"unnumbered": {}},
+        "test_stage_0": {"numbered": {}},
+    }
+    second = {"test_stage": {"incoming": {}}}
+
+    result = append_recipe_dict(first, second)
+
+    assert result == {
+        "test_stage_1": {"unnumbered": {}},
+        "test_stage_0": {"numbered": {}},
+        "test_stage_2": {"incoming": {}},
+    }
+    assert list(result) == ["test_stage_1", "test_stage_0", "test_stage_2"]


### PR DESCRIPTION
SUMMARY:

Preserve existing numbered recipe stages when merging a duplicate unnumbered stage. Previously, an existing `<name>_stage_0` entry could be overwritten while `<name>_stage` was renamed, silently dropping that stage's modifiers.

The merge now selects the next available suffix for both the original unnumbered stage and the incoming stage while preserving the existing stage order. Regression tests cover the normal duplicate case and the collision with an existing numbered stage, including key order.

TEST PLAN:

- `make quality`
- Isolated execution of `append_recipe_dict` against the regression case on macOS (passed)
- `pytest -q tests/llmcompressor/recipe/test_utils.py` (collection is blocked on macOS because `compressed-tensors` imports Triton, for which no macOS wheel is available)
