### PR TITLE
[Autoround][DDP] Fix rank-local device placement

### DIFF
--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -381,12 +381,11 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
                     str(start_gpu + i) for i in range(gpus_per_group)
                 )
             else:
-                device_index = torch.accelerator.current_device_index()
-                ar_kwargs["device_map"] = (
-                    f"{torch.accelerator.current_accelerator().type}:{device_index}"
-                    if torch.accelerator.is_available()
-                    else "cpu"
-                )
+                if torch.accelerator.is_available():
+                    device_index = torch.accelerator.current_device_index()
+                    ar_kwargs["device_map"] = f"{torch.accelerator.current_accelerator().type}:{device_index}"
+                else:
+                    ar_kwargs["device_map"] = "cpu"
 
     def _unwrapper_quantized_layer(self, model: torch.nn.Module):
         # auto-round will return WrapperWALayer if activation is quantized

--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -383,7 +383,9 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
             else:
                 if torch.accelerator.is_available():
                     device_index = torch.accelerator.current_device_index()
-                    ar_kwargs["device_map"] = f"{torch.accelerator.current_accelerator().type}:{device_index}"
+                    ar_kwargs["device_map"] = (
+                        f"{torch.accelerator.current_accelerator().type}:{device_index}"
+                    )
                 else:
                     ar_kwargs["device_map"] = "cpu"
 

--- a/src/llmcompressor/modifiers/autoround/base.py
+++ b/src/llmcompressor/modifiers/autoround/base.py
@@ -312,18 +312,13 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
             first_param = next(decoding_layer.parameters())
             device = first_param.device
             cur_inputs = self._all_module_input[decoding_layer._tmp_name]
-            ar_inputs = [((args, kwargs),) for args, kwargs in cur_inputs]
             self._set_attention_masks(ar, decoding_layer, cur_inputs)
             decoding_layer.tuning_device = device
-            # Enable auto_offload when device_ids is explicitly set OR when
-            # LLMCOMPRESSOR_GPUS_PER_GROUP > 1 (set by launch_multi_gpu.sh).
-            # This lets AutoRound load-balance the block's submodules
-            # across multiple GPUs within the rank.
+            # Only hand device placement to AutoRound when the caller explicitly
+            # requested it or when a rank is configured to use a local GPU group.
             auto_offload = False
             needs_multi_gpu = (
-                self.device_ids is not None
-                or get_local_gpu_group_size() > 1
-                or torch.accelerator.device_count() > 1
+                self.device_ids is not None or get_local_gpu_group_size() > 1
             )
             if needs_multi_gpu:
                 # Let AutoRound own placement within the rank-local GPU group.
@@ -334,6 +329,7 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
             # Ensure cached inputs are on the same device as the block.
             # Calibration forward may have run on a different GPU.
             cur_inputs = self._move_inputs_to(cur_inputs, device)
+            ar_inputs = [((args, kwargs),) for args, kwargs in cur_inputs]
 
             q_input, _ = ar.quantize_block(
                 block=decoding_layer,
@@ -385,8 +381,9 @@ class AutoRoundModifier(Modifier, QuantizationMixin):
                     str(start_gpu + i) for i in range(gpus_per_group)
                 )
             else:
+                device_index = torch.accelerator.current_device_index()
                 ar_kwargs["device_map"] = (
-                    f"{torch.accelerator.current_accelerator().type}:0"
+                    f"{torch.accelerator.current_accelerator().type}:{device_index}"
                     if torch.accelerator.is_available()
                     else "cpu"
                 )

--- a/tests/llmcompressor/modifiers/autoround/test_base.py
+++ b/tests/llmcompressor/modifiers/autoround/test_base.py
@@ -1,6 +1,8 @@
+from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 from auto_round.schemes import PRESET_SCHEMES as AR_PRESET_SCHEMES
 from auto_round.schemes import QuantizationScheme as ARQuantizationScheme
 from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
@@ -141,3 +143,77 @@ def test_build_layer_config_for_autoround_supports_mxfp4_activation_groups():
     layer_config = modifier._build_layer_config_for_autoround(wrapped)
 
     assert layer_config == {}
+
+
+def test_update_device_map_for_dp_uses_current_rank_device():
+    modifier = AutoRoundModifier(ignore=["lm_head"], iters=0, scheme="W4A16")
+    ar_kwargs = {}
+
+    with (
+        patch("torch.distributed.is_initialized", return_value=True),
+        patch(
+            "llmcompressor.modifiers.autoround.base.get_local_gpu_group_size",
+            return_value=1,
+        ),
+        patch("torch.accelerator.is_available", return_value=True),
+        patch("torch.accelerator.current_device_index", return_value=1),
+        patch("torch.accelerator.current_accelerator") as mock_accelerator,
+    ):
+        mock_accelerator.return_value.type = "cuda"
+        modifier._update_device_map_for_dp(ar_kwargs)
+
+    assert ar_kwargs["device_map"] == "cuda:1"
+
+
+def test_apply_autoround_passes_moved_inputs_to_quantize_block():
+    modifier = AutoRoundModifier(ignore=["lm_head"], iters=0, scheme="W4A16")
+    layer = _FakeDecoderLayer()
+    layer._tmp_name = "decoder"
+    modifier._sequential_targets = [layer.__class__.__name__]
+    modifier._all_module_input[layer._tmp_name] = [((torch.ones(1),), {})]
+
+    state = MagicMock(spec=State)
+    state.model.name_or_path = "stub-model"
+    state.model.config = MagicMock()
+
+    autoround = MagicMock()
+    autoround.quantize_block.return_value = (None, None)
+
+    with (
+        patch.object(
+            AutoRoundModifier, "_mapping_config_to_autoround", return_value="W4A16"
+        ),
+        patch.object(
+            AutoRoundModifier, "_build_layer_config_for_autoround", return_value={}
+        ),
+        patch.object(AutoRoundModifier, "get_unquantized_layer_names", return_value=[]),
+        patch.object(AutoRoundModifier, "_preprocess_qparams", return_value={}),
+        patch.object(AutoRoundModifier, "_postprocess_qparams"),
+        patch.object(
+            AutoRoundModifier, "_unwrapper_quantized_layer", side_effect=lambda m: m
+        ),
+        patch.object(AutoRoundModifier, "_update_device_map_for_dp"),
+        patch(
+            "llmcompressor.modifiers.autoround.base.align_module_device",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "llmcompressor.modifiers.autoround.base.suspend_offloading",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "llmcompressor.modifiers.autoround.base.get_local_gpu_group_size",
+            return_value=2,
+        ),
+        patch(
+            "llmcompressor.modifiers.autoround.base.get_main_device",
+            return_value=torch.device("meta"),
+        ),
+        patch(
+            "llmcompressor.modifiers.autoround.base.AutoRound", return_value=autoround
+        ),
+    ):
+        modifier.apply_autoround(state, [layer])
+
+    quantize_inputs = autoround.quantize_block.call_args.kwargs["inputs"]
+    assert quantize_inputs[0][0][0][0].device.type == "meta"


### PR DESCRIPTION
SUMMARY:
Fix the AutoRound DDP rank-local placement regression from #2844.

- keep AutoRound-managed multi-GPU offload disabled for normal 1-GPU-per-rank DDP
- use the current rank device when deriving the AutoRound device map
- rebuild quantize-block inputs after moving cached tensors to the selected device
- add unit coverage for rank-local device selection and moved-input handling

Fixes #2933

TEST PLAN:
- pytest tests/llmcompressor/modifiers/autoround/test_base.py 
- pytest tests/llmcompressor/transformers/compression/test_compression_ddp.py -k test_ddp_smoke_autoround