### PR TITLE
Update review rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -72,8 +72,6 @@ reviews:
       instructions: "Issues or PRs related to model transforms functionality. Match case-insensitively — 'transforms', 'Transforms', 'TRANSFORMS' all qualify."
     - label: "tracing"
       instructions: "Issues or PRs related to model tracing functionality. Match case-insensitively — 'tracing', 'Tracing', 'TRACING' all qualify."
-    - label: "two-reviews"
-      instructions: "Apply when the PR makes significant or substantial changes to source code under src/ — such as large refactors, new core functionality, public API changes, or modifications spanning multiple components (more than 3 files changed OR 100+ lines changed in src/). Do NOT apply for small, targeted changes to a single file or a narrow, self-contained fix. Also apply when the PR changes dependency version bounds in pyproject.toml or setup.py."
   auto_review:
     enabled: false
     ignore_title_keywords:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -82,26 +82,21 @@ pull_request_rules:
         remove:
           - quality-failed
 
-  - name: label community PRs for two reviews
-    conditions:
-      - label != stale
-      - -closed
-      - -draft
-      - author != kylesayrs
-      - author != dsikka
-      - author != HDCharles
-      - author != brian-dellabetta
-      - or:
-          - author != yiliu30
-          - and:
-              - author = yiliu30
-              - -files~=^(src|tests)/llmcompressor/(modifiers|transformers)/autoround/
-    actions:
-      label:
-        add:
-          - two-reviews
-
 merge_protections:
+  - name: Require one maintainer review
+    description: >-
+      All PRs must have at least one approving review from a maintainer
+      before merging.
+    if: []
+    success_conditions:
+      - or:
+          - approved-reviews-by=kylesayrs
+          - approved-reviews-by=dsikka
+          - approved-reviews-by=HDCharles
+          - approved-reviews-by=brian-dellabetta
+          - approved-reviews-by=yiliu30
+      - "#changes-requested-reviews-by = 0"
+
   - name: Require two reviews
     description: >-
       PRs labelled "two-reviews" must have at least two approving reviews


### PR DESCRIPTION
- Require one review from a maintainer, unless the two-reviews label has been applied