### PR TITLE
fix DDP obs stat deletion

### DIFF
--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -2,7 +2,7 @@ import contextlib
 
 import torch
 from compressed_tensors.distributed import greedy_bin_packing, wait_for_comms
-from compressed_tensors.offload.dist_utils import as_broadcastable, is_distributed
+from compressed_tensors.offload.dist_utils import is_distributed
 from compressed_tensors.offload.dist_utils import is_source_process as is_src
 from compressed_tensors.quantization import (
     QuantizationConfig,
@@ -36,6 +36,7 @@ from llmcompressor.modifiers.quantization.calibration import (
 from llmcompressor.modifiers.quantization.quantization import QuantizationMixin
 from llmcompressor.observers import ACTIVATION_OBS
 from llmcompressor.sentinel import Sentinel
+from llmcompressor.utils.dist import broadcast_qparams_and_cleanup
 from llmcompressor.utils.metric_logging import CompressionLogger
 
 __all__ = ["GPTQModifier"]
@@ -307,7 +308,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
         self.compress_module_list(rank_to_modules[rank])
 
         # broadcast compressed modules to each rank
-        self._broadcast_quantized_params(module_list, module_to_rank)
+        broadcast_qparams_and_cleanup(module_list, module_to_rank, _GPTQ_Q_PARAMS)
 
     def compress_module_list(self, module_list):
         for module in module_list:
@@ -359,23 +360,6 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 if rank != target_rank:
                     self._hessians.pop(module, None)
                     self._num_samples.pop(module, None)
-        wait_for_comms(pending_comms)
-
-    def _broadcast_quantized_params(self, module_list, module_to_rank):
-        pending_comms = []
-        for module in module_list:
-            src_rank = module_to_rank[module]
-
-            # Get parameters from module
-            for attr in _GPTQ_Q_PARAMS:
-                if getattr(module, attr, None) is not None:
-                    pending_comms.append(
-                        dist.broadcast(
-                            as_broadcastable(getattr(module, attr)),
-                            src=src_rank,
-                            async_op=True,
-                        )
-                    )
         wait_for_comms(pending_comms)
 
     def on_finalize(self, state: State, **kwargs) -> bool:

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -13,6 +13,7 @@ from llmcompressor.modifiers.quantization.calibration import (
     update_qparams,
 )
 from llmcompressor.modifiers.quantization.quantization.mixin import QuantizationMixin
+from llmcompressor.observers import ACTIVATION_OBS
 from llmcompressor.utils.dist import broadcast_qparams_and_cleanup
 
 __all__ = ["QuantizationModifier"]
@@ -104,9 +105,7 @@ class QuantizationModifier(Modifier, QuantizationMixin):
 
         observe(rank_to_modules[rank], "weight")
         update_qparams(rank_to_modules[rank], "weight")
-        broadcast_qparams_and_cleanup(
-            module_list, module_to_rank, _WEIGHT_Q_PARAMS
-        )
+        broadcast_qparams_and_cleanup(module_list, module_to_rank, _WEIGHT_Q_PARAMS)
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -121,6 +121,7 @@ class QuantizationModifier(Modifier, QuantizationMixin):
         module_list: list[torch.nn.Module],
         module_to_rank: dict[torch.nn.Module, int],
     ):
+        # broadcast calculate qparams from assigned rank to other ranks
         pending_comms = []
         for module in module_list:
             if get_execution_device(module) != torch.device("cpu"):
@@ -133,5 +134,12 @@ class QuantizationModifier(Modifier, QuantizationMixin):
                                 async_op=True,
                             )
                         )
+            # delete any observer stats for ranks which didn't run get_qparams
+            obs_names = ACTIVATION_OBS + ("weight",)
+            for base_name in obs_names:
+                obs = getattr(module, f"{base_name}_observer", None)
+                if obs is not None and obs.has_statistics:
+                    obs.delete_statistics(check_fused=True)
+
 
         wait_for_comms(pending_comms)

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -1,12 +1,9 @@
 import torch
 import torch.distributed as dist
 from compressed_tensors.distributed import (
-    as_broadcastable,
     greedy_bin_packing,
     is_distributed,
-    wait_for_comms,
 )
