### PR TITLE
docs: model-size guidance for scheme selection, language alignment for calibration data

### DIFF
--- a/docs/steps/choosing-dataset.md
+++ b/docs/steps/choosing-dataset.md
@@ -48,7 +48,7 @@ the scales to English activation ranges, and the languages you actually serve
 inherit whatever error is left over.
 
 A mixed set is usually enough: half target-language, half English preserves
-English behaviour while covering the target language's activation ranges. In
+English behavior while covering the target language's activation ranges. In
 one NVFP4 run on a Thai-capable 30B model, a 50/50 Thai/English calibration
 set (512 samples) left Thai multiple-choice accuracy statistically unchanged
 against the BF16 source, while English tasks moved within the same small

--- a/docs/steps/choosing-dataset.md
+++ b/docs/steps/choosing-dataset.md
@@ -40,6 +40,37 @@ Some popular datasets include:
 | `wikitext-2-raw-v1` | General language models | Clean Wikipedia text for broad language understanding |
 | `c4` | General pre-training | Large-scale web text for general-purpose models |
 
+### Language alignment
+If the model will serve non-English traffic, the calibration set should
+contain that language. Calibration determines the activation scales, and
+every dataset listed above is English — so an English-only calibration fits
+the scales to English activation ranges, and the languages you actually serve
+inherit whatever error is left over.
+
+A mixed set is usually enough: half target-language, half English preserves
+English behaviour while covering the target language's activation ranges. In
+one NVFP4 run on a Thai-capable 30B model, a 50/50 Thai/English calibration
+set (512 samples) left Thai multiple-choice accuracy statistically unchanged
+against the BF16 source, while English tasks moved within the same small
+band. Building such a set is a few lines:
+
+```python
+from datasets import load_dataset
+
+th = load_dataset("wikimedia/wikipedia", "20231101.th", split="train", streaming=True)
+en = load_dataset("HuggingFaceH4/ultrachat_200k", split="train_sft", streaming=True)
+# take N/2 from each, shuffle, then pass the result to oneshot(dataset=...)
+```
+
+The same reasoning applies to any modality split in your traffic — code,
+long-context documents, tool-call transcripts. Calibrate on what you serve.
+
+!!! tip
+    Whatever mixture you choose, evaluate the quantized model in the target
+    language too. A quantized model can hold its English scores while losing
+    ground in another language, and an English-only evaluation will not show
+    it.
+
 ### Dataset size
 Most calibration algorithms work well with relatively small datasets:
 

--- a/docs/steps/choosing-scheme.md
+++ b/docs/steps/choosing-scheme.md
@@ -82,7 +82,12 @@ Two practical consequences:
 - **Below roughly 10B parameters, prefer weight-only (W4A16) over W4A4**, or
   step up to FP8. Re-running the same 7B with W4A16 recovered the knowledge
   and instruction-following losses entirely (−0.7 pt and −3.7 pt, neither
-  significant) at the same size and speed.
+  significant) at the same 4-bit weight footprint. Note the trade: W4A16
+  keeps 16-bit activation math, so it matches W4A4 only where decode is
+  memory-bandwidth-bound (small batch, short context). At larger batches or
+  longer contexts W4A4 can use 4-bit tensor cores and pulls ahead on compute
+  throughput — measure your own serving shape before treating them as
+  interchangeable.
 - **The two halves of W4A4 fail differently.** Quantizing activations is what
   damaged instruction following and knowledge; quantizing weights is what
   damaged long-chain mathematical reasoning (−5.4 pt, unchanged whether

--- a/docs/steps/choosing-scheme.md
+++ b/docs/steps/choosing-scheme.md
@@ -64,6 +64,36 @@ FP4 can sometimes provide good results with RTN algorithms for fast quantization
 - **NVFP4**: NVIDIA's native 4-bit format with two-level micro-block scaling; requires calibration data for activation global scales
 - **MXFP4**: Microscaling FP4 format for cross-platform compatibility; per-group quantization (group_size=32) with E8M0 scales; no calibration data required if using RTN
 
+### Model size matters as much as hardware
+
+The table above answers *what your GPU can run*. It does not answer *what your
+model can absorb*: accuracy cost at 4 bits grows sharply as parameter count
+falls, because smaller models carry less redundancy to spend on quantization
+error. Recovery measured with the same recipe and the same calibration set on
+one machine, paired per-item against the BF16 source:
+
+| Model size | NVFP4 (W4A4) outcome |
+|---|---|
+| ~30B | multiple-choice recovery within noise (−0.5 pt, not significant) |
+| ~7B | significant losses on generated output: −2.4 pt knowledge, −10.2 pt instruction following |
+
+Two practical consequences:
+
+- **Below roughly 10B parameters, prefer weight-only (W4A16) over W4A4**, or
+  step up to FP8. Re-running the same 7B with W4A16 recovered the knowledge
+  and instruction-following losses entirely (−0.7 pt and −3.7 pt, neither
+  significant) at the same size and speed.
+- **The two halves of W4A4 fail differently.** Quantizing activations is what
+  damaged instruction following and knowledge; quantizing weights is what
+  damaged long-chain mathematical reasoning (−5.4 pt, unchanged whether
+  activations were 4-bit or 16-bit). If your workload is arithmetic- or
+  reasoning-heavy, weight-only does not rescue it — validate before shipping.
+
+!!! tip
+    These are one lab's measurements on one model family, offered as a
+    starting prior rather than a rule. Whatever scheme you pick, validate the
+    quantized model against its own BF16 source on your own workload.
+
 ## Compression Formats
 
 Each quantization scheme corresponds to a particular compressor, which dictates


### PR DESCRIPTION
Two documentation gaps I ran into while quantizing Thai models, each backed by paired measurements.

## 1. `choosing-scheme.md` — model size, not just GPU

The scheme table answers *what can my GPU run*. It does not answer *what can my model absorb*, and that turned out to matter more than hardware for us. Same recipe (NVFP4 W4A4 via `QuantizationModifier`), same 512-sample calibration set, same machine, paired per-item against each model's own BF16 source with exact McNemar:

| Model size | Outcome |
|---|---|
| ~30B | multiple-choice recovery within noise (−0.5 pt, n.s.) |
| ~7B | −2.4 pt knowledge (p=0.02), **−10.2 pt instruction following** (p=0.0009) |

Re-running the same 7B as **W4A16** recovered both (−0.7 and −3.7 pt, neither significant) at the same footprint and speed — hence the added rule of thumb to prefer weight-only below ~10B.

The two halves of W4A4 also fail on different task types, which the two arms isolate cleanly: dropping activation quantization fixed instruction following and knowledge, but **mathematical reasoning was unchanged (−5.4 vs −5.6 pt, both significant)** — that damage comes from the 4-bit weights and weight-only does not rescue it.

## 2. `choosing-dataset.md` — language alignment

"Domain alignment" covers general/instruct/code, and all four suggested datasets are English. There is currently no guidance that calibration data language matters, even though calibration is what sets the activation scales. Added a short subsection: use a mixed set (we used 50/50 target-language/English, 512 samples), a snippet for building one, and a note to evaluate in the target language too.

## Framing

These are one lab's numbers on one model family (Thai-capable Qwen2/Qwen3 derivatives, NVIDIA GB10). I wrote both sections as a starting prior with an explicit "validate on your own workload" caveat rather than as universal rules — happy to soften or cut anything that reads as over-claiming. All runs were pre-registered before measurement and the artifacts are public: https://github.com/spped2000/thaillm-nvfp4-dgx-spark

---

*Disclosure: prepared with assistance from Claude (Anthropic). Every figure quoted comes from paired runs on the hardware described.*