### PR TITLE
fix: use forward globals when autowrapping

### DIFF
--- a/src/llmcompressor/pipelines/sequential/ast_helpers.py
+++ b/src/llmcompressor/pipelines/sequential/ast_helpers.py
@@ -53,13 +53,18 @@ def autowrap_forward(module: torch.nn.Module, ignore: list[str]):
         )
 
     # get source code of module forward
-    source = inspect.getsource(module.forward)
+    forward_fn = inspect.unwrap(module.forward)
+    forward_fn = getattr(forward_fn, "__func__", forward_fn)
+    source = inspect.getsource(forward_fn)
     source = textwrap.dedent(source)
     tree = ast.parse(source)
 
     # construct namespace for our new code
-    defining_module = sys.modules[module.__class__.__module__]
-    namespace = defining_module.__dict__.copy()
+    namespace = getattr(forward_fn, "__globals__", None)
+    if namespace is None:
+        defining_module = sys.modules[module.__class__.__module__]
+        namespace = defining_module.__dict__
+    namespace = namespace.copy()
     namespace.update({"torch.fx.wrap": torch.fx.wrap})
     namespace.update({"self": module})
 

--- a/tests/llmcompressor/pipelines/sequential/test_helpers.py
+++ b/tests/llmcompressor/pipelines/sequential/test_helpers.py
@@ -1,4 +1,5 @@
 import math
+import sys
 
 import pytest
 import torch
@@ -6,6 +7,7 @@ import torch.fx
 from transformers import AutoModelForCausalLM
 
 from llmcompressor.args.dataset_arguments import DatasetArguments
+from llmcompressor.pipelines.sequential.ast_helpers import autowrap_forward
 from llmcompressor.pipelines.sequential.helpers import (
     Subgraph,
     get_sequential_ancestors,
@@ -45,6 +47,22 @@ class DummyModelMultipleSequentialLayers(torch.nn.Module):
         x = self.layer5(x)
         x = self.layer6(x)
         return x
+
+
+def test_autowrap_forward_uses_unwrapped_function_globals(monkeypatch):
+    def forward(self, x):
+        return torch.relu(x)
+
+    MainModule = type(
+        "MainModule", (torch.nn.Module,), {"__module__": "__main__", "forward": forward}
+    )
+    model = MainModule()
+    monkeypatch.delitem(sys.modules["__main__"].__dict__, "torch", raising=False)
+
+    with autowrap_forward(model, ignore=[]):
+        output = model(torch.ones(2))
+
+    assert torch.equal(output, torch.ones(2))
 
 
 def test_get_sequential_ancestors():


### PR DESCRIPTION
Fixes #3065.

utowrap_forward previously selected the namespace from sys.modules[module.__class__.__module__]. When a model class is defined in __main__ and the script is executed through cProfile or unpy, that module entry can refer to the runner namespace rather than the namespace that owns the forward function. The generated function then fails with a NameError for globals such as 	orch.

This change unwraps decorated forward methods before retrieving source and globals, uses the unwrapped function's __globals__ when available, retains the existing module lookup as a compatibility fallback, and adds a regression test for the __main__ mismatch.

Verification:
- pytest focused regression: 1 passed, 13 deselected
- ruff check and format check: passed
- mypy focused check: passed
- git diff --check: passed

The test exercises the real utowrap_forward context manager without model downloads, GPU requirements, or external APIs.