### PR TITLE
Add transformers>=5.15 warning to disk-offloaded examples

### DIFF
--- a/examples/disk_offloading/deepseek_v32_example.py
+++ b/examples/disk_offloading/deepseek_v32_example.py
@@ -58,6 +58,8 @@ with open(f"{BFLOAT16_SAVE_DIR}/config.json", "w") as f:
 # 3) Apply oneshot to bfloat16 model
 #    note that `load_quantizable_moe` is not required because we are using the
 #    custom model def `DeepseekV32ForCausalLM` which is already linearized
+# NOTE: `transformers==5.14` breaks saving for disk-offloaded models.
+# Please install `transformers>=5.15` or install from source
 with load_context(DeepseekV32ForCausalLM):
     model = DeepseekV32ForCausalLM.from_pretrained(
         BFLOAT16_SAVE_DIR,

--- a/examples/disk_offloading/kimi_k26_example.py
+++ b/examples/disk_offloading/kimi_k26_example.py
@@ -40,6 +40,8 @@ convert_checkpoint(
 )
 
 # Quantize bfloat16 checkpoint to NVFP4, limiting CPU RAM usage to 500GB
+# NOTE: `transformers==5.14` breaks saving for disk-offloaded models.
+# Please install `transformers>=5.15` or install from source
 with load_context():
     model = AutoModelForCausalLM.from_pretrained(
         DEQUANTIZED_SAVE_DIR,

--- a/examples/disk_offloading/kimi_k2_example.py
+++ b/examples/disk_offloading/kimi_k2_example.py
@@ -6,6 +6,8 @@ from llmcompressor.modifiers.quantization import QuantizationModifier
 from llmcompressor.utils import load_context
 
 # Select model and load it in the `load_context` context
+# NOTE: `transformers==5.14` breaks saving for disk-offloaded models.
+# Please install `transformers>=5.15` or install from source
 with load_context():
     model_id = "unsloth/Kimi-K2-Instruct-0905-BF16"
     model = AutoModelForCausalLM.from_pretrained(

--- a/examples/disk_offloading/qwen3_example.py
+++ b/examples/disk_offloading/qwen3_example.py
@@ -11,6 +11,8 @@ from llmcompressor.utils import load_context
 # Select model and load it in the `load_context` context
 # In this example, we emulate large model quantization with disk offloading by
 # restricting the theoretical size of CPU RAM to be smaller than the size of the model
+# NOTE: `transformers==5.14` breaks saving for disk-offloaded models.
+# Please install `transformers>=5.15` or install from source
 with load_context():
     model_id = "Qwen/Qwen3-0.6B"
     model = AutoModelForCausalLM.from_pretrained(

--- a/examples/quantization_w4a4_fp4/hy3_example.py
+++ b/examples/quantization_w4a4_fp4/hy3_example.py
@@ -16,6 +16,8 @@ from llmcompressor.utils import load_context
 # Select model and load it.
 MODEL_ID = "tencent/Hy3"
 
+# NOTE: `transformers==5.14` breaks saving for disk-offloaded models.
+# Please install `transformers>=5.15` or install from source
 init_dist()
 with load_context():
     model = AutoModelForCausalLM.from_pretrained(

--- a/examples/quantizing_moe/deepseek_v4_pro_example.py
+++ b/examples/quantizing_moe/deepseek_v4_pro_example.py
@@ -26,6 +26,8 @@ DeepseekV4PreTrainedModel._keep_in_fp32_modules_strict = set()
 # Swap this with a BF16 version of DeepSeek-V4-Pro
 MODEL_ID = "inference-optimization/DeepSeek-V4-Pro-0.5B-A0.37B"
 
+# NOTE: `transformers==5.14` breaks saving for disk-offloaded models.
+# Please install `transformers>=5.15` or install from source
 init_dist()
 with load_context():
     model = AutoModelForCausalLM.from_pretrained(

--- a/examples/quantizing_moe/glm5_example.py
+++ b/examples/quantizing_moe/glm5_example.py
@@ -14,6 +14,8 @@ from llmcompressor.modifiers.quantization import QuantizationModifier
 from llmcompressor.utils import load_context
 
 # Load the model
+# NOTE: `transformers==5.14` breaks saving for disk-offloaded models.
+# Please install `transformers>=5.15` or install from source
 init_dist()
 model_id = "zai-org/GLM-5.2"
 with load_context():


### PR DESCRIPTION
## Summary
- `transformers==5.14` breaks saving for disk-offloaded models
- Added a NOTE comment to all 7 examples that use `offload_folder` warning users to install `transformers>=5.15` or install from source
- Affected examples: `disk_offloading/` (4 files), `quantizing_moe/` (2 files), `quantization_w4a4_fp4/` (1 file)

## Test plan
- [x] Verify comments are correctly placed near each `load_context` / model loading block
- [x] Confirm no functional code was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)