### PR TITLE
[GPTQ] Emit an end-of-run summary when modules fall back to RTN

### DIFF
--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -134,6 +134,8 @@ class GPTQModifier(Modifier, QuantizationMixin):
     _num_samples: dict[torch.nn.Module, torch.Tensor] = PrivateAttr(
         default_factory=dict
     )
+    _num_compressed_modules: int = PrivateAttr(default=0)
+    _rtn_fallback_module_names: list[str] = PrivateAttr(default_factory=list)
 
     def resolve_quantization_config(self) -> QuantizationConfig:
         config = super().resolve_quantization_config()
@@ -308,7 +310,7 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 self._maybe_onload_hessian(module),
                 CompressionLogger(module) as comp_logger,
             ):
-                loss, q_param_dict = quantize_weight(
+                loss, q_param_dict, used_rtn_fallback = quantize_weight(
                     module=module,
                     quant_args=quant_args,
                     hessian=self._hessians.pop(module) / self._num_samples.pop(module),
@@ -316,6 +318,10 @@ class GPTQModifier(Modifier, QuantizationMixin):
                     percdamp=self.dampening_frac,
                 )
                 comp_logger.set_results(name="GPTQ", loss=loss)
+
+            self._num_compressed_modules += 1
+            if used_rtn_fallback:
+                self._rtn_fallback_module_names.append(name)
 
             for attr, val in q_param_dict.items():
                 update_offload_parameter(module, attr, val)
@@ -347,6 +353,35 @@ class GPTQModifier(Modifier, QuantizationMixin):
                     self._num_samples.pop(module, None)
         wait_for_comms(pending_comms)
 
+    def _log_rtn_fallback_summary(self):
+        """
+        Emit a single end-of-run warning if any modules fell back to
+        round-to-nearest because hessian inversion failed. Without a summary,
+        per-module fallback warnings are easy to miss and a run where every
+        module fell back looks like a successful GPTQ run (#2952). In the
+        distributed case, each rank reports the modules it compressed.
+        """
+        num_fallback = len(self._rtn_fallback_module_names)
+        if num_fallback == 0:
+            return
+
+        total = self._num_compressed_modules
+        shown = ", ".join(self._rtn_fallback_module_names[:10])
+        if num_fallback > 10:
+            shown += f", and {num_fallback - 10} more (full list at DEBUG level)"
+            logger.debug(
+                "Modules quantized with round-to-nearest due to hessian "
+                "inversion failure: " + ", ".join(self._rtn_fallback_module_names)
+            )
+        logger.warning(
+            f"Hessian inversion failed for {num_fallback}/{total} modules "
+            f"({num_fallback / total:.1%}). These modules were quantized with "
+            "round-to-nearest instead of GPTQ (the quantization scheme is "
+            "unchanged). Consider increasing GPTQModifier.dampening_frac, "
+            "increasing the number of calibration samples, or shuffling the "
+            f"calibration dataset. Affected modules: {shown}"
+        )
+
     def on_finalize(self, state: State, **kwargs) -> bool:
         """
         disable the quantization observers used by the OBCQ algorithm
@@ -356,11 +391,15 @@ class GPTQModifier(Modifier, QuantizationMixin):
         if not self.ended_:
             self.on_end(state, None)
 
+        self._log_rtn_fallback_summary()
+
         if len(self._num_samples) > 0:
             raise ValueError(f"Failed to compress {len(self._num_samples)} modules")
 
         self._hessians = dict()
         self._num_samples = dict()
+        self._num_compressed_modules = 0
+        self._rtn_fallback_module_names = []
 
         return True
 

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -70,7 +70,7 @@ def quantize_weight(
     hessian: torch.Tensor,
     blocksize: int = 128,
     percdamp: float = 0.01,
-) -> tuple[float, dict[str, torch.Tensor]]:
+) -> tuple[float, dict[str, torch.Tensor], bool]:
     """
     Quantize a module weight according to the GPTQ algorithm
 
@@ -80,7 +80,8 @@ def quantize_weight(
     :param blocksize: chunk size of quantization updates
     :param percdamp: dampening factor on hessian diagonal
     :return: loss, q_param_dict (with keys: weight, weight_scale, weight_zero_point,
-        and optionally weight_global_scale)
+        and optionally weight_global_scale), used_rtn_fallback (True if hessian
+        inversion failed and the module was quantized with round-to-nearest)
     """
     strategy = quant_args.strategy
     actorder = quant_args.actorder
@@ -135,6 +136,7 @@ def quantize_weight(
     W[:, dead] = 0
 
     # compute inverse hessian in place to save memory
+    used_rtn_fallback = False
     try:
         damp = percdamp * torch.mean(torch.diag(H))
         diag = torch.arange(H.shape[0], device=H.device)
@@ -150,6 +152,7 @@ def quantize_weight(
             "of calibration samples, or shuffling the calibration dataset. "
             "Falling back to round-to-nearest for this module."
         )
+        used_rtn_fallback = True
         Hinv = H = torch.eye(num_columns, dtype=H.dtype, device=H.device)
 
     # See section 3.4 of https://arxiv.org/abs/2203.07259
@@ -248,7 +251,7 @@ def quantize_weight(
     }
     if global_scale:
         q_param_dict["weight_global_scale"] = global_scale.to(dtype=final_dtype)
-    return (loss, q_param_dict)
+    return (loss, q_param_dict, used_rtn_fallback)
 
 
 def _apply_activation_ordering(

--- a/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
+++ b/tests/llmcompressor/modifiers/gptq/test_gptq_quantize.py
@@ -5,6 +5,7 @@ from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationScheme,
 )
+from loguru import logger
 
 from llmcompressor.modifiers.gptq import GPTQModifier
 from llmcompressor.modifiers.gptq.gptq_quantize import (
@@ -45,13 +46,14 @@ def test_quantize_weight_group_strategy_actorder(actorder):
         )
     )
 
-    loss, q_param_dict = quantize_weight(
+    loss, q_param_dict, used_rtn_fallback = quantize_weight(
         module=module,
         quant_args=quant_args,
         hessian=hessian,
     )
 
     assert loss >= 0
+    assert not used_rtn_fallback
     assert q_param_dict["weight"].shape == module.weight.shape
     assert q_param_dict["weight_scale"].shape == (6, 4)
     assert q_param_dict["weight_zero_point"].shape == (6, 4)
@@ -80,7 +82,7 @@ def test_quantize_weight_supports_block_strategy(actorder):
     hessian = make_empty_hessian(module)
     hessian += torch.eye(hessian.shape[0], dtype=hessian.dtype, device=hessian.device)
 
-    loss, q_param_dict = quantize_weight(
+    loss, q_param_dict, used_rtn_fallback = quantize_weight(
         module=module,
         quant_args=quant_args,
         hessian=hessian,
@@ -88,6 +90,7 @@ def test_quantize_weight_supports_block_strategy(actorder):
     )
 
     assert loss >= 0
+    assert not used_rtn_fallback
     assert q_param_dict["weight"].shape == module.weight.shape
     assert q_param_dict["weight_scale"].shape == (3, 2)
     assert q_param_dict["weight_zero_point"].shape == (3, 2)
@@ -118,15 +121,80 @@ def test_quantize_weight_channel_actorder_weight():
     )
     hessian += torch.diag(diag)
 
-    loss, q_param_dict = quantize_weight(
+    loss, q_param_dict, used_rtn_fallback = quantize_weight(
         module=module, quant_args=quant_args, hessian=hessian, blocksize=4
     )
 
     assert loss >= 0
+    assert not used_rtn_fallback
     assert q_param_dict["weight"].shape == module.weight.shape
     assert q_param_dict["weight_scale"].shape[0] == module.weight.shape[0]
     assert q_param_dict["weight_zero_point"].shape[0] == module.weight.shape[0]
     assert "weight_g_idx" not in q_param_dict
+
+
+def _make_channel_quantized_linear(in_features=8, out_features=4):
+    module = torch.nn.Linear(in_features, out_features, bias=False)
+    quant_args = QuantizationArgs(num_bits=4, symmetric=True, strategy="channel")
+    module.quantization_scheme = QuantizationScheme(
+        targets=["Linear"], weights=quant_args
+    )
+    initialize_observer(module, "weight")
+    observe(module, "weight")
+    return module, quant_args
+
+
+@torch.no_grad()
+def test_quantize_weight_singular_hessian_rtn_fallback():
+    module, quant_args = _make_channel_quantized_linear()
+
+    # rank-1 hessian with a nonzero diagonal, so dead-column masking does not
+    # repair it; percdamp=0.0 keeps it singular and cholesky fails
+    hessian = make_empty_hessian(module) + 1
+
+    loss, q_param_dict, used_rtn_fallback = quantize_weight(
+        module=module, quant_args=quant_args, hessian=hessian, percdamp=0.0
+    )
+
+    assert used_rtn_fallback
+    assert loss >= 0
+    assert q_param_dict["weight"].shape == module.weight.shape
+
+
+@torch.no_grad()
+def test_gptq_rtn_fallback_summary_fires():
+    module, quant_args = _make_channel_quantized_linear()
+
+    # qparams written back by compress_module_list must already exist
+    module.weight_scale = torch.nn.Parameter(
+        torch.empty(4, 1, dtype=module.weight.dtype), requires_grad=False
+    )
+    module.weight_zero_point = torch.nn.Parameter(
+        torch.empty(4, 1, dtype=quant_args.zp_dtype), requires_grad=False
+    )
+
+    name = "model.layers.0.self_attn.q_proj"
+    modifier = GPTQModifier(dampening_frac=0.0)
+    modifier._module_names[module] = name
+    modifier._hessians[module] = make_empty_hessian(module) + 1  # singular
+    modifier._num_samples[module] = torch.tensor(1.0)
+
+    messages = []
+    handler_id = logger.add(messages.append, level="WARNING")
+    try:
+        modifier.compress_modules()
+        modifier._log_rtn_fallback_summary()
+    finally:
+        logger.remove(handler_id)
+
+    assert modifier._num_compressed_modules == 1
+    assert modifier._rtn_fallback_module_names == [name]
+    summaries = [str(m) for m in messages if "Hessian inversion failed for" in str(m)]
+    assert len(summaries) == 1
+    assert "1/1" in summaries[0]
+    assert "100.0%" in summaries[0]
+    assert "round-to-nearest" in summaries[0]
+    assert name in summaries[0]
 
 
 @requires_compute_capability(9, 0)  # Requires H100 or higher


### PR DESCRIPTION
## Summary

Fixes #2952. When GPTQ hessian inversion fails, the module silently (in aggregate) falls back to round-to-nearest: each failure logs one warning, but nothing reports the overall outcome. In #2952, all 154 modules of a looped-transformer model fell back and the run still looked like a successful GPTQ run. This adds a single end-of-run WARNING summarizing how many modules fell back and which ones.

## Root cause

The RTN fallback introduced in #1283 was designed to keep large runs alive when inversions spontaneously fail, which is correct, but it reports per module only. `quantize_weight` does not tell its caller that the fallback happened, so `GPTQModifier` cannot aggregate.

## Changes

- `quantize_weight` returns `used_rtn_fallback` alongside the existing loss and qparam dict. The per-module warning and fallback behavior are unchanged; no retry logic.
- `GPTQModifier` counts compressed modules and records the names of those that fell back, then logs one WARNING at finalize with count, percentage, and affected module names (first 10; full list at DEBUG). In the distributed case each rank reports the modules it compressed.

Example output for the #2952 scenario (154/154 modules):

```
WARNING - Hessian inversion failed for 154/154 modules (100.0%). These modules were quantized with round-to-nearest instead of GPTQ (the quantization scheme is unchanged). Consider increasing GPTQModifier.dampening_frac, increasing the number of calibration samples, or shuffling the calibration dataset. Affected modules: model.layers.0.self_attn.q_proj, model.layers.1.self_attn.q_proj, ..., and 144 more (full list at DEBUG level)
```

## Validation

CPU, torch 2.13.0, Python 3.11. New tests: `test_quantize_weight_singular_hessian_rtn_fallback` forces the fallback with a singular (rank-1) hessian and `percdamp=0.0` and asserts the flag; `test_gptq_rtn_fallback_summary_fires` drives `GPTQModifier.compress_modules` through the same singular hessian and asserts the summary warning content (count, percentage, module name).

```
$ pytest tests/llmcompressor/modifiers/gptq/ -q
37 passed, 1 skipped, 14 warnings in 0.75s
```

(skip is the H100-gated NVFP4 e2e test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)