### PR TITLE
Register GptOssLinearExperts for gpt-oss expert linearization

### DIFF
--- a/src/llmcompressor/modeling/moe/gpt_oss.py
+++ b/src/llmcompressor/modeling/moe/gpt_oss.py
@@ -1,0 +1,42 @@
+import torch
+from transformers.models.gpt_oss.modeling_gpt_oss import GptOssExperts
+
+from llmcompressor.modeling.moe.helpers import FusedExpertsProtocol
+from llmcompressor.modeling.moe.linear_experts import ExpertMLPWithGate, LinearExperts2D
+
+
+class GptOssExpertMLP(ExpertMLPWithGate):
+    """
+    gate and up occupy the even and odd columns of ``gate_up_proj`` rather than its
+    halves, so the generic split would leave each projection holding a mix of both.
+    """
+
+    def copy_from_experts_module(self, experts: FusedExpertsProtocol, index: int):
+        gate_up = experts.gate_up_proj[index]
+        self.gate_proj.weight.copy_(gate_up[:, 0::2].T)
+        self.up_proj.weight.copy_(gate_up[:, 1::2].T)
+        self.down_proj.weight.copy_(experts.down_proj[index].T)
+
+        gate_up_bias = experts.gate_up_proj_bias[index]
+        self.gate_proj.bias.copy_(gate_up_bias[0::2])
+        self.up_proj.bias.copy_(gate_up_bias[1::2])
+        self.down_proj.bias.copy_(experts.down_proj_bias[index])
+
+
+class GptOssLinearExperts(LinearExperts2D):
+    is_concatenated = False
+    is_transposed = True
+    has_bias = True
+    has_gate = True
+    expert_cls_with_gate = GptOssExpertMLP
+
+    def _apply_gate(self, gate_up: torch.Tensor) -> torch.Tensor:
+        """Clamped SwiGLU of GptOssExperts, over halves rather than even and odd"""
+        gate, up = gate_up.chunk(2, dim=-1)
+        gate = gate.clamp(max=self.limit)
+        up = up.clamp(min=-self.limit, max=self.limit)
+        return (up + 1) * gate * torch.sigmoid(gate * self.alpha)
+
+
+# register in registry
+LinearExperts2D._registry[GptOssExperts] = GptOssLinearExperts

--- a/src/llmcompressor/modeling/moe/linear_experts.py
+++ b/src/llmcompressor/modeling/moe/linear_experts.py
@@ -149,6 +149,9 @@ class LinearExperts2D(torch.nn.ModuleList):
     has_gate: ClassVar[bool]
     _apply_gate: ClassVar[Callable[[torch.Tensor], torch.Tensor]]
 
+    # override to load a gate_up_proj whose halves are not gate and up
+    expert_cls_with_gate: ClassVar[type[ExpertMLP]] = ExpertMLPWithGate
+
     num_experts: int
     intermediate_size: int
 
@@ -159,6 +162,7 @@ class LinearExperts2D(torch.nn.ModuleList):
     def get_registration(
         cls, key: type[torch.nn.Module], default: Any = None
     ) -> type["LinearExperts2D"]:
+        from .gpt_oss import GptOssLinearExperts  # noqa: F401
         from .llama4 import Llama4LinearExperts  # noqa: F401
 
         return cls._registry.get(key, default)
@@ -213,7 +217,9 @@ class LinearExperts2D(torch.nn.ModuleList):
         self.intermediate_size = moe_config.intermediate_size
         act_fn: torch.nn.Module = ACT2FN[moe_config.hidden_act]
 
