### PR TITLE
Fix sequential tracer for decorated/forwards with complex conditionals

### DIFF
--- a/src/llmcompressor/pipelines/sequential/ast_helpers.py
+++ b/src/llmcompressor/pipelines/sequential/ast_helpers.py
@@ -52,8 +52,9 @@ def autowrap_forward(module: torch.nn.Module, ignore: list[str]):
             "`oneshot`. For example, `oneshot(model.thinker, ...)`"
         )
 
-    # get source code of module forward
-    source = inspect.getsource(module.forward)
+    # get source code of module forward, unwrapping decorators (e.g.
+    # ``@can_return_tuple``) so the AST reflects the raw forward body
+    source = inspect.getsource(inspect.unwrap(module.forward))
     source = textwrap.dedent(source)
     tree = ast.parse(source)
 
@@ -82,9 +83,15 @@ def autowrap_forward(module: torch.nn.Module, ignore: list[str]):
         filename,
     )
 
-    # patch forward with autowrapped forward
+    # patch forward with autowrapped forward on both the instance and the
+    # class. FX's tracer resolves forward via ``type(module).forward``, so
+    # patching only the instance leaves the decorated class forward in place
+    # and FX cannot trace through decorators like ``@capture_outputs``.
     new_forward = namespace["forward"].__get__(module)
-    with patch_attr(module, "forward", new_forward):
+    with (
+        patch_attr(module, "forward", new_forward),
+        patch_attr(type(module), "forward", namespace["forward"]),
+    ):
         yield
 
 

--- a/src/llmcompressor/pipelines/sequential/ast_utils/auto_wrapper.py
+++ b/src/llmcompressor/pipelines/sequential/ast_utils/auto_wrapper.py
@@ -8,6 +8,13 @@ from .control_flow_analyzer import ControlFlowAnalyzer
 from .name_analyzer import NameAnalyzer
 
 
+def _is_only_raise(node: ast.AST) -> bool:
+    """Return True when ``node`` consists solely of ``raise`` statements."""
+    if isinstance(node, ast.If):
+        return all(_is_only_raise(child) for child in node.body)
+    return isinstance(node, ast.Raise)
+
+
 class AutoWrapper(ast.NodeTransformer):
     """
     Automatically wraps untracable code according to the following patterns:
@@ -110,6 +117,23 @@ class AutoWrapper(ast.NodeTransformer):
             Otherwise, return a wrapper function call + assignment
         """
         try:
+            # force a wrap whenever the test combines multiple conditions, even
+            # if statically evaluable. FX cannot constant-fold across
+            # ``if`` branches whose test depends on values produced by the
+            # model itself, so replacing a mixed test with ``True``/``False``
+            # raises during tracing.
+            # Examples: ``(a is None) ^ (b is not None)`` or
+            # ``a is None and b is None``.
+            if isinstance(node.test, ast.BoolOp):
+                raise Exception("If statement combines multiple conditions")
+
+            # force a wrap whenever the body raises. ``if True/False: raise ...``
+            # would otherwise become a literal raise during tracing, killing
+            # the trace before any call_module nodes are emitted.
+            for stmt in node.body:
+                if isinstance(stmt, ast.Raise):
+                    raise Exception("If statement raises")
+
             value = bool(self._eval_expr(node.test))
 
             # force a wrap if any assignments occur within the if statement
@@ -250,6 +274,11 @@ class AutoWrapper(ast.NodeTransformer):
             kwarg=None,
         )
 
+        # The wrapper function is still executed by FX during tracing, so a
+        # body that only raises will kill the trace. Replace ``raise`` bodies
+        # with a no-op so the wrapper can be safely called.
+        body = [ast.Pass()] if _is_only_raise(node) else [node]
+
         # build body and return statement
         return_stmt = ast.Return(
             value=ast.Tuple(
@@ -257,7 +286,7 @@ class AutoWrapper(ast.NodeTransformer):
                 ctx=ast.Load(),
             )
         )