-from compressed_tensors.offload import get_execution_device
 from compressed_tensors.quantization.utils import is_module_quantized
 
 from llmcompressor.core import Event, State
@@ -16,7 +13,7 @@ from llmcompressor.modifiers.quantization.calibration import (
     update_qparams,
 )
 from llmcompressor.modifiers.quantization.quantization.mixin import QuantizationMixin
-from llmcompressor.observers import ACTIVATION_OBS
+from llmcompressor.utils.dist import broadcast_qparams_and_cleanup
 
 __all__ = ["QuantizationModifier"]
 
@@ -107,39 +104,12 @@ class QuantizationModifier(Modifier, QuantizationMixin):
 
         observe(rank_to_modules[rank], "weight")
         update_qparams(rank_to_modules[rank], "weight")
-        dist.barrier()  # wait for async offload updates to finish
-        self._broadcast_qparam_onloads(module_list, module_to_rank)
+        broadcast_qparams_and_cleanup(
+            module_list, module_to_rank, _WEIGHT_Q_PARAMS
+        )
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """
         Finish calibrating by removing observers and calibration hooks
         """
         QuantizationMixin.end_calibration(self, state.model)
-
-    def _broadcast_qparam_onloads(
-        self,
-        module_list: list[torch.nn.Module],
-        module_to_rank: dict[torch.nn.Module, int],
-    ):
-        # broadcast calculate qparams from assigned rank to other ranks
-        pending_comms = []
-        for module in module_list:
-            if get_execution_device(module) != torch.device("cpu"):
-                for qparam_name in _WEIGHT_Q_PARAMS:
-                    if (qparam := getattr(module, qparam_name, None)) is not None:
-                        pending_comms.append(
-                            dist.broadcast(
-                                as_broadcastable(qparam),
-                                src=module_to_rank[module],
-                                async_op=True,
-                            )
-                        )
-            # delete any observer stats for ranks which didn't run get_qparams
-            obs_names = ACTIVATION_OBS + ("weight",)
-            for base_name in obs_names:
-                obs = getattr(module, f"{base_name}_observer", None)
-                if obs is not None and obs.has_statistics:
-                    obs.delete_statistics(check_fused=True)
-
-
-        wait_for_comms(pending_comms)

--- a/src/llmcompressor/utils/dist.py
+++ b/src/llmcompressor/utils/dist.py
@@ -1,11 +1,16 @@
+from collections.abc import Sequence
 from typing import Hashable, TypeVar
 
+import torch
+import torch.distributed as dist
 from compressed_tensors.distributed import (
     greedy_bin_packing as _greedy_bin_packing,
 )
 from compressed_tensors.distributed import (
     wait_for_comms as _wait_for_comms,
 )
+from compressed_tensors.offload import get_execution_device
+from compressed_tensors.offload.dist_utils import as_broadcastable
 from compressed_tensors.utils.helpers import deprecated
 
 T = TypeVar("T", bound=Hashable)
