### PR TITLE
[Tests] Cover dense Qwen3-VL tracing

### DIFF
--- a/tests/llmcompressor/transformers/tracing/test_models.py
+++ b/tests/llmcompressor/transformers/tracing/test_models.py
@@ -11,6 +11,7 @@ from transformers import (
     MllamaForConditionalGeneration,
     Qwen2_5_VLForConditionalGeneration,
     Qwen2VLForConditionalGeneration,
+    Qwen3VLForConditionalGeneration,
     WhisperForConditionalGeneration,
 )
 
@@ -97,6 +98,14 @@ from tests.testing_utils import requires_hf_token
             "Qwen/Qwen2-VL-2B-Instruct",
             Qwen2VLForConditionalGeneration,
             ["Qwen2VLDecoderLayer"],
+            "vision",
+            ["torchvision"],
+        ),
+        # Keep the dense Qwen3-VL vision tower opaque during text-layer tracing.
+        (
+            "Qwen/Qwen3-VL-2B-Instruct",
+            Qwen3VLForConditionalGeneration,
+            ["Qwen3VLTextDecoderLayer"],
             "vision",
             ["torchvision"],
         ),


### PR DESCRIPTION
## Summary

Add dense `Qwen/Qwen3-VL-2B-Instruct` to the sequential tracing model enumeration. The configuration reported in #3071 is not reproducible on current `main`: the autowrapper keeps the non-traceable vision branch opaque while tracing `Qwen3VLTextDecoderLayer` modules. This test locks in that behavior.

No production quantization logic is changed because the reported failure was not reproduced on current `main`; the issue traceback also indicates a possible device/runtime fault rather than a structural tracing failure.

Closes #3071

## Testing

- `uvx --from ruff ruff check tests/llmcompressor/transformers/tracing/test_models.py`
- `uvx --from ruff ruff format --check tests/llmcompressor/transformers/tracing/test_models.py`
- `python3 -m py_compile tests/llmcompressor/transformers/tracing/test_models.py`
- Full Hugging Face tracing test not run locally because this Mac environment lacks pytest, Transformers, model weights, and an HF token.

Related: #3107