### PR TITLE
[Kimi-K3] Enable REAP expert pruning with LinearExperts2D

### DIFF
--- a/examples/reap_expert_pruning/reap_kimi_k3.py
+++ b/examples/reap_expert_pruning/reap_kimi_k3.py
@@ -1,0 +1,58 @@
+import torch
+from compressed_tensors.distributed import init_dist
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modeling.kimi_k3 import KimiK3ForConditionalGeneration
+from llmcompressor.modifiers.pruning import REAPPruningModifier
+
+MODEL_ID = "inference-optimization/Kimi-K3-0.40B"
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+init_dist()
+model = KimiK3ForConditionalGeneration.from_pretrained(
+    MODEL_ID,
+    device_map="auto",
+    dtype=torch.bfloat16,
+)
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
+
+dataset = load_dataset(
+    "HuggingFaceH4/ultrachat_200k",
+    split=f"train_sft[:{NUM_CALIBRATION_SAMPLES}]",
+).shuffle(seed=42)
+dataset = dataset.map(
+    lambda sample: {
+        "text": tokenizer.apply_chat_template(
+            sample["messages"],
+            tokenize=False,
+        )
+    }
+)
+dataset = dataset.map(
+    lambda sample: tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    ),
+    remove_columns=dataset.column_names,
+)
+
+oneshot(
+    model=model,
+    processor=tokenizer,
+    dataset=dataset,
+    recipe=REAPPruningModifier(sparsity=0.25),
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    moe_calibrate_all_experts=False,
+)
+
+save_dir = MODEL_ID.rsplit("/", 1)[-1] + "-REAP-25"
+model.save_pretrained(save_dir, save_compressed=True)
+tokenizer.save_pretrained(save_dir)
+torch.distributed.destroy_process_group()

--- a/src/llmcompressor/modeling/kimi_k3/modeling_kimi_k3_linear.py
+++ b/src/llmcompressor/modeling/kimi_k3/modeling_kimi_k3_linear.py
@@ -329,7 +329,8 @@ class KimiBlockSparseMLP(ExpertMLPWithGate):
             intermediate_size=self.ffn_dim,
             mlp_bias=False,
             _apply_gate=self._apply_gate,
-            dtype=config.dtype,
+            dtype=getattr(config, "dtype", None)
+            or getattr(config, "torch_dtype", None),
         )
         self.act_fn = act_fn
 
@@ -366,6 +367,13 @@ class KimiLinearExperts(LinearExperts2D):
                 for _ in range(self.num_experts)
             ],
         )
+        if config.hidden_act == "situ":
+            beta, linear_beta = _get_situ_activation_params(config)
+            self.act_fn = SituAndMul(beta=beta, linear_beta=linear_beta)
+        else:
+            self.act_fn = ACT2FN[config.hidden_act]
+        self.alpha = getattr(config, "alpha", None)
+        self.limit = getattr(config, "limit", None)
 
 
 class KimiMLP(nn.Module):

--- a/src/llmcompressor/modeling/kimi_k3/modeling_kimi_k3_linear.py
+++ b/src/llmcompressor/modeling/kimi_k3/modeling_kimi_k3_linear.py
@@ -33,6 +33,8 @@ from packaging import version
 from torch import nn
 from transformers.activations import ACT2FN
 from transformers.cache_utils import Cache
+from transformers.conversion_mapping import register_checkpoint_conversion_mapping
+from transformers.core_model_loading import WeightRenaming
 from transformers.generation import GenerationMixin
 from transformers.masking_utils import create_causal_mask
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
@@ -61,9 +63,38 @@ try:
 except ImportError:
     raise ImportError("Plese run `pip install -U fla-core`")
 
-from llmcompressor.modeling.moe.context import get_calibrate_all_experts_flag
+from llmcompressor.modeling.moe.linear_experts import (
+    ExpertMLPWithGate,
+    LinearExperts2D,
+)
 
 from .configuration_kimi_k3 import KimiLinearConfig
