### PR TITLE
[Example] Add Mixed W2A16 and W4A16 MoE Example

### DIFF
--- a/examples/autoround/quantization_wNa16/qwen3_moe_example_mixed_w2a16_w4a16.py
+++ b/examples/autoround/quantization_wNa16/qwen3_moe_example_mixed_w2a16_w4a16.py
@@ -8,13 +8,13 @@ from llmcompressor.modifiers.autoround import AutoRoundModifier
 
 # Select model and load it.
 model_id = "Qwen/Qwen3-30B-A3B-Instruct-2507"
-model = AutoModelForCausalLM.from_pretrained(model_id)
+model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype="auto")
 tokenizer = AutoTokenizer.from_pretrained(model_id)
 
 # Select calibration dataset.
 NUM_CALIBRATION_SAMPLES = 128
 MAX_SEQUENCE_LENGTH = 2048
-ITERS = 2
+ITERS = 200
 # Get aligned calibration dataset.
 
 ds = get_dataset(

--- a/examples/autoround/quantization_wNa16/qwen3_moe_example_mixed_w2a16_w4a16.py
+++ b/examples/autoround/quantization_wNa16/qwen3_moe_example_mixed_w2a16_w4a16.py
@@ -1,0 +1,92 @@
+from auto_round.calib_dataset import get_dataset
+from compressed_tensors.offload import dispatch_model
+from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.autoround import AutoRoundModifier
+
+# Select model and load it.
+model_id = "Qwen/Qwen3-30B-A3B-Instruct-2507"
+model = AutoModelForCausalLM.from_pretrained(model_id)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+# Select calibration dataset.
+NUM_CALIBRATION_SAMPLES = 128
+MAX_SEQUENCE_LENGTH = 2048
+ITERS = 2
+# Get aligned calibration dataset.
+
+ds = get_dataset(
+    tokenizer=tokenizer,
+    seqlen=MAX_SEQUENCE_LENGTH,
+    nsamples=NUM_CALIBRATION_SAMPLES,
+)
+
+
+# Configure the quantization algorithm to run.
+#   * quantize the attention weights to 4 bit with a group size 64
+#   * mlp weights to 2 bit with a group size 64
+
+recipe = AutoRoundModifier(
+    config_groups={
+        "attention": QuantizationScheme(
+            targets=[
+                r"re:.*self_attn\.(q|k|v|o)_proj$",
+            ],
+            weights=QuantizationArgs(
+                num_bits=4,
+                type="int",
+                strategy="group",
+                symmetric=True,
+                dynamic=False,
+                group_size=64,
+            ),
+        ),
+        "mlp": QuantizationScheme(
+            targets=[
+                r"re:.*mlp\..*(gate|up|down)_proj$",
+            ],
+            weights=QuantizationArgs(
+                num_bits=2,
+                type="int",
+                strategy="group",
+                symmetric=True,
+                dynamic=False,
+                group_size=64,
+            ),
+        ),
+    },
+    ignore=["lm_head"],
+    iters=ITERS,
+    enable_torch_compile=False,
+)
+
+
+# Apply algorithms.
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    shuffle_calibration_samples=False,
+)
+
+# Confirm generations of the quantized model look sane.
+print("\n\n")
+print("========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=100)
+print(tokenizer.decode(output[0]))
+print("==========================================\n\n")
+
+# Save to disk compressed.
+SAVE_DIR = (
+    model_id.rstrip("/").split("/")[-1] + f"-Attn4bits-Mlp2bits-AutoRound-{ITERS}iters"
+)
+print(f"save to {SAVE_DIR}")
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/examples/autoround/quantization_wNa16/qwen3_moe_example_mixed_w2a16_w4a16.py
+++ b/examples/autoround/quantization_wNa16/qwen3_moe_example_mixed_w2a16_w4a16.py
@@ -5,6 +5,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
 from llmcompressor.modifiers.autoround import AutoRoundModifier
+from llmcompressor.utils import load_context
 
 # Select model and load it.
 model_id = "Qwen/Qwen3-30B-A3B-Instruct-2507"

--- a/examples/autoround/quantization_wNa16/qwen3_moe_example_mixed_w2a16_w4a16.py
+++ b/examples/autoround/quantization_wNa16/qwen3_moe_example_mixed_w2a16_w4a16.py
@@ -8,7 +8,8 @@ from llmcompressor.modifiers.autoround import AutoRoundModifier
 
 # Select model and load it.
 model_id = "Qwen/Qwen3-30B-A3B-Instruct-2507"
-model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype="auto")
+with load_context():
+    model = AutoModelForCausalLM.from_pretrained(model_id)
 tokenizer = AutoTokenizer.from_pretrained(model_id)
 
 # Select calibration dataset.


### PR DESCRIPTION
Signed-off-by: yiliu30 <yi4.liu@intel.com>

SUMMARY:
"please provide a brief summary"


- model https://huggingface.co/INC4AI/Qwen3-30B-A3B-Instruct-2507-Attn4bits-Mlp2bits-AutoRound-200iters-TestOnly

```bash
# vllm ({'pretrained': '/home/yiliu7/workspace/llmc-ds/examples/autoround/quantization_wNa16/Qwen3-30B-A3B-Instruct-2507-Attn4bits-Mlp2bits-AutoRound-200iters', 'tensor_parallel_size': 1, 'max_model_len': 8192, 'max_num_batched_tokens': 32768, 'max_num_seqs': 128, 'add_bos_token': True, 'gpu_memory_utilization': 0.4, 'dtype': 'bfloat16', 'max_gen_toks': 2048, 'enable_prefix_caching': False}), gen_kwargs: ({}), limit: 1000.0, num_fewshot: None, batch_size: 128
# |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
# |-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
# |gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.909|±  |0.0091|
# |     |       |strict-match    |     5|exact_match|↑  |0.909|±  |0.0091|
```

The evluation is depends on vllm's PR https://github.com/vllm-project/vllm/pull/48918


