### PR TITLE
Let AWQ mappings absorb scales into a sliced projection

### DIFF
--- a/src/llmcompressor/modifiers/transform/awq/__init__.py
+++ b/src/llmcompressor/modifiers/transform/awq/__init__.py
@@ -10,5 +10,6 @@ __all__ = [
     "get_layer_mappings_from_model",
     "AWQMapping",
     "AWQ_MAPPING_REGISTRY",
+    "SlicedSmoothTarget",
     "default_mappings",
 ]

--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -38,6 +38,7 @@ from llmcompressor.modifiers.transform.awq.dynamic_mappings import (
 from llmcompressor.modifiers.transform.awq.mappings import (
     AWQMapping,
     ResolvedMapping,
+    SlicedSmoothTarget,
 )
 from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.modifiers.utils.pytorch_helpers import is_moe_model
@@ -366,6 +367,28 @@ class AWQModifier(Modifier):
                             f" not found on parent module '{ancestor_name}'"
                         )
 
+                extra_smooth_targets = []
+                if mapping.extra_smooth_targets:
+                    # Resolved against the module holding smooth_layer, not against
+                    # the balance layers' ancestor: in an AdaLN block the balance
+                    # layers sit under `attn` / `ff` while the shared modulation
+                    # projection is a sibling of the norm, one level up.
+                    smooth_parent_name = smooth_name.rpartition(".")[0]
+                    smooth_parent = (
+                        model.get_submodule(smooth_parent_name)
+                        if smooth_parent_name
+                        else model
+                    )
+                    for target in mapping.extra_smooth_targets:
+                        module = getattr_chain(smooth_parent, target.layer)
+                        if module is None:
+                            raise ValueError(
+                                f"extra_smooth_target '{target.layer}' not found on "
+                                f"'{smooth_parent_name or type(model).__name__}', the "
+                                f"module holding smooth layer '{smooth_name}'"
+                            )
+                        extra_smooth_targets.append((module, target))
+
                 resolved_mappings.append(
                     ResolvedMapping(
                         smooth_name,
@@ -375,6 +398,7 @@ class AWQModifier(Modifier):
                         parent=ancestor,
                         parent_name=ancestor_name,
                         activation_hook_target=activation_hook_target,
+                        extra_smooth_targets=extra_smooth_targets,
                     )
                 )
         if num_incompatible > 0:
@@ -495,6 +519,9 @@ class AWQModifier(Modifier):
             smooth_layer = mapping.smooth_layer
             balance_layers = mapping.balance_layers
             parent_module = mapping.parent
+            extra_smooth_modules = [
+                module for module, _ in mapping.extra_smooth_targets
+            ]
 
             # pin memory for faster onloading during grid search
             # pinned memory in cache is deleted before next mapping is pinned
@@ -503,7 +530,14 @@ class AWQModifier(Modifier):
                 cache.pin_memory(batch_index)
 
             with (
-                align_modules([parent_module, smooth_layer, *balance_layers]),
+                align_modules(
+                    [
+                        parent_module,
+                        smooth_layer,
+                        *balance_layers,
+                        *extra_smooth_modules,
+                    ]
+                ),
                 calibration_forward_context(model),
                 HooksMixin.disable_hooks(),
             ):
@@ -580,6 +614,10 @@ class AWQModifier(Modifier):
                 for layer in balance_layers:
                     _smooth(layer, orig_layer_weights)
                 _smooth(smooth_layer, orig_layer_weights)
+                for module, target in mapping.extra_smooth_targets:
+                    absorb_sliced_scales(
+                        module, target, best_scales.to(module.weight.device)
+                    )
 
                 # remove caches needed to smooth this mapping
                 del self._smooth_activation_stats[mapping.smooth_name]
@@ -966,6 +1004,57 @@ class AWQModifier(Modifier):
         if v not in (True, False, "both"):
             raise ValueError(f"duo_scaling must be True, False, or 'both', got {v!r}")
         return v