+
+_KIMI_LINEAR_WEIGHT_CONVERSIONS = [
+    WeightRenaming(
+        source_patterns=(
+            r"^(model\.layers\.\d+\.block_sparse_moe\.experts\.\d+)\.w1\."
+        ),
+        target_patterns=r"\1.gate_proj.",
+    ),
+    WeightRenaming(
+        source_patterns=(
+            r"^(model\.layers\.\d+\.block_sparse_moe\.experts\.\d+)\.w2\."
+        ),
+        target_patterns=r"\1.down_proj.",
+    ),
+    WeightRenaming(
+        source_patterns=(
+            r"^(model\.layers\.\d+\.block_sparse_moe\.experts\.\d+)\.w3\."
+        ),
+        target_patterns=r"\1.up_proj.",
+    ),
+]
+register_checkpoint_conversion_mapping(
+    KimiLinearConfig.model_type,
+    _KIMI_LINEAR_WEIGHT_CONVERSIONS,
+    overwrite=True,
+)
 
 assert version.parse(transformers.__version__) >= version.parse(
     "4.56.0"
@@ -274,42 +305,67 @@ class KimiRMSNorm(nn.Module):
 ALL_LAYERNORM_LAYERS.append(KimiRMSNorm)
 
 
-class KimiBlockSparseMLP(nn.Module):
+class KimiBlockSparseMLP(ExpertMLPWithGate):
     def __init__(
         self, config: KimiLinearConfig, hidden_size=None, intermediate_size=None
     ):
-        super().__init__()
         self.config = config
         self.ffn_dim = (
             config.intermediate_size if intermediate_size is None else intermediate_size
         )
         self.hidden_dim = config.hidden_size if hidden_size is None else hidden_size
 
-        self.w1 = nn.Linear(self.hidden_dim, self.ffn_dim, bias=False)  # gate
-        self.w2 = nn.Linear(self.ffn_dim, self.hidden_dim, bias=False)  # down
-        self.w3 = nn.Linear(self.hidden_dim, self.ffn_dim, bias=False)  # up
-
         if config.hidden_act == "situ":
             beta, linear_beta = _get_situ_activation_params(config)
-            self.act_fn = SituAndMul(
+            act_fn = SituAndMul(
                 beta=beta,
                 linear_beta=linear_beta,
             )
         else:
-            self.act_fn = ACT2FN[config.hidden_act]
+            act_fn = ACT2FN[config.hidden_act]
 
-    def forward(self, hidden_states):
+        super().__init__(
+            hidden_dim=self.hidden_dim,
+            intermediate_size=self.ffn_dim,
+            mlp_bias=False,
+            _apply_gate=self._apply_gate,
+            dtype=config.dtype,
+        )
+        self.act_fn = act_fn
+
+    def _apply_gate(self, gate_up: torch.Tensor) -> torch.Tensor:
         if self.config.hidden_act == "situ":
-            gate_up = torch.cat(
-                [self.w1(hidden_states), self.w3(hidden_states)], dim=-1
-            )
-            current_hidden_states = self.act_fn(gate_up)
-        else:
-            current_hidden_states = self.act_fn(self.w1(hidden_states)) * self.w3(
-                hidden_states
-            )
-        current_hidden_states = self.w2(current_hidden_states)
-        return current_hidden_states
+            return self.act_fn(gate_up)
+
+        gate, up = gate_up.chunk(2, dim=-1)
+        return self.act_fn(gate) * up
+
+
+class KimiLinearExperts(LinearExperts2D):
+    is_concatenated = False
+    is_transposed = False
+    has_bias = False
+    has_gate = True
+
+    def __init__(self, config: KimiLinearConfig):
+        hidden_dim = (
+            config.routed_expert_hidden_size
+            if config.routed_expert_hidden_size is not None
+            else config.hidden_size
+        )
+        self.num_experts = config.num_experts
+        self.intermediate_size = config.moe_intermediate_size
+        nn.ModuleList.__init__(
+            self,
+            [
+                KimiBlockSparseMLP(
+                    config,
+                    hidden_size=hidden_dim,
+                    intermediate_size=self.intermediate_size,
+                )
+                for _ in range(self.num_experts)
+            ],
+        )
 
 
 class KimiMLP(nn.Module):
@@ -862,19 +918,7 @@ class KimiSparseMoeBlock(nn.Module):
         )
         self.latent_moe_use_norm = getattr(config, "latent_moe_use_norm", False)
 
-        self.ep_size = 1
-        self.experts_per_rank = config.num_experts
-        self.ep_rank = 0
-        self.experts = nn.ModuleList(
-            [
-                KimiBlockSparseMLP(
-                    config,
-                    hidden_size=self.moe_hidden_size,
-                    intermediate_size=config.moe_intermediate_size,
-                )
-                for _ in range(config.num_experts)
-            ],
-        )
+        self.experts = KimiLinearExperts(config)
         self.gate = KimiMoEGate(config)
         if config.num_shared_experts is not None:
             intermediate_size = config.moe_intermediate_size * config.num_shared_experts
@@ -909,10 +953,7 @@ class KimiSparseMoeBlock(nn.Module):
         if self.use_latent_moe:
             hidden_states = self.routed_expert_down_proj(hidden_states)
 
-        if False:#if not self.training:
-            y = self.moe_infer(hidden_states, topk_idx, topk_weight)
-        else:
-            y = self.moe_train(hidden_states, topk_idx, topk_weight)
+        y = self.experts(hidden_states, topk_idx, topk_weight)
 
         if self.use_latent_moe:
             if self.latent_moe_use_norm:
@@ -924,62 +965,6 @@ class KimiSparseMoeBlock(nn.Module):
         if self.config.num_shared_experts is not None:
             y = y + self.shared_experts(identity)
         return y
-
-    def moe_train(self, x, topk_ids, topk_weight):
-        """Training-compatible MoE dispatch with gradient flow."""
-        y = torch.zeros_like(x)
-
-        with torch.no_grad():
-            expert_mask = F.one_hot(topk_ids, self.num_experts).permute(2, 1, 0)
-
-        for expert_idx, expert in enumerate(self.experts):
-            top_k_pos, token_indices = torch.where(expert_mask[expert_idx])
-
-            if get_calibrate_all_experts_flag():
-                expert_out = expert(x)[token_indices]
-            else:
-                expert_out = expert(x[token_indices])
-
-            expert_weights = topk_weight[token_indices, top_k_pos, None]
-            y.index_add_(0, token_indices, (expert_out * expert_weights).to(y.dtype))
-
-        return y
-
-    @torch.no_grad()
-    def moe_infer(self, x, topk_ids, topk_weight):
-        cnts = topk_ids.new_zeros((topk_ids.shape[0], len(self.experts)))
-        cnts.scatter_(1, topk_ids, 1)
-        tokens_per_expert = cnts.sum(dim=0)
-        idxs = topk_ids.view(-1).argsort()
-        sorted_tokens = x[idxs // topk_ids.shape[1]]
-
-        tokens_per_expert = tokens_per_expert.cpu().numpy()
-
-        outputs = []
-        start_idx = 0
-        for i, num_tokens in enumerate(tokens_per_expert):
-            end_idx = start_idx + num_tokens
-            if num_tokens == 0:
-                continue
-            expert = self.experts[i + self.ep_rank * self.experts_per_rank]
-            tokens_for_this_expert = sorted_tokens[start_idx:end_idx]
-            expert_out = expert(tokens_for_this_expert)
-            outputs.append(expert_out)
-            start_idx = end_idx
-
-        outs = torch.cat(outputs, dim=0) if len(outputs) else sorted_tokens.new_empty(0)
-
-        new_x = torch.empty_like(outs)
-        new_x[idxs] = outs
-        final_out = (
-            new_x.view(*topk_ids.shape, -1)
-            .type(topk_weight.dtype)
-            .mul_(topk_weight.unsqueeze(dim=-1))
-            .sum(dim=1)
-            .type(new_x.dtype)
-        )
-        return final_out
-
 
 class KimiDecoderLayer(nn.Module):
     def __init__(self, config: KimiLinearConfig, layer_idx: int):

--- a/src/llmcompressor/modifiers/pruning/reap/utils.py
+++ b/src/llmcompressor/modifiers/pruning/reap/utils.py
@@ -43,8 +43,13 @@ class MoeModelAttrs:
 ROUTER_ATTRS = ["router", "gate"]
 EXPERTS_ATTRS = ["experts"]
 NUM_EXPERTS_CONFIG_KEYS = ["num_experts", "num_local_experts", "moe_num_experts"]
-TOP_K_CONFIG_KEYS = ["num_experts_per_tok", "top_k", "moe_top_k"]
-N_GROUP_CONFIG_KEYS = ["n_group"]
+TOP_K_CONFIG_KEYS = [
+    "num_experts_per_tok",
+    "num_experts_per_token",
+    "top_k",
+    "moe_top_k",
+]
+N_GROUP_CONFIG_KEYS = ["n_group", "num_expert_group"]
 TOP_K_GROUP_CONFIG_KEYS = ["topk_group", "top_k_group"]
 NUM_EXPERTS_MODULE_KEYS = ["num_experts", "n_experts", "n_routed_experts"]
 
@@ -408,6 +413,11 @@ def _prune_router(router: nn.Module, retained: list[int]):
     if new_bias is not None:
         router.bias = nn.Parameter(new_bias, requires_grad=router.bias.requires_grad)
     if new_correction is not None:
+        if isinstance(correction, nn.Parameter):
+            new_correction = nn.Parameter(
+                new_correction,
+                requires_grad=correction.requires_grad,
+            )
         router.e_score_correction_bias = new_correction
 
     if isinstance(getattr(router, "out_features", None), int):

--- a/tests/llmcompressor/modeling/test_kimi_k3.py
+++ b/tests/llmcompressor/modeling/test_kimi_k3.py
@@ -1,0 +1,127 @@
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.conversion_mapping import get_checkpoint_conversion_mapping
+
+from llmcompressor.modeling.kimi_k3 import KimiK3ForConditionalGeneration
+from llmcompressor.modeling.kimi_k3.configuration_kimi_k3 import KimiLinearConfig
+from llmcompressor.modeling.kimi_k3.modeling_kimi_k3_linear import (
+    KimiSparseMoeBlock,
+)
+from llmcompressor.modeling.moe.linear_experts import LinearExperts2D
+from llmcompressor.modifiers.pruning.reap.utils import (
+    get_moe_attrs,
+    prune_moe_layer,
+)
+from tests.testing_utils import requires_gpu
+
+MODEL_ID = "inference-optimization/Kimi-K3-0.40B"
+
+
+def _legacy_dispatch(experts, hidden_states, topk_ids, topk_weights):
+    outputs = torch.zeros_like(hidden_states)
+    expert_mask = torch.nn.functional.one_hot(topk_ids, experts.num_experts).permute(
+        2, 1, 0
+    )
+
+    for expert_idx, expert in enumerate(experts):
+        topk_pos, token_indices = torch.where(expert_mask[expert_idx])
+        expert_outputs = expert(hidden_states[token_indices])
+        routing_weights = topk_weights[token_indices, topk_pos, None]
+        outputs.index_add_(
+            0,
+            token_indices,
+            (expert_outputs * routing_weights).to(outputs.dtype),
+        )
+
+    return outputs
+
+
+def test_kimi_sparse_moe_uses_equivalent_linear_experts():
+    torch.manual_seed(0)
+    config = KimiLinearConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_experts=4,
+        num_experts_per_token=2,
+        num_shared_experts=None,
+        dtype=torch.float32,
+    )
+    moe = KimiSparseMoeBlock(config)
+    with torch.no_grad():
+        moe.gate.e_score_correction_bias.zero_()
+
+    hidden_states = torch.randn(2, 3, config.hidden_size)
+    topk_ids, topk_weights = moe.gate(hidden_states)
+    flattened = hidden_states.flatten(0, 1)
+
+    expected = _legacy_dispatch(moe.experts, flattened, topk_ids, topk_weights)
+    actual = moe.experts(flattened, topk_ids, topk_weights)
+    moe_attrs = get_moe_attrs(moe, [])
+
+    assert isinstance(moe.experts, LinearExperts2D)
+    assert moe_attrs.top_k == config.num_experts_per_token
+    assert moe_attrs.n_group == config.num_expert_group
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(moe(hidden_states).flatten(0, 1), expected)
+
+    prune_moe_layer(moe, "", [0, 1, 2], moe_attrs)
+    assert isinstance(moe.gate.e_score_correction_bias, torch.nn.Parameter)
+    assert moe.gate.e_score_correction_bias.shape == (3,)
+
+
+@pytest.mark.parametrize(
+    ("source_name", "target_name"),
+    [
+        ("w1", "gate_proj"),
+        ("w2", "down_proj"),
+        ("w3", "up_proj"),
+    ],
+)
+def test_kimi_expert_weight_mapping_round_trips(source_name, target_name):
+    mappings = get_checkpoint_conversion_mapping(KimiLinearConfig.model_type)
+    source_key = f"model.layers.1.block_sparse_moe.experts.3.{source_name}.weight"
+    target_key = f"model.layers.1.block_sparse_moe.experts.3.{target_name}.weight"
+
+    converted_key = source_key
+    for mapping in mappings:
+        converted_key, _ = mapping.rename_source_key(converted_key)
+    assert converted_key == target_key
+
+    for mapping in reversed(mappings):
+        converted_key, _ = mapping.reverse_transform().rename_source_key(converted_key)
+    assert converted_key == source_key
+
+
+@pytest.mark.integration
+@requires_gpu
+@torch.no_grad()
+def test_kimi_k3_checkpoint_loads_with_equivalent_outputs():
+    input_ids = torch.tensor([[1, 42, 314, 2]], device="cuda")
+
+    reference = AutoModelForCausalLM.from_pretrained(
+        MODEL_ID,
+        trust_remote_code=True,
+        device_map="cuda",
+        dtype=torch.float16,
+    )
+    expected = reference.language_model(input_ids=input_ids, use_cache=False).logits
+    del reference
+    torch.cuda.empty_cache()
+
+    model = KimiK3ForConditionalGeneration.from_pretrained(
+        MODEL_ID,
+        device_map="cuda",
+        dtype=torch.float16,
+    )
+    actual = model.language_model(input_ids=input_ids, use_cache=False).logits
+
+    moe_layers = [
+        layer.block_sparse_moe
+        for layer in model.language_model.model.layers
+        if hasattr(layer, "block_sparse_moe")
+    ]
+    assert moe_layers
+    assert all(isinstance(layer.experts, LinearExperts2D) for layer in moe_layers)
+    torch.testing.assert_close(actual, expected, atol=5e-3, rtol=2e-2)

--- a/tests/llmcompressor/modeling/test_kimi_k3.py
+++ b/tests/llmcompressor/modeling/test_kimi_k3.py
@@ -24,7 +24,8 @@ def _legacy_dispatch(experts, hidden_states, topk_ids, topk_weights):
         2, 1, 0
     )
 
