### PR TITLE
[experiment] GPTQ on LUTB scheme

### DIFF
--- a/examples/quantization_lutb/llama3_gptq_example.py
+++ b/examples/quantization_lutb/llama3_gptq_example.py
@@ -1,0 +1,39 @@
+"""GPTQ with the LUT-B (3-bit codebook) scheme on Llama-3-8B-Instruct.
+
+This is the calibrated counterpart to `llama3_example.py` (data-free RTN LUT-B).
+GPTQLutBModifier fits a per-tile non-uniform codebook and uses the GPTQ
+Hessian-based error compensation to snap weights to codebook centers, targeting
+the same MLP projections as the RTN baseline so the numbers are comparable.
+"""
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.gptq import GPTQLutBModifier
+
+MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
+
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype="auto")
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+# Same targets as the data-free LUT-B example, now with GPTQ calibration.
+recipe = GPTQLutBModifier(
+    targets="re:.*layers.*mlp.*_proj$",
+    scheme="LUTB",
+    ignore=["lm_head"],
+)
+
+oneshot(
+    model=model,
+    dataset="perfectblend",
+    # Slice the split up front so only the first 2048 examples are tokenized,
+    # instead of tokenizing the full ~1.4M-example dataset to select 2048.
+    splits="train[:2048]",
+    recipe=recipe,
+    max_seq_length=2048,
+    num_calibration_samples=2048,
+)
+
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-LUTB-GPTQ"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/src/llmcompressor/modifiers/gptq/__init__.py
+++ b/src/llmcompressor/modifiers/gptq/__init__.py
@@ -1,4 +1,5 @@
 # ruff: noqa
 
 from .base import *
+from .lutb import *
 from .gptq_quantize import *

--- a/src/llmcompressor/modifiers/gptq/base.py
+++ b/src/llmcompressor/modifiers/gptq/base.py
@@ -1,4 +1,5 @@
 import contextlib
+from typing import ClassVar
 
 import torch
 from compressed_tensors.distributed import greedy_bin_packing, wait_for_comms