@@ -45,3 +50,39 @@ def wait_for_comms(*args, **kwargs) -> None:
         have completed.
     """
     return _wait_for_comms(*args, **kwargs)
+
+
+def broadcast_qparams_and_cleanup(
+    module_list: list[torch.nn.Module],
+    module_to_rank: dict[torch.nn.Module, int],
+    qparam_names: Sequence[str],
+    skip_cpu: bool = True,
+) -> None:
+    """Broadcast quantization params from owning rank and clean up observer stats.
+
+    :param module_list: all modules across all ranks
+    :param module_to_rank: mapping from module to the rank that computed its qparams
+    :param qparam_names: attribute names to broadcast (e.g. weight_scale, weight)
+    :param skip_cpu: if True, skip broadcasting for CPU-offloaded modules
+    """
+    pending_comms = []
+    for module in module_list:
+        should_broadcast = not skip_cpu or (
+            get_execution_device(module) != torch.device("cpu")
+        )
+        if should_broadcast:
+            for name in qparam_names:
+                if (param := getattr(module, name, None)) is not None:
+                    pending_comms.append(
+                        dist.broadcast(
+                            as_broadcastable(param),
+                            src=module_to_rank[module],
+                            async_op=True,
+                        )
+                    )
+
+        obs = getattr(module, "weight_observer", None)
+        if obs is not None and obs.has_statistics:
+            obs.delete_statistics(check_fused=True)
+
+    _wait_for_comms(pending_comms)

--- a/tests/llmcompressor/observers/test_fusion_handler.py
+++ b/tests/llmcompressor/observers/test_fusion_handler.py
@@ -6,9 +6,9 @@ from compressed_tensors.quantization import QuantizationArgs, QuantizationStrate
 from torch import nn
 
 from llmcompressor.modifiers.quantization.calibration import observe, update_qparams
-from llmcompressor.modifiers.quantization.quantization import QuantizationModifier
 from llmcompressor.observers import Observer
 from llmcompressor.observers.fusion import FusionHandler
+from llmcompressor.utils.dist import broadcast_qparams_and_cleanup
 
 
 def _make_observer(strategy=QuantizationStrategy.TENSOR_GROUP, group_size=16):
@@ -276,26 +276,36 @@ class TestNVFP4FusedLifecycle:
             assert qp["global_scale"] is not None
 
 
-def _mock_broadcast(*args, **kwargs):
-    """Stand-in for dist.broadcast that returns a mock async work handle."""
-    return MagicMock()
+_DIST_MODULE = "llmcompressor.utils.dist"
+_WEIGHT_Q_PARAMS = ["weight_scale", "weight_zero_point", "weight_global_scale"]
+_GPTQ_Q_PARAMS = ["weight", "weight_scale", "weight_zero_point", "weight_g_idx"]
 
 
-def _simulate_ddp_epoch(modifier, modules, rank_to_modules, module_to_rank):
-    """Simulate the distributed branch of on_sequential_epoch_end.
+def _simulate_ddp_broadcast(modules, rank_to_modules, module_to_rank, qparam_names,
+                            skip_cpu=False):
+    """Simulate the DDP broadcast+cleanup path.
 
-    1. observe + update_qparams on this rank's subset (rank 0)
-    2. call _broadcast_qparam_onloads on the full module list
+    1. observe + update_qparams on rank 0's subset
+    2. call broadcast_qparams_and_cleanup on the full module list
     """
     observe(rank_to_modules[0], "weight")
     update_qparams(rank_to_modules[0], "weight")
 
     with (
-        patch("llmcompressor.modifiers.quantization.quantization.base.dist.broadcast",
-              side_effect=_mock_broadcast),
-        patch("llmcompressor.modifiers.quantization.quantization.base.wait_for_comms"),
+        patch(f"{_DIST_MODULE}.dist.broadcast", return_value=MagicMock()),
+        patch(f"{_DIST_MODULE}._wait_for_comms"),
     ):
-        modifier._broadcast_qparam_onloads(modules, module_to_rank)
+        broadcast_qparams_and_cleanup(
+            modules, module_to_rank, qparam_names, skip_cpu=skip_cpu
+        )
+
+
+def _make_rank_assignment(modules, split):
+    """Build rank_to_modules / module_to_rank dicts splitting at `split`."""
+    rank_to_modules = {0: modules[:split], 1: modules[split:]}
+    module_to_rank = {m: 0 for m in modules[:split]}
+    module_to_rank.update({m: 1 for m in modules[split:]})
+    return rank_to_modules, module_to_rank
 
 
 @pytest.mark.unit
@@ -305,65 +315,56 @@ class TestDDPObserverCleanup:
     In DDP, greedy_bin_packing assigns modules to ranks and only the owning
     rank calls update_qparams (which triggers get_qparams -> delete_statistics).
     Modules assigned to other ranks kept stats forever, leaking memory per layer.
-    The fix adds a cleanup loop inside _broadcast_qparam_onloads that calls
-    delete_statistics(check_fused=True) on all modules.
+    The fix adds observer cleanup inside broadcast_qparams_and_cleanup.
 