-    for expert_idx, expert in enumerate(experts):
+    for expert_idx in range(experts.num_experts):
+        expert = experts[expert_idx]
         topk_pos, token_indices = torch.where(expert_mask[expert_idx])
         expert_outputs = expert(hidden_states[token_indices])
         routing_weights = topk_weights[token_indices, topk_pos, None]
@@ -61,6 +62,9 @@ def test_kimi_sparse_moe_uses_equivalent_linear_experts():
     moe_attrs = get_moe_attrs(moe, [])
 
     assert isinstance(moe.experts, LinearExperts2D)
+    assert isinstance(moe.experts.act_fn, torch.nn.Module)
+    assert moe.experts.alpha is None
+    assert moe.experts.limit is None
     assert moe_attrs.top_k == config.num_experts_per_token
     assert moe_attrs.n_group == config.num_expert_group
     torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
Closes #2979

## Summary

This PR integrates the Kimi-K3 routed experts with the `LinearExperts2D` representation required by REAP. It preserves the existing Kimi routing, shared-expert, latent-projection, and SiTU/SiLU behavior while exposing each routed expert as an `ExpertMLP` that REAP can score and structurally prune.

This is a stacked draft PR based on #2978 because the Kimi-K3 model definition is introduced there and is not yet available on `main`. After #2978 merges, this branch can be rebased and the base changed to `main`.

