### PR TITLE
[error message improvement] include num_calibration_samples/max_seq_length in oom resolution message

### DIFF
--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -481,7 +481,9 @@ def handle_sequential_oom(func):
             raise torch.OutOfMemoryError(
                 "Sequential pipeline ran out of memory. "
                 "Please consider choosing a smaller module "
-                "for `sequential_targets` argument, ex. 'Linear'"
+                "for `sequential_targets` argument (e.g. 'Linear'), "
+                "or choose a smaller calibration data set by reducing "
+                "num_calibration_samples or max_seq_length."
             ) from e
 
     return wrapper

--- a/src/llmcompressor/pipelines/sequential/helpers.py
+++ b/src/llmcompressor/pipelines/sequential/helpers.py
@@ -482,7 +482,7 @@ def handle_sequential_oom(func):
                 "Sequential pipeline ran out of memory. "
                 "Please consider choosing a smaller module "
                 "for `sequential_targets` argument (e.g. 'Linear'), "
-                "or choose a smaller calibration data set by reducing "
+                "or choose a smaller calibration dataset by reducing "
                 "num_calibration_samples or max_seq_length."
             ) from e
 


### PR DESCRIPTION
Fixes #3011 

SUMMARY:
Update the OOM error message to include calibration dataset considerations.


TEST PLAN:
n/a
