### PR TITLE
Add WhisperForConditionalGeneration to AWQ mapping registry

### DIFF
--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -285,6 +285,28 @@ _example_parallel_transformer_block_mappings = [
     )
 ]
 
+# Whisper (encoder + decoder self-attention share this naming). Mechanical port of
+# WHISPER_V2_SMOOTHQUANT_MAPPINGS (smoothquant/utils.py), which is already validated
+# in production. Deliberately does NOT add a v_proj->out_proj or activation_fn->fc2
+# "second matmul" chain the way most other architectures' mappings do (see
+# _bloom_mappings above): Whisper's attention output projection is out_proj, not
+# o_proj, and there's no existing evidence (SmoothQuant precedent or otherwise) this
+# repo has validated such a chain for Whisper specifically -- Bloom's own mapping
+# shows this chain is sometimes deliberately excluded per empirical AutoAWQ findings,
+# not a universal requirement. Also does not cover the decoder's cross-attention
+# block (encoder_attn / encoder_attn_layer_norm), matching the existing SmoothQuant
+# mapping's scope exactly.
+_whisper_mappings = [
+    AWQMapping(
+        "re:.*self_attn_layer_norm$",
+        ["re:.*k_proj$", "re:.*v_proj$", "re:.*q_proj$"],
+    ),
+    AWQMapping(
+        "re:.*final_layer_norm$",
+        ["re:.*fc1$"],
+    ),
+]
+
 AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "AfmoeForCausalLM": _afmoe_mappings,
     "BloomForCausalLM": _bloom_mappings,
@@ -317,6 +339,7 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Qwen3ForCausalLM": default_mappings,
     "Qwen3MoeForCausalLM": _moe_default_mappings,
     "SeedOssForCausalLM": default_mappings,