@@ -121,6 +122,11 @@ class GPTQModifier(Modifier, QuantizationMixin):
     """
 
     requires_calibration_data: bool = True
+
+    # quantization parameters produced per module, broadcast to all ranks after
+    # compression in the distributed path. Subclasses producing a different set
+    # of parameters (e.g. codebook-based schemes) override this.
+    _q_param_names: ClassVar[list[str]] = _GPTQ_Q_PARAMS
 
     # gptq modifier arguments
     block_size: int = 128
@@ -295,7 +301,21 @@ class GPTQModifier(Modifier, QuantizationMixin):
         self.compress_module_list(rank_to_modules[rank])
 
         # broadcast compressed modules to each rank
-        broadcast_qparams_and_cleanup(module_list, module_to_rank, _GPTQ_Q_PARAMS)
+        broadcast_qparams_and_cleanup(module_list, module_to_rank, self._q_param_names)
+
+    def _quantize_weight(self, module, quant_args, hessian):
+        """
+        Run the weight quantization algorithm for a single calibrated module.
+        Subclasses override this to swap in a different quantization routine
+        (e.g. codebook fitting) while reusing the surrounding bookkeeping.
+        """
+        return quantize_weight(
+            module=module,
+            quant_args=quant_args,
+            hessian=hessian,
+            blocksize=self.block_size,
+            percdamp=self.dampening_frac,
+        )
 
     def compress_module_list(self, module_list):
         for module in module_list:
@@ -310,12 +330,10 @@ class GPTQModifier(Modifier, QuantizationMixin):
                 self._maybe_onload_hessian(module),
                 CompressionLogger(module) as comp_logger,
             ):
-                loss, q_param_dict, used_rtn_fallback = quantize_weight(
+                loss, q_param_dict, used_rtn_fallback = self._quantize_weight(
                     module=module,
                     quant_args=quant_args,
                     hessian=self._hessians.pop(module) / self._num_samples.pop(module),
-                    blocksize=self.block_size,
-                    percdamp=self.dampening_frac,
                 )
                 comp_logger.set_results(name="GPTQ", loss=loss)
 

--- a/src/llmcompressor/modifiers/gptq/gptq_quantize.py
+++ b/src/llmcompressor/modifiers/gptq/gptq_quantize.py
@@ -13,7 +13,12 @@ from loguru import logger
 
 GPTQ_PRECISION = torch.float32
 
-__all__ = ["make_empty_hessian", "accumulate_hessian", "quantize_weight"]
+__all__ = [
+    "make_empty_hessian",
+    "accumulate_hessian",
+    "quantize_weight",
+    "quantize_weight_lut_b",
+]
 
 
 def make_empty_hessian(
@@ -251,6 +256,153 @@ def quantize_weight(
     }
     if global_scale:
         q_param_dict["weight_global_scale"] = global_scale.to(dtype=final_dtype)
+    return (loss, q_param_dict, used_rtn_fallback)
+
+
+def quantize_weight_lut_b(
+    module: torch.nn.Module,
+    quant_args: QuantizationArgs,
+    hessian: torch.Tensor,
+    blocksize: int = 128,
+    percdamp: float = 0.01,
+) -> tuple[float, dict[str, torch.Tensor], bool]:
+    """
+    Quantize a module weight according to the GPTQ algorithm using a non-uniform
+    LUT-B codebook rather than a uniform scale/zero-point grid.
+
+    Unlike :func:`quantize_weight`, this routine does not use observers. A per-tile
+    codebook is fit once from the original (unquantized) weight using the
+    compressed-tensors LUT-B primitives, and each column is snapped to its tile's
+    nearest codebook center during the GPTQ error-compensation loop. Because the
+    final weight only takes on E4M3 center values, the LUT-B compressor can recover
+    an identical codebook at save time, so no separate ``weight_codebook`` parameter
+    needs to be produced here.
+
+    :param module: module with weight being quantized
+    :param quant_args: quantization arguments describing the LUT-B scheme
+    :param hessian: preaccumulated hessian for quantization
+    :param blocksize: chunk size of quantization updates
+    :param percdamp: dampening factor on hessian diagonal
+    :return: loss, q_param_dict (with key: weight), used_rtn_fallback (True if
+        hessian inversion failed and the module was quantized with round-to-nearest)
+    """
+    # local import: these are compressed-tensors LUT-B internals used to build the
+    # non-uniform codebook, the intended integration point for calibration-aware
+    # codebook creation (see quantize_lut_b docstring).
+    from compressed_tensors.quantization.utils.lut_b import (
+        LUT_B_LLOYD_ITERATIONS,
+        _fit_codebooks,
+        _weight_to_tiles,
+        is_lut_b_quantization,
+    )
+
+    if not is_lut_b_quantization(quant_args):
+        raise ValueError(
+            "quantize_weight_lut_b requires a canonical LUT-B quantization scheme "
+            f"(codebook type, num_bits=3, block strategy), got {quant_args}"
+        )
+    if quant_args.actorder:
+        raise NotImplementedError(
+            "Activation ordering is not supported for LUT-B GPTQ; the 2D block "
+            "tiling requires contiguous columns. Unset `actorder`."
+        )
+
+    final_shape = module.weight.shape
+    final_dtype = module.weight.dtype
+    W = module.weight.clone().to(dtype=GPTQ_PRECISION)
+    H = hessian
+    num_rows, num_columns = W.shape
+    block_n, block_k = quant_args.block_structure
+    codebook_size = 1 << quant_args.num_bits
+
+    # Fit one codebook per tile from the original weight (data-free, no observers).
+    # centers: [num_tiles, codebook_size] E4M3 -> [row_tiles, column_tiles, cb] fp32
+    tiles = _weight_to_tiles(W, quant_args)
+    _, centers = _fit_codebooks(tiles, quant_args, LUT_B_LLOYD_ITERATIONS)
+    row_tiles = num_rows // block_n
+    column_tiles = num_columns // block_k
+    centers = centers.to(torch.float32).reshape(row_tiles, column_tiles, codebook_size)
+
+    # map each output row to its row-tile so we can gather per-row centers per column
+    row_block = torch.arange(num_rows, device=W.device) // block_n
+
+    losses = torch.zeros(num_rows, device=W.device)
+
+    # mask dead hessian values
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    W[:, dead] = 0
+
+    # compute inverse hessian in place to save memory
+    used_rtn_fallback = False
+    try:
+        damp = percdamp * torch.mean(torch.diag(H))
+        diag = torch.arange(H.shape[0], device=H.device)
+        H[diag, diag] += damp
+        H = torch.linalg.cholesky(H)
+        H = torch.cholesky_inverse(H)
+        H = torch.linalg.cholesky(H, upper=True)
+        Hinv = H
+    except torch._C._LinAlgError:
+        logger.warning(
+            "Failed to invert hessian due to numerical instability. Consider "
+            "increasing GPTQModifier.dampening_frac, increasing the number "
+            "of calibration samples, or shuffling the calibration dataset. "
+            "Falling back to round-to-nearest for this module."
+        )
+        used_rtn_fallback = True
+        Hinv = H = torch.eye(num_columns, dtype=H.dtype, device=H.device)
+
+    # cache the per-row center table for the current column-block
+    cur_cb = -1
+    cvals = None
+
+    # See section 3.4 of https://arxiv.org/abs/2203.07259
+    for i1 in range(0, num_columns, blocksize):
+        i2 = min(i1 + blocksize, num_columns)
+        count = i2 - i1
+
+        W1 = W[:, i1:i2].clone()
+        Q1 = torch.zeros_like(W1)
+        Err1 = torch.zeros_like(W1)
+        losses1 = torch.zeros_like(W1)
+        Hinv1 = Hinv[i1:i2, i1:i2]
+
+        for i in range(count):
+            w = W1[:, i]
+            d = Hinv1[i, i]
+            column_idx = i1 + i
+
+            # gather this column-block's per-row centers: [num_rows, codebook_size]
+            cb = column_idx // block_k
+            if cb != cur_cb:
+                cvals = centers[row_block, cb]
+                cur_cb = cb
+
+            # quantize column: snap each row to its tile's nearest codebook center
+            nearest = (w.unsqueeze(1) - cvals).abs().argmin(dim=1)
+            q = cvals.gather(1, nearest.unsqueeze(1)).squeeze(1)
+
+            # propagate column error
+            Q1[:, i] = q
+            losses1[:, i] = (w - q) ** 2 / d**2
+
+            err1 = (w - q) / d
+            w1_err = err1.unsqueeze(1).matmul(Hinv1[i, i:].unsqueeze(0))
+            W1[:, i:] -= w1_err
+            Err1[:, i] = err1
+
+        # propagate block error
+        W[:, i1:i2] = Q1
+        losses += torch.sum(losses1, 1) / 2
+
+        w_err = Err1.matmul(Hinv[i1:i2, i2:])
+        W[:, i2:] -= w_err
+
+    W = W.reshape(final_shape).to(final_dtype)
+
+    loss = torch.sum(losses).item()
+    q_param_dict = {"weight": W}
     return (loss, q_param_dict, used_rtn_fallback)
 
 

--- a/src/llmcompressor/modifiers/gptq/lutb.py
+++ b/src/llmcompressor/modifiers/gptq/lutb.py
@@ -1,0 +1,59 @@
+from typing import ClassVar
+
+import torch
+from compressed_tensors.quantization.quant_args import ActivationOrdering
+
+from llmcompressor.core import Event, State
+from llmcompressor.modifiers.gptq.base import GPTQModifier
+from llmcompressor.modifiers.gptq.gptq_quantize import quantize_weight_lut_b
+
+__all__ = ["GPTQLutBModifier"]
+
+
+class GPTQLutBModifier(GPTQModifier):
+    """
+    GPTQ variant for LUT-B (lookup-table / codebook) weight quantization.
+
+    Behaves exactly like :class:`GPTQModifier` -- it calibrates a hessian from
+    input activations and quantizes weights column-by-column with hessian-based
+    error propagation -- but fits a non-uniform E4M3 codebook per weight tile
+    instead of a uniform scale/zero-point grid. See :class:`GPTQModifier` for the
+    full description of parameters and lifecycle.
+
+    Differences from :class:`GPTQModifier`:
+
+    - Weights are quantized via ``quantize_weight_lut_b`` (codebook fitting)
+      rather than ``quantize_weight``.
+    - No weight/activation observers are run: the codebook is fit inside the
+      quantization routine, so there are no scale/zero-point qparams to observe.
+    - The only quantization parameter produced is ``weight`` (the LUT-B
+      compressor recovers an identical codebook at save time), so nothing else
+      needs to be broadcast/stored in the distributed path.
+    - Activation ordering is unsupported: LUT-B uses 2D block tiling
+      (``[block_n, block_k]``) and actorder would scatter a tile's columns.
+    """
+
+    # LUT-B uses 2D block tiling; activation ordering would scatter a tile's
+    # columns, so it is unsupported and defaults to off (base default is static).
+    actorder: ActivationOrdering | None = None
+
+    # LUT-B produces a non-uniform codebook, not a scale/zero-point grid. The
+    # final weight takes on E4M3 center values, so the LUT-B compressor recovers
+    # an identical codebook at save time and only the weight is broadcast/stored.
+    _q_param_names: ClassVar[list[str]] = ["weight"]
+
+    def on_sequential_epoch_end(
+        self, state: State, event: Event, modules: list[torch.nn.Module], **kwargs
+    ):
+        # LUT-B is weight-only and codebook-based: no weight or activation
+        # observers to run (the codebook is fit inside quantize_weight_lut_b).
+        self.compress_modules()
+
+    def _quantize_weight(self, module, quant_args, hessian):
+        return quantize_weight_lut_b(
+            module=module,
+            quant_args=quant_args,
+            hessian=hessian,
+            blocksize=self.block_size,
+            percdamp=self.dampening_frac,
+        )


### PR DESCRIPTION
## Prerequisites

* #3018

## Summary

Adds `GPTQLutBModifier` (GPTQ for 3-bit LUT-B codebook quant) and benchmarks it against data-free RTN-LUTB on Llama-3-8B-Instruct (MLP `_proj` layers, ~3.1 bits/w).

_This is a quick-and-dirty implementation to test GPTQ with LUTB, without requiring a hefty update to the Observer logic. We likely don't want to land this._

## Results

**GPTQ improves over RTN for a single layer, but regresses end-to-end — with or without quantization error propagation. Data-free RTN stays the better choice at 3 bits.**

Wikitext `word_perplexity` (lower is better):

| Setup | RTN | GPTQ |
|---|---|---|
| Single layer (`layers.5.mlp`) | 10.10 | **10.08** |
| All MLP layers | **13.32** | 17.76 |
| All MLP, `propagate_error=False` | — | 18.88 |

Dampening doesn't recover it (all MLP): `dampening_frac` 0.01 / 0.1 / 1.0 → 17.39 / 23.10 / 20.10.

Per-layer, GPTQ does exactly what it should — it reduces layer-5 MLP output reconstruction error `mean‖(Wq−W)·x‖²` by ~24–26% vs RTN, and the gain holds on held-out activations (so it is *not* single-layer calibration overfitting):

| proj | RTN (calib) | GPTQ (calib) | GPTQ/RTN | RTN (held-out) | GPTQ (held-out) | GPTQ/RTN |
|---|---|---|---|---|---|---|
| gate_proj | 34.30 | 25.94 | 0.76 | 34.02 | 25.10 | 0.74 |
| up_proj | 19.25 | 14.82 | 0.77 | 19.10 | 14.34 | 0.75 |
| down_proj | 0.221 | 0.182 | 0.83 | 0.217 | 0.176 | 0.81 |


A mechanism for this is unclear. (Definitely not ruling out a bug)