-        body = [node, return_stmt]
+        body.append(return_stmt)
 
         # build function definition, store in `_wrapper_fn_defs`
         fn_name = f"wrapped_{self._wrapped_counter}"

--- a/tests/llmcompressor/pipelines/sequential/test_helpers.py
+++ b/tests/llmcompressor/pipelines/sequential/test_helpers.py
@@ -1,9 +1,10 @@
 import math
+from functools import wraps
 
 import pytest
 import torch
 import torch.fx
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, PretrainedConfig
 
 from llmcompressor.args.dataset_arguments import DatasetArguments
 from llmcompressor.pipelines.sequential.helpers import (
@@ -137,3 +138,121 @@ def test_trace_subgraphs(targets_per_subgraph):
             ]
         )
         assert num_targets_present == targets_per_subgraph
+
+
+def forward_wrapper(forward):
+    @wraps(forward)
+    def wrapped(*args, **kwargs):
+        return forward(*args, **kwargs)
+
+    return wrapped
+
+
+class DecoratedDummyModel(torch.nn.Module):
+    """Minimal model whose ``forward`` is wrapped in a non-introspectable
+    decorator (e.g. ``@can_return_tuple``), the same pattern used by
+    ``Qwen3OmniMoeThinkerForConditionalGeneration.forward``."""
+
+    config = PretrainedConfig()
+    device = torch.device("cpu")
+
+    def __init__(self):
+        super().__init__()
+        self.layer1 = torch.nn.Linear(10, 10)
+        self.layer2 = torch.nn.Linear(10, 10)
+        self.layer3 = torch.nn.Linear(10, 10)
+        self.layer4 = torch.nn.Linear(10, 10)
+        self.layer5 = torch.nn.Linear(10, 10)
+        self.layer6 = torch.nn.Linear(10, 10)
+
+    @forward_wrapper
+    def forward(self, x):
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+        x = self.layer5(x)
+        return self.layer6(x)
+
+
+class CombinedConditionModel(torch.nn.Module):
+    """``forward`` whose body contains a chained ``if`` test like the
+    XOR-input validation in Qwen3-Omni Thinker."""
+
+    config = PretrainedConfig()
+    device = torch.device("cpu")
+
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(10, 10)
+        self.input_ids = None
+
+    def forward(self, x, inputs_embeds=None):
+        if (x is None) ^ (inputs_embeds is not None):
+            raise ValueError("must specify exactly one of x or inputs_embeds")
+        if inputs_embeds is None:
+            x = self.layer(x)
+        return x
+
+
+class RaiseConditionModel(torch.nn.Module):
+    """``forward`` whose body contains an ``if … raise`` block, which the
+    autowrap would otherwise execute during FX tracing and kill the trace."""
+
+    config = PretrainedConfig()
+    device = torch.device("cpu")
+
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(10, 10)
+        self.input_ids = None
+
+    def forward(self, x):
+        if self.input_ids is None:
+            raise ValueError("must provide input_ids")
+        return self.layer(x)
+
+
+def test_trace_subgraphs_unwraps_decorated_forward():
+    model = DecoratedDummyModel()
+
+    subgraphs = trace_subgraphs(
+        model,
+        {"x": torch.rand(1, 10)},
+        sequential_targets=["Linear"],
+        ignore=DatasetArguments().tracing_ignore,
+    )
+
+    assert len(subgraphs) == 7
+
+
+def test_trace_subgraphs_wraps_combined_condition():
+    model = CombinedConditionModel()
+
+    subgraphs = trace_subgraphs(
+        model,
+        {"x": torch.rand(1, 10), "inputs_embeds": None},
+        sequential_targets=["Linear"],
+        ignore=DatasetArguments().tracing_ignore,
+    )
+
+    # The XOR raise check and the conditional layer call are both wrapped
+    # into @torch.fx.wrap helpers, so the trace produces at least the
+    # preamble subgraph without crashing.
+    assert len(subgraphs) >= 1
+
+
+def test_trace_subgraphs_wraps_raise_condition():
+    model = RaiseConditionModel()
+
+    subgraphs = trace_subgraphs(
+        model,
+        {"x": torch.rand(1, 10)},
+        sequential_targets=["Linear"],
+        ignore=DatasetArguments().tracing_ignore,
+    )
+
+    # The if-raise block is wrapped with body=pass, so FX does not
+    # execute the raise and the trace completes with at least the
+    # preamble subgraph.
+    assert len(subgraphs) >= 1