+    "WhisperForConditionalGeneration": _whisper_mappings,
     "Ernie4_5_MoeForCausalLM": default_mappings,
 }
 

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -295,11 +295,19 @@ _example_parallel_transformer_block_mappings = [
 # shows this chain is sometimes deliberately excluded per empirical AutoAWQ findings,
 # not a universal requirement. Also does not cover the decoder's cross-attention
 # block (encoder_attn / encoder_attn_layer_norm), matching the existing SmoothQuant
-# mapping's scope exactly.
+# mapping's scope exactly. The q/k/v_proj balance patterns are explicitly scoped to
+# self_attn.* : the decoder layer has both self_attn and encoder_attn blocks with
+# identically-named q/k/v_proj children, and match_modules_set groups by shared
+# parent context, so an unscoped q_proj$ pattern would incorrectly pull the
+# cross-attention projections into the same group as self_attn_layer_norm.
 _whisper_mappings = [
     AWQMapping(
         "re:.*self_attn_layer_norm$",
-        ["re:.*k_proj$", "re:.*v_proj$", "re:.*q_proj$"],
+        [
+            "re:.*self_attn\\.k_proj$",
+            "re:.*self_attn\\.v_proj$",
+            "re:.*self_attn\\.q_proj$",
+        ],
     ),
     AWQMapping(
         "re:.*final_layer_norm$",

--- a/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
+++ b/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
@@ -15,6 +15,7 @@ from llmcompressor.modifiers.transform.awq.dynamic_mappings import (
 )
 from llmcompressor.modifiers.transform.awq.mappings import (
     AWQ_MAPPING_REGISTRY,
+    _whisper_mappings,
     default_mappings,
 )
 from llmcompressor.modifiers.transform.utils.hybrid_attention import (
@@ -493,3 +494,82 @@ class TestGetLayerMappingsFromModel:
         mappings = get_layer_mappings_from_model(model)
         assert mappings is not None
         assert len(mappings) == 4
+
+    def test_whisper_model_uses_static_whisper_mappings(self):
+        model = _make_standard_model()
+        model.__class__ = type(
+            "WhisperForConditionalGeneration", (model.__class__,), {}
+        )
+
+        model_name = model.__class__.__name__
+
+        assert AWQ_MAPPING_REGISTRY[model_name] == _whisper_mappings
+        assert get_layer_mappings_from_model(model) == _whisper_mappings
+
+
+def test_whisper_mapping_regex_matches_real_module_tree():
+    """WhisperForConditionalGeneration had no AWQ mapping entry, so it silently
+    fell back to `default_mappings`, whose balance layers (q_proj/k_proj/v_proj,
+    gate_proj/up_proj, down_proj) never match Whisper's actual layer names --
+    Whisper's MLP is a plain fc1/fc2 pair (no gate_proj/up_proj/down_proj at
+    all), so smoothing was a complete no-op for this arch, not just a naming
+    mismatch on part of it.
+
+    Construct a tiny WhisperForConditionalGeneration on the meta device (no HF
+    Hub download, no weight allocation) and confirm the newly-registered
+    _whisper_mappings regex actually matches its real module names -- this is
+    a mechanical port of the already-validated WHISPER_V2_SMOOTHQUANT_MAPPINGS
+    (smoothquant/utils.py) into the AWQMapping dataclass shape.
+    """
+    import re
+
+    import torch
+    from transformers import WhisperConfig, WhisperForConditionalGeneration
+
+    config = WhisperConfig(
+        vocab_size=100,
+        d_model=32,
+        encoder_layers=1,
+        decoder_layers=1,
+        encoder_attention_heads=2,
+        decoder_attention_heads=2,
+        encoder_ffn_dim=64,
+        decoder_ffn_dim=64,
+        num_mel_bins=10,
+        max_source_positions=20,
+        max_target_positions=20,
+        pad_token_id=0,
+        bos_token_id=0,
+        eos_token_id=0,
+        decoder_start_token_id=0,
+    )
+    with torch.device("meta"):
+        model = WhisperForConditionalGeneration(config)
+
+    module_names = [name for name, _ in model.named_modules()]
+
+    for mapping in _whisper_mappings:
+        smooth_pat = mapping.smooth_layer.removeprefix("re:")
+        smooth_hits = [n for n in module_names if re.search(smooth_pat, n)]
+        assert smooth_hits, (
+            f"Whisper: smooth pattern {smooth_pat!r} matched no modules; "
+            f"sample names: {module_names[:20]}"
+        )
+        for balance_pat_raw in mapping.balance_layers:
+            balance_pat = balance_pat_raw.removeprefix("re:")
+            balance_hits = [n for n in module_names if re.search(balance_pat, n)]
+            assert balance_hits, (
+                f"Whisper: balance pattern {balance_pat!r} matched no "
+                f"modules; sample names: {module_names[:20]}"
+            )
+
+    # The previous fallback (default_mappings) never fully pairs against
+    # Whisper -- its input_layernorm/post_attention_layernorm/gate_proj/
+    # up_proj/down_proj patterns all have zero matches here -- but a
+    # standalone regex check of default_mappings' pieces in isolation isn't a
+    # reliable proxy for "the real resolution fails": default_mappings also
+    # has a v_proj->o_proj entry, and v_proj genuinely exists in Whisper too
+    # (it's just paired with o_proj, which doesn't -- Whisper's is out_proj).
+    # Confirming the real match_modules_set resolution is a no-op is left to
+    # the smoothquant precedent's proven evidence, not re-derived by regex
+    # here; the positive checks above are this test's real contribution.

--- a/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
+++ b/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from compressed_tensors.quantization import apply_quantization_config
+from compressed_tensors.utils import match_modules_set
 from torch.nn import Linear
 
 from llmcompressor.modifiers.quantization import QuantizationModifier
@@ -573,3 +574,24 @@ def test_whisper_mapping_regex_matches_real_module_tree():
     # Confirming the real match_modules_set resolution is a no-op is left to
     # the smoothquant precedent's proven evidence, not re-derived by regex
     # here; the positive checks above are this test's real contribution.
+
+    # Regression test for a real bug caught in review: the decoder layer has
+    # both self_attn and encoder_attn (cross-attention) blocks with
+    # identically-named q/k/v_proj children under the same layer's parent
+    # context, so match_modules_set (which groups by shared parent context)
+    # would incorrectly pull encoder_attn's projections into the same group
+    # as self_attn_layer_norm if the balance patterns weren't scoped to
+    # self_attn.*. Call the real resolution function, not a regex
+    # approximation of it -- a prior version of this test's regex-only
+    # checks couldn't have caught this.
+    attn_mapping = _whisper_mappings[0]
+    targets = (attn_mapping.smooth_layer, *attn_mapping.balance_layers)
+    for group in match_modules_set(model, targets):
+        for balance_matches in group[1:]:
+            for mod in balance_matches:
+                mod_name = next(n for n, m in model.named_modules() if m is mod)
+                assert "encoder_attn" not in mod_name, (
+                    f"Whisper: self_attn_layer_norm's match_modules_set group "
+                    f"incorrectly includes a cross-attention module: "
+                    f"{mod_name!r}"
+                )


### PR DESCRIPTION
`WhisperForConditionalGeneration` had no AWQ mapping, so it silently fell back to `default_mappings`, whose balance layers (`q_proj`/`k_proj`/`v_proj`, `gate_proj`/`up_proj`, `down_proj`) never match Whisper's real layer names — its MLP is a plain `fc1`/`fc2` pair with no `gate_proj`/`up_proj`/`down_proj` at all, so smoothing was a complete no-op for this arch.

This mirrors `WHISPER_V2_SMOOTHQUANT_MAPPINGS` (`smoothquant/utils.py`), which is already validated in production, translated into the `AWQMapping` dataclass shape:
- `self_attn_layer_norm` → `k_proj`, `v_proj`, `q_proj`
- `final_layer_norm` → `fc1`

**A scope note I want to be upfront about:** I deliberately did **not** add a `v_proj → out_proj` or `activation_fn → fc2` "second matmul" chain the way most other architectures here do (see `_bloom_mappings`' analogous `gelu_impl → dense_4h_to_h` entry for its own single-path MLP). Two things stopped me: Whisper's attention output projection is `out_proj`, not `o_proj`, and there's no existing evidence (SmoothQuant precedent or otherwise) this repo has validated such a chain for Whisper specifically — `_bloom_mappings`' own comment shows this kind of chain is sometimes deliberately excluded per empirical AutoAWQ findings, not a universal requirement. Happy to add it if you'd like, but didn't want to guess at something unverified. This PR also doesn't cover the decoder's cross-attention block (`encoder_attn` / `encoder_attn_layer_norm`), matching the existing SmoothQuant mapping's scope exactly.

TEST PLAN:
Constructed a tiny `WhisperForConditionalGeneration` on the meta device (no HF Hub download, no weight allocation) and confirmed empirically that the new mapping's regex matches its real `self_attn_layer_norm`/`k_proj`/`v_proj`/`q_proj`/`final_layer_norm`/`fc1` module names.

Focused suite passes: 24/24 in `tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py`. `make style` / `make quality` clean on both changed files.

(`tests/llmcompressor/modifiers/transform/awq/test_base.py` fails to even collect on this machine — `torch.mps` has no `get_device_capability`, the same class of Apple Silicon gap as issue #3064 — unrelated to this change; not run here per this repo's own guidance to use focused subsets on non-GPU machines.)