### PR TITLE
refactor: unify model-free ptq into ModelFreePtqConverter class

### DIFF
--- a/src/llmcompressor/entrypoints/model_free/__init__.py
+++ b/src/llmcompressor/entrypoints/model_free/__init__.py
@@ -18,15 +18,7 @@ from compressed_tensors.utils.safetensors_load import (
 )
 from loguru import logger
 
-from llmcompressor.entrypoints.model_free.microscale import (
-    build_microscale_inverse_weight_maps,
-    is_microscale_scheme,
-)
-from llmcompressor.entrypoints.model_free.process import (
-    process_file,
-    process_file_microscale_scheme,
-    validate_file,
-)
+from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
 from llmcompressor.entrypoints.model_free.save_utils import (
     update_config,
 )
@@ -85,13 +77,14 @@ def model_free_ptq(
             logger.info(f"Copying {file_path} -> {save_path}")
             shutil.copyfile(resolved_path, save_path)
 
+    # Construct the mfptq converter
+    mfptq = ModelFreePtqConverter(scheme, ignore, converter)
+
     # build quantization jobs
-    jobs = _build_jobs(
-        model_files, save_directory, scheme, ignore, resolved_devices, converter
-    )
+    jobs = _build_jobs(model_files, save_directory, mfptq, resolved_devices)
 
     # 1. validate quantizable tensors — fail fast before long-running quantization
-    validate_jobs = [(validate_file, *job[1:]) for job in jobs]
+    validate_jobs = [(mfptq.validate_file, *job[1:]) for job in jobs]
     exec_jobs(validate_jobs, max_workers, desc="Validating")
 
     # 2-5. quantize and compress weights
@@ -136,10 +129,8 @@ def _resolve_devices(
 def _build_jobs(
     model_files: dict[str, str],
     save_directory: str | os.PathLike,
-    scheme: QuantizationScheme,
-    ignore: Iterable[str],
+    mfptq: ModelFreePtqConverter,
     devices: list[torch.device],
-    converter: Converter | None,
 ) -> list[tuple]:
     """
     Build jobs with precomputed inverse_weight_map per shard.
@@ -150,22 +141,19 @@ def _build_jobs(
     process function and eliminates redundant tensor reads.
 
     :returns: list of jobs tuples
-        (job_fn, inverse_weight_map, save_path, scheme, ignore, device, converter)
+        (mfptq.process_file, inverse_weight_map, save_path, device)
         Shards are distributed round-robin across the given devices.
     """
     weight_map = get_weight_map(model_files)
 
-    if is_microscale_scheme(scheme):
-        job_fn = process_file_microscale_scheme
-        build_inverse_weight_maps_fn = build_microscale_inverse_weight_maps
-    else:
-        job_fn = process_file
-        build_inverse_weight_maps_fn = build_inverse_weight_maps
+    converters = [mfptq]
+    if mfptq.converter is not None:
+        converters.append(mfptq.converter)
 
-    inverse_weight_maps = build_inverse_weight_maps_fn(
+    inverse_weight_maps = build_inverse_weight_maps(
         weight_map=weight_map,
         model_files=model_files,
-        converters=[converter] if converter is not None else [],
+        converters=converters,
     )
 
     shard_names = [name for name in model_files if name.endswith("safetensors")]
@@ -186,15 +174,7 @@ def _build_jobs(
         device = devices[i % len(devices)]
 
         jobs.append(
-            (
-                job_fn,
-                inverse_weight_maps[shard_name],
-                save_path,
-                scheme,
-                ignore,
-                device,
-                converter,
-            )
+            (mfptq.process_file, inverse_weight_maps[shard_name], save_path, device)
         )
 
     return jobs

--- a/src/llmcompressor/entrypoints/model_free/__init__.py
+++ b/src/llmcompressor/entrypoints/model_free/__init__.py
@@ -22,7 +22,7 @@ from compressed_tensors.utils.safetensors_load import (
 from loguru import logger
 from safetensors.torch import save_file
 
-from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
+from llmcompressor.entrypoints.model_free.converter import ModelFreePtqConverter
 from llmcompressor.entrypoints.model_free.save_utils import update_config
 from llmcompressor.entrypoints.model_free.scheduler import estimate_job_memory
 from llmcompressor.entrypoints.model_free.validate import (
@@ -93,8 +93,8 @@ def model_free_ptq(
 
     # validate first (runs on meta device)
     validate_jobs = [
-        (_validate_shard, iwm, sp, cfg, torch.device("meta"), conv)
-        for _, iwm, sp, cfg, conv in jobs
+        (_validate_shard, iwm, sp, convs, torch.device("meta"))
+        for _, iwm, sp, convs in jobs
     ]
     exec_jobs(validate_jobs, max_workers, desc="Validating")
 
@@ -102,12 +102,8 @@ def model_free_ptq(
     total_size = 0
     weight_map = dict()
     callable_jobs = [
-        (
-            lambda dev, fn=fn, iwm=iwm, sp=sp, cfg=cfg, conv=conv: fn(
-                iwm, sp, cfg, dev, conv
-            )
-        )
-        for fn, iwm, sp, cfg, conv in jobs
+        (lambda dev, fn=fn, iwm=iwm, sp=sp, convs=convs: fn(iwm, sp, convs, dev))
+        for fn, iwm, sp, convs in jobs
     ]
     quantize_results = exec_jobs_dynamic(
         jobs=callable_jobs,
@@ -161,14 +157,11 @@ def _build_jobs(
     — no separate build_microscale_inverse_weight_maps needed.
 
     :returns: (jobs, memory_estimates) where each job is
-        (_process_shard, inverse_weight_map, save_path, config, converter)
+        (_process_shard, inverse_weight_map, save_path, converters)
         and each memory estimate is in bytes.
     """
     weight_map = get_weight_map(model_files)
 
-    # Build the converter chain upfront for dependency resolution only.
-    # The chain is reconstructed per shard inside _process_shard / _validate_shard
-    # so the scheduler can inject the right device.
     mfptq = ModelFreePtqConverter(config)
     all_converters = ([converter] if converter is not None else []) + [mfptq]
     inverse_weight_maps = build_inverse_weight_maps(
@@ -190,7 +183,7 @@ def _build_jobs(
             )
 
         iwm = inverse_weight_maps[shard_name]
-        jobs.append((_process_shard, iwm, save_path, config, converter))
+        jobs.append((_process_shard, iwm, save_path, all_converters))
         mem_estimates.append(estimate_job_memory(iwm))
 
     if mem_estimates:
@@ -207,12 +200,9 @@ def _build_jobs(
 def _process_shard(
     inverse_weight_map: InverseWeightMap,
     save_path: str | os.PathLike,
-    config: QuantizationConfig,
+    converters: list[Converter],
     device: torch.device,
-    converter: Converter | None,
 ) -> tuple[int, dict[str, str]]:
-    mfptq = ModelFreePtqConverter(config)
-    converters = ([converter] if converter is not None else []) + [mfptq]
     tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
     for conv in converters:
         tensors = conv.process(tensors)
@@ -226,14 +216,9 @@ def _process_shard(
 def _validate_shard(
     inverse_weight_map: InverseWeightMap,
     save_path: str | os.PathLike,
-    config: QuantizationConfig,
+    converters: list[Converter],
     device: torch.device,
-    converter: Converter | None,
 ) -> None:
-    mfptq = ModelFreePtqConverter(config)
-    converters = ([converter] if converter is not None else []) + [mfptq]
-    tensors = load_tensors_from_inverse_weight_map(
-        inverse_weight_map, torch.device("meta")
-    )
+    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
     for conv in converters:
         tensors = conv.validate(tensors)

--- a/src/llmcompressor/entrypoints/model_free/__init__.py
+++ b/src/llmcompressor/entrypoints/model_free/__init__.py
@@ -87,15 +87,12 @@ def model_free_ptq(
             logger.info(f"Copying {file_path} -> {save_path}")
             shutil.copyfile(resolved_path, save_path)
 
-    # build jobs without baking in a device — the scheduler assigns devices
+    # build jobs without baking in a device, the scheduler assigns devices
     # dynamically based on free VRAM at submit time
     jobs, mem_estimates = _build_jobs(model_files, save_directory, config, converter)
 
-    # validate first (runs on meta device)
-    validate_jobs = [
-        (_validate_shard, iwm, sp, convs, torch.device("meta"))
-        for _, iwm, sp, convs in jobs
-    ]
+    # validate first, always on meta
+    validate_jobs = [(_validate_shard, iwm, convs) for _, iwm, _sp, convs in jobs]
     exec_jobs(validate_jobs, max_workers, desc="Validating")
 
     # quantize with dynamic GPU scheduling
@@ -154,7 +151,7 @@ def _build_jobs(
 
     Uses CT's build_inverse_weight_maps with the full converter chain so that
     ModelFreePtqConverter.get_dependencies() drives microscale partner resolution
-    — no separate build_microscale_inverse_weight_maps needed.
+    with no separate build_microscale_inverse_weight_maps needed.
 
     :returns: (jobs, memory_estimates) where each job is
         (_process_shard, inverse_weight_map, save_path, converters)
@@ -215,10 +212,10 @@ def _process_shard(
 
 def _validate_shard(
     inverse_weight_map: InverseWeightMap,
-    save_path: str | os.PathLike,
     converters: list[Converter],
-    device: torch.device,
 ) -> None:
-    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
+    tensors = load_tensors_from_inverse_weight_map(
+        inverse_weight_map, torch.device("meta")
+    )
     for conv in converters:
         tensors = conv.validate(tensors)

--- a/src/llmcompressor/entrypoints/model_free/__init__.py
+++ b/src/llmcompressor/entrypoints/model_free/__init__.py
@@ -12,25 +12,18 @@ from compressed_tensors.entrypoints.convert import (
 )
 from compressed_tensors.quantization import QuantizationConfig, QuantizationScheme
 from compressed_tensors.utils.safetensors_load import (
+    InverseWeightMap,
     get_checkpoint_files,
     get_weight_map,
     is_weights_file,
+    load_tensors_from_inverse_weight_map,
     update_safetensors_index,
 )
 from loguru import logger
+from safetensors.torch import save_file
 
-from llmcompressor.entrypoints.model_free.microscale import (
-    build_microscale_inverse_weight_maps,
-    has_microscale_scheme,
-)
-from llmcompressor.entrypoints.model_free.process import (
-    process_file,
-    process_file_microscale_scheme,
-    validate_file,
-)
-from llmcompressor.entrypoints.model_free.save_utils import (
-    update_config,
-)
+from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
+from llmcompressor.entrypoints.model_free.save_utils import update_config
 from llmcompressor.entrypoints.model_free.scheduler import estimate_job_memory
 from llmcompressor.entrypoints.model_free.validate import (
     validate_config,
@@ -74,8 +67,8 @@ def model_free_ptq(
     :param device: device(s) for quantization. Accepts a single device
         string/object or a list. When multiple devices are given, shards
         are dynamically assigned based on real-time GPU memory.
-    :param converter: optional converter to apply to the checkpoint to convert
-        it to compressed-tensors format before running model-free PTQ
+    :param converter: optional converter to apply to the checkpoint before
+        running model-free PTQ, e.g. an AWQ or fp8 dequantizer
     """
     model_files = get_checkpoint_files(model_stub)
 
@@ -98,9 +91,9 @@ def model_free_ptq(
     # dynamically based on free VRAM at submit time
     jobs, mem_estimates = _build_jobs(model_files, save_directory, config, converter)
 
-    # validate first (runs on meta device, so device arg is ignored)
+    # validate first (runs on meta device)
     validate_jobs = [
-        (validate_file, iwm, sp, cfg, torch.device("meta"), conv)
+        (_validate_shard, iwm, sp, cfg, torch.device("meta"), conv)
         for _, iwm, sp, cfg, conv in jobs
     ]
     exec_jobs(validate_jobs, max_workers, desc="Validating")
@@ -127,8 +120,6 @@ def model_free_ptq(
         total_size += _total_size
         weight_map.update(_weight_map)
 
-    # weight_map may contain tensors re-located to new shards (partner tensors
-    # re-saved alongside the shard that needed them for fused scale computation)
     update_config(save_directory, config, converter)
     update_safetensors_index(save_directory, total_size, weight_map)
 
@@ -163,28 +154,27 @@ def _build_jobs(
     config: QuantizationConfig,
     converter: Converter | None,
 ) -> tuple[list[tuple], list[int]]:
-    """Build per-shard quantization jobs **without** device assignment.
+    """Build per-shard quantization jobs without baking in a device.
 
-    Device selection is deferred to ``exec_jobs_dynamic`` which picks a GPU
-    at submit time based on real-time free VRAM.
+    Uses CT's build_inverse_weight_maps with the full converter chain so that
+    ModelFreePtqConverter.get_dependencies() drives microscale partner resolution
+    — no separate build_microscale_inverse_weight_maps needed.
 
-    :returns: ``(jobs, memory_estimates)`` — each job is a tuple of
-        ``(fn, inverse_weight_map, save_path, config, converter)``
+    :returns: (jobs, memory_estimates) where each job is
+        (_process_shard, inverse_weight_map, save_path, config, converter)
         and each memory estimate is in bytes.
     """
     weight_map = get_weight_map(model_files)
 
-    if has_microscale_scheme(config):
-        job_fn = process_file_microscale_scheme
-        build_iwm_fn = build_microscale_inverse_weight_maps
-    else:
-        job_fn = process_file
-        build_iwm_fn = build_inverse_weight_maps
-
-    inverse_weight_maps = build_iwm_fn(
+    # Build the converter chain upfront for dependency resolution only.
+    # The chain is reconstructed per shard inside _process_shard / _validate_shard
+    # so the scheduler can inject the right device.
+    mfptq = ModelFreePtqConverter(config)
+    all_converters = ([converter] if converter is not None else []) + [mfptq]
+    inverse_weight_maps = build_inverse_weight_maps(
         weight_map=weight_map,
         model_files=model_files,
-        converters=[converter] if converter is not None else [],
+        converters=all_converters,
     )
 
     shard_names = [name for name in model_files if name.endswith("safetensors")]
@@ -200,7 +190,7 @@ def _build_jobs(
             )
 
         iwm = inverse_weight_maps[shard_name]
-        jobs.append((job_fn, iwm, save_path, config, converter))
+        jobs.append((_process_shard, iwm, save_path, config, converter))
         mem_estimates.append(estimate_job_memory(iwm))
 
     if mem_estimates:
@@ -210,9 +200,40 @@ def _build_jobs(
             f"{max(mem_estimates) / 1e9:.2f} GB per shard, "
             f"{sum(mem_estimates) / 1e9:.2f} GB total"
         )
-        logger.debug(
-            "Per-shard estimates: "
-            + ", ".join(f"{m / 1e9:.2f} GB" for m in mem_estimates)
-        )
 
     return jobs, mem_estimates
+
+
+def _process_shard(
+    inverse_weight_map: InverseWeightMap,
+    save_path: str | os.PathLike,
+    config: QuantizationConfig,
+    device: torch.device,
+    converter: Converter | None,
+) -> tuple[int, dict[str, str]]:
+    mfptq = ModelFreePtqConverter(config)
+    converters = ([converter] if converter is not None else []) + [mfptq]
+    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
+    for conv in converters:
+        tensors = conv.process(tensors)
+    os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
+    save_file(tensors, save_path)
+    total_size = sum(t.nbytes for t in tensors.values())
+    weight_map = {key: os.path.basename(save_path) for key in tensors.keys()}
+    return total_size, weight_map
+
+
+def _validate_shard(
+    inverse_weight_map: InverseWeightMap,
+    save_path: str | os.PathLike,
+    config: QuantizationConfig,
+    device: torch.device,
+    converter: Converter | None,
+) -> None:
+    mfptq = ModelFreePtqConverter(config)
+    converters = ([converter] if converter is not None else []) + [mfptq]
+    tensors = load_tensors_from_inverse_weight_map(
+        inverse_weight_map, torch.device("meta")
+    )
+    for conv in converters:
+        tensors = conv.validate(tensors)

--- a/src/llmcompressor/entrypoints/model_free/converter.py
+++ b/src/llmcompressor/entrypoints/model_free/converter.py
@@ -4,6 +4,7 @@ from typing import Iterator
 
 import torch
 from compressed_tensors.compressors import compress_module
+from compressed_tensors.entrypoints.convert import Converter
 from compressed_tensors.quantization import (
     QuantizationConfig,
     QuantizationScheme,
@@ -54,7 +55,7 @@ def _match_tensors_to_schemes(
                 yield module_name, name, scheme
 
 
-class ModelFreePtqConverter:
+class ModelFreePtqConverter(Converter):
     """
     Converter that quantizes and compresses safetensors checkpoints without
     loading a model. Implements the compressed-tensors Converter protocol so
@@ -88,11 +89,10 @@ class ModelFreePtqConverter:
         Validate that each quantizable tensor can be quantized under its scheme.
         Operates on meta tensors — no real computation.
         """
-        meta_tensors = {k: v.to("meta") for k, v in tensors.items()}
-        meta_tensors = split_fused_moe_experts(meta_tensors)
-        for _, name, scheme in _match_tensors_to_schemes(meta_tensors, self.config):
-            validate_weight_for_quantization(meta_tensors[name], scheme, name)
-        return meta_tensors
+        tensors = split_fused_moe_experts(tensors)
+        for _, name, scheme in _match_tensors_to_schemes(tensors, self.config):
+            validate_weight_for_quantization(tensors[name], scheme, name)
+        return tensors
 
     def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Quantize and compress all tensors. Device is inferred from the tensors."""
@@ -101,10 +101,10 @@ class ModelFreePtqConverter:
             return self._process_microscale(tensors)
         return self._process_standard(tensors)
 
-    def update_config(self, incoming: QuantizationConfig | None) -> QuantizationConfig:
+    def update_config(self, config: QuantizationConfig | None) -> QuantizationConfig:
         """
         Build or merge the final QuantizationConfig in COMPRESSED status.
-        When chained after a dequantizer (incoming=None), creates from scratch.
+        When chained after a dequantizer (config=None), creates from scratch.
         When seeded with a pre-existing checkpoint config, merges into it.
         """
         unique_formats = {
@@ -124,10 +124,10 @@ class ModelFreePtqConverter:
             quantization_status=QuantizationStatus.COMPRESSED,
             format=format_,
         )
-        if incoming is None:
+        if config is None:
             return new_config
-        incoming.merge(new_config)
-        return incoming
+        config.merge(new_config)
+        return config
 
     def _process_standard(
         self, tensors: dict[str, torch.Tensor]

--- a/src/llmcompressor/entrypoints/model_free/converter.py
+++ b/src/llmcompressor/entrypoints/model_free/converter.py
@@ -87,7 +87,7 @@ class ModelFreePtqConverter(Converter):
     def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Validate that each quantizable tensor can be quantized under its scheme.
-        Operates on meta tensors — no real computation.
+        Operates on meta tensors.
         """
         tensors = split_fused_moe_experts(tensors)
         for _, name, scheme in _match_tensors_to_schemes(tensors, self.config):

--- a/src/llmcompressor/entrypoints/model_free/microscale.py
+++ b/src/llmcompressor/entrypoints/model_free/microscale.py
@@ -1,5 +1,3 @@
-import re
-
 from compressed_tensors.quantization import QuantizationScheme, QuantizationStrategy
 
 from llmcompressor.entrypoints.model_free.helpers import (

--- a/src/llmcompressor/entrypoints/model_free/microscale.py
+++ b/src/llmcompressor/entrypoints/model_free/microscale.py
@@ -1,8 +1,6 @@
 import re
 
-from compressed_tensors.entrypoints.convert import Converter, build_inverse_weight_maps
 from compressed_tensors.quantization import QuantizationScheme, QuantizationStrategy
-from compressed_tensors.utils.safetensors_load import InverseWeightMap
 
 from llmcompressor.entrypoints.model_free.helpers import (
     MatchedNamesSet,
@@ -10,7 +8,6 @@ from llmcompressor.entrypoints.model_free.helpers import (
 )
 
 __all__ = [
-    "build_microscale_inverse_weight_maps",
     "is_microscale_scheme",
     "get_fused_names",
     "DEFAULT_FUSED_MAPPINGS",
@@ -77,49 +74,3 @@ def get_fused_names(
         if _unmatched is not None:
             unmatched.append(_unmatched)
     return matched, unmatched
-
-
-def build_microscale_inverse_weight_maps(
-    weight_map: dict[str, str],
-    model_files: dict[str, str],
-    converters: list[Converter],
-) -> dict[str, InverseWeightMap]:
-    """
-    This function replicates the logic of
-    `compressed_tensors.entrypoints.convert.build_inverse_weight_maps` including the
-    case of microscale partner shards, as defined in DEFAULT_FUSED_MAPPINGS
-
-    For a given output shard, precompute exactly which tensors to load from
-    which source files — including required partner tensors from other shards.
-
-    This is necessary because some converters require that a set of tensors are
-    accessible in order for them to be processed correctly.
-
-    :param shard_name: the shard filename this job will process and save
-    :param weight_map: tensor name -> shard filename (from safetensors.index.json)
-    :param model_files: shard filename -> resolved absolute path
-    :return: {resolved_file_path: [tensor_names_to_load]}
-    """
-
-    # TODO move to top level, fulfill rest of Protocol contract
-    #  - ideally remove the need for separate process_file and process_microscale_file
-    #    functions
-    #  - remove build_microscale_inverse_weight_maps entirely, replace with
-    #    `compressed_tensors.entrypoints.convert.build_inverse_weight_maps`
-    class MicroscaleConverter:
-        def get_dependencies(self, weight_name: str) -> set[str]:
-            deps = set()
-            for primary_pattern, partner_templates in DEFAULT_FUSED_MAPPINGS.items():
-                match = re.match(primary_pattern, weight_name)
-                if match is None:
-                    continue
-
-                # Build partner names using named groups from the match
-                for partner_template in partner_templates:
-                    partner_name = partner_template.format(**match.groupdict())
-
-                    deps.add(partner_name)
-            return deps
-
-    converters.append(MicroscaleConverter())
-    return build_inverse_weight_maps(weight_map, model_files, converters)

--- a/src/llmcompressor/entrypoints/model_free/microscale.py
+++ b/src/llmcompressor/entrypoints/model_free/microscale.py
@@ -1,12 +1,8 @@
-import re
-
-from compressed_tensors.entrypoints.convert import Converter, build_inverse_weight_maps
 from compressed_tensors.quantization import (
     QuantizationConfig,
     QuantizationScheme,
     QuantizationStrategy,
 )
-from compressed_tensors.utils.safetensors_load import InverseWeightMap
 
 from llmcompressor.entrypoints.model_free.helpers import (
     MatchedNamesSet,
@@ -14,7 +10,6 @@ from llmcompressor.entrypoints.model_free.helpers import (
 )
 
 __all__ = [
-    "build_microscale_inverse_weight_maps",
     "has_microscale_scheme",
     "is_microscale_scheme",
     "get_fused_names",
@@ -86,49 +81,3 @@ def get_fused_names(
         if _unmatched is not None:
             unmatched.append(_unmatched)
     return matched, unmatched
-
-
-def build_microscale_inverse_weight_maps(
-    weight_map: dict[str, str],
-    model_files: dict[str, str],
-    converters: list[Converter],
-) -> dict[str, InverseWeightMap]:
-    """
-    This function replicates the logic of
-    `compressed_tensors.entrypoints.convert.build_inverse_weight_maps` including the
-    case of microscale partner shards, as defined in DEFAULT_FUSED_MAPPINGS
-
-    For a given output shard, precompute exactly which tensors to load from
-    which source files — including required partner tensors from other shards.
-
-    This is necessary because some converters require that a set of tensors are
-    accessible in order for them to be processed correctly.
-
-    :param shard_name: the shard filename this job will process and save
-    :param weight_map: tensor name -> shard filename (from safetensors.index.json)
-    :param model_files: shard filename -> resolved absolute path
-    :return: {resolved_file_path: [tensor_names_to_load]}
-    """
-
-    # TODO move to top level, fulfill rest of Protocol contract
-    #  - ideally remove the need for separate process_file and process_microscale_file
-    #    functions
-    #  - remove build_microscale_inverse_weight_maps entirely, replace with
-    #    `compressed_tensors.entrypoints.convert.build_inverse_weight_maps`
-    class MicroscaleConverter:
-        def get_dependencies(self, weight_name: str) -> set[str]:
-            deps = set()
-            for primary_pattern, partner_templates in DEFAULT_FUSED_MAPPINGS.items():
-                match = re.match(primary_pattern, weight_name)
-                if match is None:
-                    continue
-
-                # Build partner names using named groups from the match
-                for partner_template in partner_templates:
-                    partner_name = partner_template.format(**match.groupdict())
-
-                    deps.add(partner_name)
-            return deps
-
-    converters.append(MicroscaleConverter())
-    return build_inverse_weight_maps(weight_map, model_files, converters)

--- a/src/llmcompressor/entrypoints/model_free/process.py
+++ b/src/llmcompressor/entrypoints/model_free/process.py
@@ -22,9 +22,9 @@ from llmcompressor.entrypoints.model_free.lifecycle import (
     validate_weight_for_quantization,
 )
 from llmcompressor.entrypoints.model_free.microscale import (
+    DEFAULT_FUSED_MAPPINGS,
     get_fused_names,
     is_microscale_scheme,
-    DEFAULT_FUSED_MAPPINGS,
 )
 from llmcompressor.modifiers.quantization.calibration import (
     apply_calibration_status,
@@ -40,8 +40,14 @@ __all__ = [
     "split_fused_moe_experts",
 ]
 
-class ModelFreePtqConverter():
-    def __init__(self, scheme, ignore, converter=None):
+
+class ModelFreePtqConverter:
+    def __init__(
+        self,
+        scheme: QuantizationScheme,
+        ignore: Iterable[str],
+        converter: Converter | None = None,
+    ):
         self.scheme = scheme
         self.ignore = ignore
         self.converter = converter
@@ -55,18 +61,30 @@ class ModelFreePtqConverter():
 
     def create_config(self):
         return None
-    
-    def validate_file(self, inverse_weight_map, save_path, device):
+
+    def validate_file(
+        self,
+        inverse_weight_map: InverseWeightMap,
+        save_path: str | os.PathLike,
+        device: str | torch.device,
+    ):
         device = torch.device("meta")
         tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
 
         if self.converter is not None:
             self.converter.validate(tensors)
 
-        for _, name in match_quantizable_tensors(tensors, self.ignore, self.scheme.targets):
+        for _, name in match_quantizable_tensors(
+            tensors, self.ignore, self.scheme.targets
+        ):
             validate_weight_for_quantization(tensors[name], self.scheme, name)
 
-    def process_file(self, inverse_weight_map, save_path, device) -> tuple[int, dict[str, str]]:
+    def process_file(
+        self,
+        inverse_weight_map: InverseWeightMap,
+        save_path: str | os.PathLike,
+        device: str | torch.device,
+    ) -> tuple[int, dict[str, str]]:
         tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
         tensors = split_fused_moe_experts(tensors)
 
@@ -84,18 +102,20 @@ class ModelFreePtqConverter():
             }
             fused_modules: dict[int, dict[str, Module]] = defaultdict(dict)
 
-        # Per-tensor loop                
-        for module_name, name in match_quantizable_tensors(tensors, self.ignore, self.scheme.targets):
+        # Per-tensor loop
+        for module_name, name in match_quantizable_tensors(
+            tensors, self.ignore, self.scheme.targets
+        ):
             validate_weight_for_quantization(tensors[name], self.scheme, name)
             module = initialize_quantized_linear(tensors[name], self.scheme, device)
-    
+
             # Defer fused tensors for processing down the line
             if self.is_microscale and name in fused_name_to_fused_index:
                 fused_index = fused_name_to_fused_index[name]
                 fused_modules[fused_index][name] = module
                 initialize_observer(module, "weight")
                 apply_calibration_status(module)
-                
+
                 continue
 
             # Standard path
@@ -103,10 +123,10 @@ class ModelFreePtqConverter():
             compress_module(module)
 
             del tensors[name]
-            prefix = module_name + '.'
+            prefix = module_name + "."
             for key, value in module.state_dict(prefix=prefix).items():
                 tensors[key] = value.to("cpu")
-        
+
         # Only for microscale compressed fused models with a shared global state
         if self.is_microscale:
             for named_modules in fused_modules.values():
@@ -126,15 +146,14 @@ class ModelFreePtqConverter():
                     for key, value in module.state_dict(prefix=prefix).items():
                         tensors[key] = value.to("cpu")
 
-        # Save ALL tensors to this shard's output — including partner tensors fetched
+        # Save ALL tensors to this shard's output including partner tensors fetched
         # from other shards. Partners are re-saved here so future runs don't need to
-        # re-fetch them. The caller updates the safetensors index to reflect new locations.
+        # re-fetch them. The caller updates the safetensors index accordingly.
         os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
         save_file(tensors, save_path)
         total_size = sum(t.nbytes for t in tensors.values())
         weight_map = {key: os.path.basename(save_path) for key in tensors.keys()}
         return total_size, weight_map
-        
 
     def get_dependencies(self, weight_name: str) -> set[str]:
         deps = set()

--- a/src/llmcompressor/entrypoints/model_free/process.py
+++ b/src/llmcompressor/entrypoints/model_free/process.py
@@ -1,4 +1,5 @@
 import os
+import re
 from collections import defaultdict
 from typing import Iterable
 
@@ -23,6 +24,7 @@ from llmcompressor.entrypoints.model_free.lifecycle import (
 from llmcompressor.entrypoints.model_free.microscale import (
     get_fused_names,
     is_microscale_scheme,
+    DEFAULT_FUSED_MAPPINGS,
 )
 from llmcompressor.modifiers.quantization.calibration import (
     apply_calibration_status,
@@ -34,206 +36,120 @@ from llmcompressor.modifiers.quantization.calibration import (
 from llmcompressor.observers import FusionHandler
 
 __all__ = [
-    "validate_file",
-    "process_file",
-    "process_file_microscale_scheme",
+    "ModelFreePtqConverter",
+    "split_fused_moe_experts",
 ]
 
+class ModelFreePtqConverter():
+    def __init__(self, scheme, ignore, converter=None):
+        self.scheme = scheme
+        self.ignore = ignore
+        self.converter = converter
+        self.is_microscale = is_microscale_scheme(scheme)
 
-def validate_file(
-    inverse_weight_map: InverseWeightMap,
-    save_path: str | os.PathLike,
-    scheme: QuantizationScheme,
-    ignore: Iterable[str],
-    device: str | torch.device,
-    converter: Converter | None = None,
-):
-    """
-    Validate that each quantizable tensor in a safetensors file can be quantized.
+    def process(self, tensors):
+        return tensors
 
-    :param inverse_weight_map: mapping of source file path -> tensor names to validate
-    :param save_path: save path of file with quantized weights
-    :param scheme: quantization scheme to apply to tensors
-    :param ignore: modules to ignore. Modules ending with "norm" are automatically
-        ignored
-    :param device: device used to quantize and compress weights
-    :param converter: optional converter to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
-    """
-    # device is ignored: all validation is done on meta device
-    device = torch.device("meta")
-    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
+    def validate(self, tensors):
+        pass
 
-    if converter is not None:
-        converter.validate(tensors)
+    def create_config(self):
+        return None
+    
+    def validate_file(self, inverse_weight_map, save_path, device):
+        device = torch.device("meta")
+        tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
 
-    for _, name in match_quantizable_tensors(tensors, ignore, scheme.targets):
-        validate_weight_for_quantization(tensors[name], scheme, name)
+        if self.converter is not None:
+            self.converter.validate(tensors)
 
+        for _, name in match_quantizable_tensors(tensors, self.ignore, self.scheme.targets):
+            validate_weight_for_quantization(tensors[name], self.scheme, name)
 
-def process_file(
-    inverse_weight_map: InverseWeightMap,
-    save_path: str | os.PathLike,
-    scheme: QuantizationScheme,
-    ignore: Iterable[str],
-    device: str | torch.device,
-    converter: Converter | None = None,
-) -> tuple[int, dict[str, str]]:
-    """
-    Quantize and compress tensors in a given safetensors file.
+    def process_file(self, inverse_weight_map, save_path, device) -> tuple[int, dict[str, str]]:
+        tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
+        tensors = split_fused_moe_experts(tensors)
 
-    :param inverse_weight_map: mapping of source file path -> tensor names.
-        For standard mode: {{resolved_path: None}} means load all tensors to process
-    :param save_path: save path of file with quantized weights
-    :param scheme: quantization scheme to apply to tensors
-    :param ignore: modules to ignore. Modules ending with "norm" are automatically
-        ignored
-    :param device: device used to quantize and compress weights
-    :param converter: optional converter to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
-    """
-    assert not is_microscale_scheme(scheme), "Use `process_file_microscale_scheme`"
+        if self.converter is not None:
+            tensors = self.converter.process(tensors)
 
-    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
+        # Microscale only... fused lookup
+        if self.is_microscale:
+            fused_sets, _ = get_fused_names(list(tensors.keys()))
+            fused_name_to_fused_index: dict[str, int] = {
+                name: index
+                for index, matched_set in enumerate(fused_sets)
+                for name in matched_set.values()
+                if name is not None
+            }
+            fused_modules: dict[int, dict[str, Module]] = defaultdict(dict)
 
-    tensors = split_fused_moe_experts(tensors)
+        # Per-tensor loop                
+        for module_name, name in match_quantizable_tensors(tensors, self.ignore, self.scheme.targets):
+            validate_weight_for_quantization(tensors[name], self.scheme, name)
+            module = initialize_quantized_linear(tensors[name], self.scheme, device)
+    
+            # Defer fused tensors for processing down the line
+            if self.is_microscale and name in fused_name_to_fused_index:
+                fused_index = fused_name_to_fused_index[name]
+                fused_modules[fused_index][name] = module
+                initialize_observer(module, "weight")
+                apply_calibration_status(module)
+                
+                continue
 
-    if converter is not None:
-        tensors = converter.process(tensors)
-
-    for module_name, name in match_quantizable_tensors(tensors, ignore, scheme.targets):
-        validate_weight_for_quantization(tensors[name], scheme, name)
-
-        # 1. initialize module with qparams (on device)
-        module = initialize_quantized_linear(tensors[name], scheme, device)
-
-        # 2. calibrate weight qparams
-        calibrate_weight(module)
-
-        # 3. compress module using qparams
-        compress_module(module)
-
-        # 4. save compressed data (on cpu)
-        del tensors[name]
-        prefix = module_name + "."
-        for key, value in module.state_dict(prefix=prefix).items():
-            tensors[key] = value.to("cpu")
-
-    save_file(tensors, save_path)
-    total_size = sum(tensor.nbytes for tensor in tensors.values())
-    weight_map = {key: os.path.basename(save_path) for key in tensors.keys()}
-    return total_size, weight_map
-
-
-def process_file_microscale_scheme(
-    inverse_weight_map: InverseWeightMap,
-    save_path: str | os.PathLike,
-    scheme: QuantizationScheme,
-    ignore: Iterable[str],
-    device: str | torch.device,
-    converter: Converter | None = None,
-) -> tuple[int, dict[str, str]]:
-    """
-    Quantize and compress tensors for a single output shard using a microscale
-    scheme (NVFP4, MXFP4).
-
-    Accepts a precomputed inverse_weight_map that specifies exactly which tensors
-    to load from which source files — including any fused partner tensors from
-    other shards needed for global scale computation. This avoids runtime
-    discovery of fused partners and redundant tensor reads.
-
-    Partner tensors fetched from other shards are re-saved into this shard's
-    output. The caller updates the safetensors index to reflect new locations.
-
-    :param inverse_weight_map: mapping of resolved source file path ->
-        list of tensor names to load from that file.
-        Example: {"/path/shard0.safetensors": ["q_proj.weight"],
-                  "/path/shard1.safetensors": ["k_proj.weight", "v_proj.weight"]}
-    :param save_path: output path for this shard's compressed weights
-    :param scheme: microscale quantization scheme (NVFP4, MXFP4)
-    :param ignore: modules to ignore. Modules ending with "norm" are automatically
-        ignored
-    :param device: device used to quantize and compress weights
-    :param converter: optional converter to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
-    """
-    assert is_microscale_scheme(scheme), "Use `process_file` for non-microscale scheme"
-
-    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
-
-    tensors = split_fused_moe_experts(tensors)
-
-    if converter is not None:
-        tensors = converter.process(tensors)
-
-    # Get fused sets. Non-primary shards may have incomplete sets (k/v without q)
-    # since only the primary-owning shard fetches partners — this is correct.
-    fused_sets, _ = get_fused_names(list(tensors.keys()))
-
-    fused_name_to_fused_index: dict[str, int] = {
-        name: index
-        for index, matched_set in enumerate(fused_sets)
-        for name in matched_set.values()
-        if name is not None
-    }
-    fused_modules: dict[int, dict[str, Module]] = defaultdict(dict)
-
-    for module_name, name in match_quantizable_tensors(tensors, ignore, scheme.targets):
-        validate_weight_for_quantization(tensors[name], scheme, name)
-
-        # 1. initialize module with qparams (on device)
-        module = initialize_quantized_linear(tensors[name], scheme, device)
-
-        # gather fused modules for later processing
-        if name in fused_name_to_fused_index:
-            fused_index = fused_name_to_fused_index[name]
-            fused_modules[fused_index][name] = module
-            initialize_observer(module, "weight")
-            apply_calibration_status(module)
-            continue
-
-        # 2. get module qparams
-        calibrate_weight(module)
-
-        # 3. compress module using qparams
-        compress_module(module)
-
-        # 4. save compressed data (on cpu)
-        del tensors[name]
-        prefix = module_name + "."
-        for key, value in module.state_dict(prefix=prefix).items():
-            tensors[key] = value.to("cpu")
-
-    # Compress fused modules with shared global scale
-    for named_modules in fused_modules.values():
-        # 2. fuse observers, observe weights, and get qparams
-        FusionHandler.fuse(
-            [(mod.weight_observer, mod) for mod in named_modules.values()]
-        )
-        observe(named_modules.values(), base_name="weight")
-        update_qparams(named_modules.values(), base_name="weight")
-
-        for name, module in named_modules.items():
-            freeze_module_quantization(module)
-
-            # 3. compress module using microscale qparams
+            # Standard path
+            calibrate_weight(module)
             compress_module(module)
 
-            # 4. save compressed data (on cpu)
             del tensors[name]
-            module_name, _ = name.rsplit(".", 1)
-            prefix = module_name + "."
+            prefix = module_name + '.'
             for key, value in module.state_dict(prefix=prefix).items():
                 tensors[key] = value.to("cpu")
+        
+        # Only for microscale compressed fused models with a shared global state
+        if self.is_microscale:
+            for named_modules in fused_modules.values():
+                FusionHandler.fuse(
+                    [(mod.weight_observer, mod) for mod in named_modules.values()]
+                )
+                observe(named_modules.values(), base_name="weight")
+                update_qparams(named_modules.values(), base_name="weight")
 
-    # Save ALL tensors to this shard's output — including partner tensors fetched
-    # from other shards. Partners are re-saved here so future runs don't need to
-    # re-fetch them. The caller updates the safetensors index to reflect new locations.
-    os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
-    save_file(tensors, save_path)
-    total_size = sum(t.nbytes for t in tensors.values())
-    weight_map = {key: os.path.basename(save_path) for key in tensors.keys()}
-    return total_size, weight_map
+                for name, module in named_modules.items():
+                    freeze_module_quantization(module)
+                    compress_module(module)
+
+                    del tensors[name]
+                    module_name, _ = name.rsplit(".", 1)
+                    prefix = module_name + "."
+                    for key, value in module.state_dict(prefix=prefix).items():
+                        tensors[key] = value.to("cpu")
+
+        # Save ALL tensors to this shard's output — including partner tensors fetched
+        # from other shards. Partners are re-saved here so future runs don't need to
+        # re-fetch them. The caller updates the safetensors index to reflect new locations.
+        os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
+        save_file(tensors, save_path)
+        total_size = sum(t.nbytes for t in tensors.values())
+        weight_map = {key: os.path.basename(save_path) for key in tensors.keys()}
+        return total_size, weight_map
+        
+
+    def get_dependencies(self, weight_name: str) -> set[str]:
+        deps = set()
+        if self.is_microscale:
+            for primary_pattern, partner_templates in DEFAULT_FUSED_MAPPINGS.items():
+                match = re.match(primary_pattern, weight_name)
+                if match is None:
+                    continue
+
+                # Build partner names using named groups from the match
+                for partner_template in partner_templates:
+                    partner_name = partner_template.format(**match.groupdict())
+
+                    deps.add(partner_name)
+        return deps
 
 
 def split_fused_moe_experts(

--- a/src/llmcompressor/entrypoints/model_free/process.py
+++ b/src/llmcompressor/entrypoints/model_free/process.py
@@ -1,19 +1,16 @@
-import os
+import re
 from collections import defaultdict
 from typing import Iterator
 
 import torch
 from compressed_tensors.compressors import compress_module
-from compressed_tensors.entrypoints.convert import Converter
-from compressed_tensors.quantization import QuantizationConfig, QuantizationScheme
-from compressed_tensors.utils import match_quantizable_tensors
-from compressed_tensors.utils.safetensors_load import (
-    InverseWeightMap,
-    load_tensors_from_inverse_weight_map,
+from compressed_tensors.quantization import (
+    QuantizationConfig,
+    QuantizationScheme,
+    QuantizationStatus,
 )
+from compressed_tensors.utils import match_quantizable_tensors
 from loguru import logger
-from safetensors.torch import save_file
-from torch.nn import Module
 
 from llmcompressor.entrypoints.model_free.lifecycle import (
     calibrate_weight,
@@ -21,7 +18,9 @@ from llmcompressor.entrypoints.model_free.lifecycle import (
     validate_weight_for_quantization,
 )
 from llmcompressor.entrypoints.model_free.microscale import (
+    DEFAULT_FUSED_MAPPINGS,
     get_fused_names,
+    has_microscale_scheme,
     is_microscale_scheme,
 )
 from llmcompressor.modifiers.quantization.calibration import (
@@ -33,11 +32,7 @@ from llmcompressor.modifiers.quantization.calibration import (
 )
 from llmcompressor.observers import FusionHandler
 
-__all__ = [
-    "validate_file",
-    "process_file",
-    "process_file_microscale_scheme",
-]
+__all__ = ["ModelFreePtqConverter"]
 
 
 def _match_tensors_to_schemes(
@@ -59,186 +54,155 @@ def _match_tensors_to_schemes(
                 yield module_name, name, scheme
 
 
-def validate_file(
-    inverse_weight_map: InverseWeightMap,
-    save_path: str | os.PathLike,
-    config: QuantizationConfig,
-    device: str | torch.device,
-    converter: Converter | None = None,
-):
+class ModelFreePtqConverter:
     """
-    Validate that each quantizable tensor in a safetensors file can be quantized.
-
-    :param inverse_weight_map: mapping of source file path -> tensor names to validate
-    :param save_path: save path of file with quantized weights
-    :param config: quantization config specifying schemes and ignore list
-    :param device: device used to quantize and compress weights
-    :param converter: optional converter to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
+    Converter that quantizes and compresses safetensors checkpoints without
+    loading a model. Implements the compressed-tensors Converter protocol so
+    it can be chained with other converters (e.g. a dequantizer) and used
+    with convert_checkpoint.
     """
-    device = torch.device("meta")
-    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
 
-    if converter is not None:
-        converter.validate(tensors)
+    def __init__(self, config: QuantizationConfig):
+        self.config = config
 
-    for _, name, scheme in _match_tensors_to_schemes(tensors, config):
-        validate_weight_for_quantization(tensors[name], scheme, name)
+    def get_dependencies(self, weight_name: str) -> set[str]:
+        """
+        For microscale schemes, return fused partner tensor names that must be
+        loaded together to compute a shared global scale. Standard schemes have
+        no cross-tensor dependencies.
+        """
+        if not has_microscale_scheme(self.config):
+            return set()
 
+        deps = set()
+        for primary_pattern, partner_templates in DEFAULT_FUSED_MAPPINGS.items():
+            match = re.match(primary_pattern, weight_name)
+            if match is None:
+                continue
+            for template in partner_templates:
+                deps.add(template.format(**match.groupdict()))
+        return deps
 
-def process_file(
-    inverse_weight_map: InverseWeightMap,
-    save_path: str | os.PathLike,
-    config: QuantizationConfig,
-    device: str | torch.device,
-    converter: Converter | None = None,
-) -> tuple[int, dict[str, str]]:
-    """
-    Quantize and compress tensors in a given safetensors file.
+    def validate(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """
+        Validate that each quantizable tensor can be quantized under its scheme.
+        Operates on meta tensors — no real computation.
+        """
+        meta_tensors = {k: v.to("meta") for k, v in tensors.items()}
+        meta_tensors = split_fused_moe_experts(meta_tensors)
+        for _, name, scheme in _match_tensors_to_schemes(meta_tensors, self.config):
+            validate_weight_for_quantization(meta_tensors[name], scheme, name)
+        return meta_tensors
 
-    :param inverse_weight_map: mapping of source file path -> tensor names.
-        For standard mode: {{resolved_path: None}} means load all tensors to process
-    :param save_path: save path of file with quantized weights
-    :param config: quantization config specifying schemes and ignore list
-    :param device: device used to quantize and compress weights
-    :param converter: optional converter to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
-    """
-    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
+    def process(self, tensors: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Quantize and compress all tensors. Device is inferred from the tensors."""
+        tensors = split_fused_moe_experts(tensors)
+        if has_microscale_scheme(self.config):
+            return self._process_microscale(tensors)
+        return self._process_standard(tensors)
 
-    tensors = split_fused_moe_experts(tensors)
+    def update_config(self, incoming: QuantizationConfig | None) -> QuantizationConfig:
+        """
+        Build or merge the final QuantizationConfig in COMPRESSED status.
+        When chained after a dequantizer (incoming=None), creates from scratch.
+        When seeded with a pre-existing checkpoint config, merges into it.
+        """
+        unique_formats = {
+            s.format for s in self.config.config_groups.values() if s.format is not None
+        }
+        if len(unique_formats) == 1:
+            format_ = next(iter(unique_formats))
+        elif len(unique_formats) > 1:
+            format_ = "mixed-precision"
+        else:
+            format_ = "dense"
 
-    if converter is not None:
-        tensors = converter.process(tensors)
-
-    for module_name, name, scheme in _match_tensors_to_schemes(tensors, config):
-        assert not is_microscale_scheme(scheme), "Use `process_file_microscale_scheme`"
-        validate_weight_for_quantization(tensors[name], scheme, name)
-
-        # 1. initialize module with qparams (on device)
-        module = initialize_quantized_linear(tensors[name], scheme, device)
-
-        # 2. calibrate weight qparams
-        calibrate_weight(module)
-
-        # 3. compress module using qparams
-        compress_module(module)
-
-        # 4. save compressed data (on cpu)
-        del tensors[name]
-        prefix = module_name + "."
-        for key, value in module.state_dict(prefix=prefix).items():
-            tensors[key] = value.to("cpu")
-
-    save_file(tensors, save_path)
-    total_size = sum(tensor.nbytes for tensor in tensors.values())
-    weight_map = {key: os.path.basename(save_path) for key in tensors.keys()}
-    return total_size, weight_map
-
-
-def process_file_microscale_scheme(
-    inverse_weight_map: InverseWeightMap,
-    save_path: str | os.PathLike,
-    config: QuantizationConfig,
-    device: str | torch.device,
-    converter: Converter | None = None,
-) -> tuple[int, dict[str, str]]:
-    """
-    Quantize and compress tensors for a single output shard using a config
-    that contains at least one microscale scheme (NVFP4, MXFP4).
-
-    Accepts a precomputed inverse_weight_map that specifies exactly which tensors
-    to load from which source files — including any fused partner tensors from
-    other shards needed for global scale computation. This avoids runtime
-    discovery of fused partners and redundant tensor reads.
-
-    Partner tensors fetched from other shards are re-saved into this shard's
-    output. The caller updates the safetensors index to reflect new locations.
-
-    :param inverse_weight_map: mapping of resolved source file path ->
-        list of tensor names to load from that file.
-        Example: {"/path/shard0.safetensors": ["q_proj.weight"],
-                  "/path/shard1.safetensors": ["k_proj.weight", "v_proj.weight"]}
-    :param save_path: output path for this shard's compressed weights
-    :param config: quantization config with at least one microscale scheme
-    :param device: device used to quantize and compress weights
-    :param converter: optional converter to apply to the checkpoint,
-        e.g. conversion of some layers from some format to compressed-tensors
-    """
-    tensors = load_tensors_from_inverse_weight_map(inverse_weight_map, device)
-
-    tensors = split_fused_moe_experts(tensors)
-
-    if converter is not None:
-        tensors = converter.process(tensors)
-
-    # Get fused sets. Non-primary shards may have incomplete sets (k/v without q)
-    # since only the primary-owning shard fetches partners — this is correct.
-    fused_sets, _ = get_fused_names(list(tensors.keys()))
-
-    fused_name_to_fused_index: dict[str, int] = {
-        name: index
-        for index, matched_set in enumerate(fused_sets)
-        for name in matched_set.values()
-        if name is not None
-    }
-    fused_modules: dict[int, dict[str, Module]] = defaultdict(dict)
-
-    for module_name, name, scheme in _match_tensors_to_schemes(tensors, config):
-        validate_weight_for_quantization(tensors[name], scheme, name)
-
-        # 1. initialize module with qparams (on device)
-        module = initialize_quantized_linear(tensors[name], scheme, device)
-
-        # only defer for fused handling when scheme is microscale
-        if is_microscale_scheme(scheme) and name in fused_name_to_fused_index:
-            fused_index = fused_name_to_fused_index[name]
-            fused_modules[fused_index][name] = module
-            initialize_observer(module, "weight")
-            apply_calibration_status(module)
-            continue
-
-        # 2. get module qparams
-        calibrate_weight(module)
-
-        # 3. compress module using qparams
-        compress_module(module)
-
-        # 4. save compressed data (on cpu)
-        del tensors[name]
-        prefix = module_name + "."
-        for key, value in module.state_dict(prefix=prefix).items():
-            tensors[key] = value.to("cpu")
-
-    # Compress fused modules with shared global scale
-    for named_modules in fused_modules.values():
-        # 2. fuse observers, observe weights, and get qparams
-        FusionHandler.fuse(
-            [(mod.weight_observer, mod) for mod in named_modules.values()]
+        new_config = QuantizationConfig(
+            config_groups=self.config.config_groups,
+            kv_cache_scheme=self.config.kv_cache_scheme,
+            ignore=list(self.config.ignore) if self.config.ignore else [],
+            quantization_status=QuantizationStatus.COMPRESSED,
+            format=format_,
         )
-        observe(named_modules.values(), base_name="weight")
-        update_qparams(named_modules.values(), base_name="weight")
+        if incoming is None:
+            return new_config
+        incoming.merge(new_config)
+        return incoming
 
-        for name, module in named_modules.items():
-            freeze_module_quantization(module)
-
-            # 3. compress module using microscale qparams
+    def _process_standard(
+        self, tensors: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        device = _infer_device(tensors)
+        for module_name, name, scheme in _match_tensors_to_schemes(
+            tensors, self.config
+        ):
+            validate_weight_for_quantization(tensors[name], scheme, name)
+            module = initialize_quantized_linear(tensors[name], scheme, device)
+            calibrate_weight(module)
             compress_module(module)
-
-            # 4. save compressed data (on cpu)
             del tensors[name]
-            module_name, _ = name.rsplit(".", 1)
+            prefix = module_name + "."
+            for key, value in module.state_dict(prefix=prefix).items():
+                tensors[key] = value.to("cpu")
+        return tensors
+
+    def _process_microscale(
+        self, tensors: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        device = _infer_device(tensors)
+
+        fused_sets, _ = get_fused_names(list(tensors.keys()))
+        fused_name_to_fused_index: dict[str, int] = {
+            name: index
+            for index, matched_set in enumerate(fused_sets)
+            for name in matched_set.values()
+            if name is not None
+        }
+        fused_modules: dict[int, dict[str, torch.nn.Module]] = defaultdict(dict)
+
+        for module_name, name, scheme in _match_tensors_to_schemes(
+            tensors, self.config
+        ):
+            validate_weight_for_quantization(tensors[name], scheme, name)
+            module = initialize_quantized_linear(tensors[name], scheme, device)
+
+            if is_microscale_scheme(scheme) and name in fused_name_to_fused_index:
+                fused_index = fused_name_to_fused_index[name]
+                fused_modules[fused_index][name] = module
+                initialize_observer(module, "weight")
+                apply_calibration_status(module)
+                continue
+
+            calibrate_weight(module)
+            compress_module(module)
+            del tensors[name]
             prefix = module_name + "."
             for key, value in module.state_dict(prefix=prefix).items():
                 tensors[key] = value.to("cpu")
 
-    # Save ALL tensors to this shard's output — including partner tensors fetched
-    # from other shards. Partners are re-saved here so future runs don't need to
-    # re-fetch them. The caller updates the safetensors index to reflect new locations.
-    save_file(tensors, save_path)
-    total_size = sum(t.nbytes for t in tensors.values())
-    weight_map = {key: os.path.basename(save_path) for key in tensors.keys()}
-    return total_size, weight_map
+        for named_modules in fused_modules.values():
+            FusionHandler.fuse(
+                [(mod.weight_observer, mod) for mod in named_modules.values()]
+            )
+            observe(named_modules.values(), base_name="weight")
+            update_qparams(named_modules.values(), base_name="weight")
+            for name, module in named_modules.items():
+                freeze_module_quantization(module)
+                compress_module(module)
+                del tensors[name]
+                module_name, _ = name.rsplit(".", 1)
+                prefix = module_name + "."
+                for key, value in module.state_dict(prefix=prefix).items():
+                    tensors[key] = value.to("cpu")
+
+        return tensors
+
+
+def _infer_device(tensors: dict[str, torch.Tensor]) -> torch.device:
+    for t in tensors.values():
+        if t.device.type != "meta":
+            return t.device
+    return torch.device("cpu")
 
 
 def split_fused_moe_experts(

--- a/src/llmcompressor/entrypoints/model_free/save_utils.py
+++ b/src/llmcompressor/entrypoints/model_free/save_utils.py
@@ -14,7 +14,7 @@ from compressed_tensors.utils.safetensors_load import find_config_path
 from loguru import logger
 from pydantic import ValidationError
 
-from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
+from llmcompressor.entrypoints.model_free.converter import ModelFreePtqConverter
 
 __all__ = ["update_config"]
 

--- a/src/llmcompressor/entrypoints/model_free/save_utils.py
+++ b/src/llmcompressor/entrypoints/model_free/save_utils.py
@@ -9,13 +9,12 @@ from compressed_tensors.base import (
     TRANSFORM_CONFIG_NAME,
 )
 from compressed_tensors.entrypoints.convert import Converter
-from compressed_tensors.quantization import (
-    QuantizationConfig,
-    QuantizationStatus,
-)
+from compressed_tensors.quantization import QuantizationConfig
 from compressed_tensors.utils.safetensors_load import find_config_path
 from loguru import logger
 from pydantic import ValidationError
+
+from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
 
 __all__ = ["update_config"]
 
@@ -24,18 +23,37 @@ def update_config(
     save_directory: str | os.PathLike,
     config: QuantizationConfig,
     converter: Converter | None = None,
-):
+) -> None:
     """
-    Update Quantization config for model stub in save_directory.
-    Quantization config will either be created or updated, see
-    create_or_update_quant_config docstring for more info.
+    Write the final quantization config to config.json in save_directory.
+
+    Reads any pre-existing CT quantization_config from the checkpoint so that
+    sequential ptq runs append rather than overwrite. Chains through the user
+    converter (if any) then ModelFreePtqConverter to produce the final config.
     """
     config_file_path = find_config_path(save_directory)
 
-    qconfig = create_or_update_quant_config(config_file_path, config, converter)
+    # Read config.json once; seed incoming from any pre-existing CT quant config
+    config_data: dict | None = None
+    incoming: QuantizationConfig | None = None
+    if config_file_path is not None:
+        with open(config_file_path, "r") as file:
+            config_data = json.load(file)
+        if QUANTIZATION_CONFIG_NAME in config_data:
+            qdata = config_data[QUANTIZATION_CONFIG_NAME]
+            qdata.pop(COMPRESSION_VERSION_NAME, None)
+            try:
+                incoming = QuantizationConfig.model_validate(qdata)
+            except ValidationError:
+                incoming = None
 
-    # construct compression (quantization) config
-    qconfig_data = qconfig.model_dump(exclude=[QUANTIZATION_METHOD_NAME])
+    # Chain: user converter (if any) then mfptq
+    if converter is not None and hasattr(converter, "update_config"):
+        incoming = converter.update_config(incoming)
+    mfptq = ModelFreePtqConverter(config)
+    final_config = mfptq.update_config(incoming)
+
+    qconfig_data = final_config.model_dump()
     qconfig_data = {
         COMPRESSION_VERSION_NAME: ct_version,
         QUANTIZATION_METHOD_NAME: "compressed-tensors",
@@ -43,84 +61,13 @@ def update_config(
         **qconfig_data,
     }
 
-    # write results to config.json file
-    if config_file_path is not None:
-        with open(config_file_path, "r") as file:
-            config_data = json.load(file)
-
+    if config_data is not None:
         config_data[QUANTIZATION_CONFIG_NAME] = qconfig_data
-
         with open(config_file_path, "w") as file:
             json.dump(config_data, file, indent=2, sort_keys=True)
-
     else:
         logger.warning(
             f"Could not find config file in {save_directory}. Please set "
             "quantization_config to: \n"
             f"{json.dumps(qconfig_data, indent=2, sort_keys=True)}"
         )
-
-
-def create_or_update_quant_config(
-    config_file_path: str | None,
-    config: QuantizationConfig,
-    converter: Converter | None = None,
-) -> QuantizationConfig:
-    """
-    Create or update quantization_config in 3 possible ways:
-    1) If converting from a format that isn't compressed-tensors,
-        create new quant config based on converter and append config groups
-    2) If checkpoint is in a pre-existing compressed-tensors format,
-        use its quantization_config as starting point and append config groups
-    3) Otherwise, use the provided config directly
-    """
-
-    existing_config = None
-    if converter is not None:
-        existing_config = converter.create_config()
-    elif config_file_path is not None:
-        with open(config_file_path, "r") as file:
-            config_data = json.load(file)
-
-        if QUANTIZATION_CONFIG_NAME in config_data:
-            qconfigdata = config_data[QUANTIZATION_CONFIG_NAME]
-            qconfigdata.pop(COMPRESSION_VERSION_NAME, None)
-            try:
-                existing_config = QuantizationConfig.model_validate(qconfigdata)
-            except ValidationError as e:
-                logger.warning(
-                    "Unable to parse original checkpoint quantization_config. "
-                    f"The quantization_config will be created from scratch: {e}"
-                )
-        else:
-            logger.info(
-                "No pre-existing quantization_config found. "
-                "The quantization_config will be created from scratch"
-            )
-
-    # determine format from schemes
-    unique_formats = {
-        scheme.format
-        for scheme in config.config_groups.values()
-        if scheme.format is not None
-    }
-    if len(unique_formats) == 1:
-        format_ = next(iter(unique_formats))
-    elif len(unique_formats) > 1:
-        format_ = "mixed-precision"
-    else:
-        format_ = "dense"
-
-    new_config = QuantizationConfig(
-        config_groups=config.config_groups,
-        kv_cache_scheme=config.kv_cache_scheme,
-        ignore=list(config.ignore) if config.ignore else [],
-        quantization_status=QuantizationStatus.COMPRESSED,
-        format=format_,
-    )
-
-    if existing_config is None:
-        return new_config
-    else:
-        existing_config.merge(new_config)
-        return existing_config

--- a/tests/llmcompressor/entrypoints/model_free/test_model_free_validation.py
+++ b/tests/llmcompressor/entrypoints/model_free/test_model_free_validation.py
@@ -3,8 +3,11 @@ import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
 from safetensors.torch import save_file
 
-from llmcompressor.entrypoints.model_free.process import validate_file
+from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
 
+@pytest.fixture
+def mfptq():
+    return ModelFreePtqConverter(scheme=_get_block_scheme(), ignore=[])
 
 def _get_block_scheme() -> QuantizationScheme:
     return QuantizationScheme(
@@ -20,19 +23,19 @@ def _get_block_scheme() -> QuantizationScheme:
     )
 
 
-def test_validate_file_raises_for_non_2d_linear_weight(tmp_path):
+def test_validate_file_raises_for_non_2d_linear_weight(tmp_path, mfptq):
     path = tmp_path / "bad_shape.safetensors"
     save_file({"model.layers.0.mlp.down_proj.weight": torch.ones(128)}, str(path))
 
     with pytest.raises(ValueError, match="model.layers.0.mlp.down_proj.weight"):
-        validate_file({str(path): []}, None, _get_block_scheme(), [], "cpu")
+        mfptq.validate_file({str(path): []}, None, "cpu")
 
 
-def test_validate_file_does_not_raise_for_block_incompatible_shape(tmp_path):
+def test_validate_file_does_not_raise_for_block_incompatible_shape(tmp_path, mfptq):
     path = tmp_path / "bad_block.safetensors"
     save_file(
         {"model.layers.0.mlp.down_proj.weight": torch.ones(17, 16)},
         str(path),
     )
-
-    validate_file({str(path): []}, None, _get_block_scheme(), [], "cpu")
+    
+    mfptq.validate_file({str(path): []}, None, "cpu")

--- a/tests/llmcompressor/entrypoints/model_free/test_model_free_validation.py
+++ b/tests/llmcompressor/entrypoints/model_free/test_model_free_validation.py
@@ -5,9 +5,12 @@ from compressed_tensors.quantization import (
     QuantizationConfig,
     QuantizationScheme,
 )
+from compressed_tensors.utils.safetensors_load import (
+    load_tensors_from_inverse_weight_map,
+)
 from safetensors.torch import save_file
 
-from llmcompressor.entrypoints.model_free.process import validate_file
+from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
 
 
 def _get_block_config() -> QuantizationConfig:
@@ -22,25 +25,29 @@ def _get_block_config() -> QuantizationConfig:
             block_structure=[16, 16],
         ),
     )
-    return QuantizationConfig(
-        config_groups={"group_0": scheme},
-        ignore=[],
-    )
+    return QuantizationConfig(config_groups={"group_0": scheme}, ignore=[])
 
 
-def test_validate_file_raises_for_non_2d_linear_weight(tmp_path):
+@pytest.fixture
+def mfptq():
+    return ModelFreePtqConverter(config=_get_block_config())
+
+
+def test_validate_raises_for_non_2d_linear_weight(tmp_path, mfptq):
     path = tmp_path / "bad_shape.safetensors"
     save_file({"model.layers.0.mlp.down_proj.weight": torch.ones(128)}, str(path))
 
+    tensors = load_tensors_from_inverse_weight_map({str(path): []}, device="meta")
     with pytest.raises(ValueError, match="model.layers.0.mlp.down_proj.weight"):
-        validate_file({str(path): []}, None, _get_block_config(), "cpu")
+        mfptq.validate(tensors)
 
 
-def test_validate_file_does_not_raise_for_block_incompatible_shape(tmp_path):
+def test_validate_does_not_raise_for_block_incompatible_shape(tmp_path, mfptq):
     path = tmp_path / "bad_block.safetensors"
     save_file(
         {"model.layers.0.mlp.down_proj.weight": torch.ones(17, 16)},
         str(path),
     )
 
-    validate_file({str(path): []}, None, _get_block_config(), "cpu")
+    tensors = load_tensors_from_inverse_weight_map({str(path): []}, device="meta")
+    mfptq.validate(tensors)

--- a/tests/llmcompressor/entrypoints/model_free/test_model_free_validation.py
+++ b/tests/llmcompressor/entrypoints/model_free/test_model_free_validation.py
@@ -10,7 +10,7 @@ from compressed_tensors.utils.safetensors_load import (
 )
 from safetensors.torch import save_file
 
-from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
+from llmcompressor.entrypoints.model_free.converter import ModelFreePtqConverter
 
 
 def _get_block_config() -> QuantizationConfig:

--- a/tests/llmcompressor/entrypoints/model_free/test_reindexing_elimination.py
+++ b/tests/llmcompressor/entrypoints/model_free/test_reindexing_elimination.py
@@ -40,7 +40,7 @@ def _rand_weight(*shape):
 
 
 class TestBuildInverseWeightMaps:
-    def test_single_file(self, tmp_path):
+    def test_single_file(self, tmp_path, mfptq):
         weight_map = {
             "model.layers.0.self_attn.q_proj.weight": "shard-00001.safetensors",
             "model.layers.0.self_attn.k_proj.weight": "shard-00001.safetensors",
@@ -53,7 +53,7 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
         }
         inverse_weight_maps = build_inverse_weight_maps(
-            weight_map, model_files, [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])]
+            weight_map, model_files, [mfptq]
         )
         # result is {shard_name: {file_path: [tensor_names]}}, check tensor exists
         inverse_weight_maps["shard-00001.safetensors"][
@@ -72,7 +72,7 @@ class TestBuildInverseWeightMaps:
             }
         }
 
-    def test_missing_dependency(self, tmp_path):
+    def test_missing_dependency(self, tmp_path, mfptq):
         weight_map = {
             "model.layers.0.self_attn.q_proj.weight": "shard-00001.safetensors",
             "model.layers.0.self_attn.k_proj.weight": "shard-00001.safetensors",
@@ -82,9 +82,9 @@ class TestBuildInverseWeightMaps:
         }
         with pytest.raises(ValueError):
             _ = build_inverse_weight_maps(weight_map, model_files,
-                [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])])
+                [mfptq])
 
-    def test_invalid_weight_map(self, tmp_path):
+    def test_invalid_weight_map(self, tmp_path, mfptq):
         weight_map = {
             "tensor.a": "shard-00001.safetensors",
             "tensor.b": "shard-00002.safetensors",
@@ -94,9 +94,9 @@ class TestBuildInverseWeightMaps:
         }
         with pytest.raises(KeyError):
             _ = build_inverse_weight_maps(weight_map, model_files,
-                [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])])
+                [mfptq])
 
-    def test_all_colocated(self, tmp_path):
+    def test_all_colocated(self, tmp_path, mfptq):
         """All fused weights in same shard — no cross-shard fetching needed."""
         weight_map = {
             "model.layers.0.self_attn.q_proj.weight": "shard-00001.safetensors",
@@ -111,7 +111,7 @@ class TestBuildInverseWeightMaps:
             "shard-00002.safetensors": str(tmp_path / "shard-00002.safetensors"),
         }
         inverse_weight_maps = build_inverse_weight_maps(
-            weight_map, model_files, [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])]
+            weight_map, model_files, [mfptq]
         )
         assert set(
             inverse_weight_maps["shard-00001.safetensors"][
@@ -132,7 +132,7 @@ class TestBuildInverseWeightMaps:
             "model.layers.1.self_attn.v_proj.weight",
         }
 
-    def test_cross_shard_partners_found(self, tmp_path):
+    def test_cross_shard_partners_found(self, tmp_path, mfptq):
         """q_proj on shard1, k/v on shard2 — shard1 should fetch from shard2."""
         weight_map = {
             "model.layers.0.self_attn.q_proj.weight": "shard-00001.safetensors",
@@ -147,7 +147,7 @@ class TestBuildInverseWeightMaps:
             "shard-00002.safetensors": str(tmp_path / "shard-00002.safetensors"),
         }
         inverse_weight_maps = build_inverse_weight_maps(
-            weight_map, model_files, [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])]
+            weight_map, model_files, [mfptq]
         )
         assert set(
             inverse_weight_maps["shard-00001.safetensors"][
@@ -217,7 +217,7 @@ class TestProcessFileMicroscaleSchemeCrossShardInverseMap:
     """Tests for cross-shard fused weights using precomputed inverse_weight_map."""
 
     @pytest.fixture
-    def split_shards(self, tmp_path):
+    def split_shards(self, tmp_path, mfptq):
         """q_proj on shard-1, k_proj + v_proj + down_proj on shard-2."""
         shard1_tensors = {
             "model.layers.0.self_attn.q_proj.weight": _rand_weight(32, 32),
@@ -244,7 +244,7 @@ class TestProcessFileMicroscaleSchemeCrossShardInverseMap:
         }
         # Precompute inverse_weight_map for each shard
         inverse_weight_maps = build_inverse_weight_maps(
-            weight_map, model_files, [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])]
+            weight_map, model_files, [mfptq]
         )
         return (
             shard1_path,

--- a/tests/llmcompressor/entrypoints/model_free/test_reindexing_elimination.py
+++ b/tests/llmcompressor/entrypoints/model_free/test_reindexing_elimination.py
@@ -8,13 +8,17 @@ import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
 from safetensors.torch import save_file
 
-from llmcompressor.entrypoints.model_free.microscale import (
-    build_microscale_inverse_weight_maps,
-)
-from llmcompressor.entrypoints.model_free.process import (
-    process_file_microscale_scheme,
+from compressed_tensors.entrypoints.convert import (
+    build_inverse_weight_maps
 )
 
+from llmcompressor.entrypoints.model_free.process import (
+    ModelFreePtqConverter,
+)
+
+@pytest.fixture
+def mfptq():
+    return ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])
 
 def _make_nvfp4_scheme():
     return QuantizationScheme(
@@ -48,8 +52,8 @@ class TestBuildInverseWeightMaps:
         model_files = {
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
         }
-        inverse_weight_maps = build_microscale_inverse_weight_maps(
-            weight_map, model_files, []
+        inverse_weight_maps = build_inverse_weight_maps(
+            weight_map, model_files, [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])]
         )
         # result is {shard_name: {file_path: [tensor_names]}}, check tensor exists
         inverse_weight_maps["shard-00001.safetensors"][
@@ -77,7 +81,8 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
         }
         with pytest.raises(ValueError):
-            _ = build_microscale_inverse_weight_maps(weight_map, model_files, [])
+            _ = build_inverse_weight_maps(weight_map, model_files,
+                [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])])
 
     def test_invalid_weight_map(self, tmp_path):
         weight_map = {
@@ -88,7 +93,8 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
         }
         with pytest.raises(KeyError):
-            _ = build_microscale_inverse_weight_maps(weight_map, model_files, [])
+            _ = build_inverse_weight_maps(weight_map, model_files,
+                [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])])
 
     def test_all_colocated(self, tmp_path):
         """All fused weights in same shard — no cross-shard fetching needed."""