-    These tests patch dist.broadcast and call _broadcast_qparam_onloads directly
-    to simulate the DDP flow without requiring multiple processes.
+    These tests patch dist.broadcast and call the helper directly to simulate
+    the DDP flow without requiring multiple processes.
     """
 
-    def test_broadcast_cleans_up_unprocessed_modules(self):
-        """_broadcast_qparam_onloads deletes stats on modules not owned by this rank."""
+    @pytest.mark.parametrize("qparam_names", [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
+                             ids=["QuantizationModifier", "GPTQ"])
+    def test_broadcast_cleans_up_unprocessed_modules(self, qparam_names):
         modules = [_make_module_with_observer() for _ in range(4)]
         observe(modules, "weight")
 
-        # simulate rank assignment: rank 0 owns first 2, rank 1 owns last 2
-        rank_to_modules = {0: modules[:2], 1: modules[2:]}
-        module_to_rank = {m: 0 for m in modules[:2]}
-        module_to_rank.update({m: 1 for m in modules[2:]})
-
-        modifier = QuantizationModifier(targets=[])
-        _simulate_ddp_epoch(modifier, modules, rank_to_modules, module_to_rank)
+        rank_to_modules, module_to_rank = _make_rank_assignment(modules, split=2)
+        _simulate_ddp_broadcast(
+            modules, rank_to_modules, module_to_rank, qparam_names
+        )
 
         for mod in modules:
             assert not mod.weight_observer.has_statistics
 
-    def test_fused_cleanup_with_split_ranks(self):
-        """Fused observers (NVFP4 Q/K/V) split across ranks.
-
-        rank 0 gets q_proj, rank 1 gets k_proj and v_proj.
-        _broadcast_qparam_onloads cooperative deletion cleans up everything.
-        """
+    @pytest.mark.parametrize("qparam_names", [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
+                             ids=["QuantizationModifier", "GPTQ"])
+    def test_fused_cleanup_with_split_ranks(self, qparam_names):
+        """Fused observers (NVFP4 Q/K/V) split across ranks."""
         modules = _make_fused_module_group(n=3)
         observe(modules, "weight")
 
-        # q on rank 0, k/v on rank 1
-        rank_to_modules = {0: modules[:1], 1: modules[1:]}
-        module_to_rank = {modules[0]: 0, modules[1]: 1, modules[2]: 1}
-
-        modifier = QuantizationModifier(targets=[])
-        _simulate_ddp_epoch(modifier, modules, rank_to_modules, module_to_rank)
+        rank_to_modules, module_to_rank = _make_rank_assignment(modules, split=1)
+        _simulate_ddp_broadcast(
+            modules, rank_to_modules, module_to_rank, qparam_names
+        )
 
         for mod in modules:
             assert not mod.weight_observer.has_statistics
 
-    def test_repeated_layers_no_accumulation(self):
+    @pytest.mark.parametrize("qparam_names", [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
+                             ids=["QuantizationModifier", "GPTQ"])
+    def test_repeated_layers_no_accumulation(self, qparam_names):
         """Stats from previous layers never pile up across sequential layers."""
-        modifier = QuantizationModifier(targets=[])
-
         all_layer_modules = []
         for _ in range(5):
-            layer = [_make_module_with_observer() for _ in range(4)]
-            all_layer_modules.append(layer)
+            all_layer_modules.append([_make_module_with_observer() for _ in range(4)])
 
         for layer_idx, modules in enumerate(all_layer_modules):
             observe(modules, "weight")
 
-            rank_to_modules = {0: modules[:2], 1: modules[2:]}
-            module_to_rank = {m: 0 for m in modules[:2]}
-            module_to_rank.update({m: 1 for m in modules[2:]})
-
-            _simulate_ddp_epoch(modifier, modules, rank_to_modules, module_to_rank)
+            rank_to_modules, module_to_rank = _make_rank_assignment(modules, split=2)
+            _simulate_ddp_broadcast(
+                modules, rank_to_modules, module_to_rank, qparam_names
+            )
 
             for mod in modules:
                 assert not mod.weight_observer.has_statistics, (

--- a/tests/llmcompressor/observers/test_fusion_handler.py
+++ b/tests/llmcompressor/observers/test_fusion_handler.py
@@ -281,8 +281,9 @@ _WEIGHT_Q_PARAMS = ["weight_scale", "weight_zero_point", "weight_global_scale"]
 _GPTQ_Q_PARAMS = ["weight", "weight_scale", "weight_zero_point", "weight_g_idx"]
 
 
-def _simulate_ddp_broadcast(modules, rank_to_modules, module_to_rank, qparam_names,
-                            skip_cpu=False):
+def _simulate_ddp_broadcast(
+    modules, rank_to_modules, module_to_rank, qparam_names, skip_cpu=False
+):
     """Simulate the DDP broadcast+cleanup path.
 
     1. observe + update_qparams on rank 0's subset
