### PR TITLE
[Tests] Fix ddp smoke tests

### DIFF
--- a/src/llmcompressor/datasets/utils.py
+++ b/src/llmcompressor/datasets/utils.py
@@ -12,6 +12,7 @@ from collections.abc import Iterator, Sized
 from typing import Any, Callable, Optional
 
 import torch
+from compressed_tensors.distributed import is_distributed
 from datasets import Dataset
 from loguru import logger
 from torch import distributed as dist
@@ -223,7 +224,7 @@ def _make_collate_fn(args: DatasetArguments, processor: Processor) -> Callable:
 
 
 def _is_dist_and_same_ds(dataset: Dataset) -> bool:
-    if not dist.is_initialized():
+    if not is_distributed():
         return False
 
     assert len(dataset) > 0, (

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -29,6 +29,8 @@ from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from llmcompressor import oneshot
+from llmcompressor.args.dataset_arguments import DatasetArguments
+from llmcompressor.datasets.utils import get_calibration_dataloader, get_rank_partition
 from llmcompressor.modifiers.autoround import AutoRoundModifier
 from llmcompressor.modifiers.gptq import GPTQModifier
 from llmcompressor.modifiers.quantization import QuantizationModifier
@@ -49,23 +51,11 @@ MAX_SEQ_LENGTH = 512
 
 def _make_eval_dataset(model_id: str, num_samples: int = 5):
     """Create a small tokenized dataset for output comparison (not calibration)."""
-    from datasets import Dataset
-
     tok = AutoTokenizer.from_pretrained(model_id)
-    if tok.chat_template is None:
-        tok.chat_template = (
-            "{% for message in messages %}{{ message['content'] }}{% endfor %}"
-        )
-    prompts = [f"Question {i}: Explain briefly." for i in range(num_samples)]
-    ds = Dataset.from_dict({"text": prompts})
-    ds = ds.map(
-        lambda s: tok(
-            s["text"], padding=False, max_length=MAX_SEQ_LENGTH, truncation=True
-        ),
-        remove_columns=ds.column_names,
+    return get_calibration_dataloader(
+        DatasetArguments(dataset="perfectblend", splits=f"train[:{num_samples}]"),
+        processor=tok,
     )
-    ds.set_format("torch")
-    return ds
 
 
 def _run_single_gpu(
@@ -155,16 +145,9 @@ def _compare_outputs(ref_model, ddp_model, dataset, num_samples: int = 5):
     top1_total = 0
 
     with torch.no_grad():
-        for i in range(min(num_samples, len(dataset))):
-            sample = dataset[i]
-            inputs = {
-                k: v.unsqueeze(0).to("cuda:0")
-                for k, v in sample.items()
-                if k == "input_ids"
-            }
-
-            ref_out = ref_model(**inputs).logits[0].float().cpu()
-            ddp_out = ddp_model(**inputs).logits[0].float().cpu()
+        for sample in dataset:
+            ref_out = ref_model(**sample).logits[0].float().cpu()
+            ddp_out = ddp_model(**sample).logits[0].float().cpu()
 
             ref_log_probs = torch.nn.functional.log_softmax(ref_out, dim=-1)
             ddp_log_probs = torch.nn.functional.log_softmax(ddp_out, dim=-1)
@@ -257,7 +240,7 @@ def _test_ddp_modifier(
     oneshot(
         model=model,
         dataset="perfectblend",
-        splits=f"train[:{NUM_SAMPLES}]",
+        splits=get_rank_partition("train", NUM_SAMPLES),
         recipe=recipe_factory(),
         num_calibration_samples=NUM_SAMPLES,
         max_seq_length=MAX_SEQ_LENGTH,
@@ -412,8 +395,8 @@ def test_ddp_smoke_mse_cpu_offload():
         "independent",
         "cpu",
         weight_atol=1e-5,
-        min_top1_match=0.85,
-        max_kl_div=0.005,
+        min_top1_match=1.00,
+        max_kl_div=0.00,
     )
 
 
@@ -437,8 +420,8 @@ def test_ddp_smoke_rtn_disk_offload():
         "independent",
         "disk",
         weight_atol=1e-5,
-        min_top1_match=0.85,
-        max_kl_div=0.005,
+        min_top1_match=1.00,
+        max_kl_div=0.00,
         offload_folder=offload_folder,
     )
 
@@ -459,9 +442,9 @@ def test_ddp_smoke_awq():
         ],
         "independent",
         None,
-        weight_atol=5e-1,
-        min_top1_match=0.80,
-        max_kl_div=0.01,
+        weight_atol=5e-2,
+        min_top1_match=0.85,
+        max_kl_div=0.001,
     )
 
 
@@ -480,8 +463,8 @@ def test_ddp_smoke_gptq():
         "independent",
         None,
         weight_atol=1e-1,
-        min_top1_match=0.70,
-        max_kl_div=0.01,
+        min_top1_match=0.95,
+        max_kl_div=0.001,
     )
 
 
@@ -500,6 +483,6 @@ def test_ddp_smoke_autoround():
         "independent",
         None,
         weight_atol=1e-1,
