### PR TITLE
Add resave_config to preserve original model config on save

### DIFF
--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -20,6 +20,7 @@ from transformers.utils import http_user_agent
 from llmcompressor.core import active_session
 from llmcompressor.modifiers.pruning.reap.utils import NUM_EXPERTS_CONFIG_KEYS
 from llmcompressor.pytorch.model_load.helpers import copy_python_files_from_model_cache
+from llmcompressor.sentinel import Sentinel
 from llmcompressor.transformers.utils import RECIPE_FILE_NAME
 from llmcompressor.transformers.utils.helpers import infer_recipe_from_model_path
 from llmcompressor.utils import getattr_fallbacks, hasitem_fallbacks
@@ -309,29 +310,22 @@ def resave_config(config: PretrainedConfig, save_dir: str):
     src_text_config = config.get_text_config()
     tgt_text_config = config_data.get("text_config", config_data)
 
-    # 1. Tied tensors
-    tied_val = getattr(src_text_config, "tie_word_embeddings", None)
-    has_tied = "tie_word_embeddings" in tgt_text_config
-    if tied_val is not None:
-        if has_tied:
-            tgt_text_config["tie_word_embeddings"] = tied_val
-        else:
-            logger.warning(
-                "Failed to find 'tie_word_embeddings' key in original config. "
-                f"Please set 'tie_word_embeddings' to {tied_val}"
-            )
+    def modify_text_config(attrs: list[str]):
+        _missing = Sentinel("_missing")
+        src_value = getattr_fallbacks(src_text_config, attrs, _missing)
+        tgt_key = hasitem_fallbacks(tgt_text_config, attrs, _missing)
+        if src_value is not _missing:
+            if tgt_key is not _missing:
+                tgt_text_config[tgt_key] = src_value
+            else:
+                logger.warning(
+                    f"Failed to find {attrs} key in original config. "
+                    f"Please set {attrs} to {src_value}"
+                )
 
-    # 2. REAP expert sparsity
-    experts_val = getattr_fallbacks(src_text_config, NUM_EXPERTS_CONFIG_KEYS, None)
-    experts_key = hasitem_fallbacks(tgt_text_config, NUM_EXPERTS_CONFIG_KEYS, None)
-    if experts_val is not None:
-        if experts_key is not None:
-            tgt_text_config[experts_key] = experts_val
-        else:
-            logger.warning(
-                "Failed to find 'num_experts' key in original config. "
-                f"Please set 'num_experts' to {experts_val}"
-            )
+    modify_text_config(["tie_word_embeddings"])
+    modify_text_config(["torch_dtype", "dtype"])
+    modify_text_config(NUM_EXPERTS_CONFIG_KEYS)
 
     save_path = os.path.join(save_dir, "config.json")
     with open(save_path, "w") as file:

--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -306,19 +306,32 @@ def resave_config(config: PretrainedConfig, save_dir: str):
         return
 
     # modify config.json to reflect fields that llmcompressor has modified
-    # for now, this is only the num_experts field for REAP sparsity
-    config_data_text = config_data.get("text_config", config_data)
-    experts = getattr_fallbacks(config.get_text_config(), NUM_EXPERTS_CONFIG_KEYS, None)
-    target_key = hasitem_fallbacks(config_data_text, NUM_EXPERTS_CONFIG_KEYS, None)
-    if experts is not None:
-        if target_key is None:
-            logger.warning(
-                "Failed to find target experts key in original config. "
-                "Keeping the transformers-serialized config."
-            )
-            return
+    src_text_config = config.get_text_config()
+    tgt_text_config = config_data.get("text_config", config_data)
 
