### PR TITLE
perf: add Triton kernel for GPTQ block quantization

### DIFF
--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -72,178 +72,6 @@ def accumulate_hessian(
     return H, num_samples
 
 
-def _get_block_shape(strategy, quant_args, num_rows, num_columns):
-    if strategy == QuantizationStrategy.TENSOR:
-        return num_rows, num_columns
-    elif strategy == QuantizationStrategy.CHANNEL:
-        return 1, num_columns
-    elif strategy in (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP):
-        return 1, quant_args.group_size
-    elif strategy == QuantizationStrategy.BLOCK:
-        return quant_args.block_structure
-    else:
-        raise ValueError(f"Unsupported strategy for Triton GPTQ: {strategy}")
-
-
-def _build_codebook(scale, zero_point, quant_args, global_scale=None):
-    num_bits = quant_args.num_bits
-    if quant_args.symmetric:
-        q_min = -(2 ** (num_bits - 1))
-        q_max = 2 ** (num_bits - 1) - 1
-    else:
-        q_min = 0
-        q_max = 2**num_bits - 1
-
-    int_vals = torch.arange(
-        q_min, q_max + 1, device=scale.device, dtype=torch.float32
-    )
-
-    s = scale.to(dtype=torch.float32)
-    zp = zero_point.to(dtype=torch.float32)
-    while s.dim() < 2:
-        s = s.unsqueeze(0)
-        zp = zp.unsqueeze(0)
-
-    codebook = (int_vals - zp.unsqueeze(-1)) * s.unsqueeze(-1)
-
-    if global_scale is not None:
-        codebook = codebook / global_scale
-
-    return codebook.contiguous()
-
-
-def _build_cutoffs_and_codes(scale, zero_point, quant_args, global_scale=None):
-    codes = _build_codebook(scale, zero_point, quant_args, global_scale)
-    cutoffs = (codes[..., :-1] + codes[..., 1:]) * 0.5
-    return codes, cutoffs
-
-
-if _triton_available:
-
-    @triton.jit
-    def _quantize_block_triton_cutoff_kernel(
-        W1_ptr,
-        Hinv1_ptr,
-        codes_ptr,
-        cutoffs_ptr,
-        Q1_ptr,
-        Err1_ptr,
-        losses1_ptr,
-        num_rows,
-        count,
-        col_offset,
-        stride_w_row,
-        stride_h_row,
-        stride_codes_row,
-        stride_codes_col,
-        stride_cut_row,
-        stride_cut_col,
-        r_b,
-        c_b,
-        num_codes,
-        BLOCK_N: tl.constexpr,
-        BLOCK_C: tl.constexpr,
-    ):
-        row = tl.program_id(0)
-        if row >= num_rows:
-            return
-
-        qrow = row // r_b
-
-        cols = tl.arange(0, BLOCK_N)
-        cmask = cols < count
-        cut_idx = tl.arange(0, BLOCK_C)
-        num_cutoffs = num_codes - 1
-        cut_mask = cut_idx < num_cutoffs
-
-        w = tl.load(W1_ptr + row * stride_w_row + cols, mask=cmask, other=0.0)
-
-        q_out = tl.zeros([BLOCK_N], dtype=tl.float32)
-        err_out = tl.zeros([BLOCK_N], dtype=tl.float32)
-        loss_out = tl.zeros([BLOCK_N], dtype=tl.float32)
-
-        for i in range(count):
-            imask = cols == i
-            wi = tl.sum(tl.where(imask, w, 0.0))
-            d = tl.load(Hinv1_ptr + i * stride_h_row + i)
-
-            qcol = (col_offset + i) // c_b
-
-            cuts = tl.load(
-                cutoffs_ptr
-                + qrow * stride_cut_row
-                + qcol * stride_cut_col
-                + cut_idx,
-                mask=cut_mask,
-                other=float("inf"),
-            )
-
-            bin_idx = tl.sum((wi >= cuts).to(tl.int32), axis=0)
-
-            qi = tl.load(
-                codes_ptr
-                + qrow * stride_codes_row
-                + qcol * stride_codes_col
-                + bin_idx
-            )
-
-            diff = wi - qi
-            err = diff / d
-
-            q_out = tl.where(imask, qi, q_out)
-            err_out = tl.where(imask, err, err_out)
-            loss_out = tl.where(imask, diff * diff / (d * d), loss_out)
-
-            h_row = tl.load(
-                Hinv1_ptr + i * stride_h_row + cols, mask=cmask, other=0.0
-            )
-            w = tl.where(cols >= i, w - err * h_row, w)
-
-        tl.store(Q1_ptr + row * stride_w_row + cols, q_out, mask=cmask)
-        tl.store(Err1_ptr + row * stride_w_row + cols, err_out, mask=cmask)
-        tl.store(losses1_ptr + row * stride_w_row + cols, loss_out, mask=cmask)
-
-
-def _quantize_block_triton_cutoff(
-    W1, Hinv1, codes, cutoffs, count, col_offset, r_b, c_b
-):
-    num_rows = W1.shape[0]
-    num_codes = codes.shape[2]
-    Q1 = torch.zeros_like(W1)
-    Err1 = torch.zeros_like(W1)
-    losses1 = torch.zeros_like(W1)
-
-    BLOCK_N = triton.next_power_of_2(count)
-    BLOCK_C = triton.next_power_of_2(num_codes - 1) if num_codes > 1 else 1
-    grid = (num_rows,)
-
-    _quantize_block_triton_cutoff_kernel[grid](
-        W1,
-        Hinv1,
-        codes,
-        cutoffs,
-        Q1,
-        Err1,
-        losses1,
-        num_rows,
-        count,
-        col_offset,
-        W1.stride(0),
-        Hinv1.stride(0),
-        codes.stride(0),
-        codes.stride(1),
-        cutoffs.stride(0),
-        cutoffs.stride(1),
-        r_b,
-        c_b,
-        num_codes,
-        BLOCK_N=BLOCK_N,
-        BLOCK_C=BLOCK_C,
-    )
-
-    return Q1, Err1, losses1
-
-
 def quantize_weight(
     module: torch.nn.Module,
     quant_args: QuantizationArgs,
@@ -272,6 +100,19 @@ def quantize_weight(
     W = W.to(dtype=GPTQ_PRECISION)
     num_rows = W.shape[0]
     num_columns = W.shape[1]
+
+    use_triton_block = (
+        _triton_available
+        and W.is_cuda
+        and strategy
+        in (
+            QuantizationStrategy.TENSOR,
+            QuantizationStrategy.CHANNEL,
+            QuantizationStrategy.GROUP,
+            QuantizationStrategy.TENSOR_GROUP,
+            QuantizationStrategy.BLOCK,
+        )
+    )
 
     if actorder == ActivationOrdering.GROUP and strategy not in (
         QuantizationStrategy.GROUP,
@@ -318,6 +159,12 @@ def quantize_weight(
         qparams["global_scale"],
     )
 
+    if use_triton_block:
+        r_b, c_b = _get_block_shape(strategy, quant_args, num_rows, num_columns)
+        codes, cutoffs = _build_cutoffs_and_codes(
+            scale, zero_point, quant_args, global_scale
+        )
+
     losses = torch.zeros(num_rows, device=module.weight.device)
 
     # mask dead hessian values
@@ -343,45 +190,23 @@ def quantize_weight(
         )
         Hinv = H = torch.eye(num_columns, dtype=H.dtype, device=H.device)
 
-    use_triton_block = (
-        _triton_available
-        and W.is_cuda
-        and strategy
-        in (
-            QuantizationStrategy.TENSOR,
-            QuantizationStrategy.CHANNEL,
-            QuantizationStrategy.GROUP,
-            QuantizationStrategy.TENSOR_GROUP,
-            QuantizationStrategy.BLOCK,
-        )
-    )
-
-    if use_triton_block:
-        r_b, c_b = _get_block_shape(strategy, quant_args, num_rows, num_columns)
-        codes, cutoffs = _build_cutoffs_and_codes(
-            scale, zero_point, quant_args, global_scale
-        )
-
     # See section 3.4 of https://arxiv.org/abs/2203.07259
     for i1 in range(0, num_columns, blocksize):
         i2 = min(i1 + blocksize, num_columns)
+
+        if use_triton_block:
+            _quantize_block_triton_cutoff(
+                W, Hinv, codes, cutoffs, i1, i2, r_b, c_b, losses
+            )
+            continue
+
         count = i2 - i1
 
         W1 = W[:, i1:i2].clone()
-        Hinv1 = Hinv[i1:i2, i1:i2]
-
-        if use_triton_block:
-            Q1, Err1, losses1 = _quantize_block_triton_cutoff(
-                W1, Hinv1.contiguous(), codes, cutoffs, count, i1, r_b, c_b
-            )
-            W[:, i1:i2] = Q1
-            losses += torch.sum(losses1, 1) / 2
-            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
-            continue
-
         Q1 = torch.zeros_like(W1)
         Err1 = torch.zeros_like(W1)
         losses1 = torch.zeros_like(W1)
+        Hinv1 = Hinv[i1:i2, i1:i2]
 
         for i in range(count):
             w = W1[:, i]
@@ -485,3 +310,169 @@ def _apply_activation_ordering(
     """
     perm = torch.argsort(torch.diag(H), descending=True)
     return W[:, perm], H[perm][:, perm], perm
+
+
+def _get_block_shape(strategy, quant_args, num_rows, num_columns):
+    if strategy == QuantizationStrategy.TENSOR:
+        return num_rows, num_columns
+    elif strategy == QuantizationStrategy.CHANNEL:
+        return 1, num_columns
+    elif strategy in (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP):
+        return 1, quant_args.group_size
+    elif strategy == QuantizationStrategy.BLOCK:
+        return quant_args.block_structure
+    else:
+        raise ValueError(f"Unsupported strategy for Triton GPTQ: {strategy}")
+
+
+def _build_codebook(scale, zero_point, quant_args, global_scale=None):
+    num_bits = quant_args.num_bits
+    if quant_args.symmetric:
+        q_min = -(2 ** (num_bits - 1))
+        q_max = 2 ** (num_bits - 1) - 1
+    else:
+        q_min = 0
+        q_max = 2**num_bits - 1
+
+    int_vals = torch.arange(q_min, q_max + 1, device=scale.device, dtype=torch.float32)
+
+    s = scale.to(dtype=torch.float32)
+    zp = zero_point.to(dtype=torch.float32)
+    while s.dim() < 2:
+        s = s.unsqueeze(0)
+        zp = zp.unsqueeze(0)
+
+    codebook = (int_vals - zp.unsqueeze(-1)) * s.unsqueeze(-1)
+
+    if global_scale is not None:
+        codebook = codebook / global_scale
+
+    return codebook.contiguous()
+
+
+def _build_cutoffs_and_codes(scale, zero_point, quant_args, global_scale=None):
+    codes = _build_codebook(scale, zero_point, quant_args, global_scale)
+    cutoffs = (codes[..., :-1] + codes[..., 1:]) * 0.5
+    return codes, cutoffs
+
+
+if _triton_available:
+
+    @triton.jit
+    def _quantize_block_triton_cutoff_kernel(
+        W1_ptr,
+        Hinv1_ptr,
+        codes_ptr,
+        cutoffs_ptr,
+        Q1_ptr,
+        Err1_ptr,
+        losses1_ptr,
+        num_rows,
+        count,
+        col_offset,
+        stride_w_row,
+        stride_h_row,
+        stride_codes_row,
+        stride_codes_col,
+        stride_cut_row,
+        stride_cut_col,
+        r_b,
+        c_b,
+        num_codes,
+        BLOCK_N: tl.constexpr,
+        BLOCK_C: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        if row >= num_rows:
+            return
+
+        qrow = row // r_b
+
+        cols = tl.arange(0, BLOCK_N)
+        cmask = cols < count
+        cut_idx = tl.arange(0, BLOCK_C)
+        num_cutoffs = num_codes - 1
+        cut_mask = cut_idx < num_cutoffs
+
+        w = tl.load(W1_ptr + row * stride_w_row + cols, mask=cmask, other=0.0)
+
+        q_out = tl.zeros([BLOCK_N], dtype=tl.float32)
+        err_out = tl.zeros([BLOCK_N], dtype=tl.float32)
+        loss_out = tl.zeros([BLOCK_N], dtype=tl.float32)
+
+        for i in range(count):
+            imask = cols == i
+            wi = tl.sum(tl.where(imask, w, 0.0))
+            d = tl.load(Hinv1_ptr + i * stride_h_row + i)
+
+            qcol = (col_offset + i) // c_b
+
+            cuts = tl.load(
+                cutoffs_ptr + qrow * stride_cut_row + qcol * stride_cut_col + cut_idx,
+                mask=cut_mask,
+                other=float("inf"),
+            )
+
+            bin_idx = tl.sum((wi >= cuts).to(tl.int32), axis=0)
+
+            qi = tl.load(
+                codes_ptr + qrow * stride_codes_row + qcol * stride_codes_col + bin_idx
+            )
+
+            diff = wi - qi
+            err = diff / d
+
+            q_out = tl.where(imask, qi, q_out)
+            err_out = tl.where(imask, err, err_out)
+            loss_out = tl.where(imask, diff * diff / (d * d), loss_out)
+
+            h_row = tl.load(Hinv1_ptr + i * stride_h_row + cols, mask=cmask, other=0.0)
+            w = tl.where(cols >= i, w - err * h_row, w)
+
+        tl.store(Q1_ptr + row * stride_w_row + cols, q_out, mask=cmask)
+        tl.store(Err1_ptr + row * stride_w_row + cols, err_out, mask=cmask)
+        tl.store(losses1_ptr + row * stride_w_row + cols, loss_out, mask=cmask)
+
+
+def _quantize_block_triton_cutoff(W, Hinv, codes, cutoffs, i1, i2, r_b, c_b, losses):
+    count = i2 - i1
+    W1 = W[:, i1:i2].clone()
+    Hinv1 = Hinv[i1:i2, i1:i2].contiguous()
+
+    num_rows = W1.shape[0]
+    num_codes = codes.shape[2]
+    Q1 = torch.zeros_like(W1)
+    Err1 = torch.zeros_like(W1)
+    losses1 = torch.zeros_like(W1)
+
+    BLOCK_N = triton.next_power_of_2(count)
+    BLOCK_C = triton.next_power_of_2(num_codes - 1) if num_codes > 1 else 1
+    grid = (num_rows,)
+
+    _quantize_block_triton_cutoff_kernel[grid](
+        W1,
+        Hinv1,
+        codes,
+        cutoffs,
+        Q1,
+        Err1,
+        losses1,
+        num_rows,
+        count,
+        i1,
+        W1.stride(0),
+        Hinv1.stride(0),
+        codes.stride(0),
+        codes.stride(1),
+        cutoffs.stride(0),
+        cutoffs.stride(1),
+        r_b,
+        c_b,
+        num_codes,
+        BLOCK_N=BLOCK_N,
+        BLOCK_C=BLOCK_C,
+    )
+
+    W[:, i1:i2] = Q1
+    losses += torch.sum(losses1, 1) / 2
+    W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -352,7 +352,7 @@ def _build_codebook(scale, zero_point, quant_args, global_scale=None):
 
 def _build_cutoffs_and_codes(scale, zero_point, quant_args, global_scale=None):
     codes = _build_codebook(scale, zero_point, quant_args, global_scale)
-    cutoffs = (codes[..., :-1] + codes[..., 1:]) * 0.5
+    cutoffs = ((codes[..., :-1] + codes[..., 1:]) * 0.5).contiguous()
     return codes, cutoffs
 
 
@@ -414,6 +414,7 @@ if _triton_available:
             )
 
             bin_idx = tl.sum((wi >= cuts).to(tl.int32), axis=0)
+            bin_idx = tl.minimum(bin_idx, num_codes - 1)
 
             qi = tl.load(
                 codes_ptr + qrow * stride_codes_row + qcol * stride_codes_col + bin_idx

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -11,6 +11,14 @@ from compressed_tensors.quantization import (
 )
 from loguru import logger
 
+try:
+    import triton
+    import triton.language as tl
+
+    _triton_available = True
+except ImportError:
+    _triton_available = False
+
 GPTQ_PRECISION = torch.float32
 
 __all__ = ["make_empty_hessian", "accumulate_hessian", "quantize_weight"]
@@ -62,6 +70,178 @@ def accumulate_hessian(
     H += inp.matmul(inp.t())
 
     return H, num_samples
+
+
+def _get_block_shape(strategy, quant_args, num_rows, num_columns):
+    if strategy == QuantizationStrategy.TENSOR:
+        return num_rows, num_columns
+    elif strategy == QuantizationStrategy.CHANNEL:
+        return 1, num_columns
+    elif strategy in (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP):
+        return 1, quant_args.group_size
+    elif strategy == QuantizationStrategy.BLOCK:
+        return quant_args.block_structure
+    else:
+        raise ValueError(f"Unsupported strategy for Triton GPTQ: {strategy}")
+
+
+def _build_codebook(scale, zero_point, quant_args, global_scale=None):
+    num_bits = quant_args.num_bits
+    if quant_args.symmetric:
+        q_min = -(2 ** (num_bits - 1))
+        q_max = 2 ** (num_bits - 1) - 1
+    else:
+        q_min = 0
+        q_max = 2**num_bits - 1
+
+    int_vals = torch.arange(
+        q_min, q_max + 1, device=scale.device, dtype=torch.float32
+    )
+
+    s = scale.to(dtype=torch.float32)
+    zp = zero_point.to(dtype=torch.float32)
+    while s.dim() < 2:
+        s = s.unsqueeze(0)
+        zp = zp.unsqueeze(0)
+
+    codebook = (int_vals - zp.unsqueeze(-1)) * s.unsqueeze(-1)
+
+    if global_scale is not None:
+        codebook = codebook / global_scale
+
+    return codebook.contiguous()
+
+
+def _build_cutoffs_and_codes(scale, zero_point, quant_args, global_scale=None):
+    codes = _build_codebook(scale, zero_point, quant_args, global_scale)
+    cutoffs = (codes[..., :-1] + codes[..., 1:]) * 0.5
+    return codes, cutoffs
+
+
+if _triton_available:
+
+    @triton.jit
+    def _quantize_block_triton_cutoff_kernel(
+        W1_ptr,
+        Hinv1_ptr,
+        codes_ptr,
+        cutoffs_ptr,
+        Q1_ptr,
+        Err1_ptr,
+        losses1_ptr,
+        num_rows,
+        count,
+        col_offset,
+        stride_w_row,
+        stride_h_row,
+        stride_codes_row,
+        stride_codes_col,
+        stride_cut_row,
+        stride_cut_col,
+        r_b,
+        c_b,
+        num_codes,
+        BLOCK_N: tl.constexpr,
+        BLOCK_C: tl.constexpr,
+    ):
+        row = tl.program_id(0)
+        if row >= num_rows:
+            return
+
+        qrow = row // r_b
+
+        cols = tl.arange(0, BLOCK_N)
+        cmask = cols < count
+        cut_idx = tl.arange(0, BLOCK_C)
+        num_cutoffs = num_codes - 1
+        cut_mask = cut_idx < num_cutoffs
+
+        w = tl.load(W1_ptr + row * stride_w_row + cols, mask=cmask, other=0.0)
+
+        q_out = tl.zeros([BLOCK_N], dtype=tl.float32)
+        err_out = tl.zeros([BLOCK_N], dtype=tl.float32)
+        loss_out = tl.zeros([BLOCK_N], dtype=tl.float32)
+
+        for i in range(count):
+            imask = cols == i
+            wi = tl.sum(tl.where(imask, w, 0.0))
+            d = tl.load(Hinv1_ptr + i * stride_h_row + i)
+
+            qcol = (col_offset + i) // c_b
+
+            cuts = tl.load(
+                cutoffs_ptr
+                + qrow * stride_cut_row
+                + qcol * stride_cut_col
+                + cut_idx,
+                mask=cut_mask,
+                other=float("inf"),
+            )
+
+            bin_idx = tl.sum((wi >= cuts).to(tl.int32), axis=0)
+
+            qi = tl.load(
+                codes_ptr
+                + qrow * stride_codes_row
+                + qcol * stride_codes_col
+                + bin_idx
+            )
+
+            diff = wi - qi
+            err = diff / d
+
+            q_out = tl.where(imask, qi, q_out)
+            err_out = tl.where(imask, err, err_out)
+            loss_out = tl.where(imask, diff * diff / (d * d), loss_out)
+
+            h_row = tl.load(
+                Hinv1_ptr + i * stride_h_row + cols, mask=cmask, other=0.0
+            )
+            w = tl.where(cols >= i, w - err * h_row, w)
+
+        tl.store(Q1_ptr + row * stride_w_row + cols, q_out, mask=cmask)
+        tl.store(Err1_ptr + row * stride_w_row + cols, err_out, mask=cmask)
+        tl.store(losses1_ptr + row * stride_w_row + cols, loss_out, mask=cmask)
+
+
+def _quantize_block_triton_cutoff(
+    W1, Hinv1, codes, cutoffs, count, col_offset, r_b, c_b
+):
+    num_rows = W1.shape[0]
+    num_codes = codes.shape[2]
+    Q1 = torch.zeros_like(W1)
+    Err1 = torch.zeros_like(W1)
+    losses1 = torch.zeros_like(W1)
+
+    BLOCK_N = triton.next_power_of_2(count)
+    BLOCK_C = triton.next_power_of_2(num_codes - 1) if num_codes > 1 else 1
+    grid = (num_rows,)
+
+    _quantize_block_triton_cutoff_kernel[grid](
+        W1,
+        Hinv1,
+        codes,
+        cutoffs,
+        Q1,
+        Err1,
+        losses1,
+        num_rows,
+        count,
+        col_offset,
+        W1.stride(0),
+        Hinv1.stride(0),
+        codes.stride(0),
+        codes.stride(1),
+        cutoffs.stride(0),
+        cutoffs.stride(1),
+        r_b,
+        c_b,
+        num_codes,
+        BLOCK_N=BLOCK_N,
+        BLOCK_C=BLOCK_C,
+    )
+
+    return Q1, Err1, losses1
 
 
 def quantize_weight(
@@ -163,16 +343,45 @@ def quantize_weight(
         )
         Hinv = H = torch.eye(num_columns, dtype=H.dtype, device=H.device)
 
+    use_triton_block = (
+        _triton_available
+        and W.is_cuda
+        and strategy
+        in (
+            QuantizationStrategy.TENSOR,
+            QuantizationStrategy.CHANNEL,
+            QuantizationStrategy.GROUP,
+            QuantizationStrategy.TENSOR_GROUP,
+            QuantizationStrategy.BLOCK,
+        )
+    )
+
+    if use_triton_block:
+        r_b, c_b = _get_block_shape(strategy, quant_args, num_rows, num_columns)
+        codes, cutoffs = _build_cutoffs_and_codes(
+            scale, zero_point, quant_args, global_scale
+        )
+
     # See section 3.4 of https://arxiv.org/abs/2203.07259
     for i1 in range(0, num_columns, blocksize):
         i2 = min(i1 + blocksize, num_columns)
         count = i2 - i1
 
         W1 = W[:, i1:i2].clone()
+        Hinv1 = Hinv[i1:i2, i1:i2]
+
+        if use_triton_block:
+            Q1, Err1, losses1 = _quantize_block_triton_cutoff(
+                W1, Hinv1.contiguous(), codes, cutoffs, count, i1, r_b, c_b
+            )
+            W[:, i1:i2] = Q1
+            losses += torch.sum(losses1, 1) / 2
+            W[:, i2:] -= Err1.matmul(Hinv[i1:i2, i2:])
+            continue
+
         Q1 = torch.zeros_like(W1)
         Err1 = torch.zeros_like(W1)
         losses1 = torch.zeros_like(W1)
-        Hinv1 = Hinv[i1:i2, i1:i2]
 
         for i in range(count):
             w = W1[:, i]

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -7,6 +7,7 @@ from compressed_tensors.quantization import (
     ActivationOrdering,
     QuantizationArgs,
     QuantizationStrategy,
+    QuantizationType,
     fake_quantize,
 )
 from loguru import logger
@@ -327,29 +328,58 @@ def _get_block_shape(strategy, quant_args, num_rows, num_columns):
         raise ValueError(f"Unsupported strategy for Triton GPTQ: {strategy}")
 
 
-def _build_codebook(scale, zero_point, quant_args, global_scale=None):
-    num_bits = quant_args.num_bits
-    if quant_args.symmetric:
-        q_min = -(2 ** (num_bits - 1))
-        q_max = 2 ** (num_bits - 1) - 1
+def _get_float_vals(num_bits, device):
+    if num_bits == 8:
+        all_bytes = torch.arange(0, 256, device=device, dtype=torch.uint8)
+        fp_vals = all_bytes.view(torch.float8_e4m3fn).to(torch.float32)
+        return fp_vals[~fp_vals.isnan()].unique()
+    elif num_bits == 4:
+        return torch.tensor(
+            [-6.0, -4.0, -3.0, -2.0, -1.5, -1.0, -0.5,
+             0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+            device=device, dtype=torch.float32,
+        )
     else:
-        q_min = 0
-        q_max = 2**num_bits - 1
+        raise NotImplementedError(f"Float codebook not supported for {num_bits}-bit")
 
-    int_vals = torch.arange(
-        q_min, q_max + 1, device=scale.device, dtype=torch.float32
-    )
 
-    s = scale.to(dtype=torch.float32)
-    zp = zero_point.to(dtype=torch.float32)
-    while s.dim() < 2:
-        s = s.unsqueeze(0)
-        zp = zp.unsqueeze(0)
+def _build_codebook(scale, zero_point, quant_args, global_scale=None):
+    if quant_args.type == QuantizationType.FLOAT:
+        fp_vals = _get_float_vals(quant_args.num_bits, scale.device)
 
-    codebook = (int_vals - zp.unsqueeze(-1)) * s.unsqueeze(-1)
+        s = scale.to(dtype=torch.float32)
+        zp = zero_point.to(dtype=torch.float32)
+        while s.dim() < 2:
+            s = s.unsqueeze(0)
+            zp = zp.unsqueeze(0)
 
-    if global_scale is not None:
-        codebook = codebook / global_scale
+        codebook = (fp_vals - zp.unsqueeze(-1)) * s.unsqueeze(-1)
+        if global_scale is not None:
+            codebook = codebook / global_scale
+    else:
+        num_bits = quant_args.num_bits
+        signed = zero_point.is_signed()
+        if signed:
+            q_min = -(2 ** (num_bits - 1))
+            q_max = 2 ** (num_bits - 1) - 1
+        else:
+            q_min = 0
+            q_max = 2**num_bits - 1
+
+        int_vals = torch.arange(
+            q_min, q_max + 1, device=scale.device, dtype=torch.float32
+        )
+
+        s = scale.to(dtype=torch.float32)
+        zp = zero_point.to(dtype=torch.float32)
+        while s.dim() < 2:
+            s = s.unsqueeze(0)
+            zp = zp.unsqueeze(0)
+
+        codebook = (int_vals - zp.unsqueeze(-1)) * s.unsqueeze(-1)
+
+        if global_scale is not None:
+            codebook = codebook / global_scale
 
     return codebook.contiguous()
 

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -151,6 +151,8 @@ def quantize_weight(
 
         if actorder == ActivationOrdering.WEIGHT:
             g_idx = g_idx[perm]
+    elif use_triton_block:
+        g_idx = torch.zeros(num_columns, device=W.device, dtype=torch.int)
 
     qparams = observer.get_qparams()
     scale, zero_point, global_scale = (
@@ -160,7 +162,7 @@ def quantize_weight(
     )
 
     if use_triton_block:
-        r_b, c_b = _get_block_shape(strategy, quant_args, num_rows, num_columns)
+        r_b, _ = _get_block_shape(strategy, quant_args, num_rows, num_columns)
         codes, cutoffs = _build_cutoffs_and_codes(
             scale, zero_point, quant_args, global_scale
         )
@@ -196,7 +198,7 @@ def quantize_weight(
 
         if use_triton_block:
             _quantize_block_triton_cutoff(
-                W, Hinv, codes, cutoffs, i1, i2, r_b, c_b, losses
+                W, Hinv, codes, cutoffs, g_idx, i1, i2, r_b, losses
             )
             continue
 
@@ -334,7 +336,9 @@ def _build_codebook(scale, zero_point, quant_args, global_scale=None):
         q_min = 0
         q_max = 2**num_bits - 1
 
-    int_vals = torch.arange(q_min, q_max + 1, device=scale.device, dtype=torch.float32)
+    int_vals = torch.arange(
+        q_min, q_max + 1, device=scale.device, dtype=torch.float32
+    )
 
     s = scale.to(dtype=torch.float32)
     zp = zero_point.to(dtype=torch.float32)
@@ -364,12 +368,12 @@ if _triton_available:
         Hinv1_ptr,
         codes_ptr,
         cutoffs_ptr,
+        g_idx_ptr,
         Q1_ptr,
         Err1_ptr,
         losses1_ptr,
         num_rows,
         count,
-        col_offset,
         stride_w_row,
         stride_h_row,
         stride_codes_row,
@@ -377,7 +381,6 @@ if _triton_available:
         stride_cut_row,
         stride_cut_col,
         r_b,
-        c_b,
         num_codes,
         BLOCK_N: tl.constexpr,
         BLOCK_C: tl.constexpr,
@@ -405,19 +408,24 @@ if _triton_available:
             wi = tl.sum(tl.where(imask, w, 0.0))
             d = tl.load(Hinv1_ptr + i * stride_h_row + i)
 
-            qcol = (col_offset + i) // c_b
+            qcol = tl.load(g_idx_ptr + i)
 
             cuts = tl.load(
-                cutoffs_ptr + qrow * stride_cut_row + qcol * stride_cut_col + cut_idx,
+                cutoffs_ptr
+                + qrow * stride_cut_row
+                + qcol * stride_cut_col
+                + cut_idx,
                 mask=cut_mask,
                 other=float("inf"),
             )
 
             bin_idx = tl.sum((wi >= cuts).to(tl.int32), axis=0)
-            bin_idx = tl.minimum(bin_idx, num_codes - 1)
 
             qi = tl.load(
-                codes_ptr + qrow * stride_codes_row + qcol * stride_codes_col + bin_idx
+                codes_ptr
+                + qrow * stride_codes_row
+                + qcol * stride_codes_col
+                + bin_idx,
             )
 
             diff = wi - qi
@@ -427,7 +435,9 @@ if _triton_available:
             err_out = tl.where(imask, err, err_out)
             loss_out = tl.where(imask, diff * diff / (d * d), loss_out)
 
-            h_row = tl.load(Hinv1_ptr + i * stride_h_row + cols, mask=cmask, other=0.0)
+            h_row = tl.load(
+                Hinv1_ptr + i * stride_h_row + cols, mask=cmask, other=0.0
+            )
             w = tl.where(cols >= i, w - err * h_row, w)
 
         tl.store(Q1_ptr + row * stride_w_row + cols, q_out, mask=cmask)
@@ -435,10 +445,13 @@ if _triton_available:
         tl.store(losses1_ptr + row * stride_w_row + cols, loss_out, mask=cmask)
 
 
-def _quantize_block_triton_cutoff(W, Hinv, codes, cutoffs, i1, i2, r_b, c_b, losses):
+def _quantize_block_triton_cutoff(
+    W, Hinv, codes, cutoffs, g_idx, i1, i2, r_b, losses
+):
     count = i2 - i1
     W1 = W[:, i1:i2].clone()
     Hinv1 = Hinv[i1:i2, i1:i2].contiguous()
+    g_idx_block = g_idx[i1:i2].contiguous()
 
     num_rows = W1.shape[0]
     num_codes = codes.shape[2]
@@ -455,12 +468,12 @@ def _quantize_block_triton_cutoff(W, Hinv, codes, cutoffs, i1, i2, r_b, c_b, los
         Hinv1,
         codes,
         cutoffs,
+        g_idx_block,
         Q1,
         Err1,
         losses1,
         num_rows,
         count,
-        i1,
         W1.stride(0),
         Hinv1.stride(0),
         codes.stride(0),
@@ -468,7 +481,6 @@ def _quantize_block_triton_cutoff(W, Hinv, codes, cutoffs, i1, i2, r_b, c_b, los
         cutoffs.stride(0),
         cutoffs.stride(1),
         r_b,
-        c_b,
         num_codes,
         BLOCK_N=BLOCK_N,
         BLOCK_C=BLOCK_C,

--- a/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
+++ b/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
@@ -6,6 +6,8 @@ from compressed_tensors.quantization import (
     QuantizationScheme,
 )
 
+import llmcompressor.modifiers.gptq.gptq_quantize as gptq_quantize
+from llmcompressor.core import create_session
 from llmcompressor.modifiers.gptq import GPTQModifier
 from llmcompressor.modifiers.gptq.gptq_quantize import (
     make_empty_hessian,
@@ -16,6 +18,34 @@ from llmcompressor.modifiers.quantization.calibration import (
     observe,
 )
 from tests.testing_utils import requires_compute_capability
+
+
+def _make_quantize_inputs(strategy: str = "group", device: str = "cpu"):
+    torch.manual_seed(0)
+    module = torch.nn.Linear(8, 6, bias=False).to(device)
+    quant_args_kwargs = dict(
+        num_bits=4,
+        symmetric=True,
+        strategy=strategy,
+    )
+    if strategy in ("group", "tensor_group"):
+        quant_args_kwargs["group_size"] = 2
+    if strategy == "block":
+        quant_args_kwargs["num_bits"] = 8
+        quant_args_kwargs["block_structure"] = [2, 2]
+
+    quant_args = QuantizationArgs(**quant_args_kwargs)
+    module.quantization_scheme = QuantizationScheme(
+        targets=["Linear"], weights=quant_args
+    )
+    initialize_observer(module, "weight")
+    observe(module, "weight")
+
+    hessian = make_empty_hessian(module)
+    A = torch.randn(hessian.shape[0], hessian.shape[1], device=device)
+    hessian += A @ A.t()
+    hessian += torch.eye(hessian.shape[0], dtype=hessian.dtype, device=device)
+    return module, quant_args, hessian
 
 
 @pytest.mark.parametrize(
@@ -130,6 +160,55 @@ def test_quantize_weight_channel_actorder_weight():
     assert q_param_dict["weight_scale"].shape[0] == module.weight.shape[0]
     assert q_param_dict["weight_zero_point"].shape[0] == module.weight.shape[0]
     assert "weight_g_idx" not in q_param_dict
+
+
+@requires_compute_capability(8, 0)
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "strategy", ["tensor", "channel", "group", "tensor_group", "block"]
+)
+def test_quantize_weight_triton_cutoff_matches_eager(monkeypatch, strategy):
+    module, quant_args, hessian = _make_quantize_inputs(strategy, device="cuda")
+
+    monkeypatch.setattr(gptq_quantize, "_triton_available", False)
+    eager_loss, eager_qparams = quantize_weight(
+        module=module,
+        quant_args=quant_args,
+        hessian=hessian.clone(),
+        blocksize=4,
+    )
+
+    monkeypatch.setattr(gptq_quantize, "_triton_available", True)
+    observe(module, "weight")
+    triton_loss, triton_qparams = quantize_weight(
+        module=module,
+        quant_args=quant_args,
+        hessian=hessian.clone(),
+        blocksize=4,
+    )
+
+    assert triton_loss == pytest.approx(eager_loss, rel=1e-4)
+    for key in ("weight", "weight_scale", "weight_zero_point"):
+        torch.testing.assert_close(
+            triton_qparams[key], eager_qparams[key], rtol=1e-4, atol=1e-4
+        )
+
+
+@torch.no_grad()
+def test_quantize_weight_triton_unavailable_falls_back(monkeypatch):
+    module, quant_args, hessian = _make_quantize_inputs("group")
+
+    monkeypatch.setattr(gptq_quantize, "_triton_available", False)
+
+    loss, q_param_dict = quantize_weight(
+        module=module,
+        quant_args=quant_args,
+        hessian=hessian,
+        blocksize=4,
+    )
+
+    assert loss >= 0
+    assert q_param_dict["weight"].shape == module.weight.shape
 
 
 @requires_compute_capability(9, 0)  # Requires H100 or higher

--- a/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
+++ b/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
@@ -7,7 +7,6 @@ from compressed_tensors.quantization import (
 )
 
 import llmcompressor.modifiers.gptq.gptq_quantize as gptq_quantize
-from llmcompressor.core import create_session
 from llmcompressor.modifiers.gptq import GPTQModifier
 from llmcompressor.modifiers.gptq.gptq_quantize import (
     make_empty_hessian,

--- a/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
+++ b/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
@@ -32,6 +32,29 @@ def _make_quantize_inputs(strategy: str = "group", device: str = "cpu"):
     if strategy == "block":
         quant_args_kwargs["num_bits"] = 8
         quant_args_kwargs["block_structure"] = [2, 2]
+    if strategy == "fp8":
+        quant_args_kwargs["num_bits"] = 8
+        quant_args_kwargs["type"] = "float"
+        quant_args_kwargs["strategy"] = "channel"
+    if strategy == "fp8_block":
+        quant_args_kwargs["num_bits"] = 8
+        quant_args_kwargs["type"] = "float"
+        quant_args_kwargs["strategy"] = "block"
+        quant_args_kwargs["block_structure"] = [2, 2]
+    if strategy == "int_asym":
+        quant_args_kwargs["num_bits"] = 8
+        quant_args_kwargs["symmetric"] = False
+        quant_args_kwargs["strategy"] = "channel"
+    if strategy == "fp8_asym":
+        quant_args_kwargs["num_bits"] = 8
+        quant_args_kwargs["type"] = "float"
+        quant_args_kwargs["symmetric"] = False
+        quant_args_kwargs["strategy"] = "channel"
+    if strategy == "nvfp4":
+        quant_args_kwargs["num_bits"] = 4
+        quant_args_kwargs["type"] = "float"
+        quant_args_kwargs["strategy"] = "tensor_group"
+        quant_args_kwargs["group_size"] = 2
 
     quant_args = QuantizationArgs(**quant_args_kwargs)
     module.quantization_scheme = QuantizationScheme(
@@ -164,7 +187,7 @@ def test_quantize_weight_channel_actorder_weight():
 @requires_compute_capability(8, 0)
 @torch.no_grad()
 @pytest.mark.parametrize(
-    "strategy", ["tensor", "channel", "group", "tensor_group", "block"]
+    "strategy", ["tensor", "channel", "group", "tensor_group", "block", "fp8", "fp8_block", "int_asym", "fp8_asym", "nvfp4"]
 )
 def test_quantize_weight_triton_cutoff_matches_eager(monkeypatch, strategy):
     module, quant_args, hessian = _make_quantize_inputs(strategy, device="cuda")
@@ -188,9 +211,10 @@ def test_quantize_weight_triton_cutoff_matches_eager(monkeypatch, strategy):
 
     assert triton_loss == pytest.approx(eager_loss, rel=1e-4)
     for key in ("weight", "weight_scale", "weight_zero_point"):
-        torch.testing.assert_close(
-            triton_qparams[key], eager_qparams[key], rtol=1e-4, atol=1e-4
-        )
+        t, e = triton_qparams[key], eager_qparams[key]
+        if t.dtype.is_floating_point and t.element_size() == 1:
+            t, e = t.to(torch.float32), e.to(torch.float32)
+        torch.testing.assert_close(t, e, rtol=1e-4, atol=1e-4)
 
 
 @requires_compute_capability(8, 0)

--- a/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
+++ b/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
@@ -193,6 +193,64 @@ def test_quantize_weight_triton_cutoff_matches_eager(monkeypatch, strategy):
         )
 
 
+@requires_compute_capability(8, 0)
+@torch.no_grad()
+@pytest.mark.parametrize("strategy", ["group", "block"])
+def test_quantize_weight_triton_cutoff_actorder_weight(monkeypatch, strategy):
+    torch.manual_seed(0)
+    module = torch.nn.Linear(8, 6, bias=False).to("cuda")
+    quant_args_kwargs = dict(
+        num_bits=4,
+        symmetric=True,
+        strategy=strategy,
+        actorder=ActivationOrdering.WEIGHT,
+    )
+    if strategy == "group":
+        quant_args_kwargs["group_size"] = 2
+    if strategy == "block":
+        quant_args_kwargs["num_bits"] = 8
+        quant_args_kwargs["block_structure"] = [2, 2]
+
+    quant_args = QuantizationArgs(**quant_args_kwargs)
+    module.quantization_scheme = QuantizationScheme(
+        targets=["Linear"], weights=quant_args
+    )
+    initialize_observer(module, "weight")
+    observe(module, "weight")
+
+    # non-uniform diagonal so actorder produces a non-identity permutation
+    hessian = make_empty_hessian(module)
+    diag = torch.arange(
+        1, hessian.shape[0] + 1, dtype=hessian.dtype, device=hessian.device
+    )
+    hessian += torch.diag(diag)
+
+    monkeypatch.setattr(gptq_quantize, "_triton_available", False)
+    eager_loss, eager_qparams = quantize_weight(
+        module=module,
+        quant_args=quant_args,
+        hessian=hessian.clone(),
+        blocksize=4,
+    )
+
+    monkeypatch.setattr(gptq_quantize, "_triton_available", True)
+    initialize_observer(module, "weight")
+    observe(module, "weight")
+    triton_loss, triton_qparams = quantize_weight(
+        module=module,
+        quant_args=quant_args,
+        hessian=hessian.clone(),
+        blocksize=4,
+    )
+
+    # Tolerances allow ±1 quantization level from codebook vs round differences
+    # but still catch gross bugs like wrong group index mapping (116x loss).
+    assert triton_loss == pytest.approx(eager_loss, rel=0.5)
+    torch.testing.assert_close(
+        triton_qparams["weight"], eager_qparams["weight"], rtol=0.15, atol=0.05
+    )
+
+
 @torch.no_grad()
 def test_quantize_weight_triton_unavailable_falls_back(monkeypatch):
     module, quant_args, hessian = _make_quantize_inputs("group")


### PR DESCRIPTION
## Summary

benchmarks:

```
                     median        min        max   peak_mem
           eager      2.191s      2.190s      2.196s   1282.6MB
        compiled      0.294s      0.294s      0.295s   1282.6MB
          triton      0.135s      0.135s      0.135s   1282.6MB (wont work for float quant)
      triton_lut      0.151s      0.151s      0.151s   1796.6MB
   triton_cutoff      0.129s      0.129s      0.129s   2302.6MB.  <<<
    triton_fused      0.562s      0.562s      0.562s   2302.6MB
```

note we used a look up table to generalize the quantization step so that this will work for float or int quantization i.e. we use explicit quantization points rather than scale and zero_point + round.

repro:
https://gist.github.com/HDCharles/363817a9eeda410f7fef15a3a5291e1c

## Test plan
- [x] New parametrized test `test_quantize_weight_triton_cutoff_matches_eager` verifies Triton output matches eager across all 5 strategies
- [x] New test `test_quantize_weight_triton_unavailable_falls_back` confirms graceful fallback when triton is unavailable
- [x] All existing tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)