### PR TITLE
[Examples] [Tests] Add download limit for perfect blend

### DIFF
--- a/examples/.claude/skills/shared_quantization.md
+++ b/examples/.claude/skills/shared_quantization.md
@@ -289,6 +289,7 @@ Use the shared template at `.claude/skills/templates/oneshot_with_data.py` as th
   oneshot(
       model=model,
       dataset="perfectblend",
+    splits="train[:512]",
       recipe=recipe,
       max_seq_length=MAX_SEQUENCE_LENGTH,
       num_calibration_samples=NUM_CALIBRATION_SAMPLES,

--- a/examples/.claude/skills/shared_quantization.md
+++ b/examples/.claude/skills/shared_quantization.md
@@ -289,7 +289,7 @@ Use the shared template at `.claude/skills/templates/oneshot_with_data.py` as th
   oneshot(
       model=model,
       dataset="perfectblend",
-    splits="train[:512]",
+      splits="train[:512]",
       recipe=recipe,
       max_seq_length=MAX_SEQUENCE_LENGTH,
       num_calibration_samples=NUM_CALIBRATION_SAMPLES,

--- a/examples/awq/fp8_block_llama_example.py
+++ b/examples/awq/fp8_block_llama_example.py
@@ -22,6 +22,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/awq/fp8_dynamic_llama_example.py
+++ b/examples/awq/fp8_dynamic_llama_example.py
@@ -22,6 +22,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/awq/llama_example.py
+++ b/examples/awq/llama_example.py
@@ -26,6 +26,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/awq/llama_example_ddp.py
+++ b/examples/awq/llama_example_ddp.py
@@ -37,6 +37,7 @@ start_time = time.time()
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/awq/qwen3_moe_example.py
+++ b/examples/awq/qwen3_moe_example.py
@@ -30,6 +30,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/awq/qwen3_moe_example_ddp.py
+++ b/examples/awq/qwen3_moe_example_ddp.py
@@ -42,6 +42,7 @@ start_time = time.time()
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/awq/qwen3_next_example.py
+++ b/examples/awq/qwen3_next_example.py
@@ -25,6 +25,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/awq/step3p5_example.py
+++ b/examples/awq/step3p5_example.py
@@ -32,6 +32,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/awq/w4a8_fp8_llama_example.py
+++ b/examples/awq/w4a8_fp8_llama_example.py
@@ -28,6 +28,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=512,
     num_calibration_samples=256,

--- a/examples/big_models_with_sequential_onloading/llama3.3_70b.py
+++ b/examples/big_models_with_sequential_onloading/llama3.3_70b.py
@@ -25,6 +25,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=256,

--- a/examples/big_models_with_sequential_onloading/llama3_8b_w8a8_distributed.py
+++ b/examples/big_models_with_sequential_onloading/llama3_8b_w8a8_distributed.py
@@ -30,6 +30,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=256,

--- a/examples/disk_offloading/deepseek_v32_example.py
+++ b/examples/disk_offloading/deepseek_v32_example.py
@@ -102,6 +102,7 @@ oneshot(
     model=model,
     processor=tokenizer,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,

--- a/examples/disk_offloading/kimi_k26_example.py
+++ b/examples/disk_offloading/kimi_k26_example.py
@@ -78,6 +78,7 @@ oneshot(
     model=model,
     processor=tokenizer,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,

--- a/examples/disk_offloading/kimi_k2_example.py
+++ b/examples/disk_offloading/kimi_k2_example.py
@@ -34,6 +34,7 @@ oneshot(
     model=model,
     processor=tokenizer,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,

--- a/examples/disk_offloading/qwen3_example.py
+++ b/examples/disk_offloading/qwen3_example.py
@@ -39,6 +39,7 @@ recipe = QuantizationModifier(targets="Linear", scheme="NVFP4", ignore=["lm_head
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=MAX_SEQUENCE_LENGTH,
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,

--- a/examples/imatrix/llama3_imatrix_example.py
+++ b/examples/imatrix/llama3_imatrix_example.py
@@ -30,7 +30,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
-    splits="train[:5%]",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/imatrix/llama3_nvfp4_imatrix_example.py
+++ b/examples/imatrix/llama3_nvfp4_imatrix_example.py
@@ -27,6 +27,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/imatrix/llama3_nvfp4_imatrix_example_ddp.py
+++ b/examples/imatrix/llama3_nvfp4_imatrix_example_ddp.py
@@ -37,6 +37,7 @@ start_time = time.time()
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_attention/llama3_attention.py
+++ b/examples/quantization_attention/llama3_attention.py
@@ -27,6 +27,7 @@ recipe = QuantizationModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_kv_cache/gemma2_fp8_kv_example.py
+++ b/examples/quantization_kv_cache/gemma2_fp8_kv_example.py
@@ -46,6 +46,7 @@ quant_stage:
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_kv_cache/llama3_fp8_head_kv_example.py
+++ b/examples/quantization_kv_cache/llama3_fp8_head_kv_example.py
@@ -23,6 +23,7 @@ recipe = QuantizationModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_kv_cache/llama3_fp8_kv_example.py
+++ b/examples/quantization_kv_cache/llama3_fp8_kv_example.py
@@ -46,6 +46,7 @@ quant_stage:
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_kv_cache/phi3.5_fp8_kv_example.py
+++ b/examples/quantization_kv_cache/phi3.5_fp8_kv_example.py
@@ -48,6 +48,7 @@ quant_stage:
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_non_uniform/quantization_int4_int8.py
+++ b/examples/quantization_non_uniform/quantization_int4_int8.py
@@ -47,6 +47,7 @@ quant_stage:
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_non_uniform/quantization_multiple_modifiers.py
+++ b/examples/quantization_non_uniform/quantization_multiple_modifiers.py
@@ -57,6 +57,7 @@ if __name__ == "__main__":
     oneshot(
         model=model,
         dataset="perfectblend",
+        splits="train[:512]",
         recipe=recipe,
         max_seq_length=2048,
         num_calibration_samples=512,

--- a/examples/quantization_non_uniform/quantization_nvfp4_fp8.py
+++ b/examples/quantization_non_uniform/quantization_nvfp4_fp8.py
@@ -40,6 +40,7 @@ recipe = QuantizationModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=20,

--- a/examples/quantization_w4a16/llama3_ddp_example.py
+++ b/examples/quantization_w4a16/llama3_ddp_example.py
@@ -34,6 +34,7 @@ start_time = time.time()
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_w4a16/llama3_example.py
+++ b/examples/quantization_w4a16/llama3_example.py
@@ -18,6 +18,7 @@ recipe = GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"])
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_w4a16/qwen3_8_gptq_awq_example.py
+++ b/examples/quantization_w4a16/qwen3_8_gptq_awq_example.py
@@ -36,6 +36,7 @@ oneshot(
     processor=processor,
     recipe=recipe,
     dataset="perfectblend",
+    splits="train[:512]",
     max_seq_length=4096,
     num_calibration_samples=512,
     moe_calibrate_all_experts=True,

--- a/examples/quantization_w4a16_fp4/mxfp4/llama3_example.py
+++ b/examples/quantization_w4a16_fp4/mxfp4/llama3_example.py
@@ -18,6 +18,7 @@ recipe = GPTQModifier(targets="Linear", scheme="MXFP4A16", ignore=["lm_head"])
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_w4a16_fp4/nvfp4/llama3_nvfp4_expanded_mse_example.py
+++ b/examples/quantization_w4a16_fp4/nvfp4/llama3_nvfp4_expanded_mse_example.py
@@ -31,6 +31,7 @@ oneshot(
     model=model,
     recipe=recipe,
     dataset="perfectblend",
+    splits="train[:512]",
     num_calibration_samples=512,
     max_seq_length=2048,
 )

--- a/examples/quantization_w4a4_fp4/hy3_example.py
+++ b/examples/quantization_w4a4_fp4/hy3_example.py
@@ -46,6 +46,7 @@ oneshot(
     model=model,
     processor=tokenizer,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     batch_size=4,
     num_calibration_samples=512,

--- a/examples/quantization_w4a4_fp4/llama3_example.py
+++ b/examples/quantization_w4a4_fp4/llama3_example.py
@@ -22,6 +22,7 @@ recipe = QuantizationModifier(targets="Linear", scheme="NVFP4", ignore=["lm_head
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=20,

--- a/examples/quantization_w4a4_fp4/llama3_example_prefetch.py
+++ b/examples/quantization_w4a4_fp4/llama3_example_prefetch.py
@@ -28,6 +28,7 @@ start = time.perf_counter()
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=None,
     pipeline="sequential",
     sequential_prefetch=True,

--- a/examples/quantization_w4a4_fp4/llama3_gptq_example.py
+++ b/examples/quantization_w4a4_fp4/llama3_gptq_example.py
@@ -51,6 +51,7 @@ recipe = GPTQModifier(config_groups={"group_0": NVFP4}, ignore=["lm_head"])
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_w4a4_fp4/mellum2_example.py
+++ b/examples/quantization_w4a4_fp4/mellum2_example.py
@@ -22,6 +22,7 @@ recipe = QuantizationModifier(targets="Linear", scheme="NVFP4", ignore=["lm_head
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=20,

--- a/examples/quantization_w4a4_fp4/qwen3_5_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_5_example.py
@@ -36,6 +36,7 @@ oneshot(
     processor=processor,
     recipe=recipe,
     dataset="perfectblend",
+    splits="train[:512]",
     max_seq_length=4096,
     num_calibration_samples=256,
     moe_calibrate_all_experts=True,

--- a/examples/quantization_w4a4_fp4/qwen3_6_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_6_example.py
@@ -34,6 +34,7 @@ oneshot(
     processor=processor,
     recipe=recipe,
     dataset="perfectblend",
+    splits="train[:512]",
     max_seq_length=4096,
     num_calibration_samples=256,
     moe_calibrate_all_experts=True,

--- a/examples/quantization_w4a4_fp4/qwen3_8_gptq_awq_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_8_gptq_awq_example.py
@@ -58,6 +58,7 @@ oneshot(
     processor=processor,
     recipe=recipe,
     dataset="perfectblend",
+    splits="train[:512]",
     max_seq_length=4096,
     num_calibration_samples=512,
     moe_calibrate_all_experts=True,

--- a/examples/quantization_w4a4_fp4/qwen3_next_example.py
+++ b/examples/quantization_w4a4_fp4/qwen3_next_example.py
@@ -42,6 +42,7 @@ recipe = QuantizationModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=20,

--- a/examples/quantization_w4a4_fp4/qwen_30b_a3b.py
+++ b/examples/quantization_w4a4_fp4/qwen_30b_a3b.py
@@ -36,6 +36,7 @@ recipe = QuantizationModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=20,

--- a/examples/quantization_w4a4_fp4/trinity_large_nvfp4.py
+++ b/examples/quantization_w4a4_fp4/trinity_large_nvfp4.py
@@ -33,6 +33,7 @@ recipe = QuantizationModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=256,

--- a/examples/quantization_w4a8_fp8/llama3_example.py
+++ b/examples/quantization_w4a8_fp8/llama3_example.py
@@ -18,6 +18,7 @@ recipe = GPTQModifier(targets="Linear", scheme="W4AFP8", ignore=["lm_head"])
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_w8a8_fp8/nemotron_3_5_lightning_example.py
+++ b/examples/quantization_w8a8_fp8/nemotron_3_5_lightning_example.py
@@ -29,6 +29,7 @@ recipe = GPTQModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_w8a8_int8/gemma2_example.py
+++ b/examples/quantization_w8a8_int8/gemma2_example.py
@@ -19,6 +19,7 @@ recipe = GPTQModifier(targets="Linear", scheme="W8A8", ignore=["lm_head"])
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_w8a8_int8/llama3_example.py
+++ b/examples/quantization_w8a8_int8/llama3_example.py
@@ -24,6 +24,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantization_w8a8_int8/smoothquant_ddp_example.py
+++ b/examples/quantization_w8a8_int8/smoothquant_ddp_example.py
@@ -60,6 +60,7 @@ start_time = time.time()
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantizing_moe/deepseek_r1_example.py
+++ b/examples/quantizing_moe/deepseek_r1_example.py
@@ -36,6 +36,7 @@ recipe = GPTQModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantizing_moe/glm4_7_example.py
+++ b/examples/quantizing_moe/glm4_7_example.py
@@ -32,6 +32,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantizing_moe/glm5_example.py
+++ b/examples/quantizing_moe/glm5_example.py
@@ -50,6 +50,7 @@ recipe = QuantizationModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     batch_size=4,
     recipe=recipe,
     num_calibration_samples=512,

--- a/examples/quantizing_moe/glm5_gptq_example.py
+++ b/examples/quantizing_moe/glm5_gptq_example.py
@@ -41,6 +41,7 @@ num_experts = getattr(model.config, "n_routed_experts", 384)
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     batch_size=4,
     recipe=recipe,
     max_seq_length=2048,

--- a/examples/quantizing_moe/granite_moe_example.py
+++ b/examples/quantizing_moe/granite_moe_example.py
@@ -25,6 +25,7 @@ recipe = GPTQModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantizing_moe/mixtral_example.py
+++ b/examples/quantizing_moe/mixtral_example.py
@@ -24,6 +24,7 @@ recipe = QuantizationModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/quantizing_moe/qwen_3_8_example.py
+++ b/examples/quantizing_moe/qwen_3_8_example.py
@@ -51,6 +51,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=1024,

--- a/examples/quantizing_moe/qwen_example.py
+++ b/examples/quantizing_moe/qwen_example.py
@@ -25,6 +25,7 @@ recipe = GPTQModifier(
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/reap_expert_pruning/hy3_25_example.py
+++ b/examples/reap_expert_pruning/hy3_25_example.py
@@ -44,6 +44,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=1024,

--- a/examples/reap_expert_pruning/qwen38_example.py
+++ b/examples/reap_expert_pruning/qwen38_example.py
@@ -53,6 +53,7 @@ recipe = [
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=1024,

--- a/examples/reap_expert_pruning/reap_moonlight_16b.py
+++ b/examples/reap_expert_pruning/reap_moonlight_16b.py
@@ -20,6 +20,7 @@ recipe = REAPPruningModifier(sparsity=0.25)
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/examples/reap_expert_pruning/reap_qwen3_30b.py
+++ b/examples/reap_expert_pruning/reap_qwen3_30b.py
@@ -18,6 +18,7 @@ recipe = REAPPruningModifier(sparsity=0.25)
 oneshot(
     model=model,
     dataset="perfectblend",
+    splits="train[:512]",
     recipe=recipe,
     max_seq_length=2048,
     num_calibration_samples=512,

--- a/tests/e2e/configs/fp4_nvfp4.yaml
+++ b/tests/e2e/configs/fp4_nvfp4.yaml
@@ -2,5 +2,6 @@ cadence: "nightly"
 test_group: "rhaiis"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: NVFP4
-num_calibration_samples: 20
 dataset_id: perfectblend
+dataset_split: "train[:20]"
+num_calibration_samples: 20

--- a/tests/e2e/configs/fp8_static_per_tensor.yaml
+++ b/tests/e2e/configs/fp8_static_per_tensor.yaml
@@ -2,3 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: FP8
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/configs/int8_channel_weight_static_per_tensor_act.yaml
+++ b/tests/e2e/configs/int8_channel_weight_static_per_tensor_act.yaml
@@ -5,3 +5,5 @@ model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 skip_sanity_check: true
 recipe: tests/e2e/recipes/INT8/recipe_int8_channel_weight_static_per_tensor_act.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/configs/int8_dynamic_per_token.yaml
+++ b/tests/e2e/configs/int8_dynamic_per_token.yaml
@@ -2,3 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W8A8
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/configs/kv_cache_fp8.yaml
+++ b/tests/e2e/configs/kv_cache_fp8.yaml
@@ -2,3 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/kv_cache/default.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/configs/kv_cache_gptq_tinyllama.yaml
+++ b/tests/e2e/configs/kv_cache_gptq_tinyllama.yaml
@@ -3,3 +3,5 @@ test_group: "rhaiis"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/kv_cache/gptq.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/configs/multiple_modifiers_gptq_awq.yaml
+++ b/tests/e2e/configs/multiple_modifiers_gptq_awq.yaml
@@ -2,4 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/non_uniform/recipe_gptq_awq.yaml
 dataset_id: perfectblend
+dataset_split: "train[:256]"
 num_calibration_samples: 256

--- a/tests/e2e/configs/multiple_modifiers_gptq_awq_disk.yaml
+++ b/tests/e2e/configs/multiple_modifiers_gptq_awq_disk.yaml
@@ -2,6 +2,7 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/non_uniform/recipe_gptq_awq.yaml
 dataset_id: perfectblend
+dataset_split: "train[:256]"
 num_calibration_samples: 256
 max_memory:
   cpu: 500_000_000  # 0.5Gb / 2Gb, force disk offloading

--- a/tests/e2e/configs/nvfp4_fp8_mixed.yaml
+++ b/tests/e2e/configs/nvfp4_fp8_mixed.yaml
@@ -2,4 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/non_uniform/recipe_nvfp4_fp8_mixed.yaml
 dataset_id: perfectblend
+dataset_split: "train[:20]"
 num_calibration_samples: 20

--- a/tests/e2e/configs/w4a16_asym_awq.yaml
+++ b/tests/e2e/configs/w4a16_asym_awq.yaml
@@ -3,3 +3,5 @@ test_group: "rhaiis"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/WNA16/recipe_w4a16_awq_asym.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/configs/w4a16_grouped_quant.yaml
+++ b/tests/e2e/configs/w4a16_grouped_quant.yaml
@@ -2,4 +2,6 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W4A16
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 quant_type: "GPTQ"

--- a/tests/e2e/configs/w4a16_sym_awq.yaml
+++ b/tests/e2e/configs/w4a16_sym_awq.yaml
@@ -2,3 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/WNA16/recipe_w4a16_awq_sym.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/configs/w8a16_grouped_quant.yaml
+++ b/tests/e2e/configs/w8a16_grouped_quant.yaml
@@ -2,4 +2,6 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W8A16
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 quant_type: "GPTQ"

--- a/tests/e2e/configs/w8a8_dynamic_asym.yaml
+++ b/tests/e2e/configs/w8a8_dynamic_asym.yaml
@@ -2,3 +2,5 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 recipe: tests/e2e/recipes/INT8/recipe_w8a8_dynamic_asym.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/configs/w8a8_static_asym.yaml
+++ b/tests/e2e/configs/w8a8_static_asym.yaml
@@ -4,3 +4,5 @@ model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 skip_sanity_check: true
 recipe: tests/e2e/recipes/INT8/recipe_w8a8_static_asym.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512

--- a/tests/e2e/distributed_configs/w4a16_gptq_smoke.yaml
+++ b/tests/e2e/distributed_configs/w4a16_gptq_smoke.yaml
@@ -2,6 +2,7 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W4A16
 dataset_id: perfectblend
+dataset_split: "train[:64]"
 num_calibration_samples: 64
 quant_type: "GPTQ"
 num_gpus: 2

--- a/tests/e2e/distributed_configs/w4a16_rtn_smoke.yaml
+++ b/tests/e2e/distributed_configs/w4a16_rtn_smoke.yaml
@@ -2,6 +2,7 @@ cadence: "nightly"
 model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 scheme: W4A16
 dataset_id: perfectblend
+dataset_split: "train[:64]"
 num_calibration_samples: 64
 quant_type: "RTN"
 num_gpus: 2

--- a/tests/e2e/moe_configs/nvfp4_moe.yaml
+++ b/tests/e2e/moe_configs/nvfp4_moe.yaml
@@ -2,4 +2,5 @@ cadence: "nightly"
 model: Qwen/Qwen3-30B-A3B
 scheme: NVFP4
 dataset_id: perfectblend
+dataset_split: "train[:20]"
 num_calibration_samples: 20

--- a/tests/e2e/moe_configs/nvfp4_moe_awq.yaml
+++ b/tests/e2e/moe_configs/nvfp4_moe_awq.yaml
@@ -1,6 +1,7 @@
 cadence: "nightly"
 model: Qwen/Qwen3-30B-A3B
 dataset_id: perfectblend
+dataset_split: "train[:50]"
 recipe: tests/e2e/recipes/NVFP4/recipe_awq_nvfp4.yaml
 save_dir: Qwen3-30B-A3B-NVFP4-AWQ
 num_calibration_samples: 50

--- a/tests/llmcompressor/modifiers/pruning/reap/test_ddp.py
+++ b/tests/llmcompressor/modifiers/pruning/reap/test_ddp.py
@@ -55,6 +55,7 @@ def test_reap_ddp_qwen3():
         oneshot(
             model=model_ref,
             dataset="perfectblend",
+            splits="train[:512]",
             recipe=REAPPruningModifier(sparsity=0.25, report_path=ref_report),
             num_calibration_samples=NUM_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,
@@ -82,6 +83,7 @@ def test_reap_ddp_qwen3():
         oneshot(
             model=model_ddp,
             dataset="perfectblend",
+            splits="train[:512]",
             recipe=REAPPruningModifier(sparsity=0.25, report_path=ddp_report),
             num_calibration_samples=NUM_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -97,6 +97,7 @@ def _run_single_gpu(
     oneshot(
         model=model,
         dataset="perfectblend",
+        splits="train[:512]",
         recipe=recipe,
         num_calibration_samples=num_samples,
         max_seq_length=MAX_SEQ_LENGTH,
@@ -255,6 +256,7 @@ def _test_ddp_modifier(
     oneshot(
         model=model,
         dataset="perfectblend",
+        splits="train[:512]",
         recipe=recipe_factory(),
         num_calibration_samples=NUM_SAMPLES,
         max_seq_length=MAX_SEQ_LENGTH,

--- a/tests/llmcompressor/transformers/compression/test_quantization.py
+++ b/tests/llmcompressor/transformers/compression/test_quantization.py
@@ -135,6 +135,7 @@ def test_perplexity(setup_model_and_config):
     tokenizer = AutoTokenizer.from_pretrained(config["model_stub"])
     dataset_args = DatasetArguments(
         dataset="perfectblend",
+        splits="train[:512]",
         max_seq_length=config["max_seq_length"],
     )
     dataloader = _get_dataloader(dataset_args, tokenizer)

--- a/tests/llmcompressor/transformers/kv_cache/test_kv_cache.py
+++ b/tests/llmcompressor/transformers/kv_cache/test_kv_cache.py
@@ -84,6 +84,7 @@ def kv_cache_fixture():
         oneshot(
             model=model_id,
             dataset="perfectblend",
+            splits="train[:512]",
             recipe=recipe,
             max_seq_length=MAX_SEQUENCE_LENGTH,
             num_calibration_samples=NUM_CALIBRATION_SAMPLES,

--- a/tests/lmeval/configs/awq_nvfp4.yaml
+++ b/tests/lmeval/configs/awq_nvfp4.yaml
@@ -1,6 +1,7 @@
 cadence: ["nightly", "weekly"]
 model: meta-llama/Llama-3.1-8B-Instruct
 dataset_id: perfectblend
+dataset_split: "train[:20]"
 num_calibration_samples: 20
 recipe: tests/e2e/recipes/NVFP4/recipe_awq_nvfp4.yaml
 lmeval:

--- a/tests/lmeval/configs/fp8_static_per_tensor.yaml
+++ b/tests/lmeval/configs/fp8_static_per_tensor.yaml
@@ -2,6 +2,8 @@ cadence: ["nightly", "weekly"]
 model: meta-llama/Meta-Llama-3-8B-Instruct
 scheme: FP8
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 lmeval:
   metrics:
     exact_match,flexible-extract: 0.75

--- a/tests/lmeval/configs/int8_w8a8_dynamic_per_token.yaml
+++ b/tests/lmeval/configs/int8_w8a8_dynamic_per_token.yaml
@@ -2,6 +2,8 @@ cadence: ["nightly", "weekly"]
 model: meta-llama/Meta-Llama-3-8B-Instruct
 recipe: tests/e2e/recipes/INT8/recipe_int8_channel_weight_dynamic_per_token.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 lmeval:
   metrics:
     exact_match,flexible-extract: 0.75

--- a/tests/lmeval/configs/w4a16_actorder_weight.yaml
+++ b/tests/lmeval/configs/w4a16_actorder_weight.yaml
@@ -2,6 +2,8 @@ cadence: ["nightly", "weekly"]
 model: meta-llama/Meta-Llama-3-8B-Instruct
 recipe: tests/e2e/recipes/actorder/recipe_w4a16_actorder_weight.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 lmeval:
   recovery_threshold:
     exact_match,strict-match: 0.93

--- a/tests/lmeval/configs/w4a16_awq_sym.yaml
+++ b/tests/lmeval/configs/w4a16_awq_sym.yaml
@@ -2,6 +2,8 @@ cadence: ["nightly", "weekly"]
 model: meta-llama/Meta-Llama-3-8B-Instruct
 recipe: tests/e2e/recipes/WNA16/recipe_w4a16_awq_sym.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 seed: 100
 lmeval:
   recovery_threshold:

--- a/tests/lmeval/configs/w4a16_gptq.yaml
+++ b/tests/lmeval/configs/w4a16_gptq.yaml
@@ -2,6 +2,8 @@ cadence: ["nightly", "weekly"]
 model: meta-llama/Meta-Llama-3-8B-Instruct
 scheme: W4A16
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 quant_type: "GPTQ"
 lmeval:
   recovery_threshold:

--- a/tests/lmeval/configs/w4a4_nvfp4.yaml
+++ b/tests/lmeval/configs/w4a4_nvfp4.yaml
@@ -2,6 +2,7 @@ cadence: ["nightly", "weekly"]
 model: meta-llama/Llama-3.1-8B-Instruct
 scheme: NVFP4
 dataset_id: perfectblend
+dataset_split: "train[:20]"
 seed: 100
 num_calibration_samples: 20
 lmeval:

--- a/tests/lmeval/distributed_configs/nvfp4_qmod.yaml
+++ b/tests/lmeval/distributed_configs/nvfp4_qmod.yaml
@@ -2,6 +2,7 @@ cadence: ["nightly", "weekly"]
 model: Qwen/Qwen3-8B
 scheme: NVFP4
 dataset_id: perfectblend
+dataset_split: "train[:256]"
 num_calibration_samples: 256
 lmeval:
   task: gsm8k

--- a/tests/lmeval/distributed_configs/w4a16_awq.yaml
+++ b/tests/lmeval/distributed_configs/w4a16_awq.yaml
@@ -2,6 +2,8 @@ cadence: ["nightly", "weekly"]
 model: Qwen/Qwen3-8B
 recipe: tests/e2e/recipes/WNA16/recipe_w4a16_awq_sym.yaml
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 lmeval:
   task: gsm8k
   num_fewshot: 5

--- a/tests/lmeval/distributed_configs/w4a16_gptq.yaml
+++ b/tests/lmeval/distributed_configs/w4a16_gptq.yaml
@@ -2,6 +2,8 @@ cadence: ["nightly", "weekly"]
 model: Qwen/Qwen3-8B
 scheme: W4A16
 dataset_id: perfectblend
+dataset_split: "train[:512]"
+num_calibration_samples: 512
 quant_type: "GPTQ"
 lmeval:
   task: gsm8k


### PR DESCRIPTION
## Background ##
https://github.com/vllm-project/llm-compressor/pull/3062 and https://github.com/vllm-project/llm-compressor/pull/3063 both moved examples and tests to using the "perfectblend" dataset. However, they also inadvertently removed the limit on downloading the dataset split. This causes the entire train split to be downloaded and tokenized, dramatically increasing runtime.

Some of the tests never had a download limit to begin with, but this was not an issue for "small" datasets like ultrachat

## Changes ##
* Add split limit for perfectblend dataset

## Testing ##
* Tested examples and tests locally