### PR TITLE
[Bugfix] Validate expand >= 1.0 in MovingAverageMSEObserver

### DIFF
--- a/src/llmcompressor/observers/mse.py
+++ b/src/llmcompressor/observers/mse.py
@@ -78,6 +78,8 @@ class MovingAverageMSEObserver(Observer):
         self.expand = observer_kwargs.get("expand", 1.0)
         if self.chunk_size <= 0:
             raise ValueError(f"chunk_size must be positive, got {self.chunk_size}")
+        if self.expand < 1.0:
+            raise ValueError(f"expand value must be at least 1.0, got {self.expand}")
 
         # Pre-create token_args to avoid patch_attr context manager
         # which causes torch.compile graph breaks

--- a/tests/llmcompressor/observers/test_mse.py
+++ b/tests/llmcompressor/observers/test_mse.py
@@ -4,6 +4,7 @@ from compressed_tensors.quantization import fake_quantize
 from compressed_tensors.quantization.quant_args import QuantizationArgs
 
 from llmcompressor.observers import MovingAverageMSEObserver, Observer
+from llmcompressor.observers.mse import MemorylessMSEObserver
 
 
 @pytest.mark.parametrize(
@@ -117,3 +118,19 @@ def test_mse_observer_torch_compile():
     finally:
         # always restore state, even if assertions fail
         active_session().state.enable_compile = False
+
+
+@pytest.mark.parametrize(
+    "observer_cls", [MemorylessMSEObserver, MovingAverageMSEObserver]
+)
+def test_mse_observer_rejects_expand_below_one(observer_cls):
+    # `expand` scales the initial search range (min/max * expand) and the grid
+    # search can only shrink it further, so an expand < 1.0 starts below the
+    # observed range and can never cover the data. Every MSE observer must
+    # reject it rather than silently produce a degenerate range.
+    args = QuantizationArgs(num_bits=8, symmetric=True, observer="mse")
+    with pytest.raises(ValueError, match="expand value must be at least 1.0"):
+        observer_cls(base_name="weight", args=args, expand=0.5)
+
+    # expand >= 1.0 is accepted.
+    observer_cls(base_name="weight", args=args, expand=1.0)


### PR DESCRIPTION
## Summary

`MemorylessMSEObserver.__init__` validates `expand >= 1.0`, but the default `"mse"` observer, `MovingAverageMSEObserver`, is missing the same check and silently accepts `expand < 1.0`.

`expand` scales the initial MSE search range (`min_val = amin * expand`, `max_val = amax * expand` in `_grid_search_mse`), and the grid search can only **shrink** it from there (`p = 1 - i / grid <= 1`). So an `expand < 1.0` starts the search *below* the observed min/max and can never grow to cover the data — every candidate range clips the calibration values, producing a degenerate result. That's exactly why `MemorylessMSEObserver` rejects it; `MovingAverageMSEObserver` should too.

### Reproduce

```python
from compressed_tensors.quantization import QuantizationArgs
from llmcompressor.observers.mse import MemorylessMSEObserver, MovingAverageMSEObserver

args = QuantizationArgs(num_bits=8, symmetric=True)

MemorylessMSEObserver(base_name="weight", args=args, expand=0.5)
# ValueError: expand value must be at least 1.0, got 0.5   ✅

MovingAverageMSEObserver(base_name="weight", args=args, expand=0.5)
# (no error) ❌ — silently accepted, degenerate search range
```

## Changes

- Add the `expand >= 1.0` validation to `MovingAverageMSEObserver.__init__`, matching `MemorylessMSEObserver`.
- Add a parametrized regression test asserting both MSE observers reject `expand < 1.0` and accept `expand >= 1.0`.

## Testing

`tests/llmcompressor/observers/test_mse.py` passes (the new `test_mse_observer_rejects_expand_below_one` covers both observers). `ruff check` / `ruff format --check` clean on the changed files. (Note: the pre-existing `test_mse_observer_torch_compile` fails locally on macOS due to a `torch.compile` backend issue unrelated to this change — it fails the same way on `main`.)
