### PR TITLE
[Tests] Use prebaked "perfectblend" as default calibration dataset for tests

### DIFF
--- a/examples/quantization_w4a16/qwen3_8_gptq_awq_example.py
+++ b/examples/quantization_w4a16/qwen3_8_gptq_awq_example.py
@@ -1,5 +1,4 @@
-import torch
-from datasets import load_dataset
+# NOTE: to use a custom dataset, see examples/custom_dataset_example.py
 from transformers import AutoProcessor, Qwen3_5ForConditionalGeneration
 
 from llmcompressor import oneshot
@@ -31,58 +30,15 @@ recipe = [
     ),
 ]
 
-NUM_CALIBRATION_SAMPLES = 512
-MAX_SEQUENCE_LENGTH = 4096
-
-ds = load_dataset(
-    "mlabonne/open-perfectblend",
-    split=f"train[:{NUM_CALIBRATION_SAMPLES}]",
-)
-ds = ds.shuffle(seed=42)
-
-ROLE_MAP = {"human": "user", "gpt": "assistant"}
-
-
-def preprocess_function(example):
-    messages = [
-        {
-            "role": ROLE_MAP.get(msg["from"], msg["from"]),
-            "content": [{"type": "text", "text": msg["value"]}],
-        }
-        for msg in example["conversations"]
-    ]
-    return processor.apply_chat_template(
-        messages,
-        tokenize=True,
-        return_dict=True,
-        add_generation_prompt=False,
-        processor_kwargs={
-            "return_tensors": "pt",
-            "padding": False,
-            "truncation": True,
-            "max_length": MAX_SEQUENCE_LENGTH,
-            "add_special_tokens": False,
-        },
-    )
-
-
-ds = ds.map(preprocess_function, batched=False, remove_columns=ds.column_names)
-
-
-def data_collator(batch):
-    assert len(batch) == 1
-    return {key: torch.tensor(value) for key, value in batch[0].items()}
-
-
 # Apply quantization.
 oneshot(
     model=model,
+    processor=processor,
     recipe=recipe,
-    dataset=ds,
-    max_seq_length=MAX_SEQUENCE_LENGTH,
-    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    dataset="perfectblend",
+    max_seq_length=4096,
+    num_calibration_samples=512,
     moe_calibrate_all_experts=True,
-    data_collator=data_collator,
 )
 
 # Save to disk in compressed-tensors format.

--- a/examples/quantization_w4a4_fp4/qwen3_5_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_5_example.py
@@ -1,5 +1,4 @@
-import torch
-from datasets import load_dataset
+# NOTE: to use a custom dataset, see examples/custom_dataset_example.py
 from transformers import AutoProcessor, Qwen3_5MoeForConditionalGeneration
 
 from llmcompressor import oneshot
@@ -31,52 +30,15 @@ recipe = QuantizationModifier(
     ],
 )
 
-NUM_CALIBRATION_SAMPLES = 256
-MAX_SEQUENCE_LENGTH = 4096
-
-ds = load_dataset(
-    "HuggingFaceH4/ultrachat_200k",
-    split=f"train_sft[:{NUM_CALIBRATION_SAMPLES}]",
-)
-ds = ds.select_columns(["messages"])
-ds = ds.shuffle(seed=42)
-
-
-def preprocess_function(example):
-    messages = [
-        {"role": m["role"], "content": [{"type": "text", "text": m["content"]}]}
-        for m in example["messages"]
-    ]
-    return processor.apply_chat_template(
-        messages,
-        return_tensors="pt",
-        padding=False,
-        truncation=True,
-        max_length=MAX_SEQUENCE_LENGTH,
-        tokenize=True,
-        add_special_tokens=False,
-        return_dict=True,
-        add_generation_prompt=False,
-    )
-
-
-ds = ds.map(preprocess_function, batched=False, remove_columns=ds.column_names)
-
-
-def data_collator(batch):
-    assert len(batch) == 1
-    return {key: torch.tensor(value) for key, value in batch[0].items()}
-
-
 # Apply quantization.
 oneshot(
     model=model,
+    processor=processor,
     recipe=recipe,
-    dataset=ds,
-    max_seq_length=MAX_SEQUENCE_LENGTH,
-    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    dataset="perfectblend",
+    max_seq_length=4096,
+    num_calibration_samples=256,
     moe_calibrate_all_experts=True,
-    data_collator=data_collator,
 )
 
 # Save to disk in compressed-tensors format.

--- a/examples/quantization_w4a4_fp4/qwen3_6_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_6_example.py
@@ -1,5 +1,4 @@
-import torch
-from datasets import load_dataset
+# NOTE: to use a custom dataset, see examples/custom_dataset_example.py
 from transformers import AutoProcessor, Qwen3_5MoeForConditionalGeneration
 
 from llmcompressor import oneshot
@@ -29,54 +28,15 @@ recipe = QuantizationModifier(
     ],
 )
 