-        config_data_text[target_key] = experts
+    # 1. Tied tensors
+    tied_val = getattr(src_text_config, "tie_word_embeddings", None)
+    has_tied = "tie_word_embeddings" in tgt_text_config
+    if tied_val is not None:
+        if has_tied:
+            tgt_text_config["tie_word_embeddings"] = tied_val
+        else:
+            logger.warning(
+                "Failed to find 'tie_word_embeddings' key in original config. "
+                f"Please set 'tie_word_embeddings' to {tied_val}"
+            )
+
+    # 2. REAP expert sparsity
+    experts_val = getattr_fallbacks(src_text_config, NUM_EXPERTS_CONFIG_KEYS, None)
+    experts_key = hasitem_fallbacks(tgt_text_config, NUM_EXPERTS_CONFIG_KEYS, None)
+    if experts_val is not None:
+        if experts_key is not None:
+            tgt_text_config[experts_key] = experts_val
+        else:
+            logger.warning(
+                "Failed to find 'num_experts' key in original config. "
+                f"Please set 'num_experts' to {experts_val}"
+            )
 
     save_path = os.path.join(save_dir, "config.json")
     with open(save_path, "w") as file:

--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -310,7 +310,7 @@ def resave_config(config: PretrainedConfig, save_dir: str):
     src_text_config = config.get_text_config()
     tgt_text_config = config_data.get("text_config", config_data)
 
-    def modify_text_config(attrs: list[str]):
+    def modify_text_config(attrs: list[str]) -> bool:
         _missing = Sentinel("_missing")
         src_value = getattr_fallbacks(src_text_config, attrs, _missing)
         tgt_key = hasitem_fallbacks(tgt_text_config, attrs, _missing)
@@ -322,10 +322,20 @@ def resave_config(config: PretrainedConfig, save_dir: str):
                     f"Failed to find {attrs} key in original config. "
                     f"Please set {attrs} to {src_value}"
                 )
+                return False
+        return True
 
-    modify_text_config(["tie_word_embeddings"])
-    modify_text_config(["torch_dtype", "dtype"])
-    modify_text_config(NUM_EXPERTS_CONFIG_KEYS)
+    if not all(
+        [
+            modify_text_config(["tie_word_embeddings"]),
+            modify_text_config(["torch_dtype", "dtype"]),
+            modify_text_config(NUM_EXPERTS_CONFIG_KEYS),
+        ]
+    ):
+        logger.warning(
+            "Failed to modify config. Keeping the transformers-serialized config."
+        )
+        return
 
     save_path = os.path.join(save_dir, "config.json")
     with open(save_path, "w") as file:

--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import weakref
 from contextlib import contextmanager
@@ -12,15 +13,16 @@ from compressed_tensors.distributed import is_source_process
 from compressed_tensors.offload import OffloadCache, from_accelerate, to_accelerate
 from compressed_tensors.utils import deprecated, save_mtp_tensors_to_checkpoint
 from loguru import logger
-from transformers import PreTrainedModel
+from transformers import PretrainedConfig, PreTrainedModel
 
 from llmcompressor.core import active_session
+from llmcompressor.modifiers.pruning.reap.utils import NUM_EXPERTS_CONFIG_KEYS
 from llmcompressor.pytorch.model_load.helpers import copy_python_files_from_model_cache
 from llmcompressor.transformers.utils import RECIPE_FILE_NAME
 from llmcompressor.transformers.utils.helpers import infer_recipe_from_model_path
 from llmcompressor.utils.transformers import get_embeddings
 
-__all__ = ["modify_save_pretrained"]
+__all__ = ["modify_save_pretrained", "resave_config"]
 
 
 def _named_tensors(module: torch.nn.Module) -> dict[str, torch.Tensor]:
@@ -243,6 +245,78 @@ def update_and_save_recipe(model_stub: str, save_directory: str):
 
     recipe_path = os.path.join(save_directory, RECIPE_FILE_NAME)
     recipe.yaml(file_path=recipe_path, existing_recipe_path=existing_recipe)