@@ -104,8 +110,8 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
             "shard-00002.safetensors": str(tmp_path / "shard-00002.safetensors"),
         }
-        inverse_weight_maps = build_microscale_inverse_weight_maps(
-            weight_map, model_files, []
+        inverse_weight_maps = build_inverse_weight_maps(
+            weight_map, model_files, [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])]
         )
         assert set(
             inverse_weight_maps["shard-00001.safetensors"][
@@ -140,8 +146,8 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
             "shard-00002.safetensors": str(tmp_path / "shard-00002.safetensors"),
         }
-        inverse_weight_maps = build_microscale_inverse_weight_maps(
-            weight_map, model_files, []
+        inverse_weight_maps = build_inverse_weight_maps(
+            weight_map, model_files, [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])]
         )
         assert set(
             inverse_weight_maps["shard-00001.safetensors"][
@@ -187,7 +193,7 @@ class TestProcessFileMicroscaleSchemeColocated:
             "model.layers.0.mlp.down_proj.weight": _rand_weight(32, 32),
         }
 
-    def test_colocated_fused_weights(self, qkv_tensors, tmp_path):
+    def test_colocated_fused_weights(self, qkv_tensors, tmp_path, mfptq):
         """Standard case: all fused weights in one shard."""
         shard_name = "model.safetensors"
         shard_path = tmp_path / shard_name
@@ -197,11 +203,9 @@ class TestProcessFileMicroscaleSchemeColocated:
         # Build inverse_weight_map: just the one file with all tensors
         inverse_weight_map = {str(shard_path): list(qkv_tensors.keys())}
 
-        total_size, weight_map = process_file_microscale_scheme(
+        total_size, weight_map = mfptq.process_file(
             inverse_weight_map=inverse_weight_map,
             save_path=save_path,
-            scheme=_make_nvfp4_scheme(),
-            ignore=[],
             device="cpu",
         )
         assert save_path.exists()
@@ -239,8 +243,8 @@ class TestProcessFileMicroscaleSchemeCrossShardInverseMap:
             "shard-00002.safetensors": str(shard2_path),
         }
         # Precompute inverse_weight_map for each shard
-        inverse_weight_maps = build_microscale_inverse_weight_maps(
-            weight_map, model_files, []
+        inverse_weight_maps = build_inverse_weight_maps(
+            weight_map, model_files, [ModelFreePtqConverter(scheme=_make_nvfp4_scheme(), ignore=[])]
         )
         return (
             shard1_path,
@@ -249,49 +253,45 @@ class TestProcessFileMicroscaleSchemeCrossShardInverseMap:
             inverse_weight_maps["shard-00002.safetensors"],
         )
 
-    def test_shard1_produces_output(self, split_shards, tmp_path):
+    def test_shard1_produces_output(self, split_shards, tmp_path, mfptq):
         """Shard-1 (q_proj only) processes correctly using precomputed inverse map."""
         shard1_path, _, iwm1, _ = split_shards
         save_path = tmp_path / "out-00001.safetensors"
 
-        total_size, weight_map = process_file_microscale_scheme(
+        total_size, weight_map = mfptq.process_file(
             inverse_weight_map=iwm1,
             save_path=save_path,
-            scheme=_make_nvfp4_scheme(),
-            ignore=[],
             device="cpu",
         )
         assert save_path.exists()
         assert total_size > 0
         assert len(weight_map) > 0
 
-    def test_shard2_produces_output(self, split_shards, tmp_path):
+    def test_shard2_produces_output(self, split_shards, tmp_path, mfptq):
         """Shard-2 (k/v/down) processes correctly using precomputed inverse map."""
         _, shard2_path, _, iwm2 = split_shards
         save_path = tmp_path / "out-00002.safetensors"
 
-        total_size, weight_map = process_file_microscale_scheme(
+        total_size, weight_map = mfptq.process_file(
             inverse_weight_map=iwm2,
             save_path=save_path,
-            scheme=_make_nvfp4_scheme(),
-            ignore=[],
             device="cpu",
         )
         assert save_path.exists()
         assert total_size > 0
 
-    def test_both_shards_produce_same_keys_as_merged(self, split_shards, tmp_path):
+    def test_both_shards_produce_same_keys_as_merged(self, split_shards, tmp_path, mfptq):
         """Combined output keys from both shards
         should match merged single-shard keys."""
         shard1_path, shard2_path, iwm1, iwm2 = split_shards
 
         out1 = tmp_path / "out-00001.safetensors"
         out2 = tmp_path / "out-00002.safetensors"
-        _, wm1 = process_file_microscale_scheme(
-            iwm1, out1, _make_nvfp4_scheme(), [], "cpu"
+        _, wm1 = mfptq.process_file(
+            iwm1, out1, "cpu"
         )
-        _, wm2 = process_file_microscale_scheme(
-            iwm2, out2, _make_nvfp4_scheme(), [], "cpu"
+        _, wm2 = mfptq.process_file(
+            iwm2, out2, "cpu"
         )
         combined_keys = set(wm1.keys()) | set(wm2.keys())
 
@@ -303,8 +303,8 @@ class TestProcessFileMicroscaleSchemeCrossShardInverseMap:
         merged_out = tmp_path / "merged_out.safetensors"
         save_file(merged, merged_path)
         merged_iwm = {str(merged_path): list(merged.keys())}
-        _, wm_merged = process_file_microscale_scheme(
-            merged_iwm, merged_out, _make_nvfp4_scheme(), [], "cpu"
+        _, wm_merged = mfptq.process_file(
+            merged_iwm, merged_out, "cpu"
         )
 
         assert combined_keys == set(wm_merged.keys()), (

--- a/tests/llmcompressor/entrypoints/model_free/test_reindexing_elimination.py
+++ b/tests/llmcompressor/entrypoints/model_free/test_reindexing_elimination.py
@@ -5,6 +5,8 @@ reindex_fused_weights preprocessing step for microscale schemes.
 
 import pytest
 import torch
+from compressed_tensors.entrypoints.convert import build_inverse_weight_maps
+from compressed_tensors.entrypoints.convert.convert_file import convert_file
 from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationConfig,
@@ -12,16 +14,11 @@ from compressed_tensors.quantization import (
 )
 from safetensors.torch import save_file
 
-from llmcompressor.entrypoints.model_free.microscale import (
-    build_microscale_inverse_weight_maps,
-)
-from llmcompressor.entrypoints.model_free.process import (
-    process_file_microscale_scheme,
-)
+from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
 
 
-def _make_nvfp4_scheme():
-    return QuantizationScheme(
+def _make_nvfp4_config():
+    scheme = QuantizationScheme(
         targets=["Linear"],
         weights=QuantizationArgs(
             num_bits=4,
@@ -33,21 +30,20 @@ def _make_nvfp4_scheme():
             scale_dtype=torch.float8_e4m3fn,
         ),
     )
-
-
-def _make_nvfp4_config():
-    return QuantizationConfig(
-        config_groups={"group_0": _make_nvfp4_scheme()},
-        ignore=[],
-    )
+    return QuantizationConfig(config_groups={"group_0": scheme})
 
 
 def _rand_weight(*shape):
     return torch.randn(*shape, dtype=torch.float16)
 
 
+@pytest.fixture
+def mfptq():
+    return ModelFreePtqConverter(config=_make_nvfp4_config())
+
+
 class TestBuildInverseWeightMaps:
-    def test_single_file(self, tmp_path):
+    def test_single_file(self, tmp_path, mfptq):
         weight_map = {
             "model.layers.0.self_attn.q_proj.weight": "shard-00001.safetensors",
             "model.layers.0.self_attn.k_proj.weight": "shard-00001.safetensors",
@@ -59,10 +55,9 @@ class TestBuildInverseWeightMaps:
         model_files = {
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
         }
-        inverse_weight_maps = build_microscale_inverse_weight_maps(
-            weight_map, model_files, []
+        inverse_weight_maps = build_inverse_weight_maps(
+            weight_map, model_files, [mfptq]
         )
-        # result is {shard_name: {file_path: [tensor_names]}}, check tensor exists
         inverse_weight_maps["shard-00001.safetensors"][
             str(tmp_path / "shard-00001.safetensors")
         ].sort()
@@ -79,7 +74,7 @@ class TestBuildInverseWeightMaps:
             }
         }
 
-    def test_missing_dependency(self, tmp_path):
+    def test_missing_dependency(self, tmp_path, mfptq):
         weight_map = {
             "model.layers.0.self_attn.q_proj.weight": "shard-00001.safetensors",
             "model.layers.0.self_attn.k_proj.weight": "shard-00001.safetensors",
@@ -88,9 +83,9 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
         }
         with pytest.raises(ValueError):
-            _ = build_microscale_inverse_weight_maps(weight_map, model_files, [])
+            build_inverse_weight_maps(weight_map, model_files, [mfptq])
 
-    def test_invalid_weight_map(self, tmp_path):
+    def test_invalid_weight_map(self, tmp_path, mfptq):
         weight_map = {
             "tensor.a": "shard-00001.safetensors",
             "tensor.b": "shard-00002.safetensors",
@@ -99,9 +94,9 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
         }
         with pytest.raises(KeyError):
-            _ = build_microscale_inverse_weight_maps(weight_map, model_files, [])
+            build_inverse_weight_maps(weight_map, model_files, [mfptq])
 
-    def test_all_colocated(self, tmp_path):
+    def test_all_colocated(self, tmp_path, mfptq):
         """All fused weights in same shard — no cross-shard fetching needed."""
         weight_map = {
             "model.layers.0.self_attn.q_proj.weight": "shard-00001.safetensors",
@@ -115,8 +110,8 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
             "shard-00002.safetensors": str(tmp_path / "shard-00002.safetensors"),
         }
-        inverse_weight_maps = build_microscale_inverse_weight_maps(
-            weight_map, model_files, []
+        inverse_weight_maps = build_inverse_weight_maps(
+            weight_map, model_files, [mfptq]
         )
         assert set(
             inverse_weight_maps["shard-00001.safetensors"][
@@ -137,7 +132,7 @@ class TestBuildInverseWeightMaps:
             "model.layers.1.self_attn.v_proj.weight",
         }
 
-    def test_cross_shard_partners_found(self, tmp_path):
+    def test_cross_shard_partners_found(self, tmp_path, mfptq):
         """q_proj on shard1, k/v on shard2 — shard1 should fetch from shard2."""
         weight_map = {
             "model.layers.0.self_attn.q_proj.weight": "shard-00001.safetensors",
@@ -151,16 +146,14 @@ class TestBuildInverseWeightMaps:
             "shard-00001.safetensors": str(tmp_path / "shard-00001.safetensors"),
             "shard-00002.safetensors": str(tmp_path / "shard-00002.safetensors"),
         }
-        inverse_weight_maps = build_microscale_inverse_weight_maps(
-            weight_map, model_files, []
+        inverse_weight_maps = build_inverse_weight_maps(
+            weight_map, model_files, [mfptq]
         )
         assert set(
             inverse_weight_maps["shard-00001.safetensors"][
                 str(tmp_path / "shard-00001.safetensors")
             ]
-        ) == {
-            "model.layers.0.self_attn.q_proj.weight",
-        }
+        ) == {"model.layers.0.self_attn.q_proj.weight"}
         assert set(
             inverse_weight_maps["shard-00001.safetensors"][
                 str(tmp_path / "shard-00002.safetensors")
@@ -181,9 +174,7 @@ class TestBuildInverseWeightMaps:
             inverse_weight_maps["shard-00002.safetensors"][
                 str(tmp_path / "shard-00002.safetensors")
             ]
-        ) == {
-            "model.layers.1.self_attn.q_proj.weight",
-        }
+        ) == {"model.layers.1.self_attn.q_proj.weight"}
 
 
 class TestProcessFileMicroscaleSchemeColocated:
@@ -198,22 +189,15 @@ class TestProcessFileMicroscaleSchemeColocated:
             "model.layers.0.mlp.down_proj.weight": _rand_weight(32, 32),
         }
 
-    def test_colocated_fused_weights(self, qkv_tensors, tmp_path):
+    def test_colocated_fused_weights(self, qkv_tensors, tmp_path, mfptq):
         """Standard case: all fused weights in one shard."""
         shard_name = "model.safetensors"
         shard_path = tmp_path / shard_name
         save_path = tmp_path / "out.safetensors"
         save_file(qkv_tensors, shard_path)
 
-        # Build inverse_weight_map: just the one file with all tensors
         inverse_weight_map = {str(shard_path): list(qkv_tensors.keys())}
-
-        total_size, weight_map = process_file_microscale_scheme(
-            inverse_weight_map=inverse_weight_map,
-            save_path=save_path,
-            config=_make_nvfp4_config(),
-            device="cpu",
-        )
+        total_size, weight_map = convert_file(inverse_weight_map, save_path, [mfptq])
         assert save_path.exists()
         assert total_size > 0
         assert len(weight_map) > 0
@@ -223,7 +207,7 @@ class TestProcessFileMicroscaleSchemeCrossShardInverseMap:
     """Tests for cross-shard fused weights using precomputed inverse_weight_map."""
 
     @pytest.fixture
-    def split_shards(self, tmp_path):
+    def split_shards(self, tmp_path, mfptq):
         """q_proj on shard-1, k_proj + v_proj + down_proj on shard-2."""
         shard1_tensors = {
             "model.layers.0.self_attn.q_proj.weight": _rand_weight(32, 32),
@@ -248,9 +232,8 @@ class TestProcessFileMicroscaleSchemeCrossShardInverseMap:
             "shard-00001.safetensors": str(shard1_path),
             "shard-00002.safetensors": str(shard2_path),
         }
-        # Precompute inverse_weight_map for each shard
-        inverse_weight_maps = build_microscale_inverse_weight_maps(
-            weight_map, model_files, []
+        inverse_weight_maps = build_inverse_weight_maps(
+            weight_map, model_files, [mfptq]
         )
         return (
             shard1_path,
@@ -259,56 +242,45 @@ class TestProcessFileMicroscaleSchemeCrossShardInverseMap:
             inverse_weight_maps["shard-00002.safetensors"],
         )
 
-    def test_shard1_produces_output(self, split_shards, tmp_path):
+    def test_shard1_produces_output(self, split_shards, tmp_path, mfptq):
         """Shard-1 (q_proj only) processes correctly using precomputed inverse map."""
         shard1_path, _, iwm1, _ = split_shards
         save_path = tmp_path / "out-00001.safetensors"
 
-        total_size, weight_map = process_file_microscale_scheme(
-            inverse_weight_map=iwm1,
-            save_path=save_path,
-            config=_make_nvfp4_config(),
-            device="cpu",
-        )
+        total_size, weight_map = convert_file(iwm1, save_path, [mfptq])
         assert save_path.exists()
         assert total_size > 0
         assert len(weight_map) > 0
 
-    def test_shard2_produces_output(self, split_shards, tmp_path):
+    def test_shard2_produces_output(self, split_shards, tmp_path, mfptq):
         """Shard-2 (k/v/down) processes correctly using precomputed inverse map."""
         _, shard2_path, _, iwm2 = split_shards
         save_path = tmp_path / "out-00002.safetensors"
 
-        total_size, weight_map = process_file_microscale_scheme(
-            inverse_weight_map=iwm2,
-            save_path=save_path,
-            config=_make_nvfp4_config(),
-            device="cpu",
-        )
+        total_size, weight_map = convert_file(iwm2, save_path, [mfptq])
         assert save_path.exists()
         assert total_size > 0
 
-    def test_both_shards_produce_same_keys_as_merged(self, split_shards, tmp_path):
-        """Combined output keys from both shards
-        should match merged single-shard keys."""
+    def test_both_shards_produce_same_keys_as_merged(
+        self, split_shards, tmp_path, mfptq
+    ):
+        """Combined output keys from both shards should match merged single-shard."""
+        from safetensors.torch import load_file
+
         shard1_path, shard2_path, iwm1, iwm2 = split_shards
 
         out1 = tmp_path / "out-00001.safetensors"
         out2 = tmp_path / "out-00002.safetensors"
-        _, wm1 = process_file_microscale_scheme(iwm1, out1, _make_nvfp4_config(), "cpu")
-        _, wm2 = process_file_microscale_scheme(iwm2, out2, _make_nvfp4_config(), "cpu")
+        _, wm1 = convert_file(iwm1, out1, [mfptq])
+        _, wm2 = convert_file(iwm2, out2, [mfptq])
         combined_keys = set(wm1.keys()) | set(wm2.keys())
-
-        # Process merged shard as reference
-        from safetensors.torch import load_file
 
         merged = {**load_file(shard1_path), **load_file(shard2_path)}
         merged_path = tmp_path / "merged.safetensors"
         merged_out = tmp_path / "merged_out.safetensors"
         save_file(merged, merged_path)
-        merged_iwm = {str(merged_path): list(merged.keys())}
-        _, wm_merged = process_file_microscale_scheme(
-            merged_iwm, merged_out, _make_nvfp4_config(), "cpu"
+        _, wm_merged = convert_file(
+            {str(merged_path): list(merged.keys())}, merged_out, [mfptq]
         )
 
         assert combined_keys == set(wm_merged.keys()), (

--- a/tests/llmcompressor/entrypoints/model_free/test_reindexing_elimination.py
+++ b/tests/llmcompressor/entrypoints/model_free/test_reindexing_elimination.py
@@ -14,7 +14,7 @@ from compressed_tensors.quantization import (
 )
 from safetensors.torch import save_file
 
-from llmcompressor.entrypoints.model_free.process import ModelFreePtqConverter
+from llmcompressor.entrypoints.model_free.converter import ModelFreePtqConverter
 
 
 def _make_nvfp4_config():

--- a/tests/llmcompressor/entrypoints/model_free/test_split_fused_moe_experts.py
+++ b/tests/llmcompressor/entrypoints/model_free/test_split_fused_moe_experts.py
@@ -5,7 +5,7 @@ Tests for split_fused_moe_experts function.
 import torch
 from compressed_tensors.utils import match_quantizable_tensors
 
-from llmcompressor.entrypoints.model_free.process import split_fused_moe_experts
+from llmcompressor.entrypoints.model_free.converter import split_fused_moe_experts
 
 
 def test_split_fused_moe_experts():


### PR DESCRIPTION
### SUMMARY:
addresses #2929

Unifies the dual microscale/standard code paths in model_free_ptq into a
single ModelFreePtqConverter class. 

This eliminates the unnecessary branching in `__init__.py` and consolidates `process_file`, `validate_file`, and
`get_dependencies` as methods on the converter, gated by an `is_microscale` flag.

Changes:
- Add ModelFreePtqConverter class in process.py with Converter methods plus process_file/validate_file under parent class
- Remove build_microscale_inverse_weight_maps and inline MicroscaleConverter from microscale.py
- Simplify __init__.py to construct one converter, no branching
- Update test_reindexing_elimination.py and test_model_free_validation.py along with fixed pytest mfptq init for standardized testing

### TEST PLAN:
- pytest tests/llmcompressor/entrypoints/model_free/ -v (all pass, GPU
tests need CI)
- ruff check + ruff format clean