-NUM_CALIBRATION_SAMPLES = 256
-MAX_SEQUENCE_LENGTH = 4096
-
-ds = load_dataset(
-    "HuggingFaceH4/ultrachat_200k",
-    split=f"train_sft[:{NUM_CALIBRATION_SAMPLES}]",
-)
-ds = ds.select_columns(["messages"])
-ds = ds.shuffle(seed=42)
-
-
-def preprocess_function(example):
-    messages = [
-        {"role": m["role"], "content": [{"type": "text", "text": m["content"]}]}
-        for m in example["messages"]
-    ]
-    return processor.apply_chat_template(
-        messages,
-        tokenize=True,
-        return_dict=True,
-        add_generation_prompt=False,
-        processor_kwargs={
-            "return_tensors": "pt",
-            "padding": False,
-            "truncation": True,
-            "max_length": MAX_SEQUENCE_LENGTH,
-            "add_special_tokens": False,
-        },
-    )
-
-
-ds = ds.map(preprocess_function, batched=False, remove_columns=ds.column_names)
-
-
-def data_collator(batch):
-    assert len(batch) == 1
-    return {key: torch.tensor(value) for key, value in batch[0].items()}
-
-
 # Apply quantization.
 oneshot(
     model=model,
+    processor=processor,
     recipe=recipe,
-    dataset=ds,
-    max_seq_length=MAX_SEQUENCE_LENGTH,
-    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    dataset="perfectblend",
+    max_seq_length=4096,
+    num_calibration_samples=256,
     moe_calibrate_all_experts=True,
-    data_collator=data_collator,
 )
 
 # Save to disk in compressed-tensors format.

--- a/examples/quantization_w4a4_fp4/qwen3_8_gptq_awq_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_8_gptq_awq_example.py
@@ -1,10 +1,9 @@
-import torch
+# NOTE: to use a custom dataset, see examples/custom_dataset_example.py
 from compressed_tensors.quantization.quant_scheme import (
     FP8_DYNAMIC,
     NVFP4,
     QuantizationScheme,
 )
-from datasets import load_dataset
 from transformers import AutoProcessor, Qwen3_5ForConditionalGeneration
 
 from llmcompressor import oneshot
@@ -53,58 +52,15 @@ recipe = [
     ),
 ]
 
-NUM_CALIBRATION_SAMPLES = 512
-MAX_SEQUENCE_LENGTH = 4096
-
-ds = load_dataset(
-    "mlabonne/open-perfectblend",
-    split=f"train[:{NUM_CALIBRATION_SAMPLES}]",
-)
-ds = ds.shuffle(seed=42)
-
-ROLE_MAP = {"human": "user", "gpt": "assistant"}
-
-
-def preprocess_function(example):
-    messages = [
-        {
-            "role": ROLE_MAP.get(msg["from"], msg["from"]),
-            "content": [{"type": "text", "text": msg["value"]}],
-        }
-        for msg in example["conversations"]
-    ]
-    return processor.apply_chat_template(
-        messages,
-        tokenize=True,
-        return_dict=True,
-        add_generation_prompt=False,
-        processor_kwargs={
-            "return_tensors": "pt",
-            "padding": False,
-            "truncation": True,
-            "max_length": MAX_SEQUENCE_LENGTH,
-            "add_special_tokens": False,
-        },
-    )
-
-
-ds = ds.map(preprocess_function, batched=False, remove_columns=ds.column_names)
-
-
-def data_collator(batch):
-    assert len(batch) == 1
-    return {key: torch.tensor(value) for key, value in batch[0].items()}
-
-
 # Apply quantization.
 oneshot(
     model=model,
+    processor=processor,
     recipe=recipe,
-    dataset=ds,
-    max_seq_length=MAX_SEQUENCE_LENGTH,
-    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    dataset="perfectblend",
+    max_seq_length=4096,
+    num_calibration_samples=512,
     moe_calibrate_all_experts=True,
-    data_collator=data_collator,
 )
 
 # Save to disk in compressed-tensors format.

--- a/examples/reap_expert_pruning/hy3_25_example.py
+++ b/examples/reap_expert_pruning/hy3_25_example.py
@@ -1,13 +1,12 @@
+# NOTE: to use a custom dataset, see examples/custom_dataset_example.py
 from compressed_tensors.offload import init_dist
 from compressed_tensors.quantization.quant_scheme import (
     NVFP4,
     QuantizationScheme,
 )
-from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
-from llmcompressor.datasets.utils import get_rank_partition
 from llmcompressor.modifiers.pruning import REAPPruningModifier
 from llmcompressor.modifiers.quantization import QuantizationModifier
 from llmcompressor.utils import load_context
