### PR TITLE
fix(args): escape '%' in DatasetArguments.splits help so argparse builds on Python 3.14

### DIFF
--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -143,9 +143,9 @@ class DatasetArguments(CustomDatasetArguments):
         metadata={
             "help": (
                 "Optional dataset split selector. Passing a string like 'train' or "
-                "'train[:50%]' is strongly recommended. Legacy dict input is "
+                "'train[:50%%]' is strongly recommended. Legacy dict input is "
                 "deprecated and only supported for calibration compatibility "
-                "(for example: {'calibration': 'train[:50%]'})."
+                "(for example: {'calibration': 'train[:50%%]'})."
             )
         },
     )


### PR DESCRIPTION
## Summary

On Python 3.14, calling the public `oneshot()` entry point fails while `HfArgumentParser` builds its argument parser — before any model loading or calibration:

```
ValueError: unsupported format character ']' (0x5d) at index ...
ValueError: badly formed help string
```

`argparse` treats every `help` string as a percent-format template and expands it with `help % params`. The `splits` help text in `DatasetArguments` contains `train[:50%]`, and the sequence `%]` is an invalid format directive. Python 3.14 validates help strings eagerly during parser construction, so this now raises up front (earlier versions only tripped when help was actually rendered).

Fixes #3139.

## Fix

Escape the literal percent signs as `%%` in the two `train[:50%]` examples in the `splits` help metadata. `argparse` un-escapes `%%` back to `%` when rendering, so the displayed help is unchanged (`train[:50%]`), while parser construction no longer raises.

## Verification

```python
import argparse
p = argparse.ArgumentParser()
p.add_argument("--x", help="'train[:50%]'")    # ValueError: unsupported format character ']'
p.add_argument("--y", help="'train[:50%%]'")   # OK; format_help() renders 'train[:50%]'
```

Reproduced the exact `ValueError` on the unescaped string and confirmed the escaped form both builds the parser and renders `train[:50%]` in `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
