### PR TITLE
[Performance] [MoE] Don't onload weights when checking FusedExpertsProtocol

### DIFF
--- a/src/llmcompressor/modeling/moe/helpers.py
+++ b/src/llmcompressor/modeling/moe/helpers.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, ClassVar
 
 import torch
+from compressed_tensors.offload import disable_onloading
 from loguru import logger
 from transformers import PreTrainedConfig
 
@@ -33,14 +34,17 @@ class FusedExpertsProtocol(TorchModuleProtocol):
 
     @classmethod
     def __validate__(cls, object: object) -> bool:
-        return (
-            isinstance(getattr(object, "down_proj", None), torch.nn.Parameter)
-            and (
-                isinstance(getattr(object, "up_proj", None), torch.nn.Parameter)
-                or isinstance(getattr(object, "gate_up_proj", None), torch.nn.Parameter)
+        with disable_onloading():
+            return (
+                isinstance(getattr(object, "down_proj", None), torch.nn.Parameter)
+                and (
+                    isinstance(getattr(object, "up_proj", None), torch.nn.Parameter)
+                    or isinstance(
+                        getattr(object, "gate_up_proj", None), torch.nn.Parameter
+                    )
+                )
+                and get_use_experts_implementation_args(object.__class__) is not None
             )
-            and get_use_experts_implementation_args(object.__class__) is not None
-        )
 
 
 def get_use_experts_implementation_args(experts_cls: type) -> dict[str, bool] | None:


### PR DESCRIPTION
## Purpose ##
* Improve runtime by not onloading weights while checking whether an MoE layer looks like the transformers MoE standard layers