### PR TITLE
Pack only weighted modules in distributed oneshot

### DIFF
--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -97,8 +97,16 @@ class QuantizationModifier(Modifier, QuantizationMixin):
         rank = dist.get_rank()
         world_size = dist.get_world_size()
 
+        # kv_cache_scheme attaches an input-activation-only scheme to weightless
+        # attention containers; only pack modules that have a weight tensor
+        weight_modules = [
+            module
+            for module in modules
+            if hasattr(module, "weight") and isinstance(module.weight, torch.Tensor)
+        ]
+
         module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
-            modules,
+            weight_modules,
             world_size,
             item_weight_fn=lambda mod: mod.weight.numel(),
         )

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -18,6 +18,7 @@ Run with:
 
 from __future__ import annotations
 
+import itertools
 import os
 import tempfile
 
@@ -507,3 +508,86 @@ def test_ddp_smoke_autoround():
         min_top1_match=0.85,
         max_kl_div=0.01,
     )
+
+
+@pytest.mark.integration
+@pytest.mark.multi_gpu
+@requires_gpu(2)
+@torchrun(world_size=2)
+def test_ddp_smoke_rtn_kv_cache():
+    """
+    kv_cache_scheme attaches an input-activation-only scheme to weightless
+    attention containers; ensure distributed oneshot packs only weighted
+    modules and still finalizes the kv scales.
+    """
+
+    def recipe_factory():
+        return QuantizationModifier(
+            scheme={"W4A16": ["Linear"]},
+            ignore=["lm_head"],
+            kv_cache_scheme=QuantizationArgs(
+                num_bits=8, type="float", symmetric=True, strategy="tensor"
+            ),
+        )
+
+    def _kv_scales(model):
+        scales = {}
+        for name, tensor in itertools.chain(
+            model.named_parameters(), model.named_buffers()
+        ):
+            if name.endswith(("k_scale", "v_scale")):
+                scales[name] = tensor.detach().clone().cpu()
+        return scales
+
+    # Single-GPU reference (before init_dist)
+    _, ref_model, _ = _run_single_gpu(
+        MODEL, recipe_factory(), NUM_SAMPLES, return_model=True
+    )
+    ref_scales = _kv_scales(ref_model)
+    assert ref_scales, "reference run produced no k_scale/v_scale tensors"
+    del ref_model
+    torch.accelerator.empty_cache()
+
+    init_dist()
+    rank = torch.distributed.get_rank()
+
+    torch.manual_seed(42)
+    torch.get_device_module().manual_seed_all(42)
+
+    with load_offloaded_model():
+        model = AutoModelForCausalLM.from_pretrained(
+            MODEL, dtype=torch.bfloat16, device_map="auto_offload"
+        )
+    ds = _prepare_dataset(MODEL, NUM_SAMPLES)
+
+    oneshot(
+        model=model,
+        dataset=ds,
+        recipe=recipe_factory(),
+        num_calibration_samples=NUM_SAMPLES,
+        max_seq_length=MAX_SEQ_LENGTH,
+        pipeline="independent",
+    )
+
+    torch.distributed.barrier()
+
+    if rank == 0:
+        ddp_scales = _kv_scales(model)
+        assert set(ddp_scales) == set(ref_scales), (
+            f"k/v scale keys mismatch: ref has {len(ref_scales)}, "
+            f"ddp has {len(ddp_scales)}"
+        )
+        for name, scale in ddp_scales.items():
+            value = scale.float()
+            assert torch.all(torch.isfinite(value)), f"{name} is not finite"
+            assert torch.all(value > 0), f"{name} is not positive"
+            assert torch.all(value < 1e3), f"{name} looks uninitialized"
+            # Memoryless fp8 kv observers are order-sensitive: the single-GPU
+            # reference calibrates on one rank's partition while DDP all-reduces
+            # across both, so scales agree in magnitude but not bit-for-bit.
+            torch.testing.assert_close(scale, ref_scales[name], atol=1e-5, rtol=0.5)
+
+    # Free the model on every rank so later tests in the session don't OOM
+    del model
+    torch.accelerator.empty_cache()
+    torch.distributed.barrier()


### PR DESCRIPTION
SUMMARY:
Fixes #3103.

With a `kv_cache_scheme`, an input-activation-only scheme (`weights=None`) is attached directly to the attention containers matched by `is_cached_attention_module` (vllm-project/compressed-tensors#780). Those containers pass `is_module_quantized`, so they land in the quantized-module list that `on_sequential_epoch_end` hands to `greedy_bin_packing`, but they have no `.weight`, and distributed weight calibration crashes with `AttributeError` at the first sequential epoch boundary.

This keeps the quantized-module list intact for `sync_obs_act_stats` / `update_qparams(..., ACTIVATION_OBS)`, which finalize `k_scale`/`v_scale` on those containers, but restricts the weight-calibration bin packing to modules that actually carry a weight tensor. Single-GPU runs are unaffected.

TEST PLAN:
- Added `test_ddp_smoke_rtn_kv_cache` in `tests/llmcompressor/transformers/compression/test_compression_ddp.py`: a 2-rank torchrun run asserting the distributed kv scales are finalized (finite, positive, sane magnitude) and agree with the single-GPU reference.
- On upstream `main`, the distributed run crashes with the reported error:
  ```
  src/llmcompressor/modifiers/quantization/quantization/base.py:100: in on_sequential_epoch_end
      module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
  ...
  AttributeError: 'Qwen3MoeAttention' object has no attribute 'weight'
  ```
- With this fix the same run passes on 2x NVIDIA A40 (`torchrun --nproc_per_node=2`, torch 2.10.0+cu128, transformers 5.16.1, compressed-tensors 0.18.1a20260824):
  ```
  test_compression_ddp.py::test_ddp_smoke_rtn_kv_cache PASSED [100%]
  ================= 1 passed, 7 deselected, 14 warnings in 26.11s =================
  ```
