### PR TITLE
fix: Rename Recipe.dict() to to_dict() to avoid shadowing builtin dict

### DIFF
--- a/src/llmcompressor/recipe/recipe.py
+++ b/src/llmcompressor/recipe/recipe.py
@@ -232,7 +232,7 @@ class Recipe(BaseModel):
 
         return model
 
-    def dict(self, *args, **kwargs) -> dict[str, Any]:
+    def to_dict(self, *args, **kwargs) -> dict[str, Any]:
         """
         :return: A dictionary representation of the recipe
         """

--- a/src/llmcompressor/recipe/recipe.py
+++ b/src/llmcompressor/recipe/recipe.py
@@ -232,7 +232,7 @@ class Recipe(BaseModel):
 
         return model
 
-    def to_dict(self, *args, **kwargs) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         :return: A dictionary representation of the recipe
         """

--- a/tests/llmcompressor/recipe/test_recipe.py
+++ b/tests/llmcompressor/recipe/test_recipe.py
@@ -39,8 +39,8 @@ def test_serialization(recipe_str):
     serialized_recipe = recipe_instance.yaml()
     recipe_from_serialized = Recipe.create_instance(serialized_recipe)
 
-    expected_dict = recipe_instance.dict()
-    actual_dict = recipe_from_serialized.dict()
+    expected_dict = recipe_instance.to_dict()
+    actual_dict = recipe_from_serialized.to_dict()
 
     assert expected_dict == actual_dict
 


### PR DESCRIPTION
### Description

`Recipe.dict()` shadows the builtin `dict` name, making `llmcompressor` unimportable on Python 3.14. PEP 649 lazy annotations evaluate the string annotation `"dict[str, Any]"` against the class namespace, finding the `dict` method instead of the builtin, resulting in `TypeError: function object is not subscriptable`.

Renaming to `to_dict()` unshadows the builtin and resolves the Python 3.14 compatibility issue. The method is only called in tests, so the two test call sites are updated accordingly.

### Related Issues

Closes #2871

### Changes

- `src/llmcompressor/recipe/recipe.py`: `Recipe.dict()` → `Recipe.to_dict()`
- `tests/llmcompressor/recipe/test_recipe.py`: update the two call sites

### Testing

- Syntax verified with `ast.parse`
- No production code references `Recipe.dict()`