### PR TITLE
docs: update Granite 4 fp8 guide for automatic MoE expert linearization

### DIFF
--- a/examples/quantization_w8a8_fp8/README_granite4.md
+++ b/examples/quantization_w8a8_fp8/README_granite4.md
@@ -4,7 +4,7 @@
 
 For Granite 4, in addition to typical `nn.Linear` layers in `mamba` or `mlp` modules, there are three "Linear-like" layers in `GraniteMoeHybridMoe` (`moe` module) that could be quantized as well. Among the three layers, usually `router` should be kept in high precision for accuracy reason. Therefore, users could choose to quantize the other two layers, `input_linear` and `output_linear`, for better model compression.
 
-The MoE experts store their weights in 3D, i.e. [num_experts, out_feat, in_feat], rather than as `nn.Linear` modules. `llmcompressor` handles this for you: loading the model inside `load_context()` linearizes the experts on load, so each expert becomes a regular `nn.Linear` that the recipe can target like any other layer. Weights are converted back to the checkpoint's expected format on save.
+The MoE experts store their weights in 3D, i.e., [num_experts, out_feat, in_feat], rather than as `nn.Linear` modules. `llmcompressor` handles this for you: loading the model inside `load_context()` linearizes the experts, so each expert becomes a regular `nn.Linear` that the recipe can target like any other layer. Weights are converted back to the checkpoint's expected format on save.
 
 > `fp8` compuation is supported on Nvidia GPUs with compute capability > 8.9 (Ada Lovelace, Hopper).
 

--- a/examples/quantization_w8a8_fp8/README_granite4.md
+++ b/examples/quantization_w8a8_fp8/README_granite4.md
@@ -4,14 +4,7 @@
 
 For Granite 4, in addition to typical `nn.Linear` layers in `mamba` or `mlp` modules, there are three "Linear-like" layers in `GraniteMoeHybridMoe` (`moe` module) that could be quantized as well. Among the three layers, usually `router` should be kept in high precision for accuracy reason. Therefore, users could choose to quantize the other two layers, `input_linear` and `output_linear`, for better model compression.
 
-Note that input_linear and output_linear are `GraniteMoeHybridParallelExperts`, which subclasses `nn.Module` instead of `nn.Linear`, for it needs to store weights in 3D, i.e. [num_experts, out_feat, in_feat]. Because llm-compressor can only handle `nn.Linear` at the moment, our simple workaround would be:
-1. **Swap `GraniteMoeHybridParallelExperts` with `GraniteMoeHybridParallelExpertsLinear`**
-
-   The custom class is equivalent to the original one, except it subclasses nn.Linear and stores 2D weights. Moe expert weight tensors will be converted from 3D to 2D, i.e. from [num_experts, out_feat, in_feat] to [num_experts * out_feat, in_feat].
-2. **Perform dynamic fp8 quantization**
-
-   The new class is compatible with typical per-channel weight quantization, llm-compressor will be able to identify those layers and process them normally. The resulting scales will have shape of [num_experts * out_feat, 1]
-3. **Reshape weights and scales back to 3D before saving the checkpoint**
+The MoE experts store their weights in 3D, i.e. [num_experts, out_feat, in_feat], rather than as `nn.Linear` modules. `llmcompressor` handles this for you: loading the model inside `load_context()` linearizes the experts on load, so each expert becomes a regular `nn.Linear` that the recipe can target like any other layer. Weights are converted back to the checkpoint's expected format on save.
 
 > `fp8` compuation is supported on Nvidia GPUs with compute capability > 8.9 (Ada Lovelace, Hopper).
 
@@ -53,9 +46,14 @@ Load the model using `AutoModelForCausalLM`
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
+from llmcompressor.utils import load_context
+
 MODEL_ID = "ibm-granite/granite-4.0-tiny-preview"
 
-model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
+# `load_context()` linearizes the MoE experts as the model loads, so they can be
+# quantized as ordinary `Linear` layers.
+with load_context():
+    model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 ```
 
@@ -67,7 +65,7 @@ We recommend targeting all `Linear` layers using the `FP8_DYNAMIC` scheme, which
 
 Since simple PTQ does not require data for weight quantization and the activations are quantized dynamically, we do not need any calibration data for this quantization flow.
 
-Note that we replace the 3D moe expert layers with their 2D equivalent counterpart before quantization and convert them back to 3D before model saving.
+The MoE experts are linearized by `load_context()` at load time and restored to the checkpoint's expected layout on save, so `Linear` is the only target needed.
 
 ```python
 from compressed_tensors.offload import dispatch_model
