### PR TITLE
[release-0.12.0] update pillow upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
         # https://librosa.org/doc/0.11.0/changelog.html
         ("numpy>=2.0.0,<=2.4.6" if BUILD_TYPE == "release" else "numpy>=2.0.0"),
         (
-            "requests>=2.32.2,<=2.34.2"
+            "requests>=2.32.2,<2.35.0"
             if BUILD_TYPE == "release"
             else "requests>=2.32.2"
         ),
@@ -143,7 +143,7 @@ setup(
             if BUILD_TYPE == "release"
             else "nvidia-ml-py>=12.560.30"
         ),
-        ("pillow>=10.4.0,<=12.3.0" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
+        ("pillow>=10.4.0,<13.0.0" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
         (
             "compressed-tensors==0.17.1"
             if BUILD_TYPE == "release"

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ setup(
             if BUILD_TYPE == "release"
             else "nvidia-ml-py>=12.560.30"
         ),
-        ("pillow>=10.4.0,<=12.2.0" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
+        ("pillow>=10.4.0,<=12.3.0" if BUILD_TYPE == "release" else "pillow>=10.4.0"),
         (
             "compressed-tensors==0.17.1"
             if BUILD_TYPE == "release"


### PR DESCRIPTION
SUMMARY:
Bump up pillow upper bound to 12.3.0 to fix INFERENG-8765.

The requests package is already allowing latest 2.34.2 so no change is needed.


TEST PLAN:
All tests