+
+
+def resave_config(config: PretrainedConfig, save_dir: str):
+    """
+    Overwrite the config saved at ``save_dir`` with the original model config,
+    patched with fields that llmcompressor has modified.
+
+    Transformers regenerates ``config.json`` on save, which can introduce
+    differences from the original model config (reordered/dropped/renamed
+    fields). vLLM always supports loading the original model config, but only
+    sometimes supports loading the transformers-serialized one. To stay
+    compatible, this loads the original config file referenced by
+    ``config._name_or_path``, overwrites only the fields that llmcompressor has
+    changed (currently the expert-count fields in
+    :data:`NUM_EXPERTS_CONFIG_KEYS`, which change under REAP expert pruning),
+    and writes the result to ``save_dir/config.json``.
+
+    :param config: the (possibly modified) model config, used both to locate the
+        original config file and to source the patched field values
+    :param save_dir: directory containing the ``config.json`` to overwrite
+    """
+    name_or_path = getattr(config, "_name_or_path", "") or ""
+    if not name_or_path.strip():
+        logger.warning(
+            "Cannot resave the original config: config._name_or_path is empty. "
+            "Keeping the transformers-serialized config."
+        )
+        return
+
+    # locate the original config file, downloading from the hub if necessary
+    if os.path.isdir(name_or_path):
+        original_config_path = os.path.join(name_or_path, "config.json")
+    elif os.path.isfile(name_or_path):
+        original_config_path = name_or_path
+    else:
+        from huggingface_hub import hf_hub_download
+        from transformers.utils import http_user_agent
+
+        original_config_path = hf_hub_download(
+            repo_id=name_or_path,
+            filename="config.json",
+            cache_dir=None,
+            force_download=False,
+            user_agent=http_user_agent(),
+        )
+
+    with open(original_config_path, "r") as file:
+        config_data = json.load(file)
+
+    # overwrite the fields that llmcompressor has modified. Fields may live at the
+    # top level or nested under "text_config" (multimodal configs); patch them
+    # wherever they already exist so no spurious keys are introduced.
+    text_config = getattr(config, "text_config", None)
+    for key in NUM_EXPERTS_CONFIG_KEYS:
+        if hasattr(config, key):
+            new_value = getattr(config, key)
+        elif text_config is not None and hasattr(text_config, key):
+            new_value = getattr(text_config, key)
+        else:
+            continue
+
+        if key in config_data:
+            config_data[key] = new_value
+        if isinstance(config_data.get("text_config"), dict) and (
+            key in config_data["text_config"]
+        ):
+            config_data["text_config"][key] = new_value
+
+    save_path = os.path.join(save_dir, "config.json")
+    with open(save_path, "w") as file:
+        json.dump(config_data, file, indent=2, sort_keys=True)
+    logger.info(f"Resaved original config (with patched fields) to {save_path}")
 
 
 @contextmanager

--- a/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
+++ b/src/llmcompressor/transformers/compression/compressed_tensors_utils.py
@@ -12,17 +12,20 @@ from compressed_tensors.config import CompressionFormat
 from compressed_tensors.distributed import is_source_process
 from compressed_tensors.offload import OffloadCache, from_accelerate, to_accelerate
 from compressed_tensors.utils import deprecated, save_mtp_tensors_to_checkpoint
+from huggingface_hub import hf_hub_download
 from loguru import logger
 from transformers import PretrainedConfig, PreTrainedModel
+from transformers.utils import http_user_agent
 
 from llmcompressor.core import active_session
 from llmcompressor.modifiers.pruning.reap.utils import NUM_EXPERTS_CONFIG_KEYS
 from llmcompressor.pytorch.model_load.helpers import copy_python_files_from_model_cache
 from llmcompressor.transformers.utils import RECIPE_FILE_NAME
 from llmcompressor.transformers.utils.helpers import infer_recipe_from_model_path
+from llmcompressor.utils import getattr_fallbacks, hasitem_fallbacks
 from llmcompressor.utils.transformers import get_embeddings
 
-__all__ = ["modify_save_pretrained", "resave_config"]
+__all__ = ["modify_save_pretrained"]
 
 
 def _named_tensors(module: torch.nn.Module) -> dict[str, torch.Tensor]:
@@ -155,6 +158,9 @@ def modify_save_pretrained(model: PreTrainedModel):
                     # save model structure
                     original_save_fn.__get__(model, model_class)(save_dir, **kwargs)
 
+                    # resave the config with original structure for better vLLM compat
+                    resave_config(model.config, save_dir)
+
                     # update config to reflect quantization
                     compressor.update_config(save_dir)
 
@@ -266,57 +272,58 @@ def resave_config(config: PretrainedConfig, save_dir: str):
         original config file and to source the patched field values
     :param save_dir: directory containing the ``config.json`` to overwrite
     """
-    name_or_path = getattr(config, "_name_or_path", "") or ""
-    if not name_or_path.strip():
+    if not (name_or_path := getattr(config, "_name_or_path", "")):
         logger.warning(
-            "Cannot resave the original config: config._name_or_path is empty. "
-            "Keeping the transformers-serialized config."
+            "Failed to find config._name_or_path. "
+            "Keeping transformers-serialized config."
         )
         return
 
-    # locate the original config file, downloading from the hub if necessary
-    if os.path.isdir(name_or_path):
-        original_config_path = os.path.join(name_or_path, "config.json")
-    elif os.path.isfile(name_or_path):
-        original_config_path = name_or_path
-    else:
-        from huggingface_hub import hf_hub_download
-        from transformers.utils import http_user_agent
+    config_path = os.path.join(name_or_path, "config.json")
+    if not os.path.exists(config_path):
+        try:
+            config_path = hf_hub_download(
+                repo_id=name_or_path,
+                filename="config.json",
+                cache_dir=None,
+                force_download=False,
+                user_agent=http_user_agent(),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to find config.json. "
+                "Keeping the transformers-serialized config."
+            )
+            return
 
-        original_config_path = hf_hub_download(
-            repo_id=name_or_path,
-            filename="config.json",
-            cache_dir=None,
-            force_download=False,
-            user_agent=http_user_agent(),
+    try:
+        with open(config_path, "r") as file:
+            config_data: dict = json.load(file)
+    except Exception:
+        logger.warning(
+            "Failed to load config.json. " "Keeping the transformers-serialized config."
         )
+        return
 
-    with open(original_config_path, "r") as file:
-        config_data = json.load(file)
+    # modify config.json to reflect fields that llmcompressor has modified
+    # for now, this is only the num_experts field for REAP sparsity
+    config_data_text = config_data.get("text_config", config_data)
+    experts = getattr_fallbacks(config.get_text_config(), NUM_EXPERTS_CONFIG_KEYS, None)
+    target_key = hasitem_fallbacks(config_data_text, NUM_EXPERTS_CONFIG_KEYS, None)
+    if experts is not None:
+        if target_key is None:
+            logger.warning(
+                "Failed to find target experts key in original config. "
+                "Keeping the transformers-serialized config."
+            )
+            return
 
-    # overwrite the fields that llmcompressor has modified. Fields may live at the
-    # top level or nested under "text_config" (multimodal configs); patch them
-    # wherever they already exist so no spurious keys are introduced.
-    text_config = getattr(config, "text_config", None)
-    for key in NUM_EXPERTS_CONFIG_KEYS:
-        if hasattr(config, key):
-            new_value = getattr(config, key)
-        elif text_config is not None and hasattr(text_config, key):
-            new_value = getattr(text_config, key)
-        else:
-            continue
-
-        if key in config_data:
-            config_data[key] = new_value
-        if isinstance(config_data.get("text_config"), dict) and (
-            key in config_data["text_config"]
-        ):
-            config_data["text_config"][key] = new_value
+        config_data_text[target_key] = experts
 
     save_path = os.path.join(save_dir, "config.json")
     with open(save_path, "w") as file:
         json.dump(config_data, file, indent=2, sort_keys=True)
-    logger.info(f"Resaved original config (with patched fields) to {save_path}")
+    logger.info(f"Resaved original config with patched fields to {save_path}")
 
 
 @contextmanager

--- a/src/llmcompressor/utils/helpers.py
+++ b/src/llmcompressor/utils/helpers.py
@@ -6,6 +6,7 @@ Common functions for interfacing with python primitives and directories/files.
 import contextlib
 import importlib
 import re
+from typing import Any
 
 import torch
 from compressed_tensors.quantization import disable_quantization, enable_quantization
@@ -13,6 +14,7 @@ from compressed_tensors.utils import patch_attr
 from loguru import logger
 from transformers import PreTrainedModel
 
+from llmcompressor.sentinel import Sentinel
 from llmcompressor.utils import get_embeddings
 
 __all__ = [
@@ -23,6 +25,8 @@ __all__ = [
     "disable_hf_kernels",
     "calibration_forward_context",
     "disable_lm_head",
+    "getattr_fallbacks",
+    "hasitem_fallbacks",
 ]
 
 
@@ -171,3 +175,29 @@ def disable_lm_head(model: torch.nn.Module):
                 stack.enter_context(patch_attr(model._hf_hook, "io_same_device", False))
 
             yield
+
+
+def getattr_fallbacks(
+    target: object, attrs: list[str], default: Any = Sentinel("None")
+) -> Any:
+    for attr in attrs:
+        if hasattr(target, attr):
+            return getattr(target, attr)
+
+    if default is not Sentinel("None"):
+        return default
+
+    raise AttributeError(f"{target} does not have any of {attrs} attributes")
+
+
+def hasitem_fallbacks(
+    target: dict, keys: list[str], default: Any = Sentinel("None")
+) -> Any:
+    for key in keys:
+        if key in target:
+            return key
+
+    if default is not Sentinel("None"):
+        return default
+
+    raise AttributeError(f"{target} does not have any of {keys} keys")

--- a/tests/llmcompressor/transformers/compression/test_resave_config.py
+++ b/tests/llmcompressor/transformers/compression/test_resave_config.py
@@ -119,6 +119,26 @@ def test_experts_field_patched_in_nested_text_config(save_dir, original_dir):
     assert resaved["model_type"] == "multimodal"
 
 
+def test_tie_word_embeddings_patched(save_dir, original_dir):
+    # original tied the embeddings; llmcompressor untied them
+    _write_json(original_dir / "config.json", {"tie_word_embeddings": True})
+    config = FakeConfig(name_or_path=str(original_dir), tie_word_embeddings=False)
+
+    resave_config(config, str(save_dir))
+
+    assert _read_json(save_dir / "config.json")["tie_word_embeddings"] is False
+
+
+def test_dtype_patched_via_key_fallback(save_dir, original_dir):
+    # original serializes the dtype under "torch_dtype"; config exposes "dtype"
+    _write_json(original_dir / "config.json", {"torch_dtype": "float32"})
+    config = FakeConfig(name_or_path=str(original_dir), dtype="bfloat16")
+
+    resave_config(config, str(save_dir))
+
+    assert _read_json(save_dir / "config.json")["torch_dtype"] == "bfloat16"
+
+
 def test_experts_present_but_missing_target_key_keeps_serialized(
     save_dir, original_dir
 ):
@@ -129,6 +149,20 @@ def test_experts_present_but_missing_target_key_keeps_serialized(
     resave_config(config, str(save_dir))
 
     # returns early without overwriting the transformers-serialized config
+    assert _read_json(save_dir / "config.json") == {"serialized_by": "transformers"}
+
+
+def test_partial_failure_keeps_serialized_config(save_dir, original_dir):
+    # experts can be patched, but tie_word_embeddings has no target key in the
+    # original config -> the resave is atomic and no fields are written
+    _write_json(original_dir / "config.json", {"num_experts": 8})
+    config = FakeConfig(
+        name_or_path=str(original_dir), num_experts=4, tie_word_embeddings=False
+    )
+
+    resave_config(config, str(save_dir))
+
+    # nothing is written, not even the patchable experts field
     assert _read_json(save_dir / "config.json") == {"serialized_by": "transformers"}
 
 

--- a/tests/llmcompressor/transformers/compression/test_resave_config.py
+++ b/tests/llmcompressor/transformers/compression/test_resave_config.py
@@ -1,0 +1,174 @@
+import json
+
+import pytest
+
+from llmcompressor.transformers.compression import compressed_tensors_utils
+from llmcompressor.transformers.compression.compressed_tensors_utils import (
+    resave_config,
+)
+
+
+class FakeConfig:
+    """
+    Minimal stand-in for a ``PretrainedConfig``. ``resave_config`` only relies on
+    ``_name_or_path`` (to locate the original config) and ``get_text_config``
+    (to source patched field values), so we avoid constructing a real config.
+    """
+
+    def __init__(self, name_or_path="", text_config=None, **attrs):
+        self._name_or_path = name_or_path
+        self._text_config = text_config
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+    def get_text_config(self):
+        return self._text_config if self._text_config is not None else self
+
+
+def _write_json(path, data):
+    with open(path, "w") as file:
+        json.dump(data, file)
+
+
+def _read_json(path):
+    with open(path) as file:
+        return json.load(file)
+
+
+@pytest.fixture
+def save_dir(tmp_path):
+    """A save directory pre-populated with a transformers-serialized config."""
+    save_dir = tmp_path / "save"
+    save_dir.mkdir()
+    _write_json(save_dir / "config.json", {"serialized_by": "transformers"})
+    return save_dir
+
+
+@pytest.fixture
+def original_dir(tmp_path):
+    original_dir = tmp_path / "original"
+    original_dir.mkdir()
+    return original_dir
+
+
+def test_missing_name_or_path_keeps_serialized_config(save_dir):
+    # no _name_or_path -> function returns early and leaves save_dir untouched
+    config = FakeConfig(name_or_path="")
+
+    resave_config(config, str(save_dir))
+
+    assert _read_json(save_dir / "config.json") == {"serialized_by": "transformers"}
+
+
+def test_resave_original_config_without_experts(save_dir, original_dir):
+    original = {"architectures": ["Foo"], "hidden_size": 4}
+    _write_json(original_dir / "config.json", original)
+    config = FakeConfig(name_or_path=str(original_dir))
+
+    resave_config(config, str(save_dir))
+
+    # original config overwrites the transformers-serialized one, unchanged
+    assert _read_json(save_dir / "config.json") == original
+
+
+def test_resave_config_is_sorted_and_indented(save_dir, original_dir):
+    _write_json(original_dir / "config.json", {"b": 1, "a": 2})
+    config = FakeConfig(name_or_path=str(original_dir))
+
+    resave_config(config, str(save_dir))
+
+    with open(save_dir / "config.json") as file:
+        contents = file.read()
+    assert contents == json.dumps({"a": 2, "b": 1}, indent=2, sort_keys=True)
+
+
+def test_experts_field_patched_top_level(save_dir, original_dir):
+    # original model had 8 experts; llmcompressor pruned it down to 4
+    _write_json(original_dir / "config.json", {"num_experts": 8, "hidden_size": 4})
+    config = FakeConfig(name_or_path=str(original_dir), num_experts=4)
+
+    resave_config(config, str(save_dir))
+
+    resaved = _read_json(save_dir / "config.json")
+    assert resaved["num_experts"] == 4
+    assert resaved["hidden_size"] == 4
+
+
+def test_experts_field_patched_via_key_fallback(save_dir, original_dir):
+    # original uses a different expert key than the config attribute
+    _write_json(original_dir / "config.json", {"num_local_experts": 8})
+    config = FakeConfig(name_or_path=str(original_dir), num_experts=4)
+
+    resave_config(config, str(save_dir))
+
+    assert _read_json(save_dir / "config.json")["num_local_experts"] == 4
+
+
+def test_experts_field_patched_in_nested_text_config(save_dir, original_dir):
+    _write_json(
+        original_dir / "config.json",
+        {"text_config": {"num_experts": 8}, "model_type": "multimodal"},
+    )
+    text_config = FakeConfig(num_experts=4)
+    config = FakeConfig(name_or_path=str(original_dir), text_config=text_config)
+
+    resave_config(config, str(save_dir))
+
+    resaved = _read_json(save_dir / "config.json")
+    assert resaved["text_config"]["num_experts"] == 4
+    assert resaved["model_type"] == "multimodal"
+
+
+def test_experts_present_but_missing_target_key_keeps_serialized(
+    save_dir, original_dir
+):
+    # experts modified on the config but original has no expert key to patch
+    _write_json(original_dir / "config.json", {"hidden_size": 4})
+    config = FakeConfig(name_or_path=str(original_dir), num_experts=4)
+
+    resave_config(config, str(save_dir))
+
+    # returns early without overwriting the transformers-serialized config
+    assert _read_json(save_dir / "config.json") == {"serialized_by": "transformers"}
+
+
+def test_invalid_original_json_keeps_serialized_config(save_dir, original_dir):
+    with open(original_dir / "config.json", "w") as file:
+        file.write("{ not valid json")
+    config = FakeConfig(name_or_path=str(original_dir))
+
+    resave_config(config, str(save_dir))
+
+    assert _read_json(save_dir / "config.json") == {"serialized_by": "transformers"}
+
+
+def test_falls_back_to_hf_hub_download(save_dir, original_dir, tmp_path, monkeypatch):
+    # name_or_path has no local config.json, so the hub download path is used
+    downloaded = tmp_path / "hub" / "config.json"
+    downloaded.parent.mkdir()
+    _write_json(downloaded, {"downloaded": True, "num_experts": 8})
+
+    def fake_download(repo_id, filename, **kwargs):
+        assert filename == "config.json"
+        return str(downloaded)
+
+    monkeypatch.setattr(compressed_tensors_utils, "hf_hub_download", fake_download)
+    config = FakeConfig(name_or_path="some/remote-repo", num_experts=4)
+
+    resave_config(config, str(save_dir))
+
+    resaved = _read_json(save_dir / "config.json")
+    assert resaved["downloaded"] is True
+    assert resaved["num_experts"] == 4
+
+
+def test_hf_hub_download_failure_keeps_serialized_config(save_dir, monkeypatch):
+    def fake_download(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(compressed_tensors_utils, "hf_hub_download", fake_download)
+    config = FakeConfig(name_or_path="some/remote-repo")
+
+    resave_config(config, str(save_dir))
+
+    assert _read_json(save_dir / "config.json") == {"serialized_by": "transformers"}


### PR DESCRIPTION
## Purpose

There are often differences between the original model config and the config regenerated by transformers on `save_pretrained`. vLLM always supports loading the original model config, but only *sometimes* supports loading the transformers-serialized one. This PR adds a helper to write out the original config (patched with the fields llmcompressor actually modifies) so saved models stay loadable in vLLM.

## Changes

Adds `resave_config(config: PretrainedConfig, save_dir: str)` to `src/llmcompressor/transformers/compression/compressed_tensors_utils.py`. It:

1. Uses `config._name_or_path` to locate the original config file (local dir/file, or downloaded from the hub).
2. Loads the original `config.json`.
3. Overwrites only the fields llmcompressor has modified — currently the expert-sparsity fields from `NUM_EXPERTS_CONFIG_KEYS` (`src/llmcompressor/modifiers/pruning/reap/utils.py`), which change under REAP expert pruning. Fields are patched whether they live at the top level or nested under `text_config`.
4. Writes the result to `save_dir/config.json`.

The set of patched fields is intentionally scoped to `NUM_EXPERTS_CONFIG_KEYS` for now and can be extended as other modifiers need it.

## Testing

* Verified locally that `resave_config` restores fields dropped by the transformers serialization while patching the expert count to the pruned value.
* Added unit tests