### PR TITLE
[AWQ] Muse Glimmer Mappings

### DIFF
--- a/src/llmcompressor/modeling/offset_norm.py
+++ b/src/llmcompressor/modeling/offset_norm.py
@@ -56,6 +56,7 @@ class NormCalibrationModule(ABC, torch.nn.Module, RegistryMixin):
     alias=[
         "Gemma2RMSNorm",
         "Gemma3RMSNorm",
+        "MuseGlimmerTextCenteredRMSNorm",
         "Qwen3NextRMSNorm",
         "Qwen3_5RMSNorm",
         "Qwen3_5MoeRMSNorm",

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -158,6 +158,7 @@ _muse_glimmer_mappings = [
             "re:.*language_model.layers.\\d+.self_attn.q_proj$",
             "re:.*language_model.layers.\\d+.self_attn.k_proj$",
             "re:.*language_model.layers.\\d+.self_attn.v_proj$",
+            "re:.*language_model.layers.\\d+.self_attn.gate_proj$",
         ],
     ),
     AWQMapping(

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -148,6 +148,35 @@ _gemma3_mappings = [
 ]
 
 
+# Muse-Glimmer is Gemma-style with 4 norms/layer + gated attention.
+# input_layernorm feeds q/k/v (the attn gate is excluded on purpose);
+# the MLP is fed by pre_feedforward_layernorm, NOT post_attention_layernorm.
+_muse_glimmer_mappings = [
+    AWQMapping(
+        "re:.*language_model.layers.\\d+.input_layernorm$",
+        [
+            "re:.*language_model.layers.\\d+.self_attn.q_proj$",
+            "re:.*language_model.layers.\\d+.self_attn.k_proj$",
+            "re:.*language_model.layers.\\d+.self_attn.v_proj$",
+        ],
+    ),
+    AWQMapping(
+        "re:.*language_model.layers.\\d+.self_attn.v_proj$",
+        ["re:.*language_model.layers.\\d+.self_attn.o_proj$"],
+    ),
+    AWQMapping(
+        "re:.*language_model.layers.\\d+.pre_feedforward_layernorm$",
+        [
+            "re:.*language_model.layers.\\d+.mlp.gate_proj$",
+            "re:.*language_model.layers.\\d+.mlp.up_proj$",
+        ],
+    ),
+    AWQMapping(
+        "re:.*language_model.layers.\\d+.mlp.up_proj$",
+        ["re:.*language_model.layers.\\d+.mlp.down_proj$"],
+    ),
+]
+
 # Cohere architecture is similar to default, with a very fundamental difference.
 # The MLP block is executed in parallel to the attention. So the tensor goes
 # through input_layernorm and then from there it goes directly to the attention
@@ -344,6 +373,7 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Llama4ForConditionalGeneration": _llama4_default_mappings,
     "Mistral3ForConditionalGeneration": default_mappings,
     "MistralForCausalLM": default_mappings,
+    "MuseGlimmerForConditionalGeneration": _muse_glimmer_mappings,
     "NanbeigeForCausalLM": default_mappings,
     "OlmoForCausalLM": _exaone4_mappings,
     "Olmo3ForCausalLM": _exaone4_mappings,

--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -149,7 +149,7 @@ _gemma3_mappings = [
 
 
 # Muse-Glimmer is Gemma-style with 4 norms/layer + gated attention.
-# input_layernorm feeds q/k/v (the attn gate is excluded on purpose);
+# input_layernorm feeds q/k/v/gate.
 # the MLP is fed by pre_feedforward_layernorm, NOT post_attention_layernorm.
 _muse_glimmer_mappings = [
     AWQMapping(


### PR DESCRIPTION
SUMMARY:
Add muse glimmer mappings for AWQ and to the OffestNorm to account for [1.0 offset in model def](https://github.com/huggingface/transformers/blob/ac3244569528944b9d5773cafea525cd8a8b63de/src/transformers/models/muse_glimmer/modeling_muse_glimmer.py#L136)


TEST PLAN:
Using this branch and RHOAI pipelines (facilitated by an agent), i achieve the following results:

<img width="478" height="156" alt="Screenshot 2026-09-01 at 3 30 52 PM" src="https://github.com/user-attachments/assets/103b6c70-6dcf-4144-bd01-3a3f5679bd53" />

