### PR TITLE
Use forward globals when recompiling autowrapped methods

### DIFF
--- a/src/llmcompressor/pipelines/sequential/ast_helpers.py
+++ b/src/llmcompressor/pipelines/sequential/ast_helpers.py
@@ -53,13 +53,13 @@ def autowrap_forward(module: torch.nn.Module, ignore: list[str]):
         )
 
     # get source code of module forward
-    source = inspect.getsource(module.forward)
+    forward = inspect.unwrap(module.forward)
+    source = inspect.getsource(forward)
     source = textwrap.dedent(source)
     tree = ast.parse(source)
 
     # construct namespace for our new code
-    defining_module = sys.modules[module.__class__.__module__]
-    namespace = defining_module.__dict__.copy()
+    namespace = forward.__globals__.copy()
     namespace.update({"torch.fx.wrap": torch.fx.wrap})
     namespace.update({"self": module})
 

--- a/tests/llmcompressor/pipelines/sequential/test_ast_helpers.py
+++ b/tests/llmcompressor/pipelines/sequential/test_ast_helpers.py
@@ -1,0 +1,37 @@
+import subprocess
+import sys
+
+
+def test_autowrap_forward_under_cprofile(tmp_path):
+    script = tmp_path / "model.py"
+    script.write_text(
+        """
+import torch
+
+from llmcompressor.pipelines.sequential.ast_helpers import autowrap_forward
+
+activation = torch.relu
+
+
+class Model(torch.nn.Module):
+    def forward(self, value):
+        return activation(value)
+
+
+model = Model()
+with autowrap_forward(model, []):
+    model(torch.tensor(-1))
+"""
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cProfile",
+            "-o",
+            str(tmp_path / "profile.out"),
+            str(script),
+        ],
+        check=True,
+    )


### PR DESCRIPTION
SUMMARY:
Fixes #3065

`autowrap_forward` used source from the forward function but globals from its
named module. Under `cProfile`, a script-defined model names `__main__`, which
points to the runner instead of the script globals.

The forward method is now unwrapped once, and both source and globals come from
that function. A regression test runs a script-defined model through
`python -m cProfile` and accesses a script-only global.

Thanks to @Isitthakkar11 for the report and reproduction.

TEST PLAN:
- Reverted the source fix and confirmed the regression test fails with
  `NameError: name 'activation' is not defined`.
- Restored the fix and confirmed the regression test passes.
- Ran all 33 tests in `tests/llmcompressor/pipelines/sequential/`.
- Ran `make quality`.
- Ran the reduced reported benchmark under `cProfile` on Linux with Python
  3.10.14 and PyTorch 2.9.0+cu126. The node has NVIDIA A40 GPUs with driver
  560.35.03, but this verification was CPU-only.

Not verified on the reporter's macOS and Python 3.12 environment. The full-size
benchmark workload was not run.