### PR TITLE
fix(dist): write back broadcast qparams to offload storage on non-src ranks

### DIFF
--- a/src/llmcompressor/utils/dist.py
+++ b/src/llmcompressor/utils/dist.py
@@ -9,7 +9,7 @@ from compressed_tensors.distributed import (
 from compressed_tensors.distributed import (
     wait_for_comms as _wait_for_comms,
 )
-from compressed_tensors.offload import get_execution_device
+from compressed_tensors.offload import get_execution_device, update_offload_parameter
 from compressed_tensors.offload.dist_utils import as_broadcastable
 from compressed_tensors.utils.helpers import deprecated
 
@@ -60,29 +60,51 @@ def broadcast_qparams_and_cleanup(
 ) -> None:
     """Broadcast quantization params from owning rank and clean up observer stats.
 
+    For CPU-offloaded modules (e.g. those using CPUCache), ``dist.broadcast``
+    modifies a temporary onloaded tensor in-place rather than the underlying
+    offload storage. The explicit ``update_offload_parameter`` calls after
+    ``_wait_for_comms`` write the broadcast result back to the actual storage
+    on non-source ranks.
+
     :param module_list: all modules across all ranks
     :param module_to_rank: mapping from module to the rank that computed its qparams
     :param qparam_names: attribute names to broadcast (e.g. weight_scale, weight)
     :param skip_cpu: if True, skip broadcasting for CPU-offloaded modules
     """
+    is_dist_initialized = dist.is_initialized()
+    rank = dist.get_rank() if is_dist_initialized else 0
+
     pending_comms = []
+    writeback_items: list[tuple[torch.nn.Module, str, torch.Tensor, torch.Tensor]] = []
+
     for module in module_list:
-        should_broadcast = not skip_cpu or (
-            get_execution_device(module) != torch.device("cpu")
+        should_broadcast = is_dist_initialized and (
+            not skip_cpu or (get_execution_device(module) != torch.device("cpu"))
         )
         if should_broadcast:
+            src = module_to_rank[module]
             for name in qparam_names:
                 if (param := getattr(module, name, None)) is not None:
+                    broadcast_param = as_broadcastable(param)
                     pending_comms.append(
                         dist.broadcast(
-                            as_broadcastable(param),
-                            src=module_to_rank[module],
+                            broadcast_param,
+                            src=src,
                             async_op=True,
                         )
                     )
+                    if rank != src:
+                        writeback_items.append((module, name, param, broadcast_param))
 
         obs = getattr(module, "weight_observer", None)
         if obs is not None and obs.has_statistics:
             obs.delete_statistics(check_fused=True)
 
     _wait_for_comms(pending_comms)
+
+    for module, name, param, broadcast_param in writeback_items:
+        if broadcast_param is not param and (
+            broadcast_param.data_ptr() != param.data_ptr()
+        ):
+            param.copy_(broadcast_param.reshape_as(param))
+        update_offload_parameter(module, name, param)

--- a/tests/llmcompressor/utils/test_broadcast_qparams_ddp_integration.py
+++ b/tests/llmcompressor/utils/test_broadcast_qparams_ddp_integration.py
@@ -1,0 +1,125 @@
+"""Integration test: real CPUCache + real dist.broadcast.
+
+Demonstrates the writeback bug and its fix in a single distributed session.
+
+Key design:
+- offload_module is called BEFORE dist.init_process_group().
+  OffloadCache.cls_from_device checks dist.is_initialized() at call time.
+  When dist is not yet initialized, offload_device='cpu' selects CPUCache
+  (not DistributedCPUCache), so each rank holds independent CPU storage.
+- dist is initialized AFTER module setup, enabling real NCCL broadcast.
+
+This mirrors the real auto_offload DDP GPTQ scenario:
+  - GPTQ runs on each module's owning rank, computes weight_scale
+  - broadcast_qparams_and_cleanup is called to propagate to all other ranks
+  - Without the fix, dist.broadcast modifies a temporary CUDA tensor that is
+    discarded without writing back to each rank's independent CPUCache storage
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from compressed_tensors.distributed import wait_for_comms
+from compressed_tensors.offload import offload_module
+from compressed_tensors.offload.dist_utils import as_broadcastable
+
+from llmcompressor.utils.dist import broadcast_qparams_and_cleanup
+from tests.testing_utils import requires_gpu, torchrun
+
+
+def _upstream_broadcast_no_writeback(module_list, module_to_rank, qparam_names):
+    """Reproduces upstream (buggy) broadcast_qparams_and_cleanup:
+    broadcasts without writing back to CPUCache storage."""
+    pending_comms = []
+    for module in module_list:
+        src = module_to_rank[module]
+        for name in qparam_names:
+            if (param := getattr(module, name, None)) is not None:
+                pending_comms.append(
+                    dist.broadcast(as_broadcastable(param), src=src, async_op=True)
+                )
+    wait_for_comms(pending_comms)
+    # Intentionally no update_offload_parameter — this is the bug
+
+
+@pytest.mark.multi_gpu
+@requires_gpu(2)
+@torchrun(world_size=2, init_dist=False)
+def test_broadcast_qparams_writeback_with_cpu_offload():
+    """Phase A: upstream bug — non-src rank keeps stale weight_scale after broadcast.
+    Phase B: fix — all ranks get correct weight_scale after broadcast + writeback.
+
+    Critical: offload_module is called BEFORE dist.init_process_group() so that
+    OffloadCache.cls_from_device('cpu') returns CPUCache (not DistributedCPUCache),
+    giving each rank its own independent CPU memory for weight_scale.
+    """
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device(f"cuda:{local_rank}")
+    torch.accelerator.set_device_index(local_rank)
+
+    src_val = 42.0
+    stale_val = 0.0
+
+    # ── Setup: create modules with independent CPUCache BEFORE dist init ─────
+    # At this point dist.is_initialized() == False → offload_module selects CPUCache
+    def _make_module(val: float) -> torch.nn.Module:
+        mod = torch.nn.Linear(4, 4, bias=False).to(device)
+        offload_module(mod, onload_device=device, offload_device="cpu")
+        mod.register_parameter(
+            "weight_scale",
+            torch.nn.Parameter(
+                torch.full((4,), val if rank == 0 else stale_val),
+                requires_grad=False,
+            ),
+        )
+        return mod
+
+    mod_bug = _make_module(src_val)  # used for Phase A (upstream bug demo)
+    mod_fix = _make_module(src_val)  # used for Phase B (fix demo)
+    module_to_rank = {mod_bug: 0, mod_fix: 0}
+
+    # ── Init dist AFTER module setup ─────────────────────────────────────────
+    dist.init_process_group(
+        backend="nccl",
+        init_method="env://",
+        rank=rank,
+        world_size=int(os.environ["WORLD_SIZE"]),
+        device_id=device,
+    )
+
+    # ── Phase A: upstream (buggy) broadcast — no CPUCache writeback ───────────
+    _upstream_broadcast_no_writeback([mod_bug], module_to_rank, ["weight_scale"])
+    dist.barrier()
+
+    result_a = getattr(mod_bug, "weight_scale").cpu()
+    if rank == 0:
+        assert torch.all(
+            result_a == src_val
+        ), f"rank 0 (src): expected {src_val}, got {result_a}"
+    else:
+        # Bug: dist.broadcast wrote into a temporary CUDA tensor which was discarded.
+        # CPUCache storage was never updated → non-src rank still holds stale_val.
+        assert torch.all(result_a == stale_val), (
+            f"rank {rank}: upstream bug — expected stale {stale_val} in CPUCache, "
+            f"got {result_a} (bug not present or test setup incorrect)"
+        )
+        print(
+            f"\n[rank {rank}] Phase A BUG CONFIRMED: "
+            f"weight_scale={result_a.tolist()} (stale, not {src_val})"
+        )
+
+    # ── Phase B: fix — broadcast_qparams_and_cleanup with writeback ───────────
+    broadcast_qparams_and_cleanup([mod_fix], module_to_rank, ["weight_scale"])
+    dist.barrier()
+
+    result_b = getattr(mod_fix, "weight_scale").cpu()
+    assert torch.all(result_b == src_val), (
+        f"rank {rank}: Phase B (fix) — expected {src_val} after writeback, "
+        f"got {result_b}"
+    )
+    print(f"[rank {rank}] Phase B FIX CONFIRMED: weight_scale={result_b.tolist()}")
+
+    dist.destroy_process_group()

--- a/tests/llmcompressor/utils/test_broadcast_qparams_writeback.py
+++ b/tests/llmcompressor/utils/test_broadcast_qparams_writeback.py
@@ -1,0 +1,254 @@
+"""Regression tests for broadcast_qparams_and_cleanup writeback.
+
+Validates that non-source ranks correctly persist broadcast results to
+offload storage (CPUCache). Without the update_offload_parameter calls,
+dist.broadcast modifies a temporary onloaded tensor but leaves the
+underlying CPU storage stale — producing NaN weight_scale in DDP GPTQ
+with the no-copy views path (issue #2949).
+"""
+
+import importlib
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.distributed as torch_dist
+
+# Must use importlib to get the actual module object.
+# `from .dist import *` in llmcompressor/utils/__init__.py re-exports
+# `dist = torch.distributed`, so `import llmcompressor.utils.dist as m`
+# resolves `m` to torch.distributed via attribute lookup — not the file module.
+dist_module = importlib.import_module("llmcompressor.utils.dist")
+
+
+def _make_module(**params):
+    m = torch.nn.Linear(4, 4, bias=False)
+    for name, val in params.items():
+        setattr(m, name, val)
+    return m
+
+
+def _enter_dist_patches(stack, rank, world_size=2):
+    """Stub out torch.distributed calls inside an ExitStack."""
+    stack.enter_context(patch.object(torch_dist, "is_initialized", return_value=True))
+    stack.enter_context(patch.object(torch_dist, "get_rank", return_value=rank))
+    stack.enter_context(
+        patch.object(torch_dist, "get_world_size", return_value=world_size)
+    )
+    stack.enter_context(patch.object(torch_dist, "broadcast", return_value=MagicMock()))
+
+
+@pytest.mark.unit
+def test_writeback_called_on_non_src_rank():
+    """Non-src ranks must call update_offload_parameter for each broadcast param."""
+    scale = torch.ones(4)
+    zp = torch.zeros(4)
+    mod = _make_module(weight_scale=scale, weight_zero_point=zp)
+    module_to_rank = {mod: 0}
+
+    with ExitStack() as stack:
+        mock_uop = stack.enter_context(
+            patch.object(dist_module, "update_offload_parameter")
+        )
+        stack.enter_context(patch.object(dist_module, "_wait_for_comms"))
+        stack.enter_context(
+            patch.object(
+                dist_module,
+                "get_execution_device",
+                return_value=torch.device("cuda", 0),
+            )
+        )
+        _enter_dist_patches(stack, rank=1)
+
+        dist_module.broadcast_qparams_and_cleanup(
+            [mod], module_to_rank, ["weight_scale", "weight_zero_point"]
+        )
+
+    assert mock_uop.call_count == 2
+    mock_uop.assert_any_call(mod, "weight_scale", scale)
+    mock_uop.assert_any_call(mod, "weight_zero_point", zp)
+
+
+@pytest.mark.unit
+def test_no_writeback_on_src_rank():
+    """Source rank must not call update_offload_parameter (it owns the params)."""
+    scale = torch.ones(4)
+    mod = _make_module(weight_scale=scale)
+    module_to_rank = {mod: 0}
+
+    with ExitStack() as stack:
+        mock_uop = stack.enter_context(
+            patch.object(dist_module, "update_offload_parameter")
+        )
+        stack.enter_context(patch.object(dist_module, "_wait_for_comms"))
+        stack.enter_context(
+            patch.object(
+                dist_module,
+                "get_execution_device",
+                return_value=torch.device("cuda", 0),
+            )
+        )
+        _enter_dist_patches(stack, rank=0)
+
+        dist_module.broadcast_qparams_and_cleanup(
+            [mod], module_to_rank, ["weight_scale"]
+        )
+
+    mock_uop.assert_not_called()
+
+
+@pytest.mark.unit
+def test_writeback_skipped_for_missing_params():
+    """Params absent on a module are silently skipped (no broadcast, no writeback)."""
+    mod = _make_module()  # no weight_scale attribute
+    module_to_rank = {mod: 0}
+
+    with ExitStack() as stack:
+        mock_uop = stack.enter_context(
+            patch.object(dist_module, "update_offload_parameter")
+        )
+        stack.enter_context(patch.object(dist_module, "_wait_for_comms"))
+        stack.enter_context(
+            patch.object(
+                dist_module,
+                "get_execution_device",
+                return_value=torch.device("cuda", 0),
+            )
+        )
+        mock_broadcast = stack.enter_context(
+            patch.object(torch_dist, "broadcast", return_value=MagicMock())
+        )
+        stack.enter_context(
+            patch.object(torch_dist, "is_initialized", return_value=True)
+        )
+        stack.enter_context(patch.object(torch_dist, "get_rank", return_value=1))
+
+        dist_module.broadcast_qparams_and_cleanup(
+            [mod], module_to_rank, ["weight_scale"]
+        )
+
+    mock_broadcast.assert_not_called()
+    mock_uop.assert_not_called()
+
+
+@pytest.mark.unit
+def test_writeback_covers_multiple_modules():
+    """Writeback covers all non-src modules across multiple owner ranks."""
+    scale_a = torch.ones(4)
+    scale_b = torch.ones(4) * 2
+    mod_a = _make_module(weight_scale=scale_a)
+    mod_b = _make_module(weight_scale=scale_b)
+    module_to_rank = {mod_a: 0, mod_b: 1}
+
+    with ExitStack() as stack:
+        mock_uop = stack.enter_context(
+            patch.object(dist_module, "update_offload_parameter")
+        )
+        stack.enter_context(patch.object(dist_module, "_wait_for_comms"))
+        stack.enter_context(
+            patch.object(
+                dist_module,
+                "get_execution_device",
+                return_value=torch.device("cuda", 0),
+            )
+        )
+        _enter_dist_patches(stack, rank=2, world_size=3)
+
+        dist_module.broadcast_qparams_and_cleanup(
+            [mod_a, mod_b], module_to_rank, ["weight_scale"]
+        )
+
+    assert mock_uop.call_count == 2
+    mock_uop.assert_any_call(mod_a, "weight_scale", scale_a)
+    mock_uop.assert_any_call(mod_b, "weight_scale", scale_b)
+
+
+@pytest.mark.unit
+def test_copy_back_when_broadcast_param_is_distinct_storage():
+    """When as_broadcastable returns a tensor with different storage (true copy),
+    the broadcasted data must be copied back into param before writeback."""
+    scale = torch.zeros(4)
+    mod = _make_module(weight_scale=scale)
+    module_to_rank = {mod: 0}
+
+    # Simulate as_broadcastable returning a clone (different storage, different ptr)
+    clone = scale.clone()
+    clone.fill_(9.0)  # distinct values so we can verify the copy happened
+
+    with ExitStack() as stack:
+        mock_uop = stack.enter_context(
+            patch.object(dist_module, "update_offload_parameter")
+        )
+        stack.enter_context(patch.object(dist_module, "_wait_for_comms"))
+        stack.enter_context(
+            patch.object(
+                dist_module,
+                "get_execution_device",
+                return_value=torch.device("cuda", 0),
+            )
+        )
+        stack.enter_context(
+            patch.object(dist_module, "as_broadcastable", return_value=clone)
+        )
+        _enter_dist_patches(stack, rank=1)
+
+        dist_module.broadcast_qparams_and_cleanup(
+            [mod], module_to_rank, ["weight_scale"]
+        )
+
+    # param should have been updated with clone's values before writeback
+    assert torch.all(scale == 9.0)
+    mock_uop.assert_called_once_with(mod, "weight_scale", scale)
+
+
+@pytest.mark.unit
+def test_no_copy_when_broadcast_param_is_view_of_same_storage():
+    """When as_broadcastable returns a view sharing storage with param (e.g. the
+    FP8 uint8 reinterpret view), dist.broadcast already updates param in-place
+    via the shared storage — param.copy_() must NOT be called."""
+    scale = torch.zeros(4)
+    mod = _make_module(weight_scale=scale)
+    module_to_rank = {mod: 0}
+
+    # Simulate as_broadcastable returning a view: different object, same data_ptr.
+    view = scale.view(scale.numel())
+    assert view.data_ptr() == scale.data_ptr()
+    assert view is not scale
+
+    # Simulate broadcast writing 7.0 into the shared storage.
+    def _fake_broadcast(tensor, src, **kwargs):
+        tensor.fill_(7.0)
+
+    with ExitStack() as stack:
+        mock_uop = stack.enter_context(
+            patch.object(dist_module, "update_offload_parameter")
+        )
+        stack.enter_context(patch.object(dist_module, "_wait_for_comms"))
+        stack.enter_context(
+            patch.object(
+                dist_module,
+                "get_execution_device",
+                return_value=torch.device("cuda", 0),
+            )
+        )
+        stack.enter_context(
+            patch.object(dist_module, "as_broadcastable", return_value=view)
+        )
+        stack.enter_context(
+            patch.object(torch_dist, "broadcast", side_effect=_fake_broadcast)
+        )
+        stack.enter_context(
+            patch.object(torch_dist, "is_initialized", return_value=True)
+        )
+        stack.enter_context(patch.object(torch_dist, "get_rank", return_value=1))
+        stack.enter_context(patch.object(torch_dist, "get_world_size", return_value=2))
+
+        dist_module.broadcast_qparams_and_cleanup(
+            [mod], module_to_rank, ["weight_scale"]
+        )
+
+    # Broadcast wrote into the shared storage — param reflects the update without copy_.
+    assert torch.all(scale == 7.0)
+    # update_offload_parameter is still called with param (not view).
+    mock_uop.assert_called_once_with(mod, "weight_scale", scale)

--- a/tests/llmcompressor/utils/test_cpucache_temporary_tensor.py
+++ b/tests/llmcompressor/utils/test_cpucache_temporary_tensor.py
@@ -1,0 +1,111 @@
+"""Root-cause proof: CPUCache.__getattr__ returns a temporary CUDA tensor.
+
+In-place modifications (e.g. from dist.broadcast) are silently discarded
+without an explicit update_offload_parameter call. This is the underlying
+mechanism behind the broadcast_qparams_and_cleanup writeback bug.
+
+Requires 1 GPU. No distributed setup, no model weights, no calibration data.
+
+Setup that reproduces the bug path:
+  - offload_module(..., onload_device='cuda:0', offload_device='cpu') → CPUCache
+  - register_parameter('weight_scale', ...) → stored in CPUCache._parameters
+  - getattr(mod, 'weight_scale') → CPUCache onloads to GPU → returns NEW CUDA tensor
+  - dist.broadcast modifies that temporary in-place
+  - temporary is discarded → CPU storage retains original (stale) value
+
+Note: setattr / __dict__ attributes do NOT trigger this behavior.
+      CPU/CPU offload does NOT trigger this behavior (no device transfer).
+"""
+
+import pytest
+import torch
+from compressed_tensors.offload import offload_module, update_offload_parameter
+
+
+def _make_offloaded_module_with_scale(scale_value: float) -> torch.nn.Module:
+    """CPUCache-offloaded module with weight_scale as a registered parameter."""
+    mod = torch.nn.Linear(4, 4, bias=False)
+    offload_module(mod, onload_device="cuda:0", offload_device="cpu")
+    # register_parameter mirrors what quantization lifecycle does for weight_scale
+    mod.register_parameter(
+        "weight_scale",
+        torch.nn.Parameter(torch.full((4,), scale_value), requires_grad=False),
+    )
+    return mod
+
+
+@pytest.mark.unit
+def test_cpucache_getattr_returns_new_temporary_each_call():
+    """Each getattr call on a CPUCache-offloaded registered parameter returns
+    a freshly allocated CUDA tensor — not the same object or same storage.
+
+    This is the key property that makes dist.broadcast's in-place write
+    ineffective: it writes to a temporary that is immediately discarded.
+    """
+    if not torch.accelerator.is_available():
+        pytest.skip("requires CUDA")
+
+    mod = _make_offloaded_module_with_scale(2.0)
+
+    first = getattr(mod, "weight_scale")
+    second = getattr(mod, "weight_scale")
+
+    assert first.device.type == "cuda", "CPUCache should onload to CUDA"
+    assert first is not second, "each getattr must return a distinct tensor object"
+    assert (
+        first.data_ptr() != second.data_ptr()
+    ), "each getattr allocates a new CUDA buffer — data_ptrs must differ"
+
+
+@pytest.mark.unit
+def test_inplace_modification_lost_without_writeback():
+    """Simulates exactly what dist.broadcast does: modifies the temporary
+    CUDA tensor in-place. Without update_offload_parameter the modification
+    is silently discarded — the CPU offload storage keeps the original value.
+
+    This is the bug: non-source ranks end up with stale weight_scale.
+    """
+    if not torch.accelerator.is_available():
+        pytest.skip("requires CUDA")
+
+    mod = _make_offloaded_module_with_scale(2.0)
+
+    # Step 1: retrieve temporary CUDA tensor (mirrors getattr in
+    # broadcast_qparams_and_cleanup)
+    tmp = getattr(mod, "weight_scale")
+    assert tmp.device.type == "cuda"
+
+    # Step 2: simulate dist.broadcast writing into the temporary in-place
+    tmp.fill_(99.0)
+    assert torch.all(tmp == 99.0)  # modification visible on the temporary
+
+    # Step 3: re-read — CPUCache allocates a fresh onload; original CPU value survives
+    after = getattr(mod, "weight_scale")
+    assert torch.all(after == 2.0), (
+        f"Expected original 2.0 to survive (writeback not called), got {after.cpu()} — "
+        "CPUCache storage was unexpectedly updated without update_offload_parameter"
+    )
+
+
+@pytest.mark.unit
+def test_update_offload_parameter_persists_modification():
+    """update_offload_parameter correctly flushes the modified CUDA tensor
+    back into CPUCache CPU storage — this is the mechanism the fix relies on.
+
+    After calling it, subsequent getattr returns the new value.
+    """
+    if not torch.accelerator.is_available():
+        pytest.skip("requires CUDA")
+
+    mod = _make_offloaded_module_with_scale(2.0)
+
+    tmp = getattr(mod, "weight_scale")
+    tmp.fill_(99.0)
+
+    # Explicit writeback — what the fix adds after _wait_for_comms
+    update_offload_parameter(mod, "weight_scale", tmp)
+
+    after = getattr(mod, "weight_scale")
+    assert torch.all(
+        after == 99.0
+    ), f"Expected 99.0 after update_offload_parameter, got {after.cpu()}"


### PR DESCRIPTION
## Summary

`broadcast_qparams_and_cleanup` calls `dist.broadcast` on module attributes such as `weight_scale`, `weight_zero_point`, and `weight_g_idx`. When these tensors are stored in `CPUCache` (the common case with sequential pipeline `auto_offload`), `getattr(module, name)` returns a **temporary onloaded GPU tensor** — a new allocation each call. `dist.broadcast` modifies that temporary in-place, but the underlying CPU storage is never updated — leaving non-source ranks with stale or uninitialised quantization parameters.

**Trigger conditions:** multi-GPU DDP GPTQ with sequential pipeline and `auto_offload=True`, typically used to parallelize activation collection over large calibration sets. The quantization completes silently with no exception; the corruption only appears when inspecting saved checkpoints.

This PR adds an explicit `update_offload_parameter` writeback for non-source ranks after `_wait_for_comms`, which correctly flushes the broadcast result back to CPUCache storage.

## Changes

- `src/llmcompressor/utils/dist.py`: collect `(module, name, param, broadcast_param)` for non-src-rank entries before issuing async broadcasts; after comms complete, copy back and call `update_offload_parameter` (+40/-2 lines)
- `tests/llmcompressor/utils/test_broadcast_qparams_writeback.py`: unit tests covering non-src writeback, src no-writeback, missing params, and multi-module cases
- `tests/llmcompressor/utils/test_cpucache_temporary_tensor.py` (new): 3 unit tests proving CPUCache returns a new temporary CUDA tensor per `getattr` call and that in-place modification is lost without writeback
- `tests/llmcompressor/utils/test_broadcast_qparams_ddp_integration.py` (new): 2-GPU integration test using real `dist.broadcast` + real CPUCache, demonstrating the bug (Phase A) and fix (Phase B) in a single distributed session

## Empirical validation

Controlled A/B on 8× L20, `Qwen3.5-122B-A10B`, N=8192, seq=6144:

| | with fix | without fix |
|---|---|---|
| rank 0 SCALE_CHECK | ✅ CLEAN (total=37056) | ⚠️ CORRUPTED nan=31924 neg=402 |
| rank 1 SCALE_CHECK | ✅ CLEAN | ⚠️ CORRUPTED nan=840 inf=1 neg=3139 |
| rank 4 SCALE_CHECK | ✅ CLEAN | ⚠️ CORRUPTED nan=3829 neg=3 |
| all 8 ranks | CLEAN | multiple ranks CORRUPTED |

Full details in issue #3119.

Fixes #3119