@@ -85,18 +83,13 @@ tokenizer = AutoTokenizer.from_pretrained(model_id)
 
 # Configure the simple PTQ quantization
 recipe = QuantizationModifier(
-    targets=["Linear", "GraniteMoeHybridParallelExpertsLinear"],
+    targets=["Linear"],
     scheme="FP8_DYNAMIC",
     ignore=["lm_head", "re:.*block_sparse_moe.router"],
 )
 
 # Apply the quantization algorithm.
 oneshot(model=model, recipe=recipe)
-
-# Revert weights of MoE experts to 3D format (num_experts, output_size, input_size)
-for n, m in model.named_modules():
-    if isinstance(m, GraniteMoeHybridParallelExpertsLinear):
-        m.to_3d_expert()
 
 # Save the model.
 model.save_pretrained(SAVE_DIR)


### PR DESCRIPTION
SUMMARY:

Closes #3086.

`README_granite4.md` documented the pre-0.12 workflow for quantizing Granite 4.0-h MoE experts:

1. swap `GraniteMoeHybridParallelExperts` for `GraniteMoeHybridParallelExpertsLinear`
2. quantize
3. reshape weights and scales back to 3D before saving

Neither class exists any more, so anyone following the guide hits an `ImportError`. The guide also still claims "llm-compressor can only handle `nn.Linear` at the moment", and its snippets use `targets=["Linear", "GraniteMoeHybridParallelExpertsLinear"]` plus an `isinstance(m, GraniteMoeHybridParallelExpertsLinear)` revert loop.

As noted in the issue, the quantization path itself is fine on `main`. Loading under `load_context()` linearizes the experts automatically, so `targets=["Linear"]` picks them up and no manual swap or revert is needed. `granite4_example.py` already does exactly this and needed no change; only the guide was stale.

This PR rewrites the guide to match: describes the automatic linearization, updates the Load Model snippet to use `load_context()` so it matches the runnable example, drops the manual swap section and the `to_3d_expert()` loop, and keeps the router-precision guidance and vLLM version notes since those still apply.

Docs only, no source changes.

TEST PLAN:

The behavioral claim in the new text is that experts linearize on load without any manual swap. Verified on CPU with a small random config, no weights or GPU needed:

```python
import torch
from transformers.models.granitemoehybrid.configuration_granitemoehybrid import GraniteMoeHybridConfig
from transformers.models.granitemoehybrid.modeling_granitemoehybrid import GraniteMoeHybridForCausalLM
from llmcompressor.modeling.moe.linearize import linearize_moe, get_non_linearized_moes

cfg = GraniteMoeHybridConfig(hidden_size=64, intermediate_size=128, num_local_experts=4,
        num_experts_per_tok=2, num_hidden_layers=2, vocab_size=128,
        mamba_n_heads=8, mamba_expand=2, mamba_d_state=16)
m = GraniteMoeHybridForCausalLM(cfg)
print(get_non_linearized_moes(m))
linearize_moe(m)
print("remaining:", len(get_non_linearized_moes(m)))
print("expert Linears:", len([n for n, mm in m.named_modules()
                              if isinstance(mm, torch.nn.Linear) and "expert" in n]))
```

```
[('model.layers.0.block_sparse_moe.experts', 'GraniteMoeHybridExperts'),
 ('model.layers.1.block_sparse_moe.experts', 'GraniteMoeHybridExperts')]
remaining: 0
expert Linears: 24
```

Also confirmed `get_use_experts_implementation_args(GraniteMoeHybridExperts)` returns the same args as the already-supported `GraniteMoeExperts`: `{'is_concatenated': True, 'is_transposed': False, 'has_bias': False, 'has_gate': True}`.

Consistency checks on the doc itself:

- the `QuantizationModifier` block in the guide is now byte-identical to the one in `granite4_example.py`
- no references to `GraniteMoeHybridParallelExperts` or `GraniteMoeHybridParallelExpertsLinear` remain in the file

I have not run the full fp8 flow against `ibm-granite/granite-4.0-tiny-preview`, since I do not have a suitable GPU. The steps in the guide are unchanged from what `granite4_example.py` already runs, so anyone with the hardware is really just re-running that script.
