### PR TITLE
Add py.typed marker for PEP 561 compliance

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
+recursive-include src/llmcompressor py.typed
 recursive-exclude src *.png *.jpg *.jpeg *.gif *.svg *.bmp *.webp


### PR DESCRIPTION
## Summary

Adds `py.typed` marker file to enable type checkers to use inline type hints present in the package, per PEP 561.

## Changes

- Added `src/llmcompressor/py.typed` marker file
- Updated `MANIFEST.in` to include py.typed in distribution

## Testing

Verified by grep — no existing py.typed marker was present. With `include_package_data=True` in setup.py and MANIFEST.in entry, the marker will be included in wheel distributions.