### PR TITLE
Fix #2984: prevent DDP race on shared HF cache during model loading

### DIFF
--- a/examples/quantization_w4a16/llama3_ddp_example.py
+++ b/examples/quantization_w4a16/llama3_ddp_example.py
@@ -16,11 +16,13 @@ from llmcompressor import oneshot
 from llmcompressor.datasets.utils import get_rank_partition
 from llmcompressor.modifiers.gptq import GPTQModifier
 from llmcompressor.utils import load_context
+from llmcompressor.utils.dist import prefetch_model_on_rank0
 
 model_id = "meta-llama/Meta-Llama-3-8B-Instruct"
 
 ###### DDP MODEL LOAD CHANGE #####
 init_dist()
+prefetch_model_on_rank0(model_id)
 with load_context():
     model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto_offload")
 ##################################

--- a/examples/quantization_w8a8_int8/smoothquant_ddp_example.py
+++ b/examples/quantization_w8a8_int8/smoothquant_ddp_example.py
@@ -27,6 +27,7 @@ from llmcompressor.datasets.utils import get_rank_partition
 from llmcompressor.modifiers.gptq import GPTQModifier
 from llmcompressor.modifiers.transform.smoothquant import SmoothQuantModifier
 from llmcompressor.utils import load_context
+from llmcompressor.utils.dist import prefetch_model_on_rank0
 
 # ---------------------------------------------------------------------------
 # Config
@@ -41,6 +42,7 @@ MAX_SEQUENCE_LENGTH = 2048
 # DDP init + model load
 # ---------------------------------------------------------------------------
 init_dist()
