### PR TITLE
Fix DDP race condition on HF cached_files

### DIFF
--- a/src/llmcompressor/utils/dev.py
+++ b/src/llmcompressor/utils/dev.py
@@ -32,15 +32,117 @@ __all__ = [
 ]
 
 
+# redundant conversion artifacts which transformers never loads, but which repos
+# commonly ship and which are expensive to fetch (ex. `original/consolidated.00.pth`
+# in Meta's Llama repos). Kept deliberately narrow: anything broader risks skipping
+# a file some checkpoint or custom modeling code genuinely needs
+_UNUSED_CHECKPOINT_PATTERNS = ["original/**"]
+
+
+@contextlib.contextmanager
+def download_checkpoint_first(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
+    """
+    Context manager which downloads a checkpoint on local rank zero before any rank
+    attempts to load it.
+
+    Ranks which populate and resolve the same hub cache concurrently can raise
+    `OSError: ... does not appear to have files named (...)` for shards which are
+    present on disk, because transformers resolves the cache through
+    `try_to_load_from_cache` while another rank is writing it.
+    See https://github.com/vllm-project/llm-compressor/issues/2984
+
+    Prefetching removes that overlap for the ranks of this job: none of them resolve
+    the cache until every downloader has finished. One downloader per node is
+    required for node-local caches, which would otherwise stay cold on every node
+    but one. Note that this does not protect against unrelated processes writing the
+    same cache concurrently, and that a cache shared across nodes still has one
+    downloader per node.
+
+    Assumes every rank receives the same arguments and sees the same filesystem, as
+    is the case for a torchrun job running one script. Ranks which disagree on
+    whether the checkpoint is a local directory would not reach the same collectives.
+
+    :param model_cls: The model class to patch, defaults to AutoModelForCausalLM
+    """
+    if (
+        not torch.distributed.is_initialized()
+        or torch.distributed.get_world_size() <= 1
+    ):
+        yield
+        return
+
+    original_from_pretrained = model_cls.from_pretrained
+
+    @classmethod
+    @wraps(original_from_pretrained)
+    def patched(cls, *args, **kwargs):
+        stub = args[0] if args else kwargs.get("pretrained_model_name_or_path")
+
+        # local checkpoints and offline loads never populate the hub cache. A
+        # missing stub is left for transformers to report
+        if stub is None or os.path.isdir(stub) or kwargs.get("local_files_only"):
+            return original_from_pretrained(*args, **kwargs)
+
+        # raises if the launcher did not set `LOCAL_RANK`, which is safer than
+        # assuming zero and starting a downloader on every rank
+        local_rank = torch.distributed.get_node_local_rank()
+
+        error = None
+        try:
+            if local_rank == 0:
+                snapshot_download(
+                    stub,
+                    revision=kwargs.get("revision"),
+                    cache_dir=kwargs.get("cache_dir"),
+                    token=kwargs.get("token"),
+                    force_download=kwargs.get("force_download", False),
+                    ignore_patterns=_UNUSED_CHECKPOINT_PATTERNS,
+                )
+        except Exception as exception:
+            error = exception
+
+        # nccl must reduce on the accelerator, gloo reduces on cpu
+        if torch.distributed.get_backend() == "nccl":
+            accelerator = torch.accelerator.current_accelerator(check_available=True)
+            if accelerator is None:
+                raise RuntimeError("NCCL backend requires an available accelerator")
+            device = torch.device(
+                accelerator.type, torch.accelerator.current_device_index()
+            )
+        else:
+            device = torch.device("cpu")
+
+        # synchronizes ranks and ensures that none of them load against a cache
+        # which a downloader failed to populate
+        succeeded = torch.tensor(error is None, dtype=torch.uint8, device=device)
+        torch.distributed.all_reduce(succeeded, op=torch.distributed.ReduceOp.MIN)
+        if not succeeded.item():
+            if error is not None:
+                raise error
+            raise RuntimeError(
+                "Checkpoint prefetch failed on another rank. See that rank's "
+                "traceback for the underlying error"
+            )
+
+        # the checkpoint is cached now, and re-downloading it on every rank would
+        # restore exactly the concurrency this context exists to remove
+        kwargs["force_download"] = False
+
+        return original_from_pretrained(*args, **kwargs)
+
+    with patch_attr(model_cls, "from_pretrained", patched):
+        yield
+
+
 @contextlib.contextmanager
 def load_context(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
     """
     Context manager for loading HuggingFace models with both offloading and
     MoE linearization support.
 
-    This context manager combines `load_offloaded_model` and `load_quantizable_moe`
-    contexts to provide a unified interface for loading models that may require
-    either or both capabilities.
+    This context manager combines `download_checkpoint_first`, `load_offloaded_model`
+    and `load_quantizable_moe` contexts to provide a unified interface for loading
+    models that may require any of those capabilities.
 
     :param model_cls: The model class to patch, defaults to AutoModelForCausalLM
     """
@@ -49,6 +151,8 @@ def load_context(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
     with contextlib.ExitStack() as stack:
         stack.enter_context(load_offloaded_model(model_cls))
         stack.enter_context(load_quantizable_moe(model_cls))
+        # entered last so that the checkpoint is fetched before any other patch runs
+        stack.enter_context(download_checkpoint_first(model_cls))
         yield
 
 

--- a/src/llmcompressor/utils/dev.py
+++ b/src/llmcompressor/utils/dev.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import os
+import re
 import tempfile
 from functools import wraps
 from typing import Type
@@ -8,7 +9,7 @@ from typing import Type
 import torch
 from compressed_tensors.offload import dispatch_model, load_offloaded_model
 from compressed_tensors.utils import deprecated, patch_attr
-from huggingface_hub import snapshot_download
+from huggingface_hub import HfApi, snapshot_download
 from loguru import logger
 from safetensors.torch import save_file
 from transformers import AutoModelForCausalLM, PreTrainedModel
@@ -32,15 +33,80 @@ __all__ = [
 ]
 
 
+# a 40-character hex string is already an immutable commit, so needs no resolving
+_COMMIT_HASH = re.compile(r"^[0-9a-f]{40}$")
+
+
+@contextlib.contextmanager
+def pin_checkpoint_revision(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
+    """
+    Context manager which resolves a symbolic revision to an immutable commit hash
+    before any rank loads the checkpoint.
+
+    `huggingface_hub` rewrites `refs/<revision>` on every `snapshot_download` where
+    the caller passes a symbolic revision such as `main`, using a non-atomic
+    truncate-then-write. Ranks resolving the same cache read that ref with a plain
+    `open`, so a rank landing inside the write window reads an empty string and
+    reports shards as missing even though they are present on disk. This happens on
+    an already-downloaded model, since the ref is rewritten whether or not anything
+    needs fetching. See https://github.com/vllm-project/llm-compressor/issues/2984
+
+    Loading by commit hash avoids the write entirely, because `snapshot_download`
+    only touches the ref when `revision != commit_hash`. The revision is resolved
+    once and broadcast so that ranks cannot pin different commits if the branch moves
+    between resolutions.
+
+    :param model_cls: The model class to patch, defaults to AutoModelForCausalLM
+    """
+    if (
+        not torch.distributed.is_initialized()
+        or torch.distributed.get_world_size() <= 1
+    ):
+        yield
+        return
+
+    original_from_pretrained = model_cls.from_pretrained
+
+    @classmethod
+    @wraps(original_from_pretrained)
+    def patched(cls, *args, **kwargs):
+        stub = args[0] if args else kwargs.get("pretrained_model_name_or_path")
+        revision = kwargs.get("revision")
+
+        # local checkpoints have no hub cache, and a commit hash is already immutable
+        if stub is None or os.path.isdir(stub) or _COMMIT_HASH.match(revision or ""):
+            return original_from_pretrained(*args, **kwargs)
+
+        # resolved once and shared, so that ranks cannot pin different commits
+        commit = [None]
+        if torch.distributed.get_rank() == 0:
+            with contextlib.suppress(Exception):
+                api = HfApi(token=kwargs.get("token"))
+                commit[0] = api.model_info(stub, revision=revision).sha
+        torch.distributed.broadcast_object_list(commit, src=0)
+
+        if commit[0] is None:
+            # offline, gated, or otherwise unresolvable: leave the revision alone and
+            # let transformers report whatever the underlying problem is
+            logger.warning(f"Could not resolve a commit hash for {stub}")
+        else:
+            kwargs["revision"] = commit[0]
+
+        return original_from_pretrained(*args, **kwargs)
+
+    with patch_attr(model_cls, "from_pretrained", patched):
+        yield
+
+
 @contextlib.contextmanager
 def load_context(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
     """
     Context manager for loading HuggingFace models with both offloading and
     MoE linearization support.
 
-    This context manager combines `load_offloaded_model` and `load_quantizable_moe`
-    contexts to provide a unified interface for loading models that may require
-    either or both capabilities.
+    This context manager combines `pin_checkpoint_revision`, `load_offloaded_model`
+    and `load_quantizable_moe` contexts to provide a unified interface for loading
+    models that may require any of those capabilities.
 
     :param model_cls: The model class to patch, defaults to AutoModelForCausalLM
     """
@@ -49,6 +115,8 @@ def load_context(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
     with contextlib.ExitStack() as stack:
         stack.enter_context(load_offloaded_model(model_cls))
         stack.enter_context(load_quantizable_moe(model_cls))
+        # entered last so the revision is pinned before any other patch resolves it
+        stack.enter_context(pin_checkpoint_revision(model_cls))
         yield
 
 

--- a/tests/llmcompressor/utils/test_dev.py
+++ b/tests/llmcompressor/utils/test_dev.py
@@ -1,0 +1,172 @@
+import contextlib
+from functools import wraps
+from unittest.mock import patch
+
+import pytest
+import torch
+from compressed_tensors.utils import patch_attr
+
+from llmcompressor.utils.dev import load_context, pin_checkpoint_revision
+
+STUB = "nm-testing/tinysmokellama-3.2"
+SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+class DummyModel:
+    """Stands in for a `PreTrainedModel` so that no checkpoint is actually loaded."""
+
+    calls: list = []
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        cls.calls.append((args, kwargs))
+
+
+@contextlib.contextmanager
+def distributed(world_size=2, initialized=True, rank=0, resolved=SHA):
+    """Patches distributed and the hub so no network or process group is needed."""
+    DummyModel.calls.clear()
+
+    def broadcast_object_list(obj, src=0):
+        obj[0] = resolved  # what rank `src` resolved, as seen by every rank
+
+    api = patch("llmcompressor.utils.dev.HfApi")
+    with (
+        api as hf_api,
+        patch.object(
+            torch.distributed,
+            "broadcast_object_list",
+            side_effect=broadcast_object_list,
+        ) as broadcast,
+        patch.object(torch.distributed, "is_initialized", return_value=initialized),
+        patch.object(torch.distributed, "get_world_size", return_value=world_size),
+        patch.object(torch.distributed, "get_rank", return_value=rank),
+    ):
+        hf_api.return_value.model_info.return_value.sha = SHA
+        yield hf_api, broadcast
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("initialized,world_size", [(False, 2), (True, 1)])
+def test_noop_without_multi_rank_distributed(initialized, world_size):
+    with distributed(world_size, initialized) as (hf_api, broadcast):
+        with pin_checkpoint_revision(DummyModel):
+            DummyModel.from_pretrained(STUB)
+
+    hf_api.assert_not_called()
+    broadcast.assert_not_called()
+    assert DummyModel.calls[0][1].get("revision") is None
+
+
+@pytest.mark.unit
+def test_rank_zero_resolves_and_load_uses_the_commit():
+    with distributed(rank=0) as (hf_api, broadcast):
+        with pin_checkpoint_revision(DummyModel):
+            DummyModel.from_pretrained(STUB, token="hf_secret")
+
+    hf_api.assert_called_once_with(token="hf_secret")
+    hf_api.return_value.model_info.assert_called_once_with(STUB, revision=None)
+    broadcast.assert_called_once()
+    assert DummyModel.calls[0][1]["revision"] == SHA
+
+
+@pytest.mark.unit
+def test_other_ranks_take_the_broadcast_commit_without_resolving():
+    """Only rank zero queries the hub, so the branch cannot move between ranks."""
+    with distributed(rank=1) as (hf_api, broadcast):
+        with pin_checkpoint_revision(DummyModel):
+            DummyModel.from_pretrained(STUB)
+
+    hf_api.assert_not_called()
+    broadcast.assert_called_once()
+    assert DummyModel.calls[0][1]["revision"] == SHA
+
+
+@pytest.mark.unit
+def test_symbolic_revision_is_replaced():
+    with distributed(rank=0) as (hf_api, _):
+        with pin_checkpoint_revision(DummyModel):
+            DummyModel.from_pretrained(STUB, revision="my-branch")
+
+    hf_api.return_value.model_info.assert_called_once_with(STUB, revision="my-branch")
+    assert DummyModel.calls[0][1]["revision"] == SHA
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "kwargs", [{"revision": SHA}, {}, {"pretrained_model_name_or_path": None}]
+)
+def test_skips_when_there_is_nothing_to_resolve(kwargs, tmp_path):
+    """A commit hash is already immutable, local dirs have no hub cache, and a
+    missing stub is left for transformers to report."""
+    args = (
+        ()
+        if "pretrained_model_name_or_path" in kwargs
+        else ((STUB,) if kwargs else (str(tmp_path),))
+    )
+    with distributed(rank=0) as (hf_api, broadcast):
+        with pin_checkpoint_revision(DummyModel):
+            DummyModel.from_pretrained(*args, **kwargs)
+
+    hf_api.assert_not_called()
+    broadcast.assert_not_called()
+    assert len(DummyModel.calls) == 1
+
+
+@pytest.mark.unit
+def test_unresolvable_revision_loads_unpinned():
+    """Offline or gated repos should surface their own error, not ours."""
+    with distributed(rank=0, resolved=None) as (hf_api, broadcast):
+        hf_api.return_value.model_info.side_effect = OSError("offline")
+        with pin_checkpoint_revision(DummyModel):
+            DummyModel.from_pretrained(STUB, revision="main")
+
+    broadcast.assert_called_once()
+    assert DummyModel.calls[0][1]["revision"] == "main"
+
+
+@pytest.mark.unit
+def test_restores_from_pretrained():
+    original = DummyModel.__dict__["from_pretrained"]
+    with distributed():
+        with pin_checkpoint_revision(DummyModel):
+            assert DummyModel.__dict__["from_pretrained"] is not original
+
+    assert DummyModel.__dict__["from_pretrained"] is original
+
+
+@pytest.mark.unit
+def test_load_context_pins_before_inner_patches():
+    """`pin_checkpoint_revision` must be the outermost patch, so the inner contexts
+    resolve the config and estimate tensors against the pinned commit."""
+    order = []
+
+    def recorder(name):
+        @contextlib.contextmanager
+        def stub(model_cls=DummyModel):
+            original = model_cls.from_pretrained
+
+            @classmethod
+            @wraps(original)
+            def patched(cls, *args, **kwargs):
+                order.append((name, kwargs.get("revision")))
+                return original(*args, **kwargs)
+
+            with patch_attr(model_cls, "from_pretrained", patched):
+                yield
+
+        return stub
+
+    with distributed(rank=0):
+        with (
+            patch("llmcompressor.utils.dev.load_offloaded_model", recorder("offload")),
+            patch(
+                "llmcompressor.modeling.moe.linearize.load_quantizable_moe",
+                recorder("moe"),
+            ),
+            load_context(DummyModel),
+        ):
+            DummyModel.from_pretrained(STUB)
+
+    # both inner patches must already see the pinned commit
+    assert order == [("moe", SHA), ("offload", SHA)]

--- a/tests/llmcompressor/utils/test_dev.py
+++ b/tests/llmcompressor/utils/test_dev.py
@@ -1,0 +1,228 @@
+import contextlib
+import os
+from functools import wraps
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from compressed_tensors.utils import patch_attr
+
+from llmcompressor.utils.dev import download_checkpoint_first, load_context
+
+STUB = "nm-testing/tinysmokellama-3.2"
+
+
+class DummyModel:
+    """Stands in for a `PreTrainedModel` so that no checkpoint is actually loaded."""
+
+    calls: list = []
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        cls.calls.append((args, kwargs))
+
+
+@contextlib.contextmanager
+def distributed(world_size=2, initialized=True, local_rank="0", peer_failed=False):
+    DummyModel.calls.clear()
+
+    def all_reduce(tensor, op=None):
+        if peer_failed:
+            tensor.fill_(0)
+
+    with (
+        patch("llmcompressor.utils.dev.snapshot_download") as download,
+        patch.object(torch.distributed, "all_reduce", side_effect=all_reduce) as reduce,
+        patch.object(torch.distributed, "get_backend", return_value="gloo"),
+        patch.object(torch.distributed, "is_initialized", return_value=initialized),
+        patch.object(torch.distributed, "get_world_size", return_value=world_size),
+        patch.dict(os.environ, {"LOCAL_RANK": local_rank}),
+    ):
+        yield download, reduce
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("initialized,world_size", [(False, 2), (True, 1)])
+def test_noop_without_multi_rank_distributed(initialized, world_size):
+    with distributed(world_size, initialized) as (download, reduce):
+        with download_checkpoint_first(DummyModel):
+            DummyModel.from_pretrained(STUB)
+
+    download.assert_not_called()
+    reduce.assert_not_called()
+    assert len(DummyModel.calls) == 1
+
+
+@pytest.mark.unit
+def test_local_rank_zero_downloads_and_forwards_arguments():
+    with distributed(local_rank="0") as (download, reduce):
+        with download_checkpoint_first(DummyModel):
+            DummyModel.from_pretrained(
+                STUB, revision="abc123", cache_dir="/custom/cache", token="hf_secret"
+            )
+
+    assert download.call_args.args == (STUB,)
+    assert download.call_args.kwargs["revision"] == "abc123"
+    assert download.call_args.kwargs["cache_dir"] == "/custom/cache"
+    assert download.call_args.kwargs["token"] == "hf_secret"
+    reduce.assert_called_once()
+
+    # the load must target the same revision and cache as the prefetch
+    _, load_kwargs = DummyModel.calls[0]
+    assert load_kwargs["revision"] == "abc123"
+    assert load_kwargs["cache_dir"] == "/custom/cache"
+
+
+@pytest.mark.unit
+def test_other_ranks_wait_without_downloading():
+    with distributed(local_rank="1") as (download, reduce):
+        with download_checkpoint_first(DummyModel):
+            DummyModel.from_pretrained(STUB)
+
+    download.assert_not_called()
+    reduce.assert_called_once()
+    assert len(DummyModel.calls) == 1
+
+
+@pytest.mark.unit
+def test_force_download_is_disabled_after_prefetch():
+    """Otherwise every rank re-downloads after the collective, restoring the race."""
+    with distributed(local_rank="0") as (download, _):
+        with download_checkpoint_first(DummyModel):
+            DummyModel.from_pretrained(STUB, force_download=True)
+
+    assert download.call_args.kwargs["force_download"] is True
+    assert DummyModel.calls[0][1]["force_download"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "kwargs", [{"local_files_only": True}, {}, {"pretrained_model_name_or_path": None}]
+)
+def test_skips_when_cache_is_not_populated(kwargs, tmp_path):
+    """Local directories, offline loads and a missing stub never write to the hub
+    cache. The last is left for transformers to report."""
+    args = (
+        ()
+        if "pretrained_model_name_or_path" in kwargs
+        else ((STUB,) if kwargs else (str(tmp_path),))
+    )
+    with distributed(local_rank="0") as (download, reduce):
+        with download_checkpoint_first(DummyModel):
+            DummyModel.from_pretrained(*args, **kwargs)
+
+    download.assert_not_called()
+    reduce.assert_not_called()
+    assert len(DummyModel.calls) == 1
+
+
+@pytest.mark.unit
+def test_downloader_failure_propagates_and_blocks_the_load():
+    with distributed(local_rank="0", peer_failed=True) as (download, reduce):
+        download.side_effect = OSError("gated repo")
+        with download_checkpoint_first(DummyModel):
+            with pytest.raises(OSError, match="gated repo"):
+                DummyModel.from_pretrained(STUB)
+
+    reduce.assert_called_once()
+    assert len(DummyModel.calls) == 0
+
+
+@pytest.mark.unit
+def test_peer_failure_blocks_the_load():
+    """A rank whose own download succeeded must not load against a partial cache."""
+    with distributed(local_rank="1", peer_failed=True) as (_, reduce):
+        with download_checkpoint_first(DummyModel):
+            with pytest.raises(RuntimeError, match="failed on another rank"):
+                DummyModel.from_pretrained(STUB)
+
+    reduce.assert_called_once()
+    assert len(DummyModel.calls) == 0
+
+
+@pytest.mark.unit
+def test_nccl_reduces_on_the_accelerator():
+    """gloo reduces on cpu, but nccl requires the flag to live on the device."""
+    flag = MagicMock()
+    flag.item.return_value = 1
+
+    with (
+        distributed(local_rank="1"),
+        patch.object(torch.distributed, "get_backend", return_value="nccl"),
+        (
+            patch.object(
+                torch.accelerator,
+                "current_accelerator",
+                return_value=torch.device("cuda"),
+            )
+        ),
+        patch.object(torch.accelerator, "current_device_index", return_value=3),
+        patch.object(torch, "tensor", return_value=flag) as tensor,
+    ):
+        with download_checkpoint_first(DummyModel):
+            DummyModel.from_pretrained(STUB)
+
+    assert tensor.call_args.kwargs["device"] == torch.device("cuda", 3)
+    assert len(DummyModel.calls) == 1
+
+
+@pytest.mark.unit
+def test_missing_local_rank_raises_rather_than_downloading_everywhere():
+    with distributed() as (download, reduce):
+        with patch.dict(os.environ):
+            os.environ.pop("LOCAL_RANK", None)
+            with download_checkpoint_first(DummyModel):
+                with pytest.raises(RuntimeError, match="LOCAL_RANK"):
+                    DummyModel.from_pretrained(STUB)
+
+    download.assert_not_called()
+    reduce.assert_not_called()
+    assert len(DummyModel.calls) == 0
+
+
+@pytest.mark.unit
+def test_restores_from_pretrained():
+    original = DummyModel.__dict__["from_pretrained"]
+    with distributed():
+        with download_checkpoint_first(DummyModel):
+            assert DummyModel.__dict__["from_pretrained"] is not original
+
+    assert DummyModel.__dict__["from_pretrained"] is original
+
+
+@pytest.mark.unit
+def test_load_context_downloads_before_inner_patches():
+    """`download_checkpoint_first` must be the outermost patch, so the checkpoint is
+    fetched before `load_offloaded_model` estimates tensor counts and before
+    `load_quantizable_moe` resolves the config."""
+    order = []
+
+    def recorder(name):
+        @contextlib.contextmanager
+        def stub(model_cls=DummyModel):
+            original = model_cls.from_pretrained
+
+            @classmethod
+            @wraps(original)
+            def patched(cls, *args, **kwargs):
+                order.append(name)
+                return original(*args, **kwargs)
+
+            with patch_attr(model_cls, "from_pretrained", patched):
+                yield
+
+        return stub
+
+    with distributed(local_rank="0") as (download, _):
+        download.side_effect = lambda *a, **k: order.append("download")
+        with (
+            patch("llmcompressor.utils.dev.load_offloaded_model", recorder("offload")),
+            patch(
+                "llmcompressor.modeling.moe.linearize.load_quantizable_moe",
+                recorder("moe"),
+            ),
+            load_context(DummyModel),
+        ):
+            DummyModel.from_pretrained(STUB)
+
+    assert order == ["download", "moe", "offload"]


### PR DESCRIPTION
SUMMARY:

Fixes #2984.

Ranks loading an **already-downloaded** checkpoint fail with `does not appear to have a file named <shard>` for shards that are present on disk.

`huggingface_hub` rewrites `refs/<revision>` on every `snapshot_download` where the caller passes a symbolic revision, which is what transformers does. The write is a non-atomic truncate-then-write, and it is unconditional, so it runs even when the cache is fully populated and nothing needs fetching:

```python
if revision != commit_hash:                 # _snapshot_download.py
    with open(ref_path, "w") as f:
        f.write(commit_hash)
```

`try_to_load_from_cache` reads that ref with a plain `open`. A rank landing inside the window reads an empty string, fails the `revision not in cached_shas` check, and reports the shard missing. With N ranks each rewriting the ref while the others resolve, spurious missing shards are reliable.

**Fix:** resolve the symbolic revision to a commit hash before loading. `snapshot_download` only touches the ref when `revision != commit_hash`, so loading by hash skips the write entirely. The revision is resolved once and broadcast, so ranks cannot pin different commits if the branch moves between resolutions.

Entered last in `load_context`'s `ExitStack` so it is the outermost patch and the inner contexts resolve against the pinned commit. All 11 DDP examples already go through `load_context`, so no example changes were needed.

Note this is a downstream mitigation. The real fix belongs in `huggingface_hub`, whose `file_download.py` already writes this ref atomically via `_cache_commit_hash_for_specific_revision`; `_snapshot_download` keeps a second inline writer that did not get the same hardening in huggingface_hub#4306. Still present on their `main`. I intend to open that PR too.

Known limitations, happy to address any of them:

- Only covers callers that go through `load_context`.
- If the revision cannot be resolved (offline, gated, no network) it warns and loads unpinned rather than failing, so the race returns in that case.
- Adds one hub API call per load on rank zero, even for a fully cached model.

TEST PLAN:

`tests/llmcompressor/utils/test_dev.py`, 11 cases, mock-based and GPU-free: no-op when single-rank or uninitialized, rank zero resolving and the load using the commit, peers taking the broadcast value without querying the hub, symbolic branches being replaced, skipping when the revision is already a hash / the path is a local dir / the stub is missing, unresolvable revisions loading unpinned, `from_pretrained` restored on exit, and the `ExitStack` ordering.

```
$ pytest tests/llmcompressor/utils/test_dev.py -v
11 passed
```

Reproduction of the underlying race, against a warm cache with no downloads in the measured window, 96 shards, 4 writer and 4 reader processes (script in #2984):

| revision passed | spurious misses | resolution passes |
|---|---|---|
| `"main"` | **7946** | 7033 |
| commit sha | **0** | 7294 |

End-to-end over 2 gloo ranks, recording what revision actually reaches `huggingface_hub`:

```
with the fix:     ['d1abfb7465f27fd86fccb14bcb42e9145ba55d4c']  pinned: True   (both ranks)
without the fix:  ['None', 'main']                              pinned: False  (both ranks)
```

