### PR TITLE
[testfix] update small quant model for test

### DIFF
--- a/tests/llmcompressor/entrypoints/oneshot/test_oneshot_pre_quantized.py
+++ b/tests/llmcompressor/entrypoints/oneshot/test_oneshot_pre_quantized.py
@@ -9,7 +9,7 @@ from llmcompressor.utils.dev import skip_weights_initialize
 
 SMOKE_MODEL = "nm-testing/tinysmokellama-3.2"
 CT_MODEL = "nm-testing/SmolLM-1.7B-Instruct-quantized.w4a16"
-QUANTIZED_MODEL = "google/gemma-4-E2B-it-qat-mobile-transformers"
+QUANTIZED_MODEL = "ISTA-DASLab/Qwen3-0.6B-FPQuant-RTN-MXFP4"
 
 
 def _recipe():

--- a/tests/llmcompressor/entrypoints/oneshot/test_oneshot_pre_quantized.py
+++ b/tests/llmcompressor/entrypoints/oneshot/test_oneshot_pre_quantized.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from compressed_tensors.quantization import QuantizationConfig
 from loguru import logger
@@ -9,7 +11,6 @@ from llmcompressor.utils.dev import skip_weights_initialize
 
 SMOKE_MODEL = "nm-testing/tinysmokellama-3.2"
 CT_MODEL = "nm-testing/SmolLM-1.7B-Instruct-quantized.w4a16"
-QUANTIZED_MODEL = "ISTA-DASLab/Qwen3-0.6B-FPQuant-RTN-MXFP4"
 
 
 def _recipe():
@@ -53,13 +54,11 @@ def test_oneshot_warns_pre_quantized_smoke_model():
 @pytest.mark.smoke
 @pytest.mark.integration
 def test_oneshot_rejects_pre_quantized_smoke_model():
-    with skip_weights_initialize(), pytest.raises(
-        ValueError, match="already quantized"
-    ):
-        oneshot(
-            model=QUANTIZED_MODEL,
-            recipe=_recipe(),
-        )
+    with skip_weights_initialize():
+        model = AutoModelForCausalLM.from_pretrained(SMOKE_MODEL)
+    model.config.quantization_config = SimpleNamespace(quant_method="fp_quant")
+    with pytest.raises(ValueError, match="already quantized"):
+        oneshot(model=model, recipe=_recipe())
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
SUMMARY:

Update failing test with a monkey-patched smoke test model with fp_quant method
```
| Root Cause | Jobs Affected | Type |
| - | - | - |
| `test_oneshot_rejects_pre_quantized_smoke_model` fails with `RuntimeError` instead of expected `ValueError` when loading `google/gemma-4-E2B-it-qat-mobile-transformers` due to mismatched tensor sizes in transformers 5.9.0 | 1 (ibm-wdc-k8s-h100-solo, Python 3.10) | Code Regression (PR #2909) |
```


TEST PLAN:
test succeeds on any hardware/transformers version now
