### PR TITLE
[Tests] Fix reap ddp vs single comparison test

### DIFF
--- a/tests/llmcompressor/modifiers/pruning/reap/test_ddp.py
+++ b/tests/llmcompressor/modifiers/pruning/reap/test_ddp.py
@@ -58,6 +58,7 @@ def test_reap_ddp_qwen3():
             recipe=REAPPruningModifier(sparsity=0.25, report_path=ref_report),
             num_calibration_samples=NUM_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,
+            shuffle_calibration_samples=False,
             pipeline="sequential",
         )
 
@@ -85,6 +86,7 @@ def test_reap_ddp_qwen3():
             recipe=REAPPruningModifier(sparsity=0.25, report_path=ddp_report),
             num_calibration_samples=NUM_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,
+            shuffle_calibration_samples=False,
             pipeline="sequential",
         )
 


### PR DESCRIPTION
## Background ##
* The `test_reap_ddp_qwen3` test compares the pruned experts between single-threaded vs multi-gpu reap oneshot. However, #3062 removed logic for deterministically splitting the data across ranks. With the logic removed, the test defaulted to shuffling the dataset, breaking the determinism of the algorithm.

## Purpose ##
* Fix `test_reap_ddp_qwen3` ddp test

## Changes ##
* Add `shuffle_calibration_samples=False` to both single and multithreaded oneshot calls

## Testing ##
* Test passes locally