### PR TITLE
Report recipe ignore entries that matched nothing at save time

### DIFF
--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -16,6 +16,9 @@ from transformers import PreTrainedModel
 
 from llmcompressor.core import active_session
 from llmcompressor.pytorch.model_load.helpers import copy_python_files_from_model_cache
+from llmcompressor.transformers.compression.recipe_validation import (
+    warn_on_unmatched_ignore_entries,
+)
 from llmcompressor.transformers.utils import RECIPE_FILE_NAME
 from llmcompressor.transformers.utils.helpers import infer_recipe_from_model_path
 from llmcompressor.utils.transformers import get_embeddings
@@ -125,6 +128,16 @@ def modify_save_pretrained(model: PreTrainedModel):
 
             save_dir = save_directory
             kwargs.setdefault("max_shard_size", "20GB")
+
+            # Report recipe `ignore` entries which matched no module before anything
+            # is written. This is the last point at which the author can still see a
+            # divergence between the recipe and the configuration that ships; after
+            # the write, only the resolved configuration is in the checkpoint.
+            # Warns only -- the save proceeds either way.
+            if is_source_process():
+                warn_on_unmatched_ignore_entries(
+                    model, active_session().lifecycle.recipe.modifiers
+                )
 
             # without this, quantization format will be inferred from the model
             if not save_compressed and quantization_format is None:

--- a/src/llmcompressor/transformers/compression/recipe_validation.py
+++ b/src/llmcompressor/transformers/compression/recipe_validation.py
@@ -1,0 +1,102 @@
+"""
+Report recipe entries which matched no module in the model, at export time.
+
+``modifiers/quantization/group_size_validation.py`` validates a recipe against the
+model it will be applied to, at initialize. This does the same kind of check at save,
+for a different reason: ``save_pretrained_wrapper`` writes the resolved quantization
+config and, through ``update_and_save_recipe``, the recipe itself. Nothing currently
+checks that the recipe's entries correspond to anything in the model at the moment
+they are written, and after the write the checkpoint is what a consumer reads.
+
+Only ``ignore`` is checked here. Unmatched ``targets`` already surface through
+``match_named_modules(..., warn_on_fail=True)`` in
+``compressed_tensors.quantization.lifecycle.apply.apply_quantization_config``;
+``ignore`` has no equivalent, so an entry matching nothing is silent.
+
+An unmatched entry is not an error and is not treated as one. The configuration is
+applied exactly as written, and a recipe may legitimately carry an entry for a module
+a given model does not have. It is reported so the divergence between what the author
+wrote and what was resolved is visible while the checkpoint can still be rebuilt.
+"""
+
+from __future__ import annotations
+
+import torch
+from compressed_tensors.utils import is_match
+from loguru import logger
+
+from llmcompressor.modifiers import Modifier
+
+__all__ = [
+    "get_unmatched_ignore_entries",
+    "warn_on_unmatched_ignore_entries",
+]
+
+
+def _unmatched_entries(model: torch.nn.Module, entries: list[str]) -> list[str]:
+    """
+    Return the entries which match no module in the model, in their original order.
+
+    An entry stops being tested once it has matched, so each is compared against
+    modules only until its first match. Only module names and classes are examined;
+    no parameter is touched, so this does not onload an offloaded model.
+
+    :param model: model to match against
+    :param entries: entry strings, potentially containing "re:" prefixes
+    :return: the subset of entries matching no module, order preserved
+    """
+    unmatched = set(entries)
+    for name, module in model.named_modules():
+        if not unmatched:
+            break
+        unmatched -= {entry for entry in unmatched if is_match(name, module, entry)}
+
+    return [entry for entry in entries if entry in unmatched]
+
+
+def get_unmatched_ignore_entries(
+    model: torch.nn.Module,
+    modifiers: list[Modifier],
+) -> list[tuple[str, str]]:
+    """
+    Find recipe ``ignore`` entries which match no module in the model.
+
+    :param model: model about to be saved
+    :param modifiers: recipe modifiers, e.g.
+        ``active_session().lifecycle.recipe.modifiers``
+    :return: list of (modifier class name, ignore entry) for each unmatched entry
+    """
+    unmatched: list[tuple[str, str]] = []
+
+    for modifier in modifiers:
+        entries = getattr(modifier, "ignore", None)
+        if not entries:
+            continue
+
+        modifier_name = type(modifier).__name__
+        for entry in _unmatched_entries(model, list(entries)):
+            unmatched.append((modifier_name, entry))
+
+    return unmatched
+
+
+def warn_on_unmatched_ignore_entries(
+    model: torch.nn.Module,
+    modifiers: list[Modifier],
+) -> None:
+    """
+    Warn once per recipe ``ignore`` entry which matches no module in the model.
+
+    Warns only. Nothing here raises and the checkpoint is written either way.
+
+    :param model: model about to be saved
+    :param modifiers: recipe modifiers, e.g.
+        ``active_session().lifecycle.recipe.modifiers``
+    """
+    for modifier_name, entry in get_unmatched_ignore_entries(model, modifiers):
+        logger.warning(
+            f"Recipe entry `ignore: {entry}` on {modifier_name} matched no module in "
+            f"{model.__class__.__name__}, so it had no effect. The checkpoint about "
+            "to be written reflects the configuration that was resolved, not this "
+            "entry."
+        )

--- a/tests/llmcompressor/transformers/compression/test_recipe_validation.py
+++ b/tests/llmcompressor/transformers/compression/test_recipe_validation.py
@@ -1,0 +1,161 @@
+import pytest
+import torch
+import torch.nn as nn
+from accelerate.accelerator import get_state_dict_offloaded_model
+from loguru import logger
+from transformers import AutoModelForCausalLM
+
+from llmcompressor.core import active_session
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.recipe import Recipe
+from llmcompressor.transformers.compression.compressed_tensors_utils import (
+    modify_save_pretrained,
+)
+from llmcompressor.transformers.compression.recipe_validation import (
+    get_unmatched_ignore_entries,
+    warn_on_unmatched_ignore_entries,
+)
+
+TINY_MODEL = "nm-testing/tinysmokellama-3.2"
+
+
+class DummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer1 = nn.Linear(4, 4)
+        self.layer2 = nn.Linear(4, 4)
+        self.norm = nn.LayerNorm(4)
+
+
+def _modifier(ignore):
+    return QuantizationModifier(targets=["Linear"], scheme="W8A8", ignore=ignore)
+
+
+@pytest.fixture
+def warning_logs():
+    logs = []
+    handler_id = logger.add(logs.append, format="{message}", level="WARNING")
+    yield logs
+    logger.remove(handler_id)
+
+
+@pytest.mark.unit
+def test_unmatched_ignore_entry_is_reported():
+    model = DummyModel()
+    modifier = _modifier(["nonexistent_module"])
+
+    assert get_unmatched_ignore_entries(model, [modifier]) == [
+        ("QuantizationModifier", "nonexistent_module")
+    ]
+
+
+@pytest.mark.unit
+def test_matching_ignore_entries_are_not_reported():
+    model = DummyModel()
+    # by name, by regex, and by module class
+    modifier = _modifier(["layer1", "re:layer.*", "LayerNorm"])
+
+    assert get_unmatched_ignore_entries(model, [modifier]) == []
+
+
+@pytest.mark.unit
+def test_only_the_unmatched_entries_are_reported():
+    model = DummyModel()
+    modifier = _modifier(["layer1", "nonexistent_module", "norm"])
+
+    assert get_unmatched_ignore_entries(model, [modifier]) == [
+        ("QuantizationModifier", "nonexistent_module")
+    ]
+
+
+@pytest.mark.unit
+def test_entries_are_reported_per_modifier():
+    model = DummyModel()
+    modifiers = [_modifier(["nonexistent_a"]), _modifier(["layer1", "nonexistent_b"])]
+
+    assert get_unmatched_ignore_entries(model, modifiers) == [
+        ("QuantizationModifier", "nonexistent_a"),
+        ("QuantizationModifier", "nonexistent_b"),
+    ]
+
+
+@pytest.mark.unit
+def test_an_empty_recipe_reports_nothing():
+    model = DummyModel()
+
+    assert get_unmatched_ignore_entries(model, []) == []
+    assert get_unmatched_ignore_entries(model, [_modifier([])]) == []
+
+
+@pytest.mark.unit
+def test_warning_names_the_entry_and_the_modifier(warning_logs):
+    model = DummyModel()
+    modifier = _modifier(["layer1", "nonexistent_module"])
+
+    warn_on_unmatched_ignore_entries(model, [modifier])
+
+    assert len(warning_logs) == 1
+    assert "nonexistent_module" in warning_logs[0]
+    assert "QuantizationModifier" in warning_logs[0]
+    # the entry which did match is not mentioned
+    assert "layer1" not in warning_logs[0]
+
+
+@pytest.mark.unit
+def test_a_fully_matching_recipe_warns_not_at_all(warning_logs):
+    model = DummyModel()
+    modifier = _modifier(["layer1", "layer2"])
+
+    warn_on_unmatched_ignore_entries(model, [modifier])
+
+    assert warning_logs == []
+
+
+@pytest.fixture
+def session_with_recipe():
+    """Install a recipe on the active session, and restore it afterwards."""
+
+    def install(modifiers):
+        active_session().lifecycle.recipe = Recipe(modifiers=modifiers)
+
+    previous = active_session().lifecycle.recipe
+    yield install
+    active_session().lifecycle.recipe = previous
+
+
+def _save_and_reload(model, save_path):
+    modify_save_pretrained(model)
+    model.save_pretrained(save_path, safe_serialization=True)
+    return AutoModelForCausalLM.from_pretrained(save_path)
+
+
+@pytest.mark.integration
+def test_save_warns_on_unmatched_ignore_entry(
+    tmp_path, warning_logs, session_with_recipe
+):
+    """The entry is reported at save, and the checkpoint is otherwise unchanged."""
+    model = AutoModelForCausalLM.from_pretrained(TINY_MODEL, dtype=torch.float32)
+    session_with_recipe([_modifier(["re:.*nonexistent_layer.*"])])
+
+    reloaded = _save_and_reload(model, tmp_path / "save_path")
+
+    assert sum("nonexistent_layer" in log for log in warning_logs) == 1
+
+    # the checkpoint is unchanged: warning only, nothing about the save differs
+    model_dict = get_state_dict_offloaded_model(model)
+    reloaded_dict = get_state_dict_offloaded_model(reloaded)
+    assert model_dict.keys() == reloaded_dict.keys()
+    for key in model_dict:
+        assert torch.equal(model_dict[key].cpu(), reloaded_dict[key].cpu())
+
+
+@pytest.mark.integration
+def test_save_does_not_warn_when_ignore_entries_match(
+    tmp_path, warning_logs, session_with_recipe
+):
+    model = AutoModelForCausalLM.from_pretrained(TINY_MODEL, dtype=torch.float32)
+    session_with_recipe([_modifier(["re:.*lm_head.*", "LlamaRMSNorm"])])
+
+    _save_and_reload(model, tmp_path / "save_path")
+
+    assert [log for log in warning_logs if "matched no module" in log] == []


### PR DESCRIPTION
SUMMARY:

`save_pretrained_wrapper()` writes two descriptions of the same run: the resolved quantization config, via `compressor.update_config()`, and the recipe itself, via `update_and_save_recipe()`. Nothing checks that the recipe's entries correspond to anything in the model at the moment they are written.

An `ignore` entry that matches no module is the case where those two descriptions can drift apart quietly. Nothing about it is incorrect today — the configuration is applied exactly as written, and the checkpoint is a faithful record of what was resolved — but the author's intent and the resolved configuration have diverged, and the checkpoint that ships carries the recipe saying one thing and the config saying another. A stale entry is easy to produce: a module renamed upstream, a regex written against an older layer naming, a recipe copied between checkpoints or between model families.

Export is the last point at which that is still cheap to see. After the write, the entry is in the saved recipe and the resolved configuration is in `config.json`, and reconciling them is the consumer's problem.

This adds `warn_on_unmatched_ignore_entries()` and calls it from `save_pretrained_wrapper()` before anything is written. `modifiers/quantization/group_size_validation.py` is the existing precedent for validating a recipe against the model it will be applied to; this is the same kind of check at a different moment, and unlike that one it only warns.

**On the cost of this, stated plainly:** it puts a check on the user-facing export path, so it can surface a new warning on checkpoints that build cleanly today. That is a real cost and I would rather name it than have you find it. What it does not do: it does not raise, does not change what is written, does not change any resolved configuration, and does not gate the save. It changes what a producer *says*, not what it produces.

**Scope — only `ignore` is checked.** Unmatched `targets` already surface: `apply_quantization_config` calls `match_named_modules(..., warn_on_fail=True)`, which warns per unmatched target at initialize. `ignore` in that same signature is consumed by `is_match()` and has no equivalent, so an entry matching nothing is silent everywhere. Checking targets here too would duplicate a warning that already exists, so it does not.

Two smaller decisions:

- **Gated on `is_source_process()`**, so a distributed save reports each entry once rather than once per rank.
- **Only module names and classes are examined**, no parameters, so this does not onload an offloaded model. An entry also stops being tested once it has matched, so the work is bounded by the entries that will be reported.

TEST PLAN:

New `tests/llmcompressor/transformers/compression/test_recipe_validation.py`:

- unit: an entry matching nothing is reported; entries matching by name, by regex and by module class are not; only the unmatched subset is reported out of a mixed list; entries are attributed per modifier; an empty recipe reports nothing; the warning names both the entry and the modifier and does not mention entries that matched.
- integration: saving a model whose recipe carries one non-matching `ignore` entry emits the warning exactly once, **and the checkpoint is otherwise unchanged** — reloaded state dict compared key-by-key and tensor-by-tensor against the model. Saving with `ignore` entries that all match emits no such warning.

Verified the integration test fails without the call site in `save_pretrained_wrapper()` and passes with it, so the wiring is covered and not just the helper.

Locally, on a CPU-only host: `make quality` clean. `pytest tests/llmcompressor/transformers/compression` → 27 passed, 29 skipped. `pytest tests/llmcompressor --ignore tests/llmcompressor/transformers` → 465 passed, 75 skipped, 0 failed. (`tests/llmcompressor/modifiers/quantization/test_handling_shared_embeddings.py` calls `get_accelerator_type()` at module scope and cannot be collected without an accelerator; that is unrelated to this change and was excluded from the run.)

---

*Disclosure: this change was written with AI assistance. I have read and understand every line, and I am responsible for it.*
