### PR TITLE
Skip compute-capability tests on backends without get_device_capability

### DIFF
--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -394,6 +394,9 @@ def requires_compute_capability(major: int, minor: int = 0) -> pytest.MarkDecora
         )
 
     device_capability = device_module.get_device_capability(0)
+    has_capability = device_capability[0] > major or (
+        device_capability[0] == major and device_capability[1] >= minor
+    )
 
     reason = (
         f"Compute capability {major}.{minor} required, "

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -383,12 +383,17 @@ def requires_compute_capability(major: int, minor: int = 0) -> pytest.MarkDecora
     :param minor: required minor compute capability version (default 0)
     """
     if not torch.accelerator.is_available():
-        return pytest.mark.skip(reason="CUDA not available")
+        return pytest.mark.skip(reason="No accelerator available")
 
-    device_capability = torch.get_device_module().get_device_capability(0)
-    has_capability = device_capability[0] > major or (
-        device_capability[0] == major and device_capability[1] >= minor
-    )
+    device_module = torch.get_device_module()
+    if not hasattr(device_module, "get_device_capability"):
+        # not every accelerator backend reports a compute capability
+        # (e.g. `torch.mps` on Apple Silicon)
+        return pytest.mark.skip(
+            reason=f"{device_module.__name__} does not report compute capability"
+        )
+
+    device_capability = device_module.get_device_capability(0)
 
     reason = (
         f"Compute capability {major}.{minor} required, "


### PR DESCRIPTION
Fixes https://github.com/vllm-project/llm-compressor/issues/3083

## SUMMARY

`requires_compute_capability` runs in a decorator, so the `AttributeError` on
`torch.mps` fails at collection time and takes out the whole test module rather
than just the gated test.

Guard with `hasattr` and skip when the backend doesn't report a compute
capability. Skipping is the correct outcome — a machine without CUDA can't
satisfy an H100 requirement, so a crash is never the right answer.

Also corrects the skip reason from "CUDA not available" to "No accelerator
available", since the check above it is the generic accelerator guard.

Same class of gap as #3064 / #3068. Independently hit by @robertlangdonn on
#3074.

## TEST PLAN

macOS 26.5.2 / M3 Pro / torch 2.13.0, on
`tests/llmcompressor/modifiers/transform/awq/test_base.py`.

Before:
```
Interrupted: 1 error during collection
no tests collected, 1 error in 0.21s
```

After:
```
2 failed, 18 passed, 1 skipped, 14 warnings in 5.76s
```

The 1 skip is the H100-gated test skipping correctly. The 2 failures are
pre-existing and unrelated — those tests require CUDA directly
(`AssertionError: Torch not compiled with CUDA enabled`) and are not addressed
here; they should pass on a GPU runner.

`make style` and `make quality` pass.