+prefetch_model_on_rank0(MODEL_ID)
 
 with load_context():
     model = AutoModelForCausalLM.from_pretrained(

--- a/src/llmcompressor/utils/dist.py
+++ b/src/llmcompressor/utils/dist.py
@@ -45,7 +45,10 @@ def prefetch_model_on_rank0(model_id_or_path: str, **snapshot_download_kwargs) -
     if not (dist.is_available() and dist.is_initialized()):
         return  # single process: from_pretrained's own download is fine
 
-    if dist.get_rank() == 0:
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_local_master = local_rank == 0 if "LOCAL_RANK" in os.environ else dist.get_rank() == 0
+
+    if is_local_master:
         snapshot_download(model_id_or_path, **snapshot_download_kwargs)
 
     dist.barrier()

--- a/src/llmcompressor/utils/dist.py
+++ b/src/llmcompressor/utils/dist.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Sequence
 from typing import Hashable, TypeVar
 
@@ -12,8 +13,42 @@ from compressed_tensors.distributed import (
 from compressed_tensors.offload import get_execution_device
 from compressed_tensors.offload.dist_utils import as_broadcastable
 from compressed_tensors.utils.helpers import deprecated
+from huggingface_hub import snapshot_download
 
 T = TypeVar("T", bound=Hashable)
+
+
+def prefetch_model_on_rank0(model_id_or_path: str, **snapshot_download_kwargs) -> None:
+    """
+    Ensure a HuggingFace hub model is fully downloaded to the local cache
+    before every rank concurrently calls `from_pretrained`.
+
+    Without this, each DDP rank races to populate the same on-disk HF cache
+    (``HF_HOME``/``TRANSFORMERS_CACHE``) via `from_pretrained`'s internal
+    ``snapshot_download``/``cached_file`` calls. Concurrent writers can leave
+    partially-written blobs or a half-updated refs/index file behind, which
+    surfaces as flaky "file not found" / corrupt-shard errors under DDP.
+
+    Call this after ``init_dist()`` and before ``from_pretrained(...)``.
+    A no-op if ``model_id_or_path`` is a local path, or if the process
+    is not running under ``torch.distributed``.
+
+    :param model_id_or_path: hub repo id or local path, same value passed
+        to `from_pretrained`
+    :param snapshot_download_kwargs: forwarded to
+        `huggingface_hub.snapshot_download` (e.g. revision, token, cache_dir) --
+        pass the same values you pass to `from_pretrained` for these
+    """
+    if os.path.exists(model_id_or_path):
+        return  # local path: no shared cache, no race
+
+    if not (dist.is_available() and dist.is_initialized()):
+        return  # single process: from_pretrained's own download is fine
+
+    if dist.get_rank() == 0:
+        snapshot_download(model_id_or_path, **snapshot_download_kwargs)
+
+    dist.barrier()
 
 
 @deprecated("compressed_tensors.distributed.assign::greedy_bin_packing")

--- a/src/llmcompressor/utils/dist.py
+++ b/src/llmcompressor/utils/dist.py
@@ -46,7 +46,9 @@ def prefetch_model_on_rank0(model_id_or_path: str, **snapshot_download_kwargs) -
         return  # single process: from_pretrained's own download is fine
 
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    is_local_master = local_rank == 0 if "LOCAL_RANK" in os.environ else dist.get_rank() == 0
+    is_local_master = (
+        local_rank == 0 if "LOCAL_RANK" in os.environ else dist.get_rank() == 0
+    )
 
     if is_local_master:
         snapshot_download(model_id_or_path, **snapshot_download_kwargs)


### PR DESCRIPTION
## Problem

Every DDP example calls `from_pretrained(MODEL_ID, ...)` on all ranks
immediately after `init_dist()`. The `dist.barrier()` inside `init_dist()`
only synchronizes the process group — it says nothing about the filesystem
or HF cache state. Right after it returns, every rank races into
`from_pretrained` independently, and `transformers`/`huggingface_hub`
internally performs cache checks and downloads for each shard. With N
ranks hitting the same shared `HF_HOME`/`TRANSFORMERS_CACHE` at once
(the typical single-node multi-GPU `torchrun` setup), this can produce
partially-written blobs, reads of a config/index file mid-write, or
corrupted/incomplete cache entries.

I checked the repo for an existing rank-0-downloads-first guard and
didn't find one — no `accelerator.is_main_process`, `PartialState`, or
manual `if rank == 0: download(); barrier()` pattern exists in `src/`
or `examples/`.

## Fix

Adds `prefetch_model_on_rank0()` in `src/llmcompressor/utils/dist.py`.
Rank 0 calls `snapshot_download` to fully populate the shared cache,
then all ranks hit a `dist.barrier()`, so every rank's subsequent
`from_pretrained` call reads from an already-complete local cache
instead of racing to write it. No-op for local paths or non-distributed
runs.

Wired into two examples as a reference pattern:
- `examples/quantization_w8a8_int8/smoothquant_ddp_example.py`
- `examples/quantization_w4a16/llama3_ddp_example.py`

The same unguarded pattern exists in ~9 other DDP examples in the repo
(AWQ, AutoRound, imatrix, sequential offloading, MoE examples). Happy
to open a follow-up PR to wire the helper into those as well once this
approach is confirmed — wanted to keep this first PR small and reviewable.

I also checked `copy_python_files_from_model_cache` (which calls
`hf_hub_download` for `config.json`), since it looked similarly
unguarded — but it's already wrapped in `if is_source_process():` in
`compressed_tensors_utils.py`, so no fix needed there.

## Testing

- `tests/llmcompressor/observers/test_fusion_handler.py` (exercises
  `llmcompressor.utils.dist`): 28 passed
- `tests/llmcompressor/transformers/smoothquant/test_smoothquant_distributed.py -m unit`: 3 passed
- Collection-only pass (no errors) on the DDP/multi-GPU integration
  tests: `test_smoothquant_distributed.py`, `test_compression_ddp.py`,
  `test_quantization_ddp.py`, `test_dist_disk_offload.py`,
  `test_distributed.py`, `test_example_scripts.py`

I don't have multi-GPU hardware available locally, so I wasn't able to
run the actual `@requires_gpu(2)` / `@pytest.mark.multi_gpu` integration
tests. Would appreciate a maintainer running those in CI to confirm.

Fixes #2984