@@ -321,37 +322,42 @@ class TestDDPObserverCleanup:
     the DDP flow without requiring multiple processes.
     """
 
-    @pytest.mark.parametrize("qparam_names", [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
-                             ids=["QuantizationModifier", "GPTQ"])
+    @pytest.mark.parametrize(
+        "qparam_names",
+        [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
+        ids=["QuantizationModifier", "GPTQ"],
+    )
     def test_broadcast_cleans_up_unprocessed_modules(self, qparam_names):
         modules = [_make_module_with_observer() for _ in range(4)]
         observe(modules, "weight")
 
         rank_to_modules, module_to_rank = _make_rank_assignment(modules, split=2)
-        _simulate_ddp_broadcast(
-            modules, rank_to_modules, module_to_rank, qparam_names
-        )
+        _simulate_ddp_broadcast(modules, rank_to_modules, module_to_rank, qparam_names)
 
         for mod in modules:
             assert not mod.weight_observer.has_statistics
 
-    @pytest.mark.parametrize("qparam_names", [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
-                             ids=["QuantizationModifier", "GPTQ"])
+    @pytest.mark.parametrize(
+        "qparam_names",
+        [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
+        ids=["QuantizationModifier", "GPTQ"],
+    )
     def test_fused_cleanup_with_split_ranks(self, qparam_names):
         """Fused observers (NVFP4 Q/K/V) split across ranks."""
         modules = _make_fused_module_group(n=3)
         observe(modules, "weight")
 
         rank_to_modules, module_to_rank = _make_rank_assignment(modules, split=1)
-        _simulate_ddp_broadcast(
-            modules, rank_to_modules, module_to_rank, qparam_names
-        )
+        _simulate_ddp_broadcast(modules, rank_to_modules, module_to_rank, qparam_names)
 
         for mod in modules:
             assert not mod.weight_observer.has_statistics
 
-    @pytest.mark.parametrize("qparam_names", [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
-                             ids=["QuantizationModifier", "GPTQ"])
+    @pytest.mark.parametrize(
+        "qparam_names",
+        [_WEIGHT_Q_PARAMS, _GPTQ_Q_PARAMS],
+        ids=["QuantizationModifier", "GPTQ"],
+    )
     def test_repeated_layers_no_accumulation(self, qparam_names):
         """Stats from previous layers never pile up across sequential layers."""
         all_layer_modules = []
@@ -367,11 +373,11 @@ class TestDDPObserverCleanup:
             )
 
             for mod in modules:
-                assert not mod.weight_observer.has_statistics, (
-                    f"Layer {layer_idx}: observer stats not cleaned up"
-                )
+                assert (
+                    not mod.weight_observer.has_statistics
+                ), f"Layer {layer_idx}: observer stats not cleaned up"
             for prev_idx in range(layer_idx):
                 for mod in all_layer_modules[prev_idx]:
-                    assert not mod.weight_observer.has_statistics, (
-                        f"Layer {prev_idx} stats leaked into layer {layer_idx}"
-                    )
+                    assert (
+                        not mod.weight_observer.has_statistics
+                    ), f"Layer {prev_idx} stats leaked into layer {layer_idx}"

--- a/tests/llmcompressor/observers/test_fusion_handler.py
+++ b/tests/llmcompressor/observers/test_fusion_handler.py
@@ -293,8 +293,8 @@ def _simulate_ddp_broadcast(
     update_qparams(rank_to_modules[0], "weight")
 
     with (
-        patch(f"{_DIST_MODULE}.dist.broadcast", return_value=MagicMock()),
-        patch(f"{_DIST_MODULE}._wait_for_comms"),
+        patch("torch.distributed.broadcast", return_value=MagicMock()),
+        patch("compressed_tensors.distributed.utils.wait_for_comms"),
     ):
         broadcast_qparams_and_cleanup(
             modules, module_to_rank, qparam_names, skip_cpu=skip_cpu

--- a/tests/llmcompressor/observers/test_fusion_handler.py
+++ b/tests/llmcompressor/observers/test_fusion_handler.py
@@ -1,8 +1,12 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 import torch
 from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
 from torch import nn
 
+from llmcompressor.modifiers.quantization.calibration import observe, update_qparams
+from llmcompressor.modifiers.quantization.quantization import QuantizationModifier
 from llmcompressor.observers import Observer
 from llmcompressor.observers.fusion import FusionHandler
 
@@ -28,6 +32,34 @@ def _make_fused_group(n=3):
     pairs = list(zip(observers, modules))
     FusionHandler.fuse(pairs)
     return observers, modules
+
+
+def _make_module_with_observer(strategy=QuantizationStrategy.TENSOR, group_size=None):
+    """Create a Linear module with a weight observer registered as a submodule."""
+    mod = _make_linear()
+    kwargs = {"num_bits": 8, "strategy": strategy}
+    if group_size is not None:
+        kwargs["group_size"] = group_size
+    args = QuantizationArgs(**kwargs)
+    obs = Observer.load_from_registry(
+        "memoryless_minmax", base_name="weight", args=args
+    )
+    mod.register_module("weight_observer", obs)
+    return mod
+
+
+def _make_fused_module_group(n=3):
+    """Create n Linear modules with fused TENSOR_GROUP weight observers."""
+    modules = []
+    observers = []
+    for _ in range(n):
+        mod = _make_linear()
+        obs = _make_observer()
+        mod.register_module("weight_observer", obs)
+        modules.append(mod)
+        observers.append(obs)
+    FusionHandler.fuse(zip(observers, modules))
+    return modules
 
 
 @pytest.mark.unit
@@ -242,3 +274,103 @@ class TestNVFP4FusedLifecycle:
         qparams = [obs.get_qparams() for obs in observers]
         for qp in qparams:
             assert qp["global_scale"] is not None
+
+
+def _mock_broadcast(*args, **kwargs):
+    """Stand-in for dist.broadcast that returns a mock async work handle."""
+    return MagicMock()
+
+
+def _simulate_ddp_epoch(modifier, modules, rank_to_modules, module_to_rank):
+    """Simulate the distributed branch of on_sequential_epoch_end.
+
+    1. observe + update_qparams on this rank's subset (rank 0)
+    2. call _broadcast_qparam_onloads on the full module list
+    """
+    observe(rank_to_modules[0], "weight")
+    update_qparams(rank_to_modules[0], "weight")
+
+    with (
+        patch("llmcompressor.modifiers.quantization.quantization.base.dist.broadcast",
+              side_effect=_mock_broadcast),
+        patch("llmcompressor.modifiers.quantization.quantization.base.wait_for_comms"),
+    ):
+        modifier._broadcast_qparam_onloads(modules, module_to_rank)
+
+
+@pytest.mark.unit
+class TestDDPObserverCleanup:
+    """Regression tests for DDP observer stats leak.
+
+    In DDP, greedy_bin_packing assigns modules to ranks and only the owning
+    rank calls update_qparams (which triggers get_qparams -> delete_statistics).
+    Modules assigned to other ranks kept stats forever, leaking memory per layer.
+    The fix adds a cleanup loop inside _broadcast_qparam_onloads that calls
+    delete_statistics(check_fused=True) on all modules.
+
+    These tests patch dist.broadcast and call _broadcast_qparam_onloads directly
+    to simulate the DDP flow without requiring multiple processes.
+    """
+
+    def test_broadcast_cleans_up_unprocessed_modules(self):
+        """_broadcast_qparam_onloads deletes stats on modules not owned by this rank."""
+        modules = [_make_module_with_observer() for _ in range(4)]
+        observe(modules, "weight")
+
+        # simulate rank assignment: rank 0 owns first 2, rank 1 owns last 2
+        rank_to_modules = {0: modules[:2], 1: modules[2:]}
+        module_to_rank = {m: 0 for m in modules[:2]}
+        module_to_rank.update({m: 1 for m in modules[2:]})
+
+        modifier = QuantizationModifier(targets=[])
+        _simulate_ddp_epoch(modifier, modules, rank_to_modules, module_to_rank)
+
+        for mod in modules:
+            assert not mod.weight_observer.has_statistics
+
+    def test_fused_cleanup_with_split_ranks(self):
+        """Fused observers (NVFP4 Q/K/V) split across ranks.
+
+        rank 0 gets q_proj, rank 1 gets k_proj and v_proj.
+        _broadcast_qparam_onloads cooperative deletion cleans up everything.
+        """
+        modules = _make_fused_module_group(n=3)
+        observe(modules, "weight")
+
+        # q on rank 0, k/v on rank 1
+        rank_to_modules = {0: modules[:1], 1: modules[1:]}
+        module_to_rank = {modules[0]: 0, modules[1]: 1, modules[2]: 1}
+
+        modifier = QuantizationModifier(targets=[])
+        _simulate_ddp_epoch(modifier, modules, rank_to_modules, module_to_rank)
+
+        for mod in modules:
+            assert not mod.weight_observer.has_statistics
+
+    def test_repeated_layers_no_accumulation(self):
+        """Stats from previous layers never pile up across sequential layers."""
+        modifier = QuantizationModifier(targets=[])
+
+        all_layer_modules = []
+        for _ in range(5):
+            layer = [_make_module_with_observer() for _ in range(4)]
+            all_layer_modules.append(layer)
+
+        for layer_idx, modules in enumerate(all_layer_modules):
+            observe(modules, "weight")
+
+            rank_to_modules = {0: modules[:2], 1: modules[2:]}
+            module_to_rank = {m: 0 for m in modules[:2]}
+            module_to_rank.update({m: 1 for m in modules[2:]})
+
+            _simulate_ddp_epoch(modifier, modules, rank_to_modules, module_to_rank)
+
+            for mod in modules:
+                assert not mod.weight_observer.has_statistics, (
+                    f"Layer {layer_idx}: observer stats not cleaned up"
+                )
+            for prev_idx in range(layer_idx):
+                for mod in all_layer_modules[prev_idx]:
+                    assert not mod.weight_observer.has_statistics, (
+                        f"Layer {prev_idx} stats leaked into layer {layer_idx}"
+                    )


### PR DESCRIPTION
Summary:

in https://github.com/vllm-project/llm-compressor/pull/2865 we made it so obs clean up their stats to improve memory footprint during quantization. However certain modifiers weren't deleting statistics on DDP because of the job assignment, deletion was happening on obs.get_qparams which only gets called on a subset of the modules for each rank. 

This affected both GPTQ and QuantizationModifier since they both use job assignment, i took this opportunity to unify their broadcast implementations so we have a single helper and added the observer deletion to this new helper.

Test Plan:
https://gist.github.com/HDCharles/6f98c5be0cd51b8351f1ae10c97a7e8a
<img width="4948" height="2000" alt="image" src="https://github.com/user-attachments/assets/644035cd-4c72-435e-bf38-865324d069af" />


before
28948 Addr: b'7f0e9174b800_3, Size: 2.6MiB (2715648 bytes) allocation, Total memory used after allocation: **>>140.1<<**MiB (146889205 bytes), 
30878 Addr: b'7f0e663ea000_2, Size: 2.6MiB (2715648 bytes) allocation, Total memory used after allocation: **>>142.1<<**MiB (148986357 bytes), 
32804 Addr: b'7f0e64868000_4, Size: 2.6MiB (2715648 bytes) allocation, Total memory used after allocation: **>>144.1<<**MiB (151083509 bytes), 

after
28948 Addr: b'7fac5174b800_3, Size: 2.6MiB (2715648 bytes) allocation, Total memory used after allocation: **>>120.6<<**MiB (126441973 bytes), 
30878 Addr: b'7fac263ea000_2, Size: 2.6MiB (2715648 bytes) allocation, Total memory used after allocation: **>>120.6<<**MiB (126441973 bytes), 
32804 Addr: b'7fac24868000_4, Size: 2.6MiB (2715648 bytes) allocation, Total memory used after allocation: **>>120.6<<**MiB (126441973 bytes), 

CI: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/29769647748