### PR TITLE
[AWQ] Drop padding at source and stream grid-search outputs

### DIFF
--- a/src/llmcompressor/modifiers/transform/awq/base.py
+++ b/src/llmcompressor/modifiers/transform/awq/base.py
@@ -593,16 +593,38 @@ class AWQModifier(Modifier):
         self._assert_all_activations_consumed()
 
     @torch.no_grad()
-    def _run_samples(self, module: Module) -> list[torch.Tensor]:
+    def _iter_sample_outputs(self, module: Module) -> Iterator[torch.Tensor]:
+        """
+        Run each cached batch through `module`, yielding one output per batch.
+
+        Padding tokens are dropped as soon as each output is produced rather than
+        when the loss is computed, so padding is never materialized across the whole
+        calibration set. Masked outputs are shaped (num_tokens, hidden_size); when no
+        loss mask is available the module output is yielded unchanged.
+
+        :param module: module to replay cached inputs through
+        """
         cache = self._parent_args_cache[module]
-        use_prefetch = active_session().state.sequential_prefetch
+        state = active_session().state
+        loss_masks = state.loss_masks if state else None
+
+        use_prefetch = state.sequential_prefetch if state else False
         batch_iter = cache.iter_prefetch() if use_prefetch else cache
-        outputs = [module(**batch) for batch in batch_iter]
-        return [
+        for batch_idx, batch in enumerate(batch_iter):
+            output = module(**batch)
             # If tuple, assume that first argument is the input
-            output[0] if isinstance(output, tuple) else output
-            for output in outputs
-        ]
+            output = output[0] if isinstance(output, tuple) else output
+
+            loss_mask = loss_masks[batch_idx] if loss_masks else None
+            if loss_mask is not None:
+                token_mask = loss_mask.to(output.device) == 1  # (batch, seq)
+                output = output[token_mask]  # (num_tokens, hidden_size)
+
+            yield output
+
+    @torch.no_grad()
+    def _run_samples(self, module: Module) -> list[torch.Tensor]:
+        return list(self._iter_sample_outputs(module))
 
     def _compute_best_scale(
         self,
@@ -708,12 +730,8 @@ class AWQModifier(Modifier):
                         / _scalesview
                     ).to(balance_layer.weight.dtype)
 
-                # W_q * X
-                int_w_outputs = self._run_samples(mapping.parent)
-
-                # compute mean squared error (L2 norm)
-                loss = self._compute_loss(fp16_outputs, int_w_outputs)
-                del int_w_outputs
+                # W_q * X, and the mean squared error (L2 norm) against fp16_outputs
+                loss = self._compute_loss(fp16_outputs, mapping.parent)
 
                 if initial_error is None:
                     initial_error = loss
@@ -765,34 +783,32 @@ class AWQModifier(Modifier):
     def _compute_loss(
         self,
         fp16_outputs: list[torch.Tensor],
-        int_w_outputs: list[torch.Tensor],
+        module: Module,
     ) -> float:
-        session = active_session()
-        loss_masks = session.state.loss_masks if session.state else None
+        """
+        Mean squared error between `fp16_outputs` and the outputs of `module` in its
+        current (quantized) state.
 
+        The quantized outputs are consumed one batch at a time instead of being
+        materialized up front, so peak memory holds a single batch rather than a
+        second copy of the calibration set.
+
+        :param fp16_outputs: outputs of `module` in the unquantized case, one tensor
+            for each batch, already stripped of padding tokens
+        :param module: module to replay cached inputs through
+        """
         device = fp16_outputs[0].device
         loss = torch.tensor(0.0, device=device)
         num_elements = torch.tensor(0, device=device)
 
         # Compute the MSE loss for each batch
-        for batch_idx, (fp16_batch, int_w_batch) in enumerate(
-            zip(fp16_outputs, int_w_outputs)
+        for fp16_batch, int_w_batch in zip(
+            fp16_outputs, self._iter_sample_outputs(module)
         ):
-            loss_mask = loss_masks[batch_idx] if loss_masks else None
-
-            if loss_mask is not None:
-                token_mask = loss_mask.to(fp16_batch.device) == 1  # (batch, seq)
-                fp16_masked = fp16_batch[token_mask]  # (num_masked_tokens, hidden)
-                int_w_masked = int_w_batch.to(fp16_batch.device)[token_mask]
-                loss += torch.nn.functional.mse_loss(
-                    fp16_masked, int_w_masked, reduction="sum"
-                )
-                num_elements += fp16_masked.numel()
-            else:
-                loss += torch.nn.functional.mse_loss(
-                    fp16_batch, int_w_batch.to(fp16_batch.device), reduction="sum"
-                )
-                num_elements += fp16_batch.numel()
+            loss += torch.nn.functional.mse_loss(
+                fp16_batch, int_w_batch.to(fp16_batch.device), reduction="sum"
+            )
+            num_elements += fp16_batch.numel()
 
         if is_distributed():
             loss, num_elements = _allreduce_data_sum([loss, num_elements])


### PR DESCRIPTION
## Background ##

AWQ's grid search holds three full copies of the calibration set's activations at once:

1. `_parent_args_cache` — the cached parent-module inputs
2. `fp16_outputs` — unquantized outputs, retained across all grid ratios
3. `int_w_outputs` — quantized outputs, rebuilt once per grid ratio

Padding tokens are carried through all of these and only discarded at the very end, inside `_compute_loss`:

```python
token_mask = loss_mask.to(fp16_batch.device) == 1
fp16_masked = fp16_batch[token_mask]
```

So padded positions contribute nothing to the loss, but a run with `pad_to_max_length=True` (the default) still pays for them in both memory and grid-search FLOPs.

This is not hypothetical. `examples/quantization_w4a16/qwen3_8_gptq_awq_example.py` OOMs on a single GPU. On `mlabonne/open-perfectblend` `train[:512]` with the Qwen3.8-27B tokenizer, mean sample length is 565 tokens against `max_seq_length=4096` — **7.2x** more tokens than needed. At `hidden_size=5120` in bf16 that is ~21.5 GB per copy, and `offload_device` defaults to `None` for non-MoE models, so it all sits in VRAM.

## Changes ##

* Add `_iter_sample_outputs`, which applies the loss mask as each batch's output is produced. Padding is dropped at the source instead of at loss time. `_run_samples` becomes a `list()` wrapper over it.
* `_compute_loss` now takes the module and streams the quantized outputs, accumulating MSE one batch at a time. This removes the `int_w_outputs` materialization from the grid-search loop, so peak memory holds a single batch rather than a second full copy of the calibration set.

Numerics are unchanged: masking is applied to exactly the same positions, and the per-batch accumulation order is preserved.

## Testing ##

* 43/43 existing AWQ unit tests pass
* Compared against `main` on `nm-testing/tinysmokellama-3.2` with `pad_to_max_length=True`: all 18 mappings produce **bitwise-identical** `best_scales` (max abs diff 0.0), and identical `initial_error`/`best_error` values

Not yet measured: an end-to-end peak-VRAM A/B. The reduction is argued from the code structure above rather than benchmarked, so that is worth confirming before this leaves draft.

## Follow-ups (not in this PR) ##

* The `_parent_args_cache` inputs are still padded and still on GPU for dense models. The `offload_device` default is gated on `is_moe_model()` (`base.py:182-194`), which is really a proxy for "the cache is big" — a dense 27B at 4096 tokens is exactly the case it misses. A size-based default would be better.
* Trimming padding from the cached inputs themselves is a larger win but needs care around padding side and attention semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)