### PR TITLE
Implement streaming quantization pipeline

### DIFF
--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -297,6 +297,17 @@ class DatasetArguments(CustomDatasetArguments):
             "for faster calibration when GPU memory allows (two batches on device)."
         },
     )
+    streaming_release: str = field(
+        default="cpu",
+        metadata={
+            "help": "Only relevant for the streaming pipeline. Device to release "
+            "weights to after each subgraph is calibrated. 'cpu' keeps (possibly "
+            "modifier-updated) weights in host memory; 'meta' drops "
+            "checkpoint-backed weights, keeping host memory flat for models "
+            "larger than RAM. 'meta' is only valid when no modifier mutates "
+            "weights. Default is 'cpu'."
+        },
+    )
     enable_compile: bool = field(
         default=False,
         metadata={

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -50,6 +50,12 @@ if TYPE_CHECKING:
 TOKENIZERS_PARALLELISM_ENV = "TOKENIZERS_PARALLELISM"
 
 
+def _is_meta_model(model: PreTrainedModel) -> bool:
+    """True if all model parameters live on the meta device (no weights loaded)."""
+    params = list(model.parameters())
+    return len(params) > 0 and all(p.device.type == "meta" for p in params)
+
+
 class Oneshot:
     """
     Class responsible for carrying out one-shot calibration on a pretrained model.
@@ -262,6 +268,13 @@ class Oneshot:
             session.state.enable_compile = self.dataset_args.enable_compile
 
             user_pipeline = self.dataset_args.pipeline
+            if user_pipeline in (None, "independent") and _is_meta_model(self.model):
+                logger.info(
+                    "Model was loaded on the meta device; defaulting to the "
+                    "'streaming' pipeline, which materializes weights directly "
+                    "from the original checkpoint"
+                )
+                user_pipeline = "streaming"
             pipeline = CalibrationPipeline.from_modifiers(
                 session.lifecycle.recipe.modifiers, user=user_pipeline
             )

--- a/src/llmcompressor/modeling/moe/linear_experts.py
+++ b/src/llmcompressor/modeling/moe/linear_experts.py
@@ -196,8 +196,7 @@ class LinearExperts2D(torch.nn.ModuleList):
         # the checkpoint later, so no data is copied and no offload cache is
         # attached
         src_is_meta = any(
-            param.device.type == "meta"
-            for param in experts.parameters(recurse=False)
+            param.device.type == "meta" for param in experts.parameters(recurse=False)
         )
 
         if src_is_meta:

--- a/src/llmcompressor/modeling/moe/linear_experts.py
+++ b/src/llmcompressor/modeling/moe/linear_experts.py
@@ -191,6 +191,20 @@ class LinearExperts2D(torch.nn.ModuleList):
     def from_experts_module(
         cls, experts: FusedExpertsProtocol, config: PreTrainedConfig
     ):
+        # When the source module is on the meta device (streaming pipeline),
+        # linearize structurally only: weights are materialized directly from
+        # the checkpoint later, so no data is copied and no offload cache is
+        # attached
+        src_is_meta = (
+            getattr(experts, "down_proj", None) is not None
+            and experts.down_proj.device.type == "meta"
+        )
+
+        if src_is_meta:
+            with skip_weights_initialize(), torch.device("meta"):
+                self = cls(config)
+            return self
+
         with skip_weights_initialize():
             self = cls(config)
 

--- a/src/llmcompressor/modeling/moe/linear_experts.py
+++ b/src/llmcompressor/modeling/moe/linear_experts.py
@@ -195,9 +195,9 @@ class LinearExperts2D(torch.nn.ModuleList):
         # linearize structurally only: weights are materialized directly from
         # the checkpoint later, so no data is copied and no offload cache is
         # attached
-        src_is_meta = (
-            getattr(experts, "down_proj", None) is not None
-            and experts.down_proj.device.type == "meta"
+        src_is_meta = any(
+            param.device.type == "meta"
+            for param in experts.parameters(recurse=False)
         )
 
         if src_is_meta:

--- a/src/llmcompressor/modeling/moe/linearize.py
+++ b/src/llmcompressor/modeling/moe/linearize.py
@@ -74,6 +74,10 @@ def load_quantizable_moe(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM
         # load model
         model: PreTrainedModel = original_from_pretrained(*args, **kwargs)
 
+        # stash load mappings for checkpoint-referenced loading (streaming
+        # pipeline); they map checkpoint keys -> model param names
+        model._load_weight_conversions = load_map
+
         # prepare for saving to be called later
         clear_patch_mapping()
         set_save_conversion_mapping(model, save_map)

--- a/src/llmcompressor/modeling/offset_norm.py
+++ b/src/llmcompressor/modeling/offset_norm.py
@@ -89,7 +89,13 @@ class CalibrationOffsetNorm(NormCalibrationModule):
         return output.type_as(x)
 
     def restore(self, original: torch.nn.Module) -> torch.nn.Module:
-        original.weight.data = (self.weight.data.float() - 1.0).to(self._orig_dtype)
+        data = (self.weight.data.float() - 1.0).to(self._orig_dtype)
+        if original.weight.device.type == "meta":
+            # meta weights cannot be assigned data (streaming pipeline);
+            # replace the parameter object instead
+            original.weight = torch.nn.Parameter(data, requires_grad=False)
+        else:
+            original.weight.data = data
         return original
 
 

--- a/src/llmcompressor/pipelines/__init__.py
+++ b/src/llmcompressor/pipelines/__init__.py
@@ -15,3 +15,4 @@ from .data_free import *
 from .independent import *
 from .registry import *
 from .sequential import *
+from .streaming import *

--- a/src/llmcompressor/pipelines/streaming/__init__.py
+++ b/src/llmcompressor/pipelines/streaming/__init__.py
@@ -1,0 +1,3 @@
+# ruff: noqa
+
+from .pipeline import *

--- a/src/llmcompressor/pipelines/streaming/checkpoint.py
+++ b/src/llmcompressor/pipelines/streaming/checkpoint.py
@@ -272,12 +272,14 @@ def _expert_slice_spec(
         fused = f"gate_up_proj{suffix}"
         lo = 0 if proj == "gate_proj" else intermediate
         hi = intermediate if proj == "gate_proj" else 2 * intermediate
-        if transposed:
+        # biases are 2D [E, 2I] and never transposed, mirroring
+        # `ExpertMLP.copy_from_experts_module`
+        if transposed and not bias:
             return fused, (index, slice(None), slice(lo, hi)), True
         return fused, (index, slice(lo, hi)), False
     if proj == "down_proj" or (not has_gate and proj == "up_proj"):
         fused = f"{proj}{suffix}"
-        return fused, (index,), transposed
+        return fused, (index,), transposed and not bias
     return None
 
 
@@ -509,7 +511,8 @@ def materialize_buffers(
             continue
         try:
             with torch.device("cpu"):
-                fresh = type(module)(module.config)
+                config = getattr(module, "config", getattr(model, "config", None))
+                fresh = type(module)(config)
         except Exception as e:
             raise CheckpointReferenceError(
                 f"Cannot recompute meta buffers {meta_buffers} of "
@@ -573,6 +576,6 @@ def release_modules(
                     continue
             if param.device != move_to:
                 param.data = param.data.to(move_to)
-        for buf in module._buffers.values():
+        for name, buf in module._buffers.items():
             if buf is not None and getattr(buf, "device", move_to) != move_to:
-                buf.data = buf.data.to(move_to)
+                module._buffers[name] = buf.to(move_to)

--- a/src/llmcompressor/pipelines/streaming/checkpoint.py
+++ b/src/llmcompressor/pipelines/streaming/checkpoint.py
@@ -101,9 +101,9 @@ class CheckpointMap:
         unresolved: list[str] = []
         unresolved_buffers: list[str] = []
         converter_matched: set[str] = set()
-        named_tensors = list(
-            model.named_parameters(remove_duplicate=False)
-        ) + list(model.named_buffers(remove_duplicate=False))
+        named_tensors = list(model.named_parameters(remove_duplicate=False)) + list(
+            model.named_buffers(remove_duplicate=False)
+        )
         buffer_names = {name for name, _ in model.named_buffers(remove_duplicate=False)}
         for name, tensor in named_tensors:
             ckpt_key, converter_pattern = rename_source_key(
@@ -140,8 +140,9 @@ class CheckpointMap:
                     f"model {tuple(tensor.shape)}. Use the 'sequential' pipeline "
                     "instead."
                 )
-            entries[name] = CheckpointEntry(file=file, key=ckpt_key, dtype=dtype,
-                                            shape=shape)
+            entries[name] = CheckpointEntry(
+                file=file, key=ckpt_key, dtype=dtype, shape=shape
+            )
 
         if unresolved:
             logger.debug(
@@ -386,7 +387,10 @@ def stage_modules(
     grouped: dict[str, list[tuple[tuple, CheckpointEntry, torch.dtype]]] = {}
     staged: dict[tuple[torch.nn.Module, str, str], torch.Tensor] = {}
     for module in modules:
-        for kind, mapping in (("param", module._parameters), ("buffer", module._buffers)):
+        for kind, mapping in (
+            ("param", module._parameters),
+            ("buffer", module._buffers),
+        ):
             for local_name, tensor in mapping.items():
                 if tensor is None or tensor.device.type != "meta":
                     continue

--- a/src/llmcompressor/pipelines/streaming/checkpoint.py
+++ b/src/llmcompressor/pipelines/streaming/checkpoint.py
@@ -1,0 +1,578 @@
+"""
+Checkpoint-referenced weight materialization for the streaming pipeline.
+
+Models loaded with ``device_map="meta"`` carry no weight data. This module
+builds a mapping from model parameter names to keys in the original
+safetensors checkpoint (inverting the load-time weight conversions), and
+materializes parameters on demand, per subgraph, directly from the original
+shards. Unquantized weights are never copied to a secondary disk location.
+"""
+
+import json
+import os
+from dataclasses import dataclass
+
+import torch
+from loguru import logger
+from safetensors import safe_open
+from transformers import PreTrainedModel
+from transformers.conversion_mapping import extract_weight_conversions_for_model
+from transformers.core_model_loading import (
+    WeightConverter,
+    WeightRenaming,
+    rename_source_key,
+)
+
+__all__ = [
+    "CheckpointReferenceError",
+    "CheckpointEntry",
+    "CheckpointMap",
+    "stage_modules",
+    "commit_staged",
+    "materialize_modules",
+    "materialize_buffers",
+    "release_modules",
+]
+
+
+class CheckpointReferenceError(RuntimeError):
+    """
+    Raised when a model's parameters cannot be referenced directly from the
+    original checkpoint (e.g. the load-time conversions include tensor
+    transforms, or the checkpoint is not safetensors). The caller should
+    fall back to a pipeline which performs regular weight loading.
+    """
+
+
+@dataclass
+class CheckpointEntry:
+    """Location of one tensor in the original checkpoint."""
+
+    file: str  # absolute path to the safetensors shard
+    key: str  # tensor key within the shard
+    dtype: torch.dtype
+    shape: torch.Size
+    # for parameters linearized out of a fused expert tensor (e.g.
+    # `experts.gate_up_proj[i, :I]` -> `experts.i.gate_proj.weight`):
+    # slices into the fused checkpoint tensor, and whether to transpose after
+    slices: tuple | None = None
+    transpose: bool = False
+
+
+class CheckpointMap:
+    """
+    Maps model parameter names to their tensors in the original checkpoint.
+
+    Built by reversing the load-time weight conversions (the same reversion
+    transformers applies when saving), so each parameter name resolves to the
+    checkpoint key its bytes were (or would have been) loaded from.
+    """
+
+    def __init__(
+        self,
+        entries: dict[str, CheckpointEntry],
+        unresolved: list[str] | None = None,
+        unresolved_buffers: list[str] | None = None,
+    ):
+        self.entries = entries
+        # params with no checkpoint source, e.g. quantization scales attached
+        # by modifiers; they are given zeroed storage at materialize time and
+        # are expected to be written during calibration
+        self.unresolved = unresolved or []
+        # buffers with no checkpoint source, e.g. non-persistent rotary
+        # `inv_freq`; recomputed by `materialize_buffers` instead of staging
+        self.unresolved_buffers = unresolved_buffers or []
+
+    @classmethod
+    def from_model(cls, model: PreTrainedModel) -> "CheckpointMap":
+        model_dir = model.name_or_path
+        if not os.path.isdir(model_dir):
+            raise CheckpointReferenceError(
+                f"Model path '{model_dir}' is not a local directory; the "
+                "streaming pipeline requires a local safetensors checkpoint"
+            )
+
+        ckpt_index = _read_checkpoint_index(model_dir)
+        conversions = _get_load_conversions(model)
+        renamings, converters = _split_reverse_conversions(conversions)
+
+        entries: dict[str, CheckpointEntry] = {}
+        tied_sources = _tied_parameter_sources(model)
+        unresolved: list[str] = []
+        unresolved_buffers: list[str] = []
+        converter_matched: set[str] = set()
+        named_tensors = list(
+            model.named_parameters(remove_duplicate=False)
+        ) + list(model.named_buffers(remove_duplicate=False))
+        buffer_names = {name for name, _ in model.named_buffers(remove_duplicate=False)}
+        for name, tensor in named_tensors:
+            ckpt_key, converter_pattern = rename_source_key(
+                name, renamings, converters, reverse=True
+            )
+            if converter_pattern is not None:
+                # a converter matched; a linearized-expert param may still be
+                # resolvable as a slice of the fused checkpoint tensor (second
+                # pass below). Anything else cannot be referenced directly.
+                converter_matched.add(name)
+                unresolved.append(name)
+                continue
+            file_entry = ckpt_index.get(ckpt_key)
+            if file_entry is None and name in tied_sources:
+                # tied parameters (e.g. lm_head) are not stored separately;
+                # reference the source tensor they are tied to
+                source_entry = entries.get(tied_sources[name])
+                if source_entry is not None:
+                    entries[name] = source_entry
+                    continue
+            if file_entry is None:
+                # not a checkpoint tensor: either a quantization scale attached
+                # by a modifier (given zeroed storage at materialize time) or a
+                # non-persistent buffer (recomputed by `materialize_buffers`)
+                if name in buffer_names:
+                    unresolved_buffers.append(name)
+                else:
+                    unresolved.append(name)
+                continue
+            file, dtype, shape = file_entry
+            if tuple(shape) != tuple(tensor.shape):
+                raise CheckpointReferenceError(
+                    f"Shape mismatch for '{name}': checkpoint {tuple(shape)} vs "
+                    f"model {tuple(tensor.shape)}. Use the 'sequential' pipeline "
+                    "instead."
+                )
+            entries[name] = CheckpointEntry(file=file, key=ckpt_key, dtype=dtype,
+                                            shape=shape)
+
+        if unresolved:
+            logger.debug(
+                f"{len(unresolved)} parameters have no checkpoint source and "
+                f"will be calibrated from scratch (first: {unresolved[0]!r})"
+            )
+        if unresolved_buffers:
+            logger.debug(
+                f"{len(unresolved_buffers)} buffers have no checkpoint source "
+                f"and will be recomputed (first: {unresolved_buffers[0]!r})"
+            )
+
+        # second pass: params of linearized experts (LinearExperts2D) which
+        # are slices of fused checkpoint tensors, e.g. `experts.gate_up_proj[i]`
+        unresolved = _resolve_expert_slices(
+            model, ckpt_index, renamings, entries, unresolved
+        )
+        still_converted = converter_matched & set(unresolved)
+        if still_converted:
+            name = sorted(still_converted)[0]
+            raise CheckpointReferenceError(
+                f"Parameter '{name}' passes through a weight converter during "
+                "loading, so its bytes cannot be referenced directly from the "
+                "checkpoint. Use the 'sequential' pipeline instead."
+            )
+        return cls(entries, unresolved, unresolved_buffers)
+
+    def entry(self, param_name: str) -> CheckpointEntry | None:
+        return self.entries.get(param_name)
+
+
+def _read_checkpoint_index(
+    model_dir: str,
+) -> dict[str, tuple[str, torch.dtype, torch.Size]]:
+    """key -> (absolute file path, dtype, shape), read from headers only."""
+    index_path = os.path.join(model_dir, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        with open(index_path) as f:
+            weight_map = json.load(f)["weight_map"]
+        files = sorted(set(weight_map.values()))
+        key_to_file = weight_map
+    else:
+        single = os.path.join(model_dir, "model.safetensors")
+        if not os.path.exists(single):
+            raise CheckpointReferenceError(
+                f"No safetensors checkpoint found in {model_dir}; the streaming "
+                "pipeline requires a safetensors checkpoint"
+            )
+        files = ["model.safetensors"]
+        key_to_file = None
+
+    index: dict[str, tuple[str, torch.dtype, torch.Size]] = {}
+    for file_name in files:
+        file_path = os.path.join(model_dir, file_name)
+        with safe_open(file_path, framework="pt", device="cpu") as f:
+            for key in f.keys():
+                if key_to_file is not None and key_to_file.get(key) != file_name:
+                    continue
+                slice_ = f.get_slice(key)
+                index[key] = (file_path, slice_.get_dtype(), slice_.get_shape())
+    return index
+
+
+def _get_load_conversions(model: PreTrainedModel):
+    """
+    Load-time weight conversions for the model. Populated on
+    ``model._load_weight_conversions`` by `load_quantizable_moe` when
+    linearized load mappings were registered; otherwise derived from the
+    model's registered conversion mapping.
+    """
+    conversions = getattr(model, "_load_weight_conversions", None)
+    if conversions is None:
+        conversions = extract_weight_conversions_for_model(model) or []
+    return conversions
+
+
+def _split_reverse_conversions(
+    conversions: list,
+) -> tuple[list[WeightRenaming], list[WeightConverter]]:
+    """
+    Reverse load-time conversions so they map model names back to checkpoint
+    keys (the same reversion applied at save time), split by kind.
+    """
+    reversed_conversions = []
+    for conversion in conversions:
+        try:
+            reversed_conversions.append(conversion.reverse_transform())
+        except (NotImplementedError, AttributeError) as e:
+            raise CheckpointReferenceError(
+                f"Weight conversion {conversion} is not reversible: {e}. "
+                "Use the 'sequential' pipeline instead."
+            )
+    renamings = [c for c in reversed_conversions if isinstance(c, WeightRenaming)]
+    converters = [c for c in reversed_conversions if isinstance(c, WeightConverter)]
+    return renamings, converters
+
+
+def _tied_parameter_sources(model: PreTrainedModel) -> dict[str, str]:
+    """tied param name -> param name it shares an object with."""
+    sources: dict[str, str] = {}
+    seen: dict[int, str] = {}
+    for name, param in model.named_parameters(remove_duplicate=False):
+        key = id(param)
+        if key in seen:
+            sources[name] = seen[key]
+        else:
+            seen[key] = name
+    return sources
+
+
+def _expert_slice_spec(
+    experts_module, index: int, proj: str, kind: str
+) -> tuple[str, tuple, bool] | None:
+    """
+    Map a linearized expert param (`{i}.{proj}.{kind}`) to its location in the
+    fused experts tensor, mirroring `ExpertMLP.copy_from_experts_module`.
+    Returns (fused param name suffix, slices, transpose).
+    """
+    intermediate = experts_module.intermediate_size
+    transposed = experts_module.is_transposed
+    has_gate = experts_module.has_gate
+    bias = kind == "bias"
+    if bias and not experts_module.has_bias:
+        return None
+    suffix = "_bias" if bias else ""
+
+    if has_gate and proj in ("gate_proj", "up_proj"):
+        fused = f"gate_up_proj{suffix}"
+        lo = 0 if proj == "gate_proj" else intermediate
+        hi = intermediate if proj == "gate_proj" else 2 * intermediate
+        if transposed:
+            return fused, (index, slice(None), slice(lo, hi)), True
+        return fused, (index, slice(lo, hi)), False
+    if proj == "down_proj" or (not has_gate and proj == "up_proj"):
+        fused = f"{proj}{suffix}"
+        return fused, (index,), transposed
+    return None
+
+
+def _resolve_expert_slices(
+    model: PreTrainedModel,
+    ckpt_index: dict,
+    renamings: list,
+    entries: dict[str, CheckpointEntry],
+    unresolved: list[str],
+) -> list[str]:
+    """
+    Resolve params of LinearExperts2D modules which have no exact checkpoint
+    key to slices of the fused expert tensors they were linearized from.
+    Raises `CheckpointReferenceError` for unresolvable expert weights (rather
+    than letting them be materialized as zeros).
+    """
+    from llmcompressor.modeling.moe.linear_experts import LinearExperts2D
+
+    unresolved_set = set(unresolved)
+    resolved: set[str] = set()
+    for module_name, module in model.named_modules():
+        if not isinstance(module, LinearExperts2D):
+            continue
+        for index, expert in enumerate(module):
+            for proj in ("gate_proj", "up_proj", "down_proj"):
+                linear = getattr(expert, proj, None)
+                if linear is None:
+                    continue
+                for kind, param in (("weight", linear.weight), ("bias", linear.bias)):
+                    if param is None:
+                        continue
+                    fqn = f"{module_name}.{index}.{proj}.{kind}"
+                    if fqn not in unresolved_set:
+                        continue
+                    spec = _expert_slice_spec(module, index, proj, kind)
+                    if spec is None:
+                        raise CheckpointReferenceError(
+                            f"Cannot resolve '{fqn}' to a checkpoint slice "
+                            f"(layout of {type(module).__name__} unsupported). Use "
+                            "the 'sequential' pipeline instead."
+                        )
+                    fused_suffix, slices, transpose = spec
+                    fused_name = f"{module_name}.{fused_suffix}"
+                    # reverse renamings only: a converter would mean the fused
+                    # tensor itself is transformed, which we cannot reference
+                    ckpt_key, conv = rename_source_key(
+                        fused_name, renamings, [], reverse=True
+                    )
+                    file_entry = ckpt_index.get(ckpt_key) or ckpt_index.get(fused_name)
+                    if file_entry is None:
+                        raise CheckpointReferenceError(
+                            f"Fused checkpoint tensor for '{fqn}' (expected key "
+                            f"'{ckpt_key}') not found in checkpoint. Use the "
+                            "'sequential' pipeline instead."
+                        )
+                    file, dtype, shape = file_entry
+                    _validate_slice(fqn, shape, slices, transpose, param.shape)
+                    entries[fqn] = CheckpointEntry(
+                        file=file,
+                        key=ckpt_key if ckpt_key in ckpt_index else fused_name,
+                        dtype=dtype,
+                        shape=torch.Size(param.shape),
+                        slices=slices,
+                        transpose=transpose,
+                    )
+                    resolved.add(fqn)
+    return [name for name in unresolved if name not in resolved]
+
+
+def _validate_slice(fqn, fused_shape, slices, transpose, param_shape) -> None:
+    sliced = []
+    for dim, sel in enumerate(slices):
+        if isinstance(sel, slice):
+            sliced.append(len(range(*sel.indices(fused_shape[dim]))))
+    # dims beyond the slice spec are kept whole
+    for dim in range(len(slices), len(fused_shape)):
+        sliced.append(fused_shape[dim])
+    if transpose:
+        sliced = sliced[::-1]
+    if tuple(sliced) != tuple(param_shape):
+        raise CheckpointReferenceError(
+            f"Slice of fused tensor for '{fqn}' has shape {tuple(sliced)}, "
+            f"expected {tuple(param_shape)}. Use the 'sequential' pipeline instead."
+        )
+
+
+@torch.no_grad()
+def stage_modules(
+    model: torch.nn.Module,
+    modules: list[torch.nn.Module],
+    ckpt_map: CheckpointMap,
+) -> dict[tuple[torch.nn.Module, str, str], torch.Tensor]:
+    """
+    Read all meta parameters and buffers directly owned by `modules` from the
+    original checkpoint shards into CPU tensors, grouping reads by shard file.
+
+    This performs no model mutation and releases the GIL during reads, so it
+    can run in a background thread to prefetch the next subgraph while the
+    current one is being calibrated.
+
+    :return: staged tensors keyed by (owning module, "param"|"buffer", name)
+    """
+    module_names = {module: name for name, module in model.named_modules()}
+    grouped: dict[str, list[tuple[tuple, CheckpointEntry, torch.dtype]]] = {}
+    staged: dict[tuple[torch.nn.Module, str, str], torch.Tensor] = {}
+    for module in modules:
+        for kind, mapping in (("param", module._parameters), ("buffer", module._buffers)):
+            for local_name, tensor in mapping.items():
+                if tensor is None or tensor.device.type != "meta":
+                    continue
+                module_name = module_names[module]
+                fqn = f"{module_name}.{local_name}" if module_name else local_name
+                entry = ckpt_map.entry(fqn)
+                if entry is None:
+                    if fqn in ckpt_map.unresolved_buffers:
+                        # recomputed by `materialize_buffers`, not staged
+                        continue
+                    if fqn not in ckpt_map.unresolved:
+                        raise CheckpointReferenceError(
+                            f"No checkpoint entry for '{fqn}'"
+                        )
+                    # not a checkpoint tensor (e.g. a quantization scale
+                    # attached by a modifier); give it real zeroed storage so
+                    # it can be written during calibration (zeros match
+                    # observer defaults for never-calibrated params)
+                    staged[(module, kind, local_name)] = torch.zeros_like(
+                        tensor, device="cpu"
+                    )
+                    continue
+                key = (module, kind, local_name)
+                grouped.setdefault(entry.file, []).append((key, entry, tensor.dtype))
+
+    # norm calibration replacements (see offset_norm.py) hold
+    # standard-convention weights (1 + checkpoint value)
+    from llmcompressor.modeling.offset_norm import NormCalibrationModule
+
+    for file_path, items in grouped.items():
+        with safe_open(file_path, framework="pt", device="cpu") as f:
+            for key, entry, dtype in items:
+                module, kind, local_name = key
+                if entry.slices is not None:
+                    tensor = f.get_slice(entry.key)[entry.slices]
+                    if entry.transpose:
+                        tensor = tensor.T.contiguous()
+                else:
+                    tensor = f.get_tensor(entry.key)
+                if (
+                    kind == "param"
+                    and local_name == "weight"
+                    and isinstance(module, NormCalibrationModule)
+                ):
+                    tensor = 1.0 + tensor.float()
+                if tensor.dtype != dtype:
+                    tensor = tensor.to(dtype)
+                staged[key] = tensor
+    logger.debug(
+        f"staged {len(staged)} tensors from {len(grouped)} checkpoint shard files"
+    )
+    return staged
+
+
+@torch.no_grad()
+def commit_staged(
+    staged: dict[tuple[torch.nn.Module, str, str], torch.Tensor],
+    device: torch.device,
+) -> int:
+    """
+    Install staged tensors as parameters/buffers on their owning modules,
+    moving them to `device`. Objects are replaced (meta tensors cannot be
+    assigned real data); hooks hold module references and are unaffected.
+
+    :return: number of tensors materialized
+    """
+    for (module, kind, local_name), tensor in staged.items():
+        tensor = tensor.to(device)
+        if kind == "param":
+            param = module._parameters[local_name]
+            module._parameters[local_name] = torch.nn.Parameter(
+                tensor, requires_grad=param.requires_grad
+            )
+        else:
+            old = module._buffers[local_name]
+            if isinstance(old, torch.nn.Buffer):
+                tensor = torch.nn.Buffer(
+                    tensor, persistent=getattr(old, "persistent", True)
+                )
+            module._buffers[local_name] = tensor
+    return len(staged)
+
+
+@torch.no_grad()
+def materialize_modules(
+    model: torch.nn.Module,
+    modules: list[torch.nn.Module],
+    ckpt_map: CheckpointMap,
+    device: torch.device,
+) -> int:
+    """Synchronous convenience wrapper: `stage_modules` + `commit_staged`."""
+    return commit_staged(stage_modules(model, modules, ckpt_map), device)
+
+
+@torch.no_grad()
+def materialize_buffers(
+    model: torch.nn.Module, device: torch.device, ckpt_map: "CheckpointMap"
+) -> int:
+    """
+    Recompute buffers which remain on the meta device after a meta-device load
+    and have no checkpoint source (e.g. non-persistent rotary `inv_freq`), by
+    re-instantiating their owning module and copying its buffers. Buffers
+    which do exist in the checkpoint are staged from it by `stage_modules`
+    instead. Raises `CheckpointReferenceError` for buffers whose owning module
+    cannot be re-instantiated from its config.
+    """
+    module_names = {module: name for name, module in model.named_modules()}
+    count = 0
+    for module in model.modules():
+        module_name = module_names[module]
+        meta_buffers = []
+        for name, buf in module._buffers.items():
+            if buf is None or getattr(buf, "device", None) is None:
+                continue
+            if buf.device.type != "meta":
+                continue
+            fqn = f"{module_name}.{name}" if module_name else name
+            if ckpt_map.entry(fqn) is not None:
+                continue  # checkpoint-backed, staged by `stage_modules`
+            meta_buffers.append(name)
+        if not meta_buffers:
+            continue
+        try:
+            with torch.device("cpu"):
+                fresh = type(module)(module.config)
+        except Exception as e:
+            raise CheckpointReferenceError(
+                f"Cannot recompute meta buffers {meta_buffers} of "
+                f"{type(module).__name__} by re-instantiation: {e}"
+            )
+        for name in meta_buffers:
+            module._buffers[name] = fresh._buffers[name].to(device)
+        for attr in ("attention_scaling",):
+            if hasattr(fresh, attr):
+                setattr(module, attr, getattr(fresh, attr))
+        count += len(meta_buffers)
+    return count
+
+
+@torch.no_grad()
+def release_modules(
+    modules: list[torch.nn.Module],
+    device: torch.device = torch.device("cpu"),
+    ckpt_map: "CheckpointMap | None" = None,
+    model: torch.nn.Module | None = None,
+) -> None:
+    """
+    Move all parameters and buffers of the given modules to `device`.
+
+    With ``device="meta"``, checkpoint-backed parameters are dropped back to
+    the meta device instead (they can be re-materialized from the original
+    checkpoint at any time), keeping host memory flat across layers. Only
+    valid when no modifier mutates weights (e.g. RTN-style
+    `QuantizationModifier`); weight-mutating modifiers (GPTQ, AWQ, ...) must
+    use the default cpu offload. Norm-calibration replacement weights and
+    quantization params (no checkpoint source) are always kept.
+    """
+    from llmcompressor.modeling.offset_norm import NormCalibrationModule
+
+    to_meta = device.type == "meta"
+    move_to = torch.device("cpu") if to_meta else device
+    module_names = (
+        {module: name for name, module in model.named_modules()}
+        if to_meta and model is not None
+        else {}
+    )
+    for module in modules:
+        for name, param in module._parameters.items():
+            if param is None:
+                continue
+            if (
+                to_meta
+                and ckpt_map is not None
+                and not isinstance(module, NormCalibrationModule)
+            ):
+                # drop checkpoint-backed weights; they are re-readable from
+                # the original shards. Quantization params (not in the
+                # checkpoint) are kept on cpu
+                module_name = module_names.get(module, "")
+                fqn = f"{module_name}.{name}" if module_name else name
+                if ckpt_map.entry(fqn) is not None:
+                    module._parameters[name] = torch.nn.Parameter(
+                        torch.empty_like(param, device="meta"),
+                        requires_grad=param.requires_grad,
+                    )
+                    continue
+            if param.device != move_to:
+                param.data = param.data.to(move_to)
+        for buf in module._buffers.values():
+            if buf is not None and getattr(buf, "device", move_to) != move_to:
+                buf.data = buf.data.to(move_to)

--- a/src/llmcompressor/pipelines/streaming/pipeline.py
+++ b/src/llmcompressor/pipelines/streaming/pipeline.py
@@ -1,5 +1,4 @@
 import contextlib
-import os
 from typing import TYPE_CHECKING
 
 import torch
@@ -86,7 +85,7 @@ class StreamingPipeline(CalibrationPipeline):
         # re-readable from the original checkpoint), keeping host memory flat
         # for models larger than RAM. "meta" is only valid when no modifier
         # mutates weights.
-        release_mode = os.environ.get("LLMCOMPRESSOR_STREAMING_RELEASE", "cpu")
+        release_mode = dataset_args.streaming_release
         weight_mutating = {
             "GPTQModifier",
             "SparseGPTModifier",
@@ -100,7 +99,7 @@ class StreamingPipeline(CalibrationPipeline):
             type(m).__name__ in weight_mutating for m in modifiers
         ):
             logger.warning(
-                "LLMCOMPRESSOR_STREAMING_RELEASE=meta requires modifiers which "
+                "streaming_release='meta' requires modifiers which "
                 "do not mutate weights; falling back to 'cpu'"
             )
             release_mode = "cpu"

--- a/src/llmcompressor/pipelines/streaming/pipeline.py
+++ b/src/llmcompressor/pipelines/streaming/pipeline.py
@@ -1,0 +1,282 @@
+import contextlib
+import os
+import threading
+from typing import TYPE_CHECKING
+
+import torch
+from torch.utils.data.dataloader import DataLoader
+
+from llmcompressor.core import LifecycleCallbacks, active_session
+from llmcompressor.modifiers.utils.hooks import HooksMixin
+from llmcompressor.pipelines.cache import IntermediatesCache
+from llmcompressor.pipelines.registry import CalibrationPipeline
+from llmcompressor.pipelines.sequential.helpers import (
+    handle_sequential_oom,
+    trace_subgraphs,
+)
+from llmcompressor.pipelines.sequential.pipeline import _get_batches
+from llmcompressor.pipelines.streaming.checkpoint import (
+    CheckpointMap,
+    commit_staged,
+    materialize_buffers,
+    materialize_modules,
+    release_modules,
+    stage_modules,
+)
+from llmcompressor.utils.dev import get_main_device
+from llmcompressor.utils.helpers import DisableQuantization, calibration_forward_context
+from llmcompressor.utils.pytorch.module import infer_sequential_targets
+
+if TYPE_CHECKING:
+    from llmcompressor.args.dataset_arguments import DatasetArguments
+
+__all__ = ["StreamingPipeline"]
+
+
+class _SubgraphPrefetcher:
+    """
+    Prefetches the next subgraph's weights from the original checkpoint into
+    CPU memory in a background thread, overlapping disk reads with the
+    current subgraph's calibration.
+    """
+
+    def __init__(self, model: torch.nn.Module, ckpt_map: CheckpointMap):
+        self.model = model
+        self.ckpt_map = ckpt_map
+        self._thread: threading.Thread | None = None
+        self._staged = None
+        self._error: BaseException | None = None
+
+    def start(self, modules: list[torch.nn.Module]):
+        def _run():
+            try:
+                self._staged = stage_modules(self.model, modules, self.ckpt_map)
+            except BaseException as e:  # surfaced on join
+                self._error = e
+
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+
+    def join(self) -> dict:
+        self._thread.join()
+        self._thread = None
+        if self._error is not None:
+            raise self._error
+        staged, self._staged = self._staged, None
+        return staged
+
+
+@CalibrationPipeline.register("streaming")
+class StreamingPipeline(CalibrationPipeline):
+    @staticmethod
+    @handle_sequential_oom
+    def __call__(
+        model: torch.nn.Module,
+        dataloader: DataLoader,
+        dataset_args: "DatasetArguments",
+    ):
+        """
+        Run a sequential data pipeline which materializes weights directly from
+        the original checkpoint, one subgraph at a time:
+
+        1. The model is expected on the meta device (``device_map="meta"``);
+           no weights are loaded before this pipeline runs
+        2. Before each subgraph executes, its parameters are read in bulk from
+           the original safetensors shards; the next subgraph's weights are
+           prefetched in a background thread during calibration
+        3. After each subgraph is calibrated and compressed, its parameters are
+           moved to the offload device for the final save
+
+        Unquantized weights are never written to a secondary disk location.
+        Models whose checkpoints require tensor conversions on load are not
+        supported (see `CheckpointReferenceError`); use the "sequential"
+        pipeline for those.
+
+        :param model: model being calibrated
+        :param dataloader: loads data for calibration
+        :param dataset_args: dataset arguments relevant to pipelines
+        """
+        session = active_session()
+        onload_device = get_main_device()
+        offload_device = torch.device(dataset_args.sequential_offload_device)
+
+        ckpt_map = CheckpointMap.from_model(model)
+        # buffers without a checkpoint source (e.g. non-persistent rotary
+        # inv_freq) are recomputed once on the execution device
+        materialize_buffers(model, onload_device, ckpt_map)
+
+        # AutoRoundModifier optimizes each layer independently using its own
+        # forward passes, so quantization error should not be propagated between
+        # layers during the calibration stage
+        modifiers = session.lifecycle.recipe.modifiers
+        if any(type(m).__name__ == "AutoRoundModifier" for m in modifiers):
+            dataset_args.propagate_error = False
+
+        # weight release mode after each subgraph: "cpu" keeps (possibly
+        # modifier-updated) weights in host memory; "meta" drops
+        # checkpoint-backed weights back to the meta device (they are
+        # re-readable from the original checkpoint), keeping host memory flat
+        # for models larger than RAM. "meta" is only valid when no modifier
+        # mutates weights.
+        release_mode = os.environ.get("LLMCOMPRESSOR_STREAMING_RELEASE", "cpu")
+        weight_mutating = {
+            "GPTQModifier",
+            "SparseGPTModifier",
+            "AWQModifier",
+            "SmoothQuantModifier",
+            "AutoRoundModifier",
+            "SpinQuantModifier",
+            "QuIPModifier",
+        }
+        if release_mode == "meta" and any(
+            type(m).__name__ in weight_mutating for m in modifiers
+        ):
+            logger.warning(
+                "LLMCOMPRESSOR_STREAMING_RELEASE=meta requires modifiers which "
+                "do not mutate weights; falling back to 'cpu'"
+            )
+            release_mode = "cpu"
+        weight_release_device = torch.device(release_mode)
+
+        # prepare to trace subgraphs
+        sequential_targets = infer_sequential_targets(
+            model, dataset_args.sequential_targets
+        )
+        ignore = dataset_args.tracing_ignore
+
+        # trace subgraphs
+        sample_input = next(iter(dataloader))
+        subgraphs = trace_subgraphs(
+            model,
+            sample_input,
+            sequential_targets,
+            ignore,
+            dataset_args.sequential_targets_per_subgraph,
+        )
+        num_subgraphs = len(subgraphs)
+
+        LifecycleCallbacks.calibration_start()
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(calibration_forward_context(model))
+            stack.enter_context(DisableQuantization(model))
+            # prepare intermediates cache
+            activations = IntermediatesCache.from_dataloader(
+                dataloader, onload_device, offload_device
+            )
+
+            # Populate loss_masks once from cached activations for AWQ masking support
+            use_loss_mask = getattr(dataset_args, "use_loss_mask", False)
+            if use_loss_mask:
+                session.state.loss_masks = [
+                    activations.fetch(batch_idx, ["loss_mask"]).get("loss_mask")
+                    for batch_idx in range(len(dataloader))
+                ]
+            else:
+                session.state.loss_masks = None
+
+            sequential_prefetch = getattr(dataset_args, "sequential_prefetch", False)
+            session.state.sequential_prefetch = sequential_prefetch
+
+            # modules outside every subgraph (e.g. embed_tokens, whose call is
+            # not traced as a call_module node) are materialized once upfront
+            # and stay resident
+            claimed = set()
+            for subgraph in subgraphs:
+                claimed.update(subgraph.submodules(model))
+            unclaimed = [
+                module
+                for module in model.modules()
+                if module not in claimed
+                and any(
+                    param is not None and param.device.type == "meta"
+                    for param in module._parameters.values()
+                )
+            ]
+            if unclaimed:
+                materialize_modules(model, unclaimed, ckpt_map, onload_device)
+
+            # synchronously stage the first subgraph; later subgraphs are
+            # staged by the prefetcher during the previous subgraph's passes
+            staged = stage_modules(
+                model, subgraphs[0].submodules(model), ckpt_map
+            )
+            prefetcher = _SubgraphPrefetcher(model, ckpt_map)
+
+            for subgraph_index, subgraph in enumerate(subgraphs):
+                commit_staged(staged, onload_device)
+                if subgraph_index + 1 < num_subgraphs:
+                    prefetcher.start(subgraphs[subgraph_index + 1].submodules(model))
+
+                # prepare tqdm description texts
+                calib_desc = f"({subgraph_index + 1}/{num_subgraphs}): Calibrating"
+                prop_desc = f"({subgraph_index + 1}/{num_subgraphs}): Propagating"
+
+                submodules = subgraph.submodules(model)
+                num_batches = len(dataloader)
+
+                # do a preliminary pass to trigger modifier hooks
+                for batch_idx, inputs in _get_batches(
+                    activations,
+                    num_batches,
+                    subgraph.input_names,
+                    calib_desc,
+                    sequential_prefetch,
+                ):
+                    session.state.current_batch_idx = batch_idx
+                    outputs = subgraph.forward(model, **inputs)
+
+                    if not dataset_args.propagate_error:
+                        if subgraph_index < num_subgraphs - 1:
+                            activations.update(batch_idx, outputs)
+                            activations.delete(batch_idx, subgraph.consumed_names)
+
+                LifecycleCallbacks.sequential_epoch_end(submodules)
+
+                if dataset_args.propagate_error:
+                    # this pass does not trigger modifier hooks
+                    # and is only used for capturing outputs of compressed modules
+                    with HooksMixin.disable_hooks():
+                        for batch_idx, inputs in _get_batches(
+                            activations,
+                            num_batches,
+                            subgraph.input_names,
+                            prop_desc,
+                            sequential_prefetch,
+                        ):
+                            output = subgraph.forward(model, **inputs)
+                            if subgraph_index < num_subgraphs - 1:
+                                activations.update(batch_idx, output)
+                                activations.delete(
+                                    batch_idx, subgraph.consumed_names
+                                )
+
+                # keep (compressed) params on the offload device for the final
+                # save and free execution-device memory
+                release_modules(
+                    submodules, weight_release_device, ckpt_map=ckpt_map, model=model
+                )
+
+                if subgraph_index + 1 < num_subgraphs:
+                    staged = prefetcher.join()
+
+            # recipe-targeted modules which were never traced into a subgraph
+            # (e.g. a vision tower when calibrating with text-only data) are
+            # compressed during `calibration_end`; materialize them first
+            remaining = [
+                module
+                for module in model.modules()
+                if any(
+                    param is not None and param.device.type == "meta"
+                    for param in module._parameters.values()
+                )
+            ]
+            if remaining:
+                materialize_modules(model, remaining, ckpt_map, onload_device)
+
+            # redundant, finish any remaining compression
+            LifecycleCallbacks.calibration_end()
+            if remaining:
+                release_modules(
+                    remaining, weight_release_device, ckpt_map=ckpt_map, model=model
+                )

--- a/src/llmcompressor/pipelines/streaming/pipeline.py
+++ b/src/llmcompressor/pipelines/streaming/pipeline.py
@@ -4,6 +4,7 @@ import threading
 from typing import TYPE_CHECKING
 
 import torch
+from loguru import logger
 from torch.utils.data.dataloader import DataLoader
 
 from llmcompressor.core import LifecycleCallbacks, active_session
@@ -198,9 +199,7 @@ class StreamingPipeline(CalibrationPipeline):
 
             # synchronously stage the first subgraph; later subgraphs are
             # staged by the prefetcher during the previous subgraph's passes
-            staged = stage_modules(
-                model, subgraphs[0].submodules(model), ckpt_map
-            )
+            staged = stage_modules(model, subgraphs[0].submodules(model), ckpt_map)
             prefetcher = _SubgraphPrefetcher(model, ckpt_map)
 
             for subgraph_index, subgraph in enumerate(subgraphs):
@@ -247,9 +246,7 @@ class StreamingPipeline(CalibrationPipeline):
                             output = subgraph.forward(model, **inputs)
                             if subgraph_index < num_subgraphs - 1:
                                 activations.update(batch_idx, output)
-                                activations.delete(
-                                    batch_idx, subgraph.consumed_names
-                                )
+                                activations.delete(batch_idx, subgraph.consumed_names)
 
                 # keep (compressed) params on the offload device for the final
                 # save and free execution-device memory

--- a/src/llmcompressor/pipelines/streaming/pipeline.py
+++ b/src/llmcompressor/pipelines/streaming/pipeline.py
@@ -1,6 +1,5 @@
 import contextlib
 import os
-import threading
 from typing import TYPE_CHECKING
 
 import torch
@@ -24,6 +23,7 @@ from llmcompressor.pipelines.streaming.checkpoint import (
     release_modules,
     stage_modules,
 )
+from llmcompressor.pipelines.streaming.prefetch import SubgraphPrefetcher
 from llmcompressor.utils.dev import get_main_device
 from llmcompressor.utils.helpers import DisableQuantization, calibration_forward_context
 from llmcompressor.utils.pytorch.module import infer_sequential_targets
@@ -32,39 +32,6 @@ if TYPE_CHECKING:
     from llmcompressor.args.dataset_arguments import DatasetArguments
 
 __all__ = ["StreamingPipeline"]
-
-
-class _SubgraphPrefetcher:
-    """
-    Prefetches the next subgraph's weights from the original checkpoint into
-    CPU memory in a background thread, overlapping disk reads with the
-    current subgraph's calibration.
-    """
-
-    def __init__(self, model: torch.nn.Module, ckpt_map: CheckpointMap):
-        self.model = model
-        self.ckpt_map = ckpt_map
-        self._thread: threading.Thread | None = None
-        self._staged = None
-        self._error: BaseException | None = None
-
-    def start(self, modules: list[torch.nn.Module]):
-        def _run():
-            try:
-                self._staged = stage_modules(self.model, modules, self.ckpt_map)
-            except BaseException as e:  # surfaced on join
-                self._error = e
-
-        self._thread = threading.Thread(target=_run, daemon=True)
-        self._thread.start()
-
-    def join(self) -> dict:
-        self._thread.join()
-        self._thread = None
-        if self._error is not None:
-            raise self._error
-        staged, self._staged = self._staged, None
-        return staged
 
 
 @CalibrationPipeline.register("streaming")
@@ -200,7 +167,7 @@ class StreamingPipeline(CalibrationPipeline):
             # synchronously stage the first subgraph; later subgraphs are
             # staged by the prefetcher during the previous subgraph's passes
             staged = stage_modules(model, subgraphs[0].submodules(model), ckpt_map)
-            prefetcher = _SubgraphPrefetcher(model, ckpt_map)
+            prefetcher = SubgraphPrefetcher(model, ckpt_map)
 
             for subgraph_index, subgraph in enumerate(subgraphs):
                 commit_staged(staged, onload_device)

--- a/src/llmcompressor/pipelines/streaming/prefetch.py
+++ b/src/llmcompressor/pipelines/streaming/prefetch.py
@@ -1,0 +1,48 @@
+"""
+Background prefetching of subgraph weights for the streaming pipeline.
+
+While the current subgraph is being calibrated, the next subgraph's weights
+are read from the original checkpoint shards on a background thread (see
+`stage_modules`), overlapping disk I/O with calibration compute.
+"""
+
+import threading
+
+import torch
+
+from llmcompressor.pipelines.streaming.checkpoint import CheckpointMap, stage_modules
+
+__all__ = ["SubgraphPrefetcher"]
+
+
+class SubgraphPrefetcher:
+    """
+    Prefetches the next subgraph's weights from the original checkpoint into
+    CPU memory in a background thread, overlapping disk reads with the
+    current subgraph's calibration.
+    """
+
+    def __init__(self, model: torch.nn.Module, ckpt_map: CheckpointMap):
+        self.model = model
+        self.ckpt_map = ckpt_map
+        self._thread: threading.Thread | None = None
+        self._staged = None
+        self._error: BaseException | None = None
+
+    def start(self, modules: list[torch.nn.Module]):
+        def _run():
+            try:
+                self._staged = stage_modules(self.model, modules, self.ckpt_map)
+            except BaseException as e:  # surfaced on join
+                self._error = e
+
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+
+    def join(self) -> dict:
+        self._thread.join()
+        self._thread = None
+        if self._error is not None:
+            raise self._error
+        staged, self._staged = self._staged, None
+        return staged

--- a/src/llmcompressor/utils/dev.py
+++ b/src/llmcompressor/utils/dev.py
@@ -33,7 +33,9 @@ __all__ = [
 
 
 @contextlib.contextmanager
-def load_context(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
+def load_context(
+    model_cls: Type[PreTrainedModel] = AutoModelForCausalLM, meta: bool = False
+):
     """
     Context manager for loading HuggingFace models with both offloading and
     MoE linearization support.
@@ -43,11 +45,17 @@ def load_context(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM):
     either or both capabilities.
 
     :param model_cls: The model class to patch, defaults to AutoModelForCausalLM
+    :param meta: If True, skip the offloading conversion; the model is expected
+        to be loaded with `device_map="meta"` and calibrated with the
+        "streaming" pipeline, which materializes weights directly from the
+        original checkpoint. Offloaded (meta) models have no weight data and
+        cannot be used with the regular pipelines.
     """
     from llmcompressor.modeling.moe.linearize import load_quantizable_moe
 
     with contextlib.ExitStack() as stack:
-        stack.enter_context(load_offloaded_model(model_cls))
+        if not meta:
+            stack.enter_context(load_offloaded_model(model_cls))
         stack.enter_context(load_quantizable_moe(model_cls))
         yield
 

--- a/tests/llmcompressor/pipelines/streaming/test_streaming.py
+++ b/tests/llmcompressor/pipelines/streaming/test_streaming.py
@@ -1,0 +1,212 @@
+import pytest
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
+
+from llmcompressor.pipelines.streaming.checkpoint import (
+    CheckpointMap,
+    CheckpointReferenceError,
+    materialize_buffers,
+    materialize_modules,
+    release_modules,
+)
+from llmcompressor.utils import load_context
+
+
+@pytest.fixture(scope="module")
+def tiny_moe_path(tmp_path_factory):
+    path = tmp_path_factory.mktemp("tiny_qwen3moe")
+    config = Qwen3MoeConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=64,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_experts=4,
+        num_experts_per_tok=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_config(config, dtype=torch.bfloat16)
+    model.save_pretrained(path, safe_serialization=True)
+    del model
+    return str(path)
+
+
+@pytest.fixture
+def meta_model(tiny_moe_path):
+    with load_context(meta=True):
+        model = AutoModelForCausalLM.from_pretrained(tiny_moe_path, device_map="meta")
+    yield model
+    del model
+
+
+@pytest.mark.unit
+def test_checkpoint_map_covers_all_params(meta_model):
+    ckpt_map = CheckpointMap.from_model(meta_model)
+    for name, param in meta_model.named_parameters():
+        entry = ckpt_map.entry(name)
+        assert entry is not None, f"{name} has no checkpoint entry"
+        assert tuple(entry.shape) == tuple(param.shape)
+
+
+@pytest.mark.unit
+def test_checkpoint_map_requires_local_checkpoint(meta_model):
+    meta_model.name_or_path = "not-a-local-dir"
+    with pytest.raises(CheckpointReferenceError):
+        CheckpointMap.from_model(meta_model)
+
+
+@pytest.mark.unit
+def test_materialize_matches_from_pretrained(tiny_moe_path, meta_model):
+    ckpt_map = CheckpointMap.from_model(meta_model)
+    materialize_modules(
+        meta_model, list(meta_model.modules()), ckpt_map, torch.device("cpu")
+    )
+    materialize_buffers(meta_model, torch.device("cpu"), ckpt_map)
+
+    reference = AutoModelForCausalLM.from_pretrained(tiny_moe_path, device_map="cpu")
+    # reference loads with fused (non-linearized) experts; compare via the
+    # linearized view of the same weights using named param intersection
+    stream_params = dict(meta_model.named_parameters())
+    matched = 0
+    for name, ref_param in reference.named_parameters():
+        if name in stream_params:
+            assert torch.equal(stream_params[name], ref_param), name
+            matched += 1
+    # all non-expert params are shared; expert params are linearized
+    assert matched > 0
+    assert all(
+        p.device.type != "meta" for p in meta_model.parameters()
+    )
+
+
+@pytest.mark.unit
+def test_materialize_buffers_recomputes_rotary(tiny_moe_path, meta_model):
+    assert meta_model.model.rotary_emb.inv_freq.device.type == "meta"
+    ckpt_map = CheckpointMap.from_model(meta_model)
+    materialize_buffers(meta_model, torch.device("cpu"), ckpt_map)
+    assert meta_model.model.rotary_emb.inv_freq.device.type == "cpu"
+
+    reference = AutoModelForCausalLM.from_pretrained(tiny_moe_path, device_map="cpu")
+    assert torch.equal(
+        meta_model.model.rotary_emb.inv_freq, reference.model.rotary_emb.inv_freq
+    )
+
+
+@pytest.mark.unit
+def test_release_modules_moves_to_cpu(meta_model):
+    ckpt_map = CheckpointMap.from_model(meta_model)
+    materialize_buffers(meta_model, torch.device("cpu"), ckpt_map)
+    materialize_modules(
+        meta_model, list(meta_model.modules()), ckpt_map, torch.device("cpu")
+    )
+    release_modules(list(meta_model.modules()), torch.device("cpu"))
+    assert all(p.device.type == "cpu" for p in meta_model.parameters())
+
+
+@pytest.mark.unit
+def test_fused_checkpoint_expert_slices(tmp_path):
+    """Linearized experts must resolve to slices of fused checkpoint tensors."""
+    from safetensors.torch import save_file
+
+    from llmcompressor.modeling.moe.linearize import linearize_moe
+
+    config = Qwen3MoeConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=64,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_experts=4,
+        num_experts_per_tok=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_config(config, dtype=torch.bfloat16)
+    # save the raw (fused 3D expert) state dict, bypassing save conversions
+    save_file(dict(model.state_dict()), str(tmp_path / "model.safetensors"))
+    # reference values before freeing the model
+    ref_gate_up = model.model.layers[0].mlp.experts.gate_up_proj.detach().clone()
+    ref_down = model.model.layers[0].mlp.experts.down_proj.detach().clone()
+    del model
+    config.save_pretrained(tmp_path)
+
+    # meta-load and linearize structurally (no weight data is copied)
+    meta_model = AutoModelForCausalLM.from_pretrained(tmp_path, device_map="meta")
+    linearize_moe(meta_model)
+    assert all(p.device.type == "meta" for p in meta_model.parameters())
+
+    ckpt_map = CheckpointMap.from_model(meta_model)
+    entry = ckpt_map.entry("model.layers.0.mlp.experts.1.gate_proj.weight")
+    assert entry is not None and entry.slices is not None
+
+    materialize_modules(
+        meta_model, list(meta_model.modules()), ckpt_map, torch.device("cpu")
+    )
+    I = config.moe_intermediate_size
+    expert = meta_model.model.layers[0].mlp.experts[1]
+    assert torch.equal(expert.gate_proj.weight, ref_gate_up[1, :I])
+    assert torch.equal(expert.up_proj.weight, ref_gate_up[1, I:])
+    assert torch.equal(expert.down_proj.weight, ref_down[1])
+
+
+@pytest.mark.regression
+def test_streaming_matches_sequential(tiny_moe_path):
+    """Streaming (meta) and sequential (offloaded) pipelines must produce
+    bitwise-identical quantized weights on the same data."""
+    from compressed_tensors.quantization.quant_scheme import (
+        NVFP4,
+        QuantizationScheme,
+    )
+    from torch.utils.data import DataLoader, TensorDataset
+
+    from llmcompressor import oneshot
+    from llmcompressor.modifiers.quantization import QuantizationModifier
+
+    def run(meta: bool):
+        with load_context(meta=meta):
+            model = AutoModelForCausalLM.from_pretrained(
+                tiny_moe_path, device_map="meta" if meta else "cpu"
+            )
+        recipe = QuantizationModifier(
+            config_groups={
+                "mlp": QuantizationScheme(
+                    targets=[r"re:.*(self_attn|mlp)\..*"], **NVFP4
+                )
+            },
+            ignore=[r"lm_head"],
+        )
+        torch.manual_seed(1)
+        input_ids = torch.randint(0, 256, (8, 16))
+
+        def collate(batch):
+            return {
+                "input_ids": torch.stack([b[0] for b in batch]),
+                "attention_mask": torch.ones(len(batch), 16, dtype=torch.long),
+            }
+
+        kwargs = {"recipe": recipe, "num_calibration_samples": 8}
+        if not meta:
+            kwargs["pipeline"] = "sequential"
+        # meta models default to the streaming pipeline via oneshot inference
+        oneshot(
+            model=model,
+            dataset=DataLoader(
+                TensorDataset(input_ids), batch_size=2, collate_fn=collate
+            ),
+            **kwargs,
+        )
+        return dict(model.named_parameters())
+
+    reference = run(meta=False)
+    streamed = run(meta=True)
+    assert set(reference) == set(streamed)
+    for name in reference:
+        assert torch.equal(reference[name].cpu(), streamed[name].cpu()), name

--- a/tests/llmcompressor/pipelines/streaming/test_streaming.py
+++ b/tests/llmcompressor/pipelines/streaming/test_streaming.py
@@ -79,9 +79,7 @@ def test_materialize_matches_from_pretrained(tiny_moe_path, meta_model):
             matched += 1
     # all non-expert params are shared; expert params are linearized
     assert matched > 0
-    assert all(
-        p.device.type != "meta" for p in meta_model.parameters()
-    )
+    assert all(p.device.type != "meta" for p in meta_model.parameters())
 
 
 @pytest.mark.unit
@@ -150,10 +148,10 @@ def test_fused_checkpoint_expert_slices(tmp_path):
     materialize_modules(
         meta_model, list(meta_model.modules()), ckpt_map, torch.device("cpu")
     )
-    I = config.moe_intermediate_size
+    inter = config.moe_intermediate_size
     expert = meta_model.model.layers[0].mlp.experts[1]
-    assert torch.equal(expert.gate_proj.weight, ref_gate_up[1, :I])
-    assert torch.equal(expert.up_proj.weight, ref_gate_up[1, I:])
+    assert torch.equal(expert.gate_proj.weight, ref_gate_up[1, :inter])
+    assert torch.equal(expert.up_proj.weight, ref_gate_up[1, inter:])
     assert torch.equal(expert.down_proj.weight, ref_down[1])
 
 


### PR DESCRIPTION
SUMMARY:
"please provide a brief summary"

- This PR implement streaming quantization pipeline to avoid offload/dispatch overheads for efficient quantization on extremely large models
- Firstly, we initialize model on meta device, than prefetch and h2d weights for each layer on demand similar to distributed layerwise offload (DLO): https://vllm.ai/blog/2026-08-17-distributed-layerwise-offload
- Not DLO yet, will implement it in a followup PR after this PR merge


TEST PLAN:
"please outline how the changes were tested"
## Setup

- Hardware: 1 node, 4x NVIDIA GB300 (284 GiB each), 956 GiB RAM; checkpoints on
  a shared network filesystem.
- Recipe (same as `examples/quantizing_moe/glm5_example.py`): FP8_BLOCK for
  attention, NVFP4 for MLP, `lm_head` and first layers ignored.
- Calibration: 8 samples, batch size 4, seq len 1024, identical pre-tokenized
  data for both pipelines. Saving was not timed.

## Example code

Baseline and streaming differ only in model loading and the `pipeline` argument;
the recipe is identical.

<details>
<summary>Baseline (auto_offload + sequential)</summary>

```python
import torch
from compressed_tensors.offload import init_dist
from transformers import AutoModelForCausalLM, AutoTokenizer

from llmcompressor import oneshot
from llmcompressor.utils import load_context

init_dist()  # requires torchrun
model_id = "zai-org/GLM-5.2"
with load_context():
    model = AutoModelForCausalLM.from_pretrained(
        model_id,
        device_map="auto_offload",
        max_memory={"cpu": "500GiB"},
        offload_folder="offload_folder",
    )
tokenizer = AutoTokenizer.from_pretrained(model_id)

oneshot(
    model=model,
    dataset="perfectblend",
    batch_size=4,
    recipe=recipe,
    num_calibration_samples=512,
)
```

</details>

<details>
<summary>Streaming (meta skeleton + checkpoint-referenced layers)</summary>

```python
from transformers import AutoModelForCausalLM, AutoTokenizer

from llmcompressor import oneshot
from llmcompressor.utils import load_context

model_id = "zai-org/GLM-5.2"
with load_context(meta=True):
    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="meta")
tokenizer = AutoTokenizer.from_pretrained(model_id)

oneshot(
    model=model,
    dataset="perfectblend",
    batch_size=4,
    recipe=recipe,
    pipeline="streaming",  # default for meta-device models
    num_calibration_samples=512,
)
```
</details>

## Results

### Qwen3.6-35B-A3B (82 GiB bf16, 40 MoE layers x 256 experts, fused 3D expert checkpoint)

Baseline ran with `max_memory={"cpu": "20GiB"}` to force the disk-offload path.

| Phase | baseline (`auto_offload` + `sequential`) | `streaming` | Speedup |
|---|---|---|---|
| Model load | 128.2 s | 2.1 s | 61x |
| `oneshot` (calibration + layer dispatch) | 328.5 s | 198.5 s | 1.65x |
| **Total (no save)** | **460.0 s** | **207.8 s** | **2.2x** |

### Reduced GLM-5.3-BF16 (12 layers, 176 GiB, per-expert checkpoint, local NVMe)

| Phase | baseline (`auto_offload` + `sequential`) | `streaming` | Speedup |
|---|---|---|---|
| Model load | 20.4 s | 2.8 s | 7.3x |
| `oneshot` | 146.6 s | 112.0 s | 1.3x |
| **Total (no save)** | **171.7 s** | **118.1 s** | **1.45x** |

