### PR TITLE
docs: drop deprecated reindex_fused_weights step from model-free PTQ guides

### DIFF
--- a/docs/guides/entrypoints/model-free-ptq.md
+++ b/docs/guides/entrypoints/model-free-ptq.md
@@ -77,24 +77,13 @@ model_free_ptq(
 
 ## Microscale Flow (NVFP4)
 
-NVFP4 requires a **global scale** that is fused across related weight groups (e.g. qkv projections, gate/up projections). For this fusion to work correctly, the weights of each fused group must reside in the **same safetensors shard**.
-
-Standard model checkpoints often split these weights across different shards. To fix this, run the `reindex_fused_weights` CLI tool first to reorganize the checkpoint:
-
-```bash
-llmcompressor.reindex_fused_weights \
-    unsloth/Kimi-K2-Thinking-BF16 \
-    Kimi-K2-Thinking-BF16-reindexed \
-    --num_workers=10
-```
-
-Then run `model_free_ptq` on the reindexed checkpoint:
+NVFP4 requires a **global scale** that is fused across related weight groups (e.g. qkv projections, gate/up projections). `model_free_ptq` handles this fusion directly, so no preprocessing step is required — run it just like the block/tensor schemes above:
 
 ```python
 from llmcompressor import model_free_ptq
 
 model_free_ptq(
-    model_stub="Kimi-K2-Thinking-BF16-reindexed",
+    model_stub="unsloth/Kimi-K2-Thinking-BF16",
     save_directory="Kimi-K2-Thinking-NVFP4A16",
     scheme="NVFP4A16",
     ignore=[
@@ -108,9 +97,6 @@ model_free_ptq(
     device="cuda:0",
 )
 ```
-
-!!! note
-    Reindexing is only required for **NVFP4**, which uses a global scale. MXFP4 does not use a global scale and does not require reindexing.
 
 ## Ignoring Layers
 

--- a/docs/guides/entrypoints/model-free-ptq.md
+++ b/docs/guides/entrypoints/model-free-ptq.md
@@ -77,7 +77,7 @@ model_free_ptq(
 
 ## Microscale Flow (NVFP4)
 
-NVFP4 requires a **global scale** that is fused across related weight groups (e.g. qkv projections, gate/up projections). `model_free_ptq` handles this fusion directly, so no preprocessing step is required — run it just like the block/tensor schemes above:
+NVFP4 requires a **global scale** that is fused across related weight groups (e.g. qkv projections, gate/up projections). `model_free_ptq` handles this fusion directly, so no preprocessing step is required — run it just like the non-microscale schemes above:
 
 ```python
 from llmcompressor import model_free_ptq

--- a/examples/model_free_ptq/README.md
+++ b/examples/model_free_ptq/README.md
@@ -36,7 +36,7 @@ model_free_ptq(
 
 # Quantizing models to NVFP4A16/ MXFP4A16
 
-Using model_free_ptq to quantize models with microscale schemes (NVFP4/MXFP4) is the same as quantizing models with non-microscale schemes. `model_free_ptq` fuses the global scales across fused modules (qkv, gate_up) directly, so no additional reindexing step is required.
+Using `model_free_ptq` to quantize models with microscale schemes (NVFP4/MXFP4) is the same as quantizing models with non-microscale schemes. `model_free_ptq` fuses the global scales across fused modules (qkv, gate_up) directly, so no additional reindexing step is required.
 
 Call `model_free_ptq` with a microscale scheme:
 ```python

--- a/examples/model_free_ptq/README.md
+++ b/examples/model_free_ptq/README.md
@@ -36,20 +36,12 @@ model_free_ptq(
 
 # Quantizing models to NVFP4A16/ MXFP4A16
 
-Using model_free_ptq to quantize models with microscale schemes (NVFP4/MXFP4) is the same as quantizing models with non-microscale schemes, except for one additional step. That extra step is that the safetensors in the model files must be reindexed to ensure that fused modules (qkv, gate_up) end up in the same safetensors files, which allows model_free_ptq to fuse global scales.
+Using model_free_ptq to quantize models with microscale schemes (NVFP4/MXFP4) is the same as quantizing models with non-microscale schemes. `model_free_ptq` fuses the global scales across fused modules (qkv, gate_up) directly, so no additional reindexing step is required.
 
-First, apply `llmcompressor.reindex_fused_weights` from the command line entrypoint
-```bash
-llmcompressor.reindex_fused_weights \
-    unsloth/Kimi-K2-Thinking-BF16 \
-    Kimi-K2-Thinking-BF16-reindexed \
-    --num_workers=10
-```
-
-Then, call `model_free_ptq` on the reindex files
+Call `model_free_ptq` with a microscale scheme:
 ```python
 model_free_ptq(
-    model_stub="Kimi-K2-Thinking-BF16-reindexed",
+    model_stub="unsloth/Kimi-K2-Thinking-BF16",
     save_directory="Kimi-K2-Thinking-BF16-NVFP4A16",
     scheme="NVFP4A16",
     ignore=[


### PR DESCRIPTION
SUMMARY:
The NVFP4/microscale sections of the model-free PTQ guides walk users through a broken flow:

```bash
llmcompressor.reindex_fused_weights unsloth/Kimi-K2-Thinking-BF16 Kimi-K2-Thinking-BF16-reindexed --num_workers=10
```
```python
model_free_ptq(model_stub="Kimi-K2-Thinking-BF16-reindexed", ...)
```

But `reindex_fused_weights` is `@deprecated` and a no-op — its entire body is a single `logger.warning(...)`:

```python
@deprecated(
    "The reindex_fused_weights preprocessing step is no longer necessary. "
    "model_free_ptq now handles fused weights directly without requiring reindexing."
)
def reindex_fused_weights(model_stub, save_directory, num_workers=5):
    logger.warning("reindex_fused_weights is deprecated and does nothing. ...")
```

Because it writes nothing, the `Kimi-K2-Thinking-BF16-reindexed` directory is never created, so the very next step — `model_free_ptq(model_stub="Kimi-K2-Thinking-BF16-reindexed", ...)` — points at a path that does not exist. (`setup.py` even comments the entrypoint as `# reindex_fused_weights is deprecated`.)

This PR follows the code’s own deprecation message: remove the dead reindex step, call `model_free_ptq` directly on the original `unsloth/Kimi-K2-Thinking-BF16` stub, and drop the now-obsolete "reindexing is only required for NVFP4" note. Touches:
- `docs/guides/entrypoints/model-free-ptq.md`
- `examples/model_free_ptq/README.md`

TEST PLAN:
Docs-only; no code paths change. Verified in-source that `reindex_fused_weights` is `@deprecated` with a `logger.warning`-only body (writes no output directory), and that its deprecation message + docstring state `model_free_ptq` now handles fused weights directly. The corrected snippets pass the original `unsloth/Kimi-K2-Thinking-BF16` stub straight to `model_free_ptq`, which is the flow the deprecation message prescribes. Confirmed no remaining `reindex`/`-reindexed` references in either file.