### PR DESCRIPTION
Fixes vllm-project/compressed-tensors#832 (Saved Qwen3-Omni GPTQ W4A16 checkpoints contain NaN/Inf weight_scale tensors).

The NaN/Inf scales are a *symptom* of an upstream llm-compressor tracing failure: `Qwen3OmniMoeThinkerForConditionalGeneration.forward` cannot be traced by FX end-to-end, so zero decoder-layer `call_module` nodes reach calibration, and every `weight_scale` parameter is left at its `torch.empty()` initialisation values (frequently NaN/Inf in BF16).

This PR contains three verified autowrap fixes, each with a passing local unit test:

1. `ast_helpers.autowrap_forward`: unwrap `module.forward` with `inspect.unwrap` so the AST reflects the raw forward body. The Qwen3-Omni Thinker forward is decorated with `@can_return_tuple`, which `inspect.getsource` cannot parse.

2. `ast_helpers.autowrap_forward`: patch both `module.forward` *and* `type(module).forward`. FX resolves forward via `type(root).forward`, so patching only the instance leaves the decorated class forward in place and FX cannot trace through decorators like `@capture_outputs` or `@merge_with_config_defaults` on ancestor modules (`Qwen3OmniMoeThinkerTextModel`).

3. `ast_utils.AutoWrapper`: force any `if`-statement whose body only raises to be wrapped with `body=pass`, and force any `BoolOp` test into a `@torch.fx.wrap` helper. FX cannot constant-fold across `if` branches that depend on values produced by the model itself, so rewriting `(a is None) ^ (b is not None)` to `if True: raise ValueError(...)` kills the trace before any `call_module` nodes are emitted.

These fixes are *necessary* but I have not been able to confirm they are *sufficient* to resolve the full Qwen3-Omni Thinker tracing on local CPU. The complex multimodal forward in `Qwen3OmniMoeThinkerForConditionalGeneration.forward` continues to truncate the FX graph at the rope-deltas block, and reaching `self.model(...)` from there likely requires either an architectural change in llm-compressor or additional autowrap logic.

Three regression tests are included:
- `test_trace_subgraphs_unwraps_decorated_forward` — minimal model with `@can_return_tuple`-like decorated forward
- `test_trace_subgraphs_wraps_combined_condition` — XOR-style combined-condition test like the one in the Thinker forward
- `test_trace_subgraphs_wraps_raise_condition` — `if … raise` block

Local test status:
- All 12 `tests/llmcompressor/pipelines/sequential/test_helpers.py` tests pass (including the 3 new ones and the existing `test_trace_subgraphs[1-5]` that exercises the full Qwen3-0.6B model)
- All other `tests/llmcompressor/pipelines/` tests pass except `test_device_handling`, which is a pre-existing CUDA-only failure unrelated to this PR

Reproduction confirmation on GPU was via H200 jobs `6a7e679d8747785b3ad53546` and `6a7e6e868747785b3ad5361b` documented in the linked issue thread. The diagnostic job `6a7e6bc473ce7897b8939fd1` showed the FX graph has 4 placeholders + 2 `call_function` + 8 `getitem` = 14 nodes total, zero `call_module`, zero target nodes — the graph truncates after the rope-deltas wrapper before reaching `self.model(...)`.

For users needing to ship a Qwen3-Omni GPTQ artifact before the upstream fix is fully validated, a 30-line user-side guard that fails fast on any non-finite `weight_scale` after calibration has been deployed in `hammertoe/bimomni` at `src/bimomni/publish/quantize_gptq.py:runtime.validate_weight_scales`.

cc `@brian-dellabetta` per the comment thread on the linked issue.