+
+
+@torch.no_grad()
+def absorb_sliced_scales(
+    module: Module,
+    target: SlicedSmoothTarget,
+    scales: torch.Tensor,
+) -> None:
+    """
+    Absorb ``1/scales`` into the rows of ``module`` that emit ``target``'s chunk.
+
+    Used for AdaLN-modulated blocks, where the balance layers' input is
+    ``norm(x) * (1 + scale) + shift`` and ``shift`` is a slice of a shared
+    projection's output. Dividing ``norm.weight`` handles the
+    ``norm(x) * (1 + scale)`` term, and this function handles ``shift``, which
+    together make the smoothing exactly output preserving.
+
+    Unlike the fused-qkv case in ``_apply_smoothing``, the rows cannot be taken
+    from the end of the weight: the chunk sits at a known offset inside the output
+    and is tiled ``target.repeat`` times across it.
+
+    :param module: the projection to slice
+    :param target: which chunk of the projection's output to scale
+    :param scales: per-channel smoothing scales, already on ``module``'s device
+    """
+    hidden = scales.size(0)
+    group = target.num_chunks * hidden
+    expected = group * target.repeat
+    if module.weight.size(0) != expected:
+        raise ValueError(
+            f"extra_smooth_target '{target.layer}' expects {expected} out_features "
+            f"({target.num_chunks} chunks of {hidden} x {target.repeat} repeats) "
+            f"but the module has {module.weight.size(0)}"
+        )
+    if not 0 <= target.chunk_index < target.num_chunks:
+        raise ValueError(
+            f"chunk_index {target.chunk_index} out of range for "
+            f"num_chunks {target.num_chunks}"
+        )
+
+    weight = module.weight
+    bias = getattr(module, "bias", None)
+    for group_index in range(target.repeat):
+        start = group_index * group + target.chunk_index * hidden
+        stop = start + hidden
+        weight[start:stop].div_(scales.view(-1, 1))
+        if bias is not None:
+            bias[start:stop].div_(scales)
+    update_offload_parameter(module, "weight", weight)
+    if bias is not None:
+        update_offload_parameter(module, "bias", bias)
 
 
 def _check_layers_are_compatible(

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -1,12 +1,50 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from torch.nn import Module
 
 __all__ = [
     "AWQMapping",
     "AWQ_MAPPING_REGISTRY",
+    "SlicedSmoothTarget",
     "default_mappings",
 ]
+
+
+@dataclass
+class SlicedSmoothTarget:
+    """
+    A contiguous row slice of another linear's output that co-produces the input
+    of the balance layers, and therefore has to absorb ``1/s`` alongside
+    ``AWQMapping.smooth_layer``.
+
+    Needed by AdaLN-modulated blocks, where the balance layers see
+
+        norm(x) * (1 + scale) + shift
+
+    and ``scale`` / ``shift`` are slices of one shared projection's output rather
+    than modules of their own. Only the ``shift`` slice takes ``1/s``: dividing
+    ``norm.weight`` already scales the ``norm(x) * (1 + scale)`` term, so scaling
+    ``scale`` too would double-apply it.
+
+    The projection's output is read as ``repeat`` consecutive groups of
+    ``num_chunks`` equally sized chunks -- the layout produced by a
+    ``view(-1, num_chunks * hidden_size)`` followed by ``chunk(num_chunks, -1)``
+    -- and this target names chunk ``chunk_index`` of every group.
+
+    :param layer: dotted attribute path of the projection to slice, relative to the
+        module holding ``AWQMapping.smooth_layer``. Not relative to the balance
+        layers' ancestor: in an AdaLN block the balance layers sit under ``attn`` or
+        ``ff`` while the shared modulation projection is a sibling of the norm.
+    :param chunk_index: which chunk of each group this target names
+    :param num_chunks: number of chunks per group
+    :param repeat: number of groups, i.e. how many times the chunk layout is
+        tiled across the output features
+    """
+
+    layer: str
+    chunk_index: int
+    num_chunks: int
+    repeat: int = 1
 
 
 @dataclass
@@ -29,11 +67,16 @@ class AWQMapping:
         blocks (e.g. Cohere, Gemma 3) where the first balance layer is not the
         correct place to capture activations. When ``None`` (default), the hook
         is placed on ``balance_layers[0]``.
+    :param extra_smooth_targets: optional row slices of other layers that also
+        produce the balance layers' input and must absorb ``1/s`` together with
+        ``smooth_layer``. Empty for every architecture whose balance-layer input
+        comes from a single module.
     """
 
     smooth_layer: str
     balance_layers: list[str]
     activation_hook_target: str | None = None
+    extra_smooth_targets: list[SlicedSmoothTarget] = field(default_factory=list)
 
 
 default_mappings = [
@@ -269,6 +312,42 @@ _example_parallel_transformer_block_mappings = [
     )
 ]
 
+# MiniMax-H3's joint video/audio diffusion transformer. Its blocks are pre-norm
+# attention and feed-forward, each modulated by AdaLN parameters that one shared
+# `adaln_proj` emits for every (timestep, modality) pair, so the balance layers'
+# input is produced by `norm1`/`norm2` and a slice of `adaln_proj` together.
+# `adaln_proj` emits 6 * hidden_size * MODALITY_NUM features in the order
+# shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp, tiled once per
+# modality, hence chunks 0 and 3 with num_chunks=6 and repeat=3. The gates modulate
+# the branch outputs rather than their inputs and take no part in smoothing.
+_minimax_h3_mappings = [
+    AWQMapping(
+        "re:.*norm1$",
+        ["re:.*attn.to_q$", "re:.*attn.to_k$", "re:.*attn.to_v$"],
+        extra_smooth_targets=[
+            SlicedSmoothTarget(
+                "adaln_proj.linear", chunk_index=0, num_chunks=6, repeat=3
+            )
+        ],
+    ),
+    AWQMapping("re:.*attn.to_v$", ["re:.*attn.to_out.0$"]),
+    AWQMapping(
+        "re:.*norm2$",
+        ["re:.*ff.net.0.proj$"],
+        extra_smooth_targets=[
+            SlicedSmoothTarget(
+                "adaln_proj.linear", chunk_index=3, num_chunks=6, repeat=3
+            )
+        ],
+    ),
+    # No `ff.net.0.proj -> ff.net.2` mapping on purpose. That projection is a fused
+    # SwiGLU, and `_apply_smoothing` folds `1/s` into a smooth linear's *last*
+    # out_features, which here are the gate half. The block output is not linear in
+    # the gate, so that fold would not be equivalence-preserving. Smoothing the up
+    # half needs a sliced target on the smooth side, which this mapping type does
+    # not express yet.
+]
+
 AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "AfmoeForCausalLM": _afmoe_mappings,
     "BloomForCausalLM": _bloom_mappings,
@@ -301,6 +380,7 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Qwen3MoeForCausalLM": _moe_default_mappings,
     "SeedOssForCausalLM": default_mappings,
     "Ernie4_5_MoeForCausalLM": default_mappings,
+    "MiniMaxH3Transformer3DModel": _minimax_h3_mappings,
 }
 
 
@@ -321,6 +401,9 @@ class ResolvedMapping:
         caching. When set, the activation cache hook is placed on this module
         instead of ``balance_layers[0]``. Populated from
         ``AWQMapping.activation_hook_target``.
+    :param extra_smooth_targets: resolved ``(module, SlicedSmoothTarget)`` pairs whose
+        row slices must absorb ``1/s`` together with ``smooth_layer``. Populated from
+        ``AWQMapping.extra_smooth_targets``.
     """
 
     smooth_name: str
@@ -330,3 +413,6 @@ class ResolvedMapping:
     parent: Module
     parent_name: str
     activation_hook_target: Module | None = None
+    extra_smooth_targets: list[tuple[Module, SlicedSmoothTarget]] = field(
+        default_factory=list
+    )

--- a/tests/llmcompressor/modifiers/transform/awq/test_sliced_smooth.py
+++ b/tests/llmcompressor/modifiers/transform/awq/test_sliced_smooth.py
@@ -1,0 +1,251 @@
+import pytest
+import torch
+from compressed_tensors.quantization import apply_quantization_config
+from torch.nn import Linear
+from torch.testing import assert_close
+
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.modifiers.transform.awq import (
+    AWQ_MAPPING_REGISTRY,
+    AWQMapping,
+    AWQModifier,
+    SlicedSmoothTarget,
+)
+from llmcompressor.modifiers.transform.awq.base import absorb_sliced_scales
+
+HIDDEN = 8
+NUM_CHUNKS = 6
+REPEAT = 3
+TEMB = 5
+TOKENS = 7
+
+SHIFT_CHUNK = 0
+SCALE_CHUNK = 1
+GATE_CHUNK = 2
+
+
+class _AdaLNProj(torch.nn.Module):
+    """Shared modulation projection, shaped like MiniMax-H3's ``adaln_proj``."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = Linear(TEMB, NUM_CHUNKS * HIDDEN * REPEAT)
+
+    def forward(self, temb):
+        out = self.linear(torch.nn.functional.silu(temb))
+        return out.view(-1, NUM_CHUNKS * HIDDEN).chunk(NUM_CHUNKS, dim=-1)
+
+
+class _AdaLNBlock(torch.nn.Module):
+    """
+    Minimal stand-in for an AdaLN-modulated transformer block: the balance layer's
+    input is ``norm1(x) * (1 + scale) + shift`` with both terms coming out of one
+    shared projection, which is the case ``SlicedSmoothTarget`` exists for.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.norm1 = torch.nn.RMSNorm(HIDDEN)
+        self.attn = torch.nn.ModuleDict({"to_q": Linear(HIDDEN, HIDDEN, bias=False)})
+        self.adaln_proj = _AdaLNProj()
+
+    def forward(self, hidden_states, temb, adaln_indices):
+        chunks = self.adaln_proj(temb)
+        shift, scale, gate = (
+            chunks[SHIFT_CHUNK],
+            chunks[SCALE_CHUNK],
+            chunks[GATE_CHUNK],
+        )
+        normed = self.norm1(hidden_states) * (
+            1.0 + scale.index_select(0, adaln_indices)
+        ) + shift.index_select(0, adaln_indices)
+        return hidden_states + gate.index_select(0, adaln_indices) * self.attn.to_q(
+            normed
+        )
+
+
+def _make_block(dtype=torch.float64):
+    torch.manual_seed(0)
+    block = _AdaLNBlock().to(dtype)
+    with torch.no_grad():
+        # RMSNorm starts at 1.0; randomize so an incorrect fold cannot hide
+        block.norm1.weight.normal_(1.0, 0.2)
+        block.adaln_proj.linear.weight.normal_(0.0, 0.05)
+        block.adaln_proj.linear.bias.normal_(0.0, 0.05)
+    return block.eval()
+
+
+def _make_inputs(dtype=torch.float64):
+    torch.manual_seed(1234)
+    return (
+        torch.randn(TOKENS, HIDDEN, dtype=dtype),
+        torch.randn(REPEAT, TEMB, dtype=dtype),
+        torch.randint(0, REPEAT * REPEAT, (TOKENS,)),
+    )
+
+
+@pytest.mark.unit
+def test_absorb_sliced_scales_preserves_output():
+    """
+    Folding 1/s into norm1 and into the shift rows of the shared projection, while
+    scaling the balance layer's input columns by s, must leave the block's output
+    unchanged. This is the equivalence that makes AWQ applicable to AdaLN blocks.
+    """
+    inputs = _make_inputs()
+    reference = _make_block()
+    with torch.no_grad():
+        expected = reference(*inputs)
+
+    block = _make_block()
+    scales = torch.rand(HIDDEN, dtype=torch.float64) * 3.0 + 0.25
+
+    with torch.no_grad():
+        block.norm1.weight.div_(scales)
+        absorb_sliced_scales(
+            block.adaln_proj.linear,
+            SlicedSmoothTarget(
+                "adaln_proj.linear",
+                chunk_index=SHIFT_CHUNK,
+                num_chunks=NUM_CHUNKS,
+                repeat=REPEAT,
+            ),
+            scales,
+        )
+        block.attn.to_q.weight.mul_(scales.view(1, -1))
+        actual = block(*inputs)
+
+    assert_close(actual, expected, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.unit
+def test_absorbing_the_scale_chunk_is_not_equivalent():
+    """
+    Guards the choice of chunk. The multiplicative ``scale`` term is already
+    accounted for by dividing norm1.weight, so folding 1/s into it as well changes
+    the output. Without this the test above would pass for the wrong reason.
+    """
+    inputs = _make_inputs()
+    reference = _make_block()
+    with torch.no_grad():
+        expected = reference(*inputs)
+
+    block = _make_block()
+    scales = torch.rand(HIDDEN, dtype=torch.float64) * 3.0 + 0.25
+
+    with torch.no_grad():
+        block.norm1.weight.div_(scales)
+        absorb_sliced_scales(
+            block.adaln_proj.linear,
+            SlicedSmoothTarget(
+                "adaln_proj.linear",
+                chunk_index=SCALE_CHUNK,
+                num_chunks=NUM_CHUNKS,
+                repeat=REPEAT,
+            ),
+            scales,
+        )
+        block.attn.to_q.weight.mul_(scales.view(1, -1))
+        actual = block(*inputs)
+
+    assert not torch.allclose(actual, expected, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.unit
+def test_absorb_sliced_scales_only_touches_its_own_chunk():
+    block = _make_block()
+    before = block.adaln_proj.linear.weight.clone()
+    scales = torch.full((HIDDEN,), 2.0, dtype=torch.float64)
+
+    absorb_sliced_scales(
+        block.adaln_proj.linear,
+        SlicedSmoothTarget(
+            "adaln_proj.linear",
+            chunk_index=SHIFT_CHUNK,
+            num_chunks=NUM_CHUNKS,
+            repeat=REPEAT,
+        ),
+        scales,
+    )
+    after = block.adaln_proj.linear.weight
+
+    group = NUM_CHUNKS * HIDDEN
+    changed = torch.zeros(before.size(0), dtype=torch.bool)
+    for group_index in range(REPEAT):
+        start = group_index * group + SHIFT_CHUNK * HIDDEN
+        changed[start : start + HIDDEN] = True
+
+    assert_close(after[changed], before[changed] / 2.0)
+    assert_close(after[~changed], before[~changed])
+
+
+@pytest.mark.unit
+def test_absorb_sliced_scales_rejects_shape_mismatch():
+    block = _make_block()
+    scales = torch.ones(HIDDEN, dtype=torch.float64)
+    with pytest.raises(ValueError, match="out_features"):
+        absorb_sliced_scales(
+            block.adaln_proj.linear,
+            SlicedSmoothTarget(
+                "adaln_proj.linear",
+                chunk_index=SHIFT_CHUNK,
+                num_chunks=NUM_CHUNKS,
+                repeat=REPEAT + 1,
+            ),
+            scales,
+        )
+
+
+@pytest.mark.unit
+def test_extra_smooth_targets_resolve_against_the_smooth_layer_parent():
+    """
+    The projection is a sibling of the norm, while the balance layers sit under
+    ``attn``, so resolving against the balance layers' ancestor would not find it.
+    """
+    awq = AWQModifier(
+        mappings=[
+            AWQMapping(
+                "re:.*norm1$",
+                ["re:.*attn.to_q$"],
+                extra_smooth_targets=[
+                    SlicedSmoothTarget(
+                        "adaln_proj.linear",
+                        chunk_index=SHIFT_CHUNK,
+                        num_chunks=NUM_CHUNKS,
+                        repeat=REPEAT,
+                    )
+                ],
+            )
+        ],
+    )
+    model = torch.nn.ModuleDict(
+        {"transformer_blocks": torch.nn.ModuleList([_AdaLNBlock() for _ in range(2)])}
+    )
+    apply_quantization_config(
+        model,
+        config=QuantizationModifier(scheme="W4A16_ASYM").resolve_quantization_config(),
+    )
+
+    awq._set_resolved_mappings(model)
+
+    assert len(awq._resolved_mappings) == 2
+    for index, mapping in enumerate(awq._resolved_mappings):
+        assert len(mapping.extra_smooth_targets) == 1
+        module, target = mapping.extra_smooth_targets[0]
+        assert module is model.transformer_blocks[index].adaln_proj.linear
+        assert target.chunk_index == SHIFT_CHUNK
+
+
+@pytest.mark.unit
+def test_minimax_h3_mappings_are_registered():
+    mappings = AWQ_MAPPING_REGISTRY["MiniMaxH3Transformer3DModel"]
+    sliced = {
+        mapping.smooth_layer: mapping.extra_smooth_targets[0]
+        for mapping in mappings
+        if mapping.extra_smooth_targets
+    }
+    # shift_msa and shift_mlp of the shift/scale/gate x msa/mlp layout
+    assert sliced["re:.*norm1$"].chunk_index == 0
+    assert sliced["re:.*norm2$"].chunk_index == 3
+    for target in sliced.values():
+        assert (target.num_chunks, target.repeat) == (6, 3)
+        assert target.layer == "adaln_proj.linear"


### PR DESCRIPTION
SUMMARY:

`AWQMapping.smooth_layer` is a single module name, and `_apply_smoothing` folds `1/s`
into that one module's weight. That covers every architecture in the registry today,
because in all of them the balance layers' input is produced by one module (a norm, or
a preceding projection).

It cannot express an AdaLN-modulated block. There the balance layers see

```
norm(x) * (1 + scale) + shift
```

and `scale` / `shift` are slices of one shared projection's output, not modules of
their own. Concretely, in MiniMax-H3's diffusion transformer
(`MiniMaxH3Transformer3DModel`, [diffusers#14355](https://github.com/huggingface/diffusers/pull/14355)):

```python
shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaln_proj(temb)
norm_hidden_states = self.norm1(hidden_states) * (
    1.0 + scale_msa.index_select(0, adaln_indices)
) + shift_msa.index_select(0, adaln_indices)
```

There is no module whose weight can absorb `1/s`, so AWQ has nothing to fold into and
these models fall back to `default_mappings`, which do not match.

The absorption does exist, and it is exact:

```
y / s = (norm(x) / s) * (1 + scale) + (shift / s)
```

`norm(x)/s` comes from dividing the norm's weight, and `shift/s` from dividing the rows
of the shared projection that emit the `shift` chunk. `scale` is left alone: it multiplies
elementwise, and the `1 +` term is already handled by the norm weight, so scaling `scale`
as well would double-apply the correction.

This PR adds the smallest thing that can express that:

* `SlicedSmoothTarget(layer, chunk_index, num_chunks, repeat)` names a contiguous row
  slice of another projection's output, in the layout produced by
  `view(-1, num_chunks * hidden)` followed by `chunk(num_chunks, -1)`, tiled `repeat`
  times.
* `AWQMapping.extra_smooth_targets` — an optional list of them, defaulting to empty.
* `absorb_sliced_scales()` applies `1/s` to those rows, weight and bias.
* Mappings for `MiniMaxH3Transformer3DModel`.

I deliberately did **not** widen `smooth_layer`'s type to a union. That would ripple
through `match_modules_set`, `ResolvedMapping`, `_check_layers_are_compatible` and every
registered architecture for no benefit, since the primary smooth layer stays a single
module in this case too. The extra targets are resolved the way
`activation_hook_target` already is, by dotted path, with one difference documented in
the dataclass: they resolve against the module holding `smooth_layer`, not against the
balance layers' ancestor. In an AdaLN block the balance layers sit under `attn` / `ff`
while the shared projection is a sibling of the norm, so resolving against the ancestor
would not find it.

Two things left out on purpose:

* **No `ff.net.0.proj -> ff.net.2` mapping for MiniMax-H3.** That projection is a fused
  SwiGLU, and the existing Linear-smooth branch folds `1/s` into the *last*
  out_features, which here are the gate half. The block output is not linear in the
  gate, so that fold would not be equivalence preserving. Smoothing the up half needs a
  sliced target on the smooth side, which is a separate change; the same gap applies to
  any fused-SwiGLU architecture, not just this one.
* **No diffusion calibration path.** `oneshot` feeds tokenized text, while a DiT takes
  `(hidden_states, temb, adaln_indices, rotary_emb, attention_mask)` that only a real
  sampling run produces. So the mapping this PR registers is not reachable end to end
  from llm-compressor today. I would rather land the mapping mechanism separately from
  the data pipeline, but if you would prefer this to wait until a diffusion calibration
  source exists, say so and I will hold it.

TEST PLAN:

New `tests/llmcompressor/modifiers/transform/awq/test_sliced_smooth.py`, six unit tests
on a synthetic AdaLN block, so nothing here depends on diffusers or on a downloaded
checkpoint:

```
$ pytest tests/llmcompressor/modifiers/transform/awq/ -v -m unit
...
test_sliced_smooth.py::test_absorb_sliced_scales_preserves_output PASSED                  [ 89%]
test_sliced_smooth.py::test_absorbing_the_scale_chunk_is_not_equivalent PASSED            [ 91%]
test_sliced_smooth.py::test_absorb_sliced_scales_only_touches_its_own_chunk PASSED        [ 93%]
test_sliced_smooth.py::test_absorb_sliced_scales_rejects_shape_mismatch PASSED            [ 95%]
test_sliced_smooth.py::test_extra_smooth_targets_resolve_against_the_smooth_layer_parent PASSED [ 97%]
test_sliced_smooth.py::test_minimax_h3_mappings_are_registered PASSED                     [100%]

================ 46 passed, 3 deselected, 14 warnings in 3.34s =================
```

That run covers the whole `transform/awq` directory, so the 40 pre-existing tests in
`test_base.py` and `test_dynamic_mappings.py` are in it and still pass: the new dataclass
field is optional and defaults to empty, so no registered architecture changes behaviour.
Environment: torch 2.13.0+cu130, transformers 5.14.1, compressed-tensors
0.17.2.a20260731, CPU only, no GPU needed.

The load-bearing one is `test_absorb_sliced_scales_preserves_output`: fold `1/s` into the
norm weight and the shift rows, scale the balance layer's input columns by `s`, and the
block's output must be unchanged. In float64 it matches to `rtol=atol=1e-12`.

`test_absorbing_the_scale_chunk_is_not_equivalent` is the control. It does the same thing
but folds into the `scale` chunk instead of `shift`, and asserts the output *changes*.
Without it the first test would pass for the wrong reason, since a no-op would also
"preserve" the output.

One caveat on the usual "does the test fail without the patch" check: for a new API it
fails only with `ImportError`, which proves nothing. That control test is the real guard,
which is why I wrote it.

I also ran the derivation against the real module rather than only the synthetic one.
Building `MiniMaxH3TransformerBlock` from diffusers' `minimax-h3` branch, hidden 64,
float64, and applying the same fold:

```
max abs diff : 2.220e-16
max rel diff : 6.876e-17
control (wrong fold) rel diff: 1.752e-02
```

Checks on the changed files:

```
$ ruff check src/llmcompressor/modifiers/transform/awq/ tests/llmcompressor/modifiers/transform/awq/test_sliced_smooth.py
All checks passed!
```

`ruff format --check` reports one pre-existing reformat in `base.py` (an `assert` at
line ~789) and one in `test_base.py`, neither of which this PR touches; my local ruff is
0.15.18 and evidently differs from the pinned one, so I left both alone rather than add
unrelated churn.

Context: I hit this quantizing MiniMax-H3's 33B joint video/audio DiT to fit on 2x24GB.
`adaln_proj` is 13.0B of the 33.1B parameters there, which is also why keeping it out of
the quantized set matters: the diffusers docstring notes that a rounding applied before
its silu biases every block's modulation identically at every sampling step, so the error
accumulates coherently along the denoising trajectory.

@brian-dellabetta, since you built the mapping mechanism this extends in #2526 and #2451,
and @kylesayrs as a second pair of eyes on the `_apply_smoothing` change. Happy to reshape
the API if you would rather express this differently, or to hold it until a diffusion
calibration source lands.