## Changes

### Standardize Kimi-K3 routed experts

- Add `KimiLinearExperts`, a `LinearExperts2D` subclass containing the Kimi routed experts.
- Change `KimiBlockSparseMLP` to inherit from `ExpertMLPWithGate`.
- Preserve the Kimi-specific SiTU activation, standard SiLU gated activation, latent expert hidden size, and bias-free projections.
- Keep `KimiSparseMoeBlock` as the owner of routing, shared experts, and latent down/up projections.
- Replace its custom `moe_train` and `moe_infer` dispatch paths with `LinearExperts2D.forward(hidden_states, topk_ids, topk_weights)`.

### Preserve checkpoint compatibility

Register reversible Transformers weight renames for routed experts:

- `w1` -> `gate_proj`
- `w2` -> `down_proj`
- `w3` -> `up_proj`

The mappings allow the original Kimi-K3 checkpoint layout to load into the standardized runtime modules and restore the original names when saving.

### Support Kimi-K3 in REAP

- Recognize `num_experts_per_token` as a top-k config field.
- Recognize `num_expert_group` as an expert-group config field.
- Preserve `e_score_correction_bias` as an `nn.Parameter` when the router is resized. Existing routers that register it as a buffer retain buffer behavior.

### Tests and example

- Add module-level equivalence coverage against the previous Kimi expert dispatch.
- Verify the checkpoint mappings round-trip for `w1`, `w2`, and `w3`.
- Verify Kimi config discovery and correction-bias pruning.
- Load `inference-optimization/Kimi-K3-0.40B` through both the original remote definition and the LLM Compressor definition and compare logits.
- Add a 25% REAP example for the tiny Kimi-K3 checkpoint.

## Duplicate-work check

No open PR references #2979, and no open PR was found for Kimi-K3 REAP or `LinearExperts2D` integration. Draft PR #2978 provides the prerequisite Kimi-K3 model definition and quantization work; it does not implement REAP integration, checkpoint renaming to `LinearExperts2D`, or expert pruning.

## Validation

```text
PYTHONPATH=src /tmp/llmc-dev-venv/bin/python -m pytest tests/llmcompressor/modeling/test_kimi_k3.py -q
5 passed

PYTHONPATH=src /tmp/llmc-dev-venv/bin/python -m pytest tests/llmcompressor/modifiers/pruning/reap/test_base.py -q
24 passed

RUFF_CACHE_DIR=/tmp/issue2979/ruff-cache ruff check --ignore E501 <changed files>
All checks passed

git diff --check -- <changed files>
Passed
```

A four-sample GPU REAP smoke run completed end-to-end on `inference-optimization/Kimi-K3-0.40B`. REAP discovered all seven MoE layers and pruned each layer from 8 experts to 6 at 25% sparsity.

The smoke run used the matching `compressed-tensors` dependency commit `7074ea1` from `kylesayrs/july28`; #2978 currently depends on its `leave_decompressed` API, which is not yet on `compressed-tensors/main`.

## Model-output validation

The unpruned local definition matches the original remote definition within FP16 accumulation-order tolerance (`atol=5e-3`, `rtol=2e-2`). The observed maximum absolute difference was `0.00390625`, with 10 differing values out of 655,360 logits at a stricter `1e-3` tolerance.

No downstream accuracy benchmark was run for the pruned checkpoint; the end-to-end run validates algorithm execution and structural pruning only.

## AI assistance

AI assistance was used to analyze issue #2979, implement the changes, write tests and the example, run validation, and draft this PR description. The human submitter will review every changed line and is responsible for understanding and defending the change before marking the PR ready for review.