### PR TITLE
Extend XPU CI test cases with AutoRound

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,9 @@ steps:
   - label: ":gear: llm-compressor XPU Tests"
     if_changed:
       - "src/llmcompressor/modifiers/**"
+      - "src/llmcompressor/transformers/**"
       - "tests/llmcompressor/modifiers/**"
+      - "tests/llmcompressor/transformers/autoround/**"
       - ".buildkite/xpu-tests/**"
     command: |
       buildkite-agent pipeline upload .buildkite/xpu-tests/xpu-tests-B60.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,10 +17,14 @@ steps:
   # Test check pipeline on XPU (only when relevant paths changed)
   - label: ":gear: llm-compressor XPU Tests"
     if_changed:
-      - "src/llmcompressor/modifiers/**"
-      - "src/llmcompressor/transformers/**"
-      - "tests/llmcompressor/modifiers/**"
-      - "tests/llmcompressor/transformers/autoround/**"
       - ".buildkite/xpu-tests/**"
+      - "pytest-xpu.ini"
+      - "src/llmcompressor/modifiers/**"
+      - "tests/llmcompressor/modifiers/**"
+      - "src/llmcompressor/entrypoints/**"
+      - "src/llmcompressor/core/**"
+      - "src/llmcompressor/datasets/**"
+      - "src/llmcompressor/pipelines/**"
+      - "tests/llmcompressor/transformers/autoround/**"
     command: |
       buildkite-agent pipeline upload .buildkite/xpu-tests/xpu-tests-B60.yml

--- a/pytest-xpu.ini
+++ b/pytest-xpu.ini
@@ -4,6 +4,7 @@ testpaths =
     tests/llmcompressor/modifiers/quantization/test_group_size_validation.py
     tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
     tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
+    tests/llmcompressor/transformers/autoround/
 markers =
     unit: unit test marker
     multi_gpu: tests that require multiple accelerators

--- a/pytest-xpu.ini
+++ b/pytest-xpu.ini
@@ -4,7 +4,7 @@ testpaths =
     tests/llmcompressor/modifiers/quantization/test_group_size_validation.py
     tests/llmcompressor/modifiers/quantization/test_kv_cache_calibration.py
     tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
-    tests/llmcompressor/transformers/autoround/
+    tests/llmcompressor/transformers/autoround/test_autoround_oneshot.py
 markers =
     unit: unit test marker
     multi_gpu: tests that require multiple accelerators


### PR DESCRIPTION
## SUMMARY:

This pull request extends the XPU test coverage to ensure that changes related to AutoRound will be included in CI test. 

**Buildkite pipeline improvements:**

* Expanded the `if_changed` list for the ":gear: llm-compressor XPU Tests" step to include `src/llmcompressor/entrypoints/**`, `src/llmcompressor/core/**`, `src/llmcompressor/datasets/**`, `src/llmcompressor/pipelines/**`, and `pytest-xpu.ini`, ensuring the XPU tests run when any of these files change.

**Test coverage enhancements:**

* Added `tests/llmcompressor/transformers/autoround/test_autoround_oneshot.py` to the `testpaths` in `pytest-xpu.ini`, so it is now part of the XPU test suite and helps guard against regressions like [#2998](https://github.com/vllm-project/llm-compressor/issues/2998).

## TEST PLAN:

The new added test case will be triggered in XPU CI test. 