-        expert_cls = ExpertMLPWithGate if self.has_gate else ExpertMLPWithoutGate
+        expert_cls = (
+            self.expert_cls_with_gate if self.has_gate else ExpertMLPWithoutGate
+        )
         post_up_fn = self._apply_gate if self.has_gate else act_fn.forward
         super().__init__(
             [

--- a/src/llmcompressor/modeling/moe/linear_experts.py
+++ b/src/llmcompressor/modeling/moe/linear_experts.py
@@ -149,8 +149,9 @@ class LinearExperts2D(torch.nn.ModuleList):
     has_gate: ClassVar[bool]
     _apply_gate: ClassVar[Callable[[torch.Tensor], torch.Tensor]]
 
-    # override to load a gate_up_proj whose halves are not gate and up
+    # override when the generic gate_up_proj split does not fit the model
     expert_cls_with_gate: ClassVar[type[ExpertMLP]] = ExpertMLPWithGate
+    expert_cls_without_gate: ClassVar[type[ExpertMLP]] = ExpertMLPWithoutGate
 
     num_experts: int
     intermediate_size: int
@@ -218,7 +219,7 @@ class LinearExperts2D(torch.nn.ModuleList):
         act_fn: torch.nn.Module = ACT2FN[moe_config.hidden_act]
 
         expert_cls = (
-            self.expert_cls_with_gate if self.has_gate else ExpertMLPWithoutGate
+            self.expert_cls_with_gate if self.has_gate else self.expert_cls_without_gate
         )
         post_up_fn = self._apply_gate if self.has_gate else act_fn.forward
         super().__init__(

--- a/tests/llmcompressor/modeling/test_linearize.py
+++ b/tests/llmcompressor/modeling/test_linearize.py
@@ -198,6 +198,55 @@ def test_linearize_moe(model_type):
         assert torch.nn.functional.mse_loss(calib_outputs, true_outputs) < MODULE_MSE
 
 
+def test_linearize_moe_gpt_oss():
+    from transformers.models.gpt_oss.configuration_gpt_oss import GptOssConfig
+    from transformers.models.gpt_oss.modeling_gpt_oss import GptOssExperts
+
+    config = GptOssConfig(
+        hidden_size=64,
+        intermediate_size=32,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+    )
+    experts = GptOssExperts(config)
+    init.normal_(experts.gate_up_proj, mean=0.0, std=config.initializer_range)
+    init.normal_(experts.gate_up_proj_bias, mean=0.0, std=config.initializer_range)
+    init.normal_(experts.down_proj, mean=0.0, std=config.initializer_range)
+    init.normal_(experts.down_proj_bias, mean=0.0, std=config.initializer_range)
+    gate_up_proj = experts.gate_up_proj.clone()
+    gate_up_proj_bias = experts.gate_up_proj_bias.clone()
+
+    mock_model = DummyModel(experts, config)
+    linearize_moe(mock_model)
+    assert mock_model.module is not experts
+
+    # gate and up are interleaved along the last dim, not concatenated
+    for index in range(config.num_local_experts):
+        expert = mock_model.module[index]
+        assert torch.equal(expert.gate_proj.weight, gate_up_proj[index][:, 0::2].T)
+        assert torch.equal(expert.up_proj.weight, gate_up_proj[index][:, 1::2].T)
+        assert torch.equal(expert.gate_proj.bias, gate_up_proj_bias[index][0::2])
+        assert torch.equal(expert.up_proj.bias, gate_up_proj_bias[index][1::2])
+
+    moe_config = MoEConfig.from_config(config)
+    hidden_states = torch.randn(
+        NUM_TEST_TOKENS, moe_config.hidden_dim, dtype=moe_config.dtype
+    )
+    top_k_index = torch.randint(
+        0,
+        moe_config.num_experts,
+        size=(NUM_TEST_TOKENS, moe_config.num_experts_per_tok),
+    )
+    top_k_weights = torch.randn(
+        NUM_TEST_TOKENS, moe_config.num_experts_per_tok, dtype=moe_config.dtype
+    )
+    true_outputs = experts(hidden_states, top_k_index, top_k_weights)
+    outputs = mock_model(hidden_states, top_k_index, top_k_weights)
+
+    assert torch.any(true_outputs != 0), "Bad test setup, output is all zeros"
+    assert torch.nn.functional.mse_loss(outputs, true_outputs) < MODULE_MSE
+
+
 def test_linearize_moe_llama4():
     from transformers.models.llama4.configuration_llama4 import (
         Llama4Config,

--- a/tests/llmcompressor/modeling/test_linearize.py
+++ b/tests/llmcompressor/modeling/test_linearize.py
@@ -153,7 +153,9 @@ class DummyModel(torch.nn.Module):
 
 @torch.no_grad()
 @requires_gpu
-@pytest.mark.parametrize("model_type", list(ARCH_TO_IMPORT_PATHS.keys() - {"llama4"}))
+@pytest.mark.parametrize(
+    "model_type", list(ARCH_TO_IMPORT_PATHS.keys() - {"llama4", "gpt_oss"})
+)
 def test_linearize_moe(model_type):
     config_path, experts_path = ARCH_TO_IMPORT_PATHS[model_type]
     config_cls = import_or_none(config_path)


### PR DESCRIPTION





SUMMARY:
gpt-oss interleaves gate and up along the last dim of `gate_up_proj`, so the generic linearizer's half-split leaves `gate_proj` and `up_proj` each holding a mix of both projections. This registers a `GptOssLinearExperts` that splits on the even and odd
columns instead, so the per-projection weights mean what they say.
The class reuses `LinearExperts2D.__init__` and `from_experts_module` and overrides only the expert copy. `MoEConfig.from_config` already special-cases `gpt_oss` for `alpha`, `limit` and `use_bias`, so there is nothing to restate here. Selecting the per-expert class needs one hook in the base, `expert_cls_with_gate`, which defaults to today's `ExpertMLPWithGate`.

TEST PLAN:
`test_linearize_moe_gpt_oss` asserts that each expert's `gate_proj` and `up_proj` weights and biases equal the even and odd columns of the original `gate_up_proj`, then checks the linearized forward against `GptOssExperts` (MSE < 1e-10). The MSE half passes with or without this change, so the column assertions are what pin the layout down. It runs on CPU, unlike the parametrized `test_linearize_moe`, which is `@requires_gpu` and already covers `gpt_oss` for numerics only.

