### PR TITLE
[For 0.7.1.3] bump maximum pillow version to 12.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ setup(
             else "pynvml>=11.5.3"
         ),
         (
-            "pillow>=10.4.0,<=12.2.0"
+            "pillow>=10.4.0,<=12.3.0"
             if BUILD_TYPE == "release"
             else "pillow>=10.4.0"
         ),


### PR DESCRIPTION
fixes CVE-2026-55379

https://www.cve.org/CVERecord?id=CVE-2026-55379
https://github.com/python-pillow/Pillow/blob/main/docs/releasenotes/12.3.0.rst
