### PR TITLE
[release-0.7.1] bump up pillow upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
             else "numpy>=2.0.0"
         ),
         (
-            "requests>=2.32.2,<=2.34.2"
+            "requests>=2.32.2,<2.35.0"
             if BUILD_TYPE == "release"
             else "requests>=2.32.2"
         ),
@@ -163,7 +163,7 @@ setup(
             else "pynvml>=11.5.3"
         ),
         (
-            "pillow>=10.4.0,<=12.3.0"
+            "pillow>=10.4.0,<13.0.0"
             if BUILD_TYPE == "release"
             else "pillow>=10.4.0"
         ),

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ setup(
             else "pynvml>=11.5.3"
         ),
         (
-            "pillow>=10.4.0,<=12.2.0"
+            "pillow>=10.4.0,<=12.3.0"
             if BUILD_TYPE == "release"
             else "pillow>=10.4.0"
         ),


### PR DESCRIPTION
SUMMARY:
Bump up pillow upper bound to 12.3.0 to fix INFERENG-8765.

The requests package is already allowing latest 2.34.2 so no change is needed.

TEST PLAN:
All tests
