### PR TITLE
ci: add pre-commit hooks mirroring make quality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+# See https://pre-commit.com for usage.
+# Install the git hooks with: pre-commit install
+# These hooks mirror the checks in `make quality` so issues are caught
+# locally before CI runs them.
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+default_stages:
+  - pre-commit
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep in sync with the `ruff` pin in setup.py ([dev] extra).
+    rev: v0.4.8
+    hooks:
+      # Scoped to the CHECKDIRS from `make quality` (src tests examples setup.py)
+      # so pre-commit flags exactly what CI does, no more and no less.
+      - id: ruff
+        args: [--fix]
+        files: ^(src|tests|examples)/|^setup\.py$
+      - id: ruff-format
+        files: ^(src|tests|examples)/|^setup\.py$
+  - repo: local
+    hooks:
+      # Mirrors `python tools/lint_cuda.py <dirs> --fail-on-issues` from
+      # `make quality`. Runs from the active (dev) environment; the script
+      # accepts individual files, so pre-commit passes the changed ones.
+      - id: lint-cuda
+        name: lint cuda
+        entry: python tools/lint_cuda.py --fail-on-issues
+        language: system
+        types: [python]
+        files: ^(src|tests|examples)/|^setup\.py$
+        require_serial: true
+      # Append a DCO Signed-off-by trailer if the commit message lacks one,
+      # matching the `git commit -s` requirement for vllm-project repos.
+      - id: signoff-commit
+        name: Sign-off commit
+        entry: bash
+        args:
+          - -c
+          - |
+            trailer="Signed-off-by: $(git config user.name) <$(git config user.email)>"
+            msg_file="$(git rev-parse --git-path COMMIT_EDITMSG)"
+            # -F/-x match the trailer as a literal, complete line so names/emails
+            # containing regex metacharacters (or a line with an extra suffix)
+            # can't be mistaken for an existing sign-off.
+            if ! grep -Fqx -- "$trailer" "$msg_file"; then
+              printf "\n%s\n" "$trailer" >> "$msg_file"
+            fi
+        language: system
+        stages: [commit-msg]
+        verbose: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,22 @@ make style
 make quality
 ```
 
+### Pre-commit Hooks
+
+We provide [pre-commit](https://pre-commit.com/) hooks that run the same linting and formatting checks as `make quality` (plus a DCO sign-off hook) before each commit, so problems are caught locally instead of in CI. After installing the `[dev]` dependencies, enable them once per clone:
+
+```bash
+pre-commit install
+```
+
+The hooks then run automatically on `git commit`. To run them against all files on demand:
+
+```bash
+pre-commit run --all-files
+```
+
+To bypass the hooks for a single commit, use `git commit --no-verify`; to skip one hook, prefix the command with `SKIP=<hook-id>` (e.g. `SKIP=lint-cuda`).
+
 ### Testing
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ setup(
             "mypy~=1.10.0",
             "ruff~=0.4.8",
             # pre commit hooks
-            "pre-commit",
+            "pre-commit~=4.0",
             # docs - zensical
             "mkdocstrings-python",
             "zensical",


### PR DESCRIPTION
Adds [pre-commit](https://pre-commit.com/) hooks that mirror the checks in `make quality`, so contributors catch issues locally before CI runs them. Modeled on vllm-project/speculators#1044, adapted to this repo's tooling.

## What runs

The hooks mirror `make quality` (and its `CHECKDIRS`: `src tests examples setup.py`):

- **ruff** (`ruff check --fix`) and **ruff-format** — from the pinned `ruff-pre-commit` mirror, kept in sync with the `ruff` pin in `setup.py`.
- **lint-cuda** — `tools/lint_cuda.py --fail-on-issues`, as a local hook.
- **signoff-commit** — a `commit-msg` hook that appends a DCO `Signed-off-by` trailer if missing, matching the `git commit -s` requirement.

Each hook is scoped with `files:` to the same paths `make quality` checks, so pre-commit flags exactly what CI does — no more, no less. `mypy` is intentionally omitted, matching `make quality` (which leaves it out).

## Also

- Pin `pre-commit~=4.0` in the `[dev]` extra.
- Document the hooks in `CONTRIBUTING.md`.

## Usage

```bash
pip install -e .[dev]
pre-commit install
```

> Opened as a draft for review of the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)