### PR TITLE
[Tests] Initialize every expert parameter in the linearize tests

### DIFF
--- a/tests/llmcompressor/modeling/test_linearize.py
+++ b/tests/llmcompressor/modeling/test_linearize.py
@@ -6,7 +6,7 @@ import torch
 from compressed_tensors.utils import patch_attr
 from huggingface_hub.errors import StrictDataclassError
 from safetensors import safe_open
-from transformers import AutoConfig, AutoModelForCausalLM
+from transformers import AutoConfig, AutoModelForCausalLM, PreTrainedConfig
 from transformers import initialization as init
 from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
     DeepseekV4PreTrainedModel,
@@ -17,7 +17,6 @@ from llmcompressor.modeling.moe.conversion_mappings import ARCH_TO_IMPORT_PATHS
 from llmcompressor.modeling.moe.helpers import (
     FusedExpertsProtocol,
     MoEConfig,
-    _getattr_fallbacks,
     import_or_none,
 )
 from llmcompressor.modeling.moe.linearize import linearize_moe, load_quantizable_moe
@@ -32,6 +31,7 @@ CONFIG_OVERRIDES = {
     "cohere2_moe": {"hidden_size": 256, "intermediate_size": 256},
     "gemma4": {"num_experts": 16, "top_k_experts": 4, "moe_intermediate_size": 2304},
     "glm_moe_dsa": {"hidden_size": 512},
+    "gpt_oss": {"hidden_size": 256, "intermediate_size": 256, "num_local_experts": 16},
     "hy_v3": {"hidden_size": 256, "moe_intermediate_size": 256, "num_experts": 16},
     "jamba": {"hidden_size": 256, "intermediate_size": 256, "num_experts": 16},
     "nemotron_h": {"hidden_size": 32, "moe_intermediate_size": 64},
@@ -151,6 +151,22 @@ class DummyModel(torch.nn.Module):
         return self.module(*args, **kwargs)
 
 
+def init_experts(experts: FusedExpertsProtocol, config: PreTrainedConfig):
+    """
+    Initialize every parameter of an experts module.
+
+    Experts modules allocate their parameters with `torch.empty`, so a parameter which
+    is not initialized here holds whatever the allocator hands back. Architectures with
+    expert biases (such as `gpt_oss`) then read that memory during forward, which
+    produces non-finite outputs for whichever tokens are routed to the affected expert.
+
+    :param experts: fused experts module to initialize in place
+    :param config: config of the model the experts module belongs to
+    """
+    for parameter in experts.parameters():
+        init.normal_(parameter, mean=0.0, std=config.initializer_range)
+
+
 @torch.no_grad()
 @requires_gpu
 @pytest.mark.parametrize("model_type", list(ARCH_TO_IMPORT_PATHS.keys() - {"llama4"}))
@@ -168,9 +184,7 @@ def test_linearize_moe(model_type):
         config = config_cls(**CONFIG_OVERRIDES.get(model_type, {}))
         experts = experts_cls(config)
         assert isinstance(experts, FusedExpertsProtocol)
-        up_proj = _getattr_fallbacks(experts, ["gate_up_proj", "up_proj"])
-        init.normal_(up_proj, mean=0.0, std=config.initializer_range)
-        init.normal_(experts.down_proj, mean=0.0, std=config.initializer_range)
+        init_experts(experts, config)
 
         mock_model = DummyModel(experts, config)
         linearize_moe(mock_model)
@@ -194,6 +208,9 @@ def test_linearize_moe(model_type):
             calib_outputs = mock_model(hidden_states, top_k_index, top_k_weights)
 
         assert torch.any(true_outputs != 0), "Bad test setup, output is all zeros"
+        assert torch.isfinite(
+            true_outputs
+        ).all(), "Bad test setup, output is not finite"
         assert torch.nn.functional.mse_loss(outputs, true_outputs) < MODULE_MSE
         assert torch.nn.functional.mse_loss(calib_outputs, true_outputs) < MODULE_MSE
 
@@ -208,8 +225,7 @@ def test_linearize_moe_llama4():
     text_config = Llama4TextConfig(hidden_size=512, intermediate_size=1024)
     config = Llama4Config(text_config=text_config)
     experts = Llama4TextExperts(config.text_config)
-    init.normal_(experts.gate_up_proj, mean=0.0, std=text_config.initializer_range)
-    init.normal_(experts.down_proj, mean=0.0, std=text_config.initializer_range)
+    init_experts(experts, text_config)
 
     mock_model = DummyModel(experts, config)
     linearize_moe(mock_model)
@@ -225,5 +241,53 @@ def test_linearize_moe_llama4():
         calib_outputs = mock_model(hidden_states)
 
     assert torch.any(true_outputs != 0), "Bad test setup, output is all zeros"
+    assert torch.nn.functional.mse_loss(outputs, true_outputs) < MODULE_MSE
+    assert torch.nn.functional.mse_loss(calib_outputs, true_outputs) < MODULE_MSE
+
+
+def test_linearize_moe_gpt_oss():
+    """
+    `gpt_oss` is an architecture whose experts carry biases, which are the parameters
+    most easily left uninitialized by a test. Cover it on cpu so that a forward through
+    uninitialized memory, which yields non-finite outputs and a NaN mse, is caught
+    without requiring a gpu.
+    """
+    config_path, experts_path = ARCH_TO_IMPORT_PATHS["gpt_oss"]
+    config_cls = import_or_none(config_path)
+    experts_cls = import_or_none(experts_path)
+
+    if config_cls is None or experts_cls is None:
+        pytest.skip(
+            "Could not import gpt_oss, please upgrade your transformers version"
+        )
+
+    config = config_cls(**CONFIG_OVERRIDES["gpt_oss"])
+    experts = experts_cls(config)
+    init_experts(experts, config)
+    assert all(torch.isfinite(parameter).all() for parameter in experts.parameters())
+
+    mock_model = DummyModel(experts, config)
+    linearize_moe(mock_model)
+    assert mock_model.module is not experts
+
+    moe_config = MoEConfig.from_config(config)
+    hidden_states = torch.randn(
+        NUM_TEST_TOKENS, moe_config.hidden_dim, dtype=moe_config.dtype
+    )
+    top_k_index = torch.randint(
+        0,
+        moe_config.num_experts,
+        size=(NUM_TEST_TOKENS, moe_config.num_experts_per_tok),
+    )
+    top_k_weights = torch.randn(
+        NUM_TEST_TOKENS, moe_config.num_experts_per_tok, dtype=moe_config.dtype
+    )
+    true_outputs = experts(hidden_states, top_k_index, top_k_weights)
+    outputs = mock_model(hidden_states, top_k_index, top_k_weights)
+    with moe_calibration_context():
+        calib_outputs = mock_model(hidden_states, top_k_index, top_k_weights)
+
+    assert torch.any(true_outputs != 0), "Bad test setup, output is all zeros"
+    assert torch.isfinite(true_outputs).all(), "Bad test setup, output is not finite"
     assert torch.nn.functional.mse_loss(outputs, true_outputs) < MODULE_MSE
     assert torch.nn.functional.mse_loss(calib_outputs, true_outputs) < MODULE_MSE


### PR DESCRIPTION
# Issue #3059: Noisy gpt_oss test

`tests/llmcompressor/modeling/test_linearize.py::test_linearize_moe[gpt_oss]` failed
intermittently with `AssertionError: assert tensor(nan, device='cuda:0') < 1e-10`.

## 1. Root cause

`test_linearize_moe` builds an experts module directly (`experts_cls(config)`) and then
initialized only two tensors:

```python
up_proj = _getattr_fallbacks(experts, ["gate_up_proj", "up_proj"])
init.normal_(up_proj, mean=0.0, std=config.initializer_range)
init.normal_(experts.down_proj, mean=0.0, std=config.initializer_range)
```

Transformers experts modules allocate their parameters with `torch.empty`, and building
the module outside `from_pretrained` means nothing else initializes them. For almost
every architecture in `ARCH_TO_IMPORT_PATHS` that is fine, because `gate_up_proj`/
`up_proj` and `down_proj` are the only parameters. `gpt_oss` is different:

```python
self.gate_up_proj      = nn.Parameter(torch.empty(...))
self.gate_up_proj_bias = nn.Parameter(torch.empty(...))   # never initialized
self.down_proj         = nn.Parameter(torch.empty(...))
self.down_proj_bias    = nn.Parameter(torch.empty(...))   # never initialized
```

Both bias tensors were therefore whatever the allocator handed back. The test is
parametrized over ~30 architectures in one process, so by the time `gpt_oss` runs the
caching allocator is recycling blocks from previous parameters and activations, and
those blocks can hold NaN bit patterns. Any token routed to an expert whose bias slice
contains a NaN yields a NaN row.

That explains the exact failure signature in the issue: the reference tensor and the
linearized tensor have NaN in the *same* rows and identical finite values everywhere
else. The two forwards read the same poisoned bias, so `mse_loss` is NaN and
`nan < 1e-10` is false. The linearization path itself is correct; nothing in
`LinearExperts2D` was producing the NaNs.

`gpt_oss` and `openai_privacy_filter` are the only two registered architectures whose
experts carry biases (verified by instantiating every entry of `ARCH_TO_IMPORT_PATHS`
on the meta device), so they were the only ones exposed.

## 2. The fix and why

- Added `init_experts(experts, config)`, which initializes **every** parameter of the
  experts module rather than a hand-picked pair, and used it in `test_linearize_moe`
  and `test_linearize_moe_llama4`. This removes the class of bug rather than patching
  the two `gpt_oss` bias names: a future architecture that adds a parameter is covered
  automatically. For the bias-free architectures the set of initialized parameters is
  unchanged, so their coverage is identical.
- Added `assert torch.isfinite(true_outputs).all(), "Bad test setup, ..."` next to the
  existing `"Bad test setup, output is all zeros"` guard. If an uninitialized parameter
  ever creeps back in, the failure names the setup problem instead of surfacing as an
  opaque `nan < 1e-10`.
- Added a `CONFIG_OVERRIDES` entry for `gpt_oss`. Its defaults are 128 experts at
  hidden/intermediate 2880, i.e. ~12.7 GB of fp32 expert parameters, doubled while
  linearization holds the fused and linear copies at once. This is not the NaN cause,
  but it is the other half of "this test is noisy": it made the `gpt_oss` case by far
  the heaviest allocation in the file. Other oversized architectures are already
  trimmed the same way.
- Added `test_linearize_moe_gpt_oss`, a cpu regression test for the biased
  architecture. `test_linearize_moe` is `@requires_gpu`, but this bug is entirely
  device independent, so the regression is now caught without a gpu, in the same style
  as the existing `test_linearize_moe_llama4` special case.

No `src/` change was needed. The linearized module reconstructs `gate_up` in the
original column order and reuses the architecture's own `_apply_gate`, so it is
numerically equivalent to the fused module (measured mse 3.6e-16).

## 3. Files changed

- `tests/llmcompressor/modeling/test_linearize.py`

## 4. Risk / uncertainty

- Low risk: test-only change.
- `init_experts` calls `init.normal_` on every expert parameter. I confirmed no
  registered architecture has a non-floating-point expert parameter, so there is no
  dtype hazard; if one is added later, `normal_` will fail loudly at setup rather than
  silently.
- The `gpt_oss` config override reduces the shape the test exercises. The linearization
  path is shape agnostic and every other trimmed architecture is already covered at
  reduced size, so this trades no meaningful coverage. If maintainers prefer the test to
  run at release shapes, dropping that one dict entry leaves the NaN fix intact.
- I could not run the gpu-only `test_linearize_moe` parametrization itself (no gpu in
  this environment). I ran its body on cpu instead, see below.

## 5. How I verified it

Environment: cpu-only venv with torch 2.13.0+cpu, transformers 5.16.1,
compressed-tensors 0.18.1a20260827.

1. **Reproduced the mechanism.** A fresh `torch.empty(16, 512)` allocated right after a
   NaN-filled buffer of the same size was freed came back holding 8192 NaNs, i.e.
   `torch.empty` really does hand back the poisoned block.
2. **Reproduced the failure signature.** With the old setup (only the two weights
   initialized) and a single NaN in `gate_up_proj_bias`, the reference and linearized
   outputs had NaN in the same 44 of 64 token rows and `mse_loss` was `nan`, matching
   the traceback in the issue. With every parameter initialized: 0 NaN rows and
   `mse = 3.58e-16`, well under `MODULE_MSE = 1e-10`.
3. **New test passes.**
   `pytest tests/llmcompressor/modeling/test_linearize.py -k "llama4 or gpt_oss"`
   -> 2 passed, 1 skipped (the gpu parametrization).
4. **No regressions in the directory.** `pytest tests/llmcompressor/modeling/`
   -> 8 passed, 36 skipped (all skips are `requires_gpu`).
5. **Exercised the gpu test body on cpu.** Ran `test_linearize_moe.__wrapped__` with
   `torch.device("cuda")` redirected to cpu for `nemotron_h`, `cohere2_moe`,
   `glm_moe_dsa` and `gpt_oss` (a bias-free arch, two already-trimmed arches, and the
   fixed one): all four pass.
6. **Checked every architecture's expert parameters.** Instantiated all 31 entries of
   `ARCH_TO_IMPORT_PATHS` on the meta device: only `gpt_oss` and
   `openai_privacy_filter` have bias parameters, and no architecture has a
   non-floating-point expert parameter.
7. **Quality gates.** `ruff check`, `ruff format --check` and
   `python tools/lint_cuda.py --fail-on-issues` all clean on the changed file.
