### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,29 @@
 # See https://help.github.com/articles/about-codeowners/
 # for more info about CODEOWNERS file
 
-/src/llmcompressor/ @kylesayrs @dsikka @brian-dellabetta @HDCharles
-/src/llmcompressor/args/ @kylesayrs @brian-dellabetta
+/src/llmcompressor/ @kylesayrs @dsikka @HDCharles
+/src/llmcompressor/args/ @kylesayrs
 /src/llmcompressor/core/ @kylesayrs @dsikka
 /src/llmcompressor/core/events/ @kylesayrs @dsikka
-/src/llmcompressor/datasets/ @HDCharles @brian-dellabetta
-/src/llmcompressor/entrypoints/ @kylesayrs @brian-dellabetta @dsikka
-/src/llmcompressor/entrypoints/model_free/ @kylesayrs @brian-dellabetta @dsikka
+/src/llmcompressor/datasets/ @HDCharles
+/src/llmcompressor/entrypoints/ @kylesayrs @dsikka
+/src/llmcompressor/entrypoints/model_free/ @kylesayrs @dsikka
 /src/llmcompressor/modeling/ @dsikka @kylesayrs @yiliu30
 /src/llmcompressor/modeling/deepseekv32/ @dsikka @kylesayrs
 /src/llmcompressor/modeling/moe/ @dsikka @kylesayrs
 /src/llmcompressor/modeling/patch/ @dsikka @kylesayrs
 /src/llmcompressor/observers/ @dsikka @kylesayrs @HDCharles
-/src/llmcompressor/pytorch/ @kylesayrs @brian-dellabetta
-/src/llmcompressor/pytorch/model_load/ @kylesayrs @brian-dellabetta @HDCharles
-/src/llmcompressor/pytorch/utils/ @kylesayrs @brian-dellabetta @HDCharles
-/src/llmcompressor/pytorch/utils/sparsification_info/ @kylesayrs @brian-dellabetta
-/src/llmcompressor/recipe/ @kylesayrs @dsikka @brian-dellabetta
-/src/llmcompressor/utils/ @kylesayrs @HDCharles @brian-dellabetta @yiliu30
-/src/llmcompressor/utils/pytorch/ @kylesayrs @HDCharles @brian-dellabetta @yiliu30
+/src/llmcompressor/pytorch/ @kylesayrs
+/src/llmcompressor/pytorch/model_load/ @kylesayrs @HDCharles
+/src/llmcompressor/pytorch/utils/ @kylesayrs @HDCharles
+/src/llmcompressor/pytorch/utils/sparsification_info/ @kylesayrs
+/src/llmcompressor/recipe/ @kylesayrs @dsikka
+/src/llmcompressor/utils/ @kylesayrs @HDCharles @yiliu30
+/src/llmcompressor/utils/pytorch/ @kylesayrs @HDCharles @yiliu30
 
-/src/llmcompressor/modifiers/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
-/src/llmcompressor/modifiers/autoround/ @yiliu30 @kylesayrs @HDCharles @brian-dellabetta
-/src/llmcompressor/modifiers/awq/ @brian-dellabetta @HDCharles @kylesayrs
+/src/llmcompressor/modifiers/ @kylesayrs @dsikka @HDCharles
+/src/llmcompressor/modifiers/autoround/ @yiliu30 @kylesayrs @HDCharles
+/src/llmcompressor/modifiers/awq/ @HDCharles @kylesayrs
 /src/llmcompressor/modifiers/experimental/ @kylesayrs @HDCharles @dsikka
 /src/llmcompressor/modifiers/logarithmic_equalization/ @kylesayrs @HDCharles
 /src/llmcompressor/modifiers/obcq/ @kylesayrs @HDCharles
@@ -35,17 +35,17 @@
 /src/llmcompressor/modifiers/pruning/utils/ @kylesayrs @HDCharles
 /src/llmcompressor/modifiers/pruning/utils/pytorch/ @kylesayrs @HDCharles
 /src/llmcompressor/modifiers/pruning/wanda/ @kylesayrs @HDCharles
-/src/llmcompressor/modifiers/quantization/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
+/src/llmcompressor/modifiers/quantization/ @kylesayrs @dsikka @HDCharles
 /src/llmcompressor/modifiers/quantization/gptq/ @kylesayrs @HDCharles
 /src/llmcompressor/modifiers/quantization/quantization/ @kylesayrs @HDCharles
 /src/llmcompressor/modifiers/smoothquant/ @kylesayrs @HDCharles
-/src/llmcompressor/modifiers/transform/ @kylesayrs @brian-dellabetta @HDCharles
-/src/llmcompressor/modifiers/transform/awq/ @kylesayrs @brian-dellabetta @HDCharles
-/src/llmcompressor/modifiers/transform/imatrix/ @kylesayrs @brian-dellabetta @HDCharles
-/src/llmcompressor/modifiers/transform/quip/ @kylesayrs @brian-dellabetta @HDCharles
-/src/llmcompressor/modifiers/transform/smoothquant/ @kylesayrs @brian-dellabetta @HDCharles
-/src/llmcompressor/modifiers/transform/spinquant/ @kylesayrs @brian-dellabetta @HDCharles
-/src/llmcompressor/modifiers/transform/utils/ @kylesayrs @brian-dellabetta @HDCharles
+/src/llmcompressor/modifiers/transform/ @kylesayrs @HDCharles
+/src/llmcompressor/modifiers/transform/awq/ @kylesayrs @HDCharles
+/src/llmcompressor/modifiers/transform/imatrix/ @kylesayrs @HDCharles
+/src/llmcompressor/modifiers/transform/quip/ @kylesayrs @HDCharles
+/src/llmcompressor/modifiers/transform/smoothquant/ @kylesayrs @HDCharles
+/src/llmcompressor/modifiers/transform/spinquant/ @kylesayrs @HDCharles
+/src/llmcompressor/modifiers/transform/utils/ @kylesayrs @HDCharles
 /src/llmcompressor/modifiers/utils/ @kylesayrs @dsikka @HDCharles
 /src/llmcompressor/modifiers/gptq/ @kylesayrs @HDCharles
 
@@ -62,50 +62,50 @@
 /src/llmcompressor/pipelines/sequential/ @kylesayrs @dsikka
 /src/llmcompressor/pipelines/sequential/ast_utils/ @kylesayrs @dsikka
 
-/tests/llmcompressor/ @kylesayrs @dsikka @brian-dellabetta @HDCharles
+/tests/llmcompressor/ @kylesayrs @dsikka @HDCharles
 /tests/llmcompressor/core/ @kylesayrs @dsikka
 /tests/llmcompressor/datasets/ @HDCharles @kylesayrs
-/tests/llmcompressor/entrypoints/ @kylesayrs @brian-dellabetta @dsikka
-/tests/llmcompressor/entrypoints/model_free/ @kylesayrs @brian-dellabetta @dsikka
+/tests/llmcompressor/entrypoints/ @kylesayrs @dsikka
+/tests/llmcompressor/entrypoints/model_free/ @kylesayrs @dsikka
 /tests/llmcompressor/modeling/ @dsikka @kylesayrs
 /tests/llmcompressor/observers/ @kylesayrs @HDCharles
 /tests/llmcompressor/recipe/ @kylesayrs @dsikka
-/tests/llmcompressor/utils/ @kylesayrs @brian-dellabetta
+/tests/llmcompressor/utils/ @kylesayrs
 
-/tests/llmcompressor/modifiers/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
-/tests/llmcompressor/modifiers/autoround/ @yiliu30 @kylesayrs @HDCharles @brian-dellabetta
-/tests/llmcompressor/modifiers/calibration/ @kylesayrs @dsikka @brian-dellabetta
+/tests/llmcompressor/modifiers/ @kylesayrs @dsikka @HDCharles
+/tests/llmcompressor/modifiers/autoround/ @yiliu30 @kylesayrs @HDCharles
+/tests/llmcompressor/modifiers/calibration/ @kylesayrs @dsikka
 /tests/llmcompressor/modifiers/gptq/ @kylesayrs @HDCharles
-/tests/llmcompressor/modifiers/logarithmic_equalization/ @kylesayrs @dsikka @brian-dellabetta
-/tests/llmcompressor/modifiers/pruning/ @kylesayrs @dsikka @brian-dellabetta
-/tests/llmcompressor/modifiers/pruning/reap/ @kylesayrs @dsikka @brian-dellabetta
-/tests/llmcompressor/modifiers/quantization/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
-/tests/llmcompressor/modifiers/transform/ @kylesayrs @brian-dellabetta @HDCharles
-/tests/llmcompressor/modifiers/transform/awq/ @kylesayrs @brian-dellabetta @HDCharles
-/tests/llmcompressor/modifiers/transform/imatrix/ @kylesayrs @brian-dellabetta @HDCharles
-/tests/llmcompressor/modifiers/transform/smoothquant/ @kylesayrs @brian-dellabetta @HDCharles
-/tests/llmcompressor/modifiers/utils/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
+/tests/llmcompressor/modifiers/logarithmic_equalization/ @kylesayrs @dsikka
+/tests/llmcompressor/modifiers/pruning/ @kylesayrs @dsikka
+/tests/llmcompressor/modifiers/pruning/reap/ @kylesayrs @dsikka
+/tests/llmcompressor/modifiers/quantization/ @kylesayrs @dsikka @HDCharles
+/tests/llmcompressor/modifiers/transform/ @kylesayrs @HDCharles
+/tests/llmcompressor/modifiers/transform/awq/ @kylesayrs @HDCharles
+/tests/llmcompressor/modifiers/transform/imatrix/ @kylesayrs @HDCharles
+/tests/llmcompressor/modifiers/transform/smoothquant/ @kylesayrs @HDCharles
+/tests/llmcompressor/modifiers/utils/ @kylesayrs @dsikka @HDCharles
 
-/tests/llmcompressor/transformers/ @kylesayrs @dsikka @brian-dellabetta @HDCharles
-/tests/llmcompressor/transformers/autoround/ @yiliu30 @kylesayrs @HDCharles @brian-dellabetta
-/tests/llmcompressor/transformers/compression/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
-/tests/llmcompressor/transformers/compression/configs/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
-/tests/llmcompressor/transformers/compression/decompression_configs/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
-/tests/llmcompressor/transformers/compression/recipes/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
-/tests/llmcompressor/transformers/compression/run_compressed_configs/ @kylesayrs @dsikka @HDCharles @brian-dellabetta
-/tests/llmcompressor/transformers/data/ @kylesayrs @dsikka @brian-dellabetta @HDCharles
+/tests/llmcompressor/transformers/ @kylesayrs @dsikka @HDCharles
+/tests/llmcompressor/transformers/autoround/ @yiliu30 @kylesayrs @HDCharles
+/tests/llmcompressor/transformers/compression/ @kylesayrs @dsikka @HDCharles
+/tests/llmcompressor/transformers/compression/configs/ @kylesayrs @dsikka @HDCharles
+/tests/llmcompressor/transformers/compression/decompression_configs/ @kylesayrs @dsikka @HDCharles
+/tests/llmcompressor/transformers/compression/recipes/ @kylesayrs @dsikka @HDCharles
+/tests/llmcompressor/transformers/compression/run_compressed_configs/ @kylesayrs @dsikka @HDCharles
+/tests/llmcompressor/transformers/data/ @kylesayrs @dsikka @HDCharles
 /tests/llmcompressor/transformers/gptq/ @kylesayrs @HDCharles
 /tests/llmcompressor/transformers/kv_cache/ @kylesayrs @dsikka @HDCharles
-/tests/llmcompressor/transformers/smoothquant/ @HDCharles @kylesayrs @brian-dellabetta
-/tests/llmcompressor/transformers/tracing/ @kylesayrs @brian-dellabetta
+/tests/llmcompressor/transformers/smoothquant/ @HDCharles @kylesayrs
+/tests/llmcompressor/transformers/tracing/ @kylesayrs
 
 /tests/llmcompressor/pipelines/ @kylesayrs @dsikka
 /tests/llmcompressor/pipelines/sequential/ @kylesayrs @dsikka
 /tests/llmcompressor/pipelines/sequential/ast_utils.py/ @kylesayrs @dsikka
 
-/tests/e2e/ @dsikka @kylesayrs @brian-dellabetta @HDCharles
+/tests/e2e/ @dsikka @kylesayrs @HDCharles
 /tests/examples/ @kylesayrs @dsikka
-/tests/lmeval/ @dsikka @brian-dellabetta @kylesayrs
+/tests/lmeval/ @dsikka @kylesayrs
 /tests/sparsity/ @kylesayrs @dsikka
 /tests/test_timer/ @kylesayrs @dsikka
 /tests/tools/ @kylesayrs @dsikka


### PR DESCRIPTION
Removes @brian-dellabetta as a code owner across all entries in .github/CODEOWNERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)