-        min_top1_match=0.70,
-        max_kl_div=0.02,
+        min_top1_match=0.85,
+        max_kl_div=0.01,
     )

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -97,7 +97,7 @@ def _run_single_gpu(
     oneshot(
         model=model,
         dataset="perfectblend",
-        splits="train[:512]",
+        splits=f"train[:{num_samples}]",
         recipe=recipe,
         num_calibration_samples=num_samples,
         max_seq_length=MAX_SEQ_LENGTH,
@@ -257,7 +257,7 @@ def _test_ddp_modifier(
     oneshot(
         model=model,
         dataset="perfectblend",
-        splits="train[:512]",
+        splits=f"train[:{NUM_SAMPLES}]",
         recipe=recipe_factory(),
         num_calibration_samples=NUM_SAMPLES,
         max_seq_length=MAX_SEQ_LENGTH,
@@ -412,8 +412,8 @@ def test_ddp_smoke_mse_cpu_offload():
         "independent",
         "cpu",
         weight_atol=1e-5,
-        min_top1_match=1.00,
-        max_kl_div=0.00,
+        min_top1_match=0.85,
+        max_kl_div=0.005,
     )
 
 
@@ -437,8 +437,8 @@ def test_ddp_smoke_rtn_disk_offload():
         "independent",
         "disk",
         weight_atol=1e-5,
-        min_top1_match=1.00,
-        max_kl_div=0.00,
+        min_top1_match=0.85,
+        max_kl_div=0.005,
         offload_folder=offload_folder,
     )
 
@@ -459,9 +459,9 @@ def test_ddp_smoke_awq():
         ],
         "independent",
         None,
-        weight_atol=5e-2,
-        min_top1_match=0.85,
-        max_kl_div=0.001,
+        weight_atol=5e-1,
+        min_top1_match=0.80,
+        max_kl_div=0.01,
     )
 
 
@@ -480,8 +480,8 @@ def test_ddp_smoke_gptq():
         "independent",
         None,
         weight_atol=1e-1,
-        min_top1_match=0.95,
-        max_kl_div=0.001,
+        min_top1_match=0.70,
+        max_kl_div=0.01,
     )
 
 
@@ -500,6 +500,6 @@ def test_ddp_smoke_autoround():
         "independent",
         None,
         weight_atol=1e-1,
-        min_top1_match=0.85,
-        max_kl_div=0.01,
+        min_top1_match=0.70,
+        max_kl_div=0.02,
     )

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -101,6 +101,7 @@ def _run_single_gpu(
         recipe=recipe,
         num_calibration_samples=num_samples,
         max_seq_length=MAX_SEQ_LENGTH,
+        shuffle_calibration_samples=False,
     )
 
     # Extract quantized weights (exclude common ignored parameters)
@@ -261,6 +262,7 @@ def _test_ddp_modifier(
         num_calibration_samples=NUM_SAMPLES,
         max_seq_length=MAX_SEQ_LENGTH,
         pipeline=pipeline,
+        shuffle_calibration_samples=False,
     )
 
     # Extract DDP weights (exclude common ignored parameters)

--- a/tests/llmcompressor/transformers/compression/test_compression_ddp.py
+++ b/tests/llmcompressor/transformers/compression/test_compression_ddp.py
@@ -483,6 +483,6 @@ def test_ddp_smoke_autoround():
         "independent",
         None,
         weight_atol=1e-1,
-        min_top1_match=0.85,
+        min_top1_match=0.80,
         max_kl_div=0.01,
     )


### PR DESCRIPTION
## Purpose

Fix the multi-GPU DDP compression smoke tests (`test_compression_ddp.py`), which were failing when comparing DDP compression against a single-GPU reference.

## Root cause

The tests compare weights/outputs of a DDP run against a single-GPU run of the same recipe. After the switch to the prebaked `perfectblend` dataset (#3063), the single-GPU run started calibrating on half as many samples as before due to an unexpected interaction between `_is_dist_and_same_ds` and the test setup.

The bug occurs in how the dataset was being truncated for the test
* Before, the dataset was truncated **outside** of oneshot using **`get_rank_partition`**
* After, the dataset was truncated **inside** of oneshot using **`_is_dist_and_same_ds` + `_get_partition_start_end`**

The difference is that `get_rank_partition` checks `compressed_tensors.distributed::is_distributed()`, while `_is_dist_and_same_ds` checks `torch.distributed.is_initialized()`. For this test, the former would return `False` (since `init_dist()` hadn't been called yet) while the later would return `True`.

This means that the dataset was unintentionally truncated as if it were DDP, despite being called in the single-GPU run, thus leading to a divergence.

## Changes
* Fix `_is_dist_and_same_ds` to use `is_distributed` as source of truth
* Use `get_rank_partition` when loading ddp datasets (I'm not fully sure why, but the models diverge if you rely on the `_make_sampler` logic
* Relax the bounds for autoround: I believe that this is purely due to numerical differences between ultrachat and perfect blend. I do not know the true root cause.
* Unrelated but useful
  * Add `shuffle_calibration_samples=False` for better reproducability 
  * Use perfect blend for KL-divergence evaluation dataset (previously it was static tokens)

## Testing
`pytest tests/llmcompressor/transformers/compression/test_compression_ddp.py` — all 7 tests pass on a 2×A100 node.