@@ -23,48 +22,6 @@ with load_context():
         offload_folder="offload_folder",
     )
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
-
-DATASET_ID = "HuggingFaceH4/ultrachat_200k"
-DATASET_SPLIT = "train_sft"
-NUM_CALIBRATION_SAMPLES = 1024
-MAX_SEQUENCE_LENGTH = 2048
-
-ds = load_dataset(
-    DATASET_ID, split=get_rank_partition(DATASET_SPLIT, NUM_CALIBRATION_SAMPLES)
-)
-ds = ds.shuffle(seed=42)
-
-
-def preprocess(example):
-    BOS = "<｜begin▁of▁sentence｜>"
-    EOS = "<｜end▁of▁sentence｜>"
-    text = BOS
-    for message in example["messages"]:
-        role = message["role"]
-        content = message["content"]
-        if role == "system":
-            text += content
-        elif role == "user":
-            text += f"<｜User｜>{content}"
-        elif role == "assistant":
-            text += f"<｜Assistant｜></think>{content}{EOS}"
-    return {"text": text}
-
-
-ds = ds.map(preprocess)
-
-
-def tokenize(sample):
-    return tokenizer(
-        sample["text"],
-        padding=False,
-        max_length=MAX_SEQUENCE_LENGTH,
-        truncation=True,
-        add_special_tokens=False,
-    )
-
-
-ds = ds.map(tokenize, remove_columns=ds.column_names)
 
 recipe = [
     REAPPruningModifier(sparsity=0.25),
@@ -86,10 +43,10 @@ recipe = [
 
 oneshot(
     model=model,
-    dataset=ds,
+    dataset="perfectblend",
     recipe=recipe,
-    max_seq_length=MAX_SEQUENCE_LENGTH,
-    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    max_seq_length=2048,
+    num_calibration_samples=1024,
     batch_size=1,
     shuffle_calibration_samples=True,
     propagate_error=False,

--- a/tests/e2e/configs/fp4_nvfp4.yaml
+++ b/tests/e2e/configs/fp4_nvfp4.yaml
@@ -3,5 +3,4 @@ test_group: "rhaiis"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: NVFP4
 num_calibration_samples: 20
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/fp8_static_per_tensor.yaml
+++ b/tests/e2e/configs/fp8_static_per_tensor.yaml
@@ -1,5 +1,4 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: FP8
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/int8_channel_weight_static_per_tensor_act.yaml
+++ b/tests/e2e/configs/int8_channel_weight_static_per_tensor_act.yaml
@@ -4,5 +4,4 @@ test_group: "rhaiis"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 skip_sanity_check: true
 recipe: tests/e2e/recipes/INT8/recipe_int8_channel_weight_static_per_tensor_act.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/int8_dynamic_per_token.yaml
+++ b/tests/e2e/configs/int8_dynamic_per_token.yaml
@@ -1,5 +1,4 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W8A8
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/kv_cache_fp8.yaml
+++ b/tests/e2e/configs/kv_cache_fp8.yaml
@@ -1,5 +1,4 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/kv_cache/default.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/kv_cache_gptq_tinyllama.yaml
+++ b/tests/e2e/configs/kv_cache_gptq_tinyllama.yaml
@@ -2,5 +2,4 @@ cadence: "nightly"
 test_group: "rhaiis"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/kv_cache/gptq.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/multiple_modifiers_gptq_awq.yaml
+++ b/tests/e2e/configs/multiple_modifiers_gptq_awq.yaml
@@ -1,6 +1,5 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/non_uniform/recipe_gptq_awq.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 num_calibration_samples: 256

--- a/tests/e2e/configs/multiple_modifiers_gptq_awq_disk.yaml
+++ b/tests/e2e/configs/multiple_modifiers_gptq_awq_disk.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/non_uniform/recipe_gptq_awq.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 num_calibration_samples: 256
 max_memory:
   cpu: 500_000_000  # 0.5Gb / 2Gb, force disk offloading

--- a/tests/e2e/configs/nvfp4_fp8_mixed.yaml
+++ b/tests/e2e/configs/nvfp4_fp8_mixed.yaml
@@ -1,6 +1,5 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/non_uniform/recipe_nvfp4_fp8_mixed.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 num_calibration_samples: 20

--- a/tests/e2e/configs/w4a16_asym_awq.yaml
+++ b/tests/e2e/configs/w4a16_asym_awq.yaml
@@ -2,5 +2,4 @@ cadence: "nightly"
 test_group: "rhaiis"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/WNA16/recipe_w4a16_awq_asym.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/w4a16_grouped_quant.yaml
+++ b/tests/e2e/configs/w4a16_grouped_quant.yaml
@@ -1,6 +1,5 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W4A16
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 quant_type: "GPTQ"

--- a/tests/e2e/configs/w4a16_sym_awq.yaml
+++ b/tests/e2e/configs/w4a16_sym_awq.yaml
@@ -1,5 +1,4 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/WNA16/recipe_w4a16_awq_sym.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/w8a16_grouped_quant.yaml
+++ b/tests/e2e/configs/w8a16_grouped_quant.yaml
@@ -1,6 +1,5 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W8A16
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 quant_type: "GPTQ"

--- a/tests/e2e/configs/w8a8_dynamic_asym.yaml
+++ b/tests/e2e/configs/w8a8_dynamic_asym.yaml
@@ -1,5 +1,4 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/INT8/recipe_w8a8_dynamic_asym.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/configs/w8a8_static_asym.yaml
+++ b/tests/e2e/configs/w8a8_static_asym.yaml
@@ -3,5 +3,4 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 skip_sanity_check: true
 recipe: tests/e2e/recipes/INT8/recipe_w8a8_static_asym.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend

--- a/tests/e2e/distributed_configs/w4a16_gptq_smoke.yaml
+++ b/tests/e2e/distributed_configs/w4a16_gptq_smoke.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W4A16
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 num_calibration_samples: 64
 quant_type: "GPTQ"
 num_gpus: 2

--- a/tests/e2e/distributed_configs/w4a16_rtn_smoke.yaml
+++ b/tests/e2e/distributed_configs/w4a16_rtn_smoke.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W4A16
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 num_calibration_samples: 64
 quant_type: "RTN"
 num_gpus: 2

--- a/tests/e2e/e2e_utils.py
+++ b/tests/e2e/e2e_utils.py
@@ -240,38 +240,44 @@ def prepare_oneshot_kwargs(
     kwargs = {"model": loaded_model}
 
     if dataset_id:
-        split = get_rank_partition(dataset_split, num_calibration_samples)
+        if "/" not in dataset_id:
+            # Prebaked dataset name (e.g., "perfectblend") — let oneshot handle
+            # loading, preprocessing, and DDP partitioning automatically
+            kwargs["dataset"] = dataset_id
+        else:
+            split = get_rank_partition(dataset_split, num_calibration_samples)
 
-        ds = load_dataset(dataset_id, name=dataset_config, split=split)
-        if shuffle_calibration_samples:
-            ds = ds.shuffle(seed=42)
+            ds = load_dataset(dataset_id, name=dataset_config, split=split)
+            if shuffle_calibration_samples:
+                ds = ds.shuffle(seed=42)
 
-        ds = process_dataset(ds, processor, max_seq_length)
-        kwargs["dataset"] = ds
+            ds = process_dataset(ds, processor, max_seq_length)
+            kwargs["dataset"] = ds
+
+            if "flickr30k" in dataset_id:
+
+                def data_collator(batch):
+                    assert len(batch) == 1
+                    return {key: torch.tensor(value) for key, value in batch[0].items()}
+
+                kwargs["data_collator"] = data_collator
+            elif "calibration" in dataset_id:
+
+                def data_collator(batch):
+                    assert len(batch) == 1
+                    return {
+                        key: (
+                            torch.tensor(value)
+                            if key != "pixel_values"
+                            else torch.tensor(value, dtype=torch.bfloat16).squeeze(0)
+                        )
+                        for key, value in batch[0].items()
+                    }
+
+                kwargs["data_collator"] = data_collator
+
         kwargs["max_seq_length"] = max_seq_length
         kwargs["num_calibration_samples"] = num_calibration_samples
-
-        if "flickr30k" in dataset_id:
-
-            def data_collator(batch):
-                assert len(batch) == 1
-                return {key: torch.tensor(value) for key, value in batch[0].items()}
-
-            kwargs["data_collator"] = data_collator
-        elif "calibration" in dataset_id:
-
-            def data_collator(batch):
-                assert len(batch) == 1
-                return {
-                    key: (
-                        torch.tensor(value)
-                        if key != "pixel_values"
-                        else torch.tensor(value, dtype=torch.bfloat16).squeeze(0)
-                    )
-                    for key, value in batch[0].items()
-                }
-
-            kwargs["data_collator"] = data_collator
 
     kwargs["recipe"] = build_recipe(recipe, quant_type, scheme)
     kwargs["shuffle_calibration_samples"] = shuffle_calibration_samples

--- a/tests/e2e/moe_configs/nvfp4_moe.yaml
+++ b/tests/e2e/moe_configs/nvfp4_moe.yaml
@@ -1,6 +1,5 @@
 cadence: "nightly"
 model: Qwen/Qwen3-30B-A3B
 scheme: NVFP4
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 num_calibration_samples: 20

--- a/tests/e2e/moe_configs/nvfp4_moe_awq.yaml
+++ b/tests/e2e/moe_configs/nvfp4_moe_awq.yaml
@@ -1,7 +1,6 @@
 cadence: "nightly"
 model: Qwen/Qwen3-30B-A3B
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 recipe: tests/e2e/recipes/NVFP4/recipe_awq_nvfp4.yaml
 save_dir: Qwen3-30B-A3B-NVFP4-AWQ
 num_calibration_samples: 50

--- a/tests/llmcompressor/modeling/test_moe_context.py
+++ b/tests/llmcompressor/modeling/test_moe_context.py
@@ -15,8 +15,7 @@ def test_oneshot_integration():
         cadence="commit",
         model="nm-testing/tinysmokeqwen3moe",
         scheme="NVFP4",
-        dataset_id="HuggingFaceH4/ultrachat_200k",
-        dataset_split="train_sft",
+        dataset_id="perfectblend",
         num_calibration_samples=1,
         max_seq_length=1,  # not enough tokens to send to all experts w/o context
     )

--- a/tests/llmcompressor/modifiers/pruning/reap/test_ddp.py
+++ b/tests/llmcompressor/modifiers/pruning/reap/test_ddp.py
@@ -18,11 +18,9 @@ import pytest
 import torch
 import torch.distributed as dist
 from compressed_tensors.offload import init_dist, load_offloaded_model
-from datasets import load_dataset
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM
 
 from llmcompressor import oneshot
-from llmcompressor.datasets.utils import get_rank_partition
 from llmcompressor.modifiers.pruning.reap import REAPPruningModifier
 from tests.testing_utils import requires_gpu, torchrun
 
@@ -34,28 +32,6 @@ MAX_SEQ_LENGTH = 512
 def _load_report(path):
     with open(path) as f:
         return json.load(f)
-
-
-def _prepare_dataset(model_id, num_samples, max_seq_length):
-    """Prepare calibration dataset with rank-aware partitioning."""
-    tok = AutoTokenizer.from_pretrained(model_id)
-    if tok.chat_template is None:
-        tok.chat_template = (
-            "{% for message in messages %}{{ message['content'] }}{% endfor %}"
-        )
-    split = get_rank_partition("train_sft", num_samples)
-    ds = load_dataset("HuggingFaceH4/ultrachat_200k", split=split)
-    ds = ds.map(
-        lambda ex: {"text": tok.apply_chat_template(ex["messages"], tokenize=False)}
-    )
-    ds = ds.map(
-        lambda s: tok(
-            s["text"], padding=False, max_length=max_seq_length, truncation=True
-        ),
-        remove_columns=ds.column_names,
-    )
-    ds.set_format("torch")
-    return ds
 
 
 @pytest.mark.integration
@@ -75,11 +51,10 @@ def test_reap_ddp_qwen3():
             model_ref = AutoModelForCausalLM.from_pretrained(
                 QWEN_MODEL, dtype=torch.bfloat16, device_map="auto_offload"
             )
-        ds_ref = _prepare_dataset(QWEN_MODEL, NUM_SAMPLES, MAX_SEQ_LENGTH)
 
         oneshot(
             model=model_ref,
-            dataset=ds_ref,
+            dataset="perfectblend",
             recipe=REAPPruningModifier(sparsity=0.25, report_path=ref_report),
             num_calibration_samples=NUM_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,
@@ -87,7 +62,7 @@ def test_reap_ddp_qwen3():
         )
 
         ref_retained = _load_report(ref_report)
-        del model_ref, ds_ref
+        del model_ref
         torch.accelerator.empty_cache()
 
         # DDP run
@@ -103,11 +78,10 @@ def test_reap_ddp_qwen3():
             model_ddp = AutoModelForCausalLM.from_pretrained(
                 QWEN_MODEL, dtype=torch.bfloat16, device_map="auto_offload"
             )
-        ds_ddp = _prepare_dataset(QWEN_MODEL, NUM_SAMPLES, MAX_SEQ_LENGTH)
 
         oneshot(
             model=model_ddp,
-            dataset=ds_ddp,
+            dataset="perfectblend",
             recipe=REAPPruningModifier(sparsity=0.25, report_path=ddp_report),
             num_calibration_samples=NUM_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,
@@ -122,6 +96,6 @@ def test_reap_ddp_qwen3():
                 f"  ddp: {ddp_retained}"
             )
 
-        del model_ddp, ds_ddp
+        del model_ddp
         torch.accelerator.empty_cache()
         dist.barrier()

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -26,11 +26,9 @@ import torch
 import torch.distributed
 from compressed_tensors.offload import init_dist, load_offloaded_model
 from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
-from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
-from llmcompressor.datasets.utils import get_rank_partition
 from llmcompressor.modifiers.autoround import AutoRoundModifier
 from llmcompressor.modifiers.gptq import GPTQModifier
 from llmcompressor.modifiers.quantization import QuantizationModifier
@@ -49,21 +47,17 @@ MAX_SEQ_LENGTH = 512
 # ---------------------------------------------------------------------------
 
 
-def _prepare_dataset(model_id: str, num_samples: int):
-    """Prepare calibration dataset with minimal preprocessing."""
-    tok = AutoTokenizer.from_pretrained(model_id)
+def _make_eval_dataset(model_id: str, num_samples: int = 5):
+    """Create a small tokenized dataset for output comparison (not calibration)."""
+    from datasets import Dataset
 
+    tok = AutoTokenizer.from_pretrained(model_id)
     if tok.chat_template is None:
         tok.chat_template = (
             "{% for message in messages %}{{ message['content'] }}{% endfor %}"
         )
-
-    split = get_rank_partition("train_sft", num_samples)
-    ds = load_dataset("HuggingFaceH4/ultrachat_200k", split=split)
-
-    ds = ds.map(
-        lambda ex: {"text": tok.apply_chat_template(ex["messages"], tokenize=False)}
-    )
+    prompts = [f"Question {i}: Explain briefly." for i in range(num_samples)]
+    ds = Dataset.from_dict({"text": prompts})
     ds = ds.map(
         lambda s: tok(
             s["text"], padding=False, max_length=MAX_SEQ_LENGTH, truncation=True
@@ -89,20 +83,20 @@ def _run_single_gpu(
         recipe: Compression recipe
         num_samples: Number of calibration samples
         device: Device to run on
-        return_model: If True, return (weights, model, dataset) instead of just weights
+        return_model: If True, return (weights, model, eval_dataset) instead of just
+            weights
 
     Returns:
-        weights dict if return_model=False, else (weights, model, dataset)
+        weights dict if return_model=False, else (weights, model, eval_dataset)
     """
     with load_offloaded_model():
         model = AutoModelForCausalLM.from_pretrained(
             model_id, dtype=torch.bfloat16, device_map="auto_offload"
         )
-    ds = _prepare_dataset(model_id, num_samples)
 
     oneshot(
         model=model,
-        dataset=ds,
+        dataset="perfectblend",
         recipe=recipe,
         num_calibration_samples=num_samples,
         max_seq_length=MAX_SEQ_LENGTH,
@@ -116,7 +110,8 @@ def _run_single_gpu(
     }
 
     if return_model:
-        return weights, model, ds
+        eval_ds = _make_eval_dataset(model_id)
+        return weights, model, eval_ds
 
     del model
     torch.accelerator.empty_cache()
@@ -256,13 +251,10 @@ def _test_ddp_modifier(
     with load_offloaded_model():
         model = AutoModelForCausalLM.from_pretrained(MODEL, **load_kwargs)
 
-    # Prepare dataset with rank partitioning
-    ds = _prepare_dataset(MODEL, NUM_SAMPLES)
-
-    # Run oneshot with DDP
+    # Run oneshot with DDP — prebaked dataset handles rank partitioning automatically
     oneshot(
         model=model,
-        dataset=ds,
+        dataset="perfectblend",
         recipe=recipe_factory(),
         num_calibration_samples=NUM_SAMPLES,
         max_seq_length=MAX_SEQ_LENGTH,

--- a/tests/llmcompressor/transformers/compression/test_quantization.py
+++ b/tests/llmcompressor/transformers/compression/test_quantization.py
@@ -60,7 +60,7 @@ def setup_model_and_config(request, tmpdir_factory):
         "new_recipe": None,
         "ppl_threshold": None,
         "model_stub": None,
-        "dataset": "ultrachat-200k",
+        "dataset": "perfectblend",
         "output": "tiny_llama_out",
         "max_seq_length": 512,
         "weight_dtype": torch.float16,
@@ -134,7 +134,7 @@ def test_perplexity(setup_model_and_config):
         pytest.skip("Skipping perplexity calculation.")
     tokenizer = AutoTokenizer.from_pretrained(config["model_stub"])
     dataset_args = DatasetArguments(
-        dataset="ultrachat-200k",
+        dataset="perfectblend",
         max_seq_length=config["max_seq_length"],
     )
     dataloader = _get_dataloader(dataset_args, tokenizer)

--- a/tests/llmcompressor/transformers/compression/test_quantization.py
+++ b/tests/llmcompressor/transformers/compression/test_quantization.py
@@ -20,7 +20,7 @@ def _get_dataloader(dataset_args, tokenizer):
     dataset_manager = TextGenerationDataset.load_from_registry(
         dataset_args.dataset,
         dataset_args=dataset_args,
-        split="train_gen[:5%]",
+        split="train[:5%]",
         processor=tokenizer,
     )
     calib_dataset = dataset_manager()
@@ -84,7 +84,7 @@ def setup_model_and_config(request, tmpdir_factory):
         num_calibration_samples=num_calibration_samples,
         recipe=config["new_recipe"],
         pad_to_max_length=pad_to_max_length,
-        splits=f"train_gen[:{num_calibration_samples}]",
+        splits=f"train[:{num_calibration_samples}]",
         save_compressed=False,
     )
 

--- a/tests/llmcompressor/transformers/compression/test_recipe_parsing.py
+++ b/tests/llmcompressor/transformers/compression/test_recipe_parsing.py
@@ -24,7 +24,7 @@ def setup_model_and_config(tmp_path):
 
     return {
         "model": model,
-        "dataset": "ultrachat-200k",
+        "dataset": "perfectblend",
         "output_dir": str(tmp_path / "compressed_output"),
         "splits": "train_gen[:10]",
         "max_seq_length": 2048,

--- a/tests/llmcompressor/transformers/compression/test_recipe_parsing.py
+++ b/tests/llmcompressor/transformers/compression/test_recipe_parsing.py
@@ -26,7 +26,7 @@ def setup_model_and_config(tmp_path):
         "model": model,
         "dataset": "perfectblend",
         "output_dir": str(tmp_path / "compressed_output"),
-        "splits": "train_gen[:10]",
+        "splits": "train[:10]",
         "max_seq_length": 2048,
         "pad_to_max_length": False,
         "num_calibration_samples": 8,

--- a/tests/llmcompressor/transformers/kv_cache/test_kv_cache.py
+++ b/tests/llmcompressor/transformers/kv_cache/test_kv_cache.py
@@ -3,8 +3,7 @@ from pathlib import Path
 
 import pytest
 from compressed_tensors.quantization import is_cached_attention_module
-from datasets import load_dataset
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoConfig, AutoModelForCausalLM
 from transformers.utils.quantization_config import CompressedTensorsConfig
 
 from llmcompressor import oneshot
@@ -13,8 +12,6 @@ from tests.testing_utils import requires_gpu, requires_version
 
 NUM_CALIBRATION_SAMPLES = 16
 MAX_SEQUENCE_LENGTH = 512
-DATASET_ID = "HuggingFaceH4/ultrachat_200k"
-DATASET_SPLIT = f"train_sft[:{NUM_CALIBRATION_SAMPLES}]"
 
 MODEL_IDS = [
     "nm-testing/tinysmokeqwen3",
@@ -82,44 +79,16 @@ def kv_cache_fixture():
 
         model_id = "nm-testing/tinysmokeqwen3"
 
-        ds = load_dataset(DATASET_ID, split=DATASET_SPLIT)
-        ds = ds.shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))
-
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
-
-        def preprocess(example):
-            return {
-                "text": tokenizer.apply_chat_template(
-                    example["messages"],
-                    tokenize=False,
-                )
-            }
-
-        ds = ds.map(preprocess)
-
-        def tokenize(sample):
-            return tokenizer(
-                sample["text"],
-                padding=False,
-                max_length=MAX_SEQUENCE_LENGTH,
-                truncation=True,
-                add_special_tokens=False,
-            )
-
-        ds = ds.map(tokenize, remove_columns=ds.column_names)
-
         output_dir = os.path.join(tmp_path, model_id[-1].replace("-", "_"))
 
-        oneshot_args = dict(
+        oneshot(
             model=model_id,
-            dataset=ds,
+            dataset="perfectblend",
             recipe=recipe,
             max_seq_length=MAX_SEQUENCE_LENGTH,
             num_calibration_samples=NUM_CALIBRATION_SAMPLES,
             output_dir=output_dir,
         )
-
-        oneshot(**oneshot_args)
         reset_session()
 
         yield (

--- a/tests/lmeval/configs/awq_nvfp4.yaml
+++ b/tests/lmeval/configs/awq_nvfp4.yaml
@@ -1,7 +1,6 @@
 cadence: "nightly"
 model: meta-llama/Llama-3.1-8B-Instruct
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 num_calibration_samples: 20
 recipe: tests/e2e/recipes/NVFP4/recipe_awq_nvfp4.yaml
 lmeval:

--- a/tests/lmeval/configs/fp8_static_per_tensor.yaml
+++ b/tests/lmeval/configs/fp8_static_per_tensor.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: meta-llama/Meta-Llama-3-8B-Instruct
 scheme: FP8
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 lmeval:
   metrics:
     exact_match,flexible-extract: 0.75

--- a/tests/lmeval/configs/int8_w8a8_dynamic_per_token.yaml
+++ b/tests/lmeval/configs/int8_w8a8_dynamic_per_token.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: meta-llama/Meta-Llama-3-8B-Instruct
 recipe: tests/e2e/recipes/INT8/recipe_int8_channel_weight_dynamic_per_token.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 lmeval:
   metrics:
     exact_match,flexible-extract: 0.75

--- a/tests/lmeval/configs/w4a16_actorder_weight.yaml
+++ b/tests/lmeval/configs/w4a16_actorder_weight.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: meta-llama/Meta-Llama-3-8B-Instruct
 recipe: tests/e2e/recipes/actorder/recipe_w4a16_actorder_weight.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 lmeval:
   recovery_threshold:
     exact_match,strict-match: 0.93

--- a/tests/lmeval/configs/w4a16_awq_sym.yaml
+++ b/tests/lmeval/configs/w4a16_awq_sym.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: meta-llama/Meta-Llama-3-8B-Instruct
 recipe: tests/e2e/recipes/WNA16/recipe_w4a16_awq_sym.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 seed: 100
 lmeval:
   recovery_threshold:

--- a/tests/lmeval/configs/w4a16_gptq.yaml
+++ b/tests/lmeval/configs/w4a16_gptq.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: meta-llama/Meta-Llama-3-8B-Instruct
 scheme: W4A16
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 quant_type: "GPTQ"
 lmeval:
   recovery_threshold:

--- a/tests/lmeval/configs/w4a4_nvfp4.yaml
+++ b/tests/lmeval/configs/w4a4_nvfp4.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: meta-llama/Llama-3.1-8B-Instruct
 scheme: NVFP4
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 seed: 100
 num_calibration_samples: 20
 lmeval:

--- a/tests/lmeval/distributed_configs/nvfp4_qmod.yaml
+++ b/tests/lmeval/distributed_configs/nvfp4_qmod.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: Qwen/Qwen3-8B
 scheme: NVFP4
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 num_calibration_samples: 256
 lmeval:
   task: gsm8k

--- a/tests/lmeval/distributed_configs/w4a16_awq.yaml
+++ b/tests/lmeval/distributed_configs/w4a16_awq.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: Qwen/Qwen3-8B
 recipe: tests/e2e/recipes/WNA16/recipe_w4a16_awq_sym.yaml
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 lmeval:
   task: gsm8k
   num_fewshot: 5

--- a/tests/lmeval/distributed_configs/w4a16_gptq.yaml
+++ b/tests/lmeval/distributed_configs/w4a16_gptq.yaml
@@ -1,8 +1,7 @@
 cadence: "nightly"
 model: Qwen/Qwen3-8B
 scheme: W4A16
-dataset_id: HuggingFaceH4/ultrachat_200k
-dataset_split: train_sft
+dataset_id: perfectblend
 quant_type: "GPTQ"
 lmeval:
   task: gsm8k

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -67,12 +67,13 @@ class BaseTestConfig(BaseModel):
     Optional calibration dataset fields
     ------------------------------------
     dataset_id : str | None
-        HuggingFace dataset ID for calibration. Leave unset to skip calibration.
-        Datasets with special data-collator handling in run_oneshot_for_e2e_testing:
-          - "HuggingFaceH4/ultrachat_200k"  → text, DefaultDataCollator
+        Calibration dataset. Leave unset to skip calibration.
+        Names without "/" are treated as prebaked datasets (e.g. "perfectblend")
+        and passed directly to oneshot, which handles loading and preprocessing.
+        Names with "/" are HuggingFace dataset IDs loaded manually:
           - "neuralmagic/calibration"        → multimodal; set dataset_config="LLM"
           - any ID containing "flickr30k"   → multimodal, flickr30k collator
-        Any other dataset ID uses DefaultDataCollator.
+        Any other HuggingFace ID uses DefaultDataCollator.
     dataset_config : str | None
         Dataset config/subset name (e.g. "LLM" for "neuralmagic/calibration").
         Required for datasets with multiple configurations.
@@ -133,8 +134,7 @@ class BaseTestConfig(BaseModel):
         cadence: commit
         model: meta-llama/Meta-Llama-3-8B-Instruct
         scheme: FP8_DYNAMIC
-        dataset_id: HuggingFaceH4/ultrachat_200k
-        dataset_split: train_sft
+        dataset_id: perfectblend
         num_calibration_samples: 512
         ```
 
@@ -208,11 +208,11 @@ class BaseTestConfig(BaseModel):
     dataset_id: Optional[str] = Field(
         None,
         description=(
-            "HuggingFace dataset ID. Known datasets with special collator handling:\n"
-            " 'HuggingFaceH4/ultrachat_200k' — text, DefaultDataCollator\n"
+            "Calibration dataset. Names without '/' are prebaked (e.g. 'perfectblend')\n"
+            "and handled automatically by oneshot. Names with '/' are HuggingFace IDs:\n"
             " 'neuralmagic/calibration'      — multimodal (set dataset_config='LLM')\n"
             " any ID containing 'flickr30k'  — multimodal, flickr30k collator\n"
-            "Any other ID uses DefaultDataCollator."
+            "Any other HuggingFace ID uses DefaultDataCollator."
         ),
     )
     dataset_config: Optional[str] = Field(

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -208,10 +208,8 @@ class BaseTestConfig(BaseModel):
     dataset_id: Optional[str] = Field(
         None,
         description=(
-            "Calibration dataset. Names without '/' are prebaked (e.g. 'perfectblend')\n"
-            "and handled automatically by oneshot. Names with '/' are HuggingFace IDs:\n"
-            " 'neuralmagic/calibration'      — multimodal (set dataset_config='LLM')\n"
-            " any ID containing 'flickr30k'  — multimodal, flickr30k collator\n"
+            "Calibration dataset. Supports prebaked datasets (e.g. 'perfectblend')\n"
+            "Any ID containing 'flickr30k' uses the multimodal collator\n"
             "Any other HuggingFace ID uses DefaultDataCollator."
         ),
     )


### PR DESCRIPTION
* Update straggler examples not caught by https://github.com/vllm-project/llm-compressor/pull/3062
* Update tests to use perfect blend
  * This is create a slight difference in lm_eval tests, but will mean that our lm_eval tests are more representative of our default flows