### PR TITLE
Add Nanbeige AWQ mappings

### DIFF
--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -288,6 +288,7 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Llama4ForConditionalGeneration": _llama4_default_mappings,
     "Mistral3ForConditionalGeneration": default_mappings,
     "MistralForCausalLM": default_mappings,
+    "NanbeigeForCausalLM": default_mappings,
     "Olmo3ForCausalLM": _exaone4_mappings,
     "Phi3ForCausalLM": _phi_mappings,
     "Phi3VForCausalLM": _phi_mappings,

--- a/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
+++ b/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
@@ -13,6 +13,10 @@ from llmcompressor.modifiers.transform.awq.dynamic_mappings import (
     build_step3p5_mappings,
     get_layer_mappings_from_model,
 )
+from llmcompressor.modifiers.transform.awq.mappings import (
+    AWQ_MAPPING_REGISTRY,
+    default_mappings,
+)
 from llmcompressor.modifiers.transform.utils.hybrid_attention import (
     get_hybrid_attention_config,
 )
@@ -464,6 +468,15 @@ class TestGetLayerMappingsFromModel:
         mappings = get_layer_mappings_from_model(model)
         assert len(mappings) == 4
         assert not any("|" in m.smooth_layer for m in mappings)
+
+    def test_nanbeige_model_uses_static_default_mappings(self):
+        model = _make_standard_model()
+        model.__class__ = type("NanbeigeForCausalLM", (model.__class__,), {})
+
+        model_name = model.__class__.__name__
+
+        assert AWQ_MAPPING_REGISTRY[model_name] == default_mappings
+        assert get_layer_mappings_from_model(model) == default_mappings
 
     def test_unknown_model_gets_default_mappings(self):
         model = _make_standard_model()


### PR DESCRIPTION
SUMMARY:
Added NanbeigeForCausalLM to the AWQ static mapping registry. Nanbeige's decoder layout uses input_layernorm, q/k/v/o attention projections, post_attention_layernorm, and gate/up/down MLP projections, which matches the default AWQ mapping pattern. So this PR simply adds the mapping explicitly as default.

Closes #2953

TEST PLAN:
- git diff --check
- python3 -m py_compile src/llmcompressor/modifiers/transform/awq/mappings.py tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
- pytest tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
