### PR TITLE
examples: add Llama 3.3 70B MXFP8 and FP8 attention example

### DIFF
--- a/examples/autoround/README.md
+++ b/examples/autoround/README.md
@@ -69,6 +69,7 @@ The accuracy of the quantized model is configured by tuning-related parameters. 
 | `wNa16`             | [qwen3_example_custom_dataset.py](./quantization_wNa16/qwen3_example_custom_dataset.py) | Using custom calibration datasets |                                   |
 | `wNa16` + `FP8 Attention` | [qwen3_quantize_example.py](./quantization_attention/qwen3_quantize_example.py) | `Qwen/Qwen3-8B`, per-tensor FP8 attention |
 | `wNa16` + `FP8 Attention` | [qwen3_moe_quantize_example.py](./quantization_attention/qwen3_moe_quantize_example.py) | `Qwen/Qwen3-30B-A3B` (MoE). |
+| `MXFP8` + `FP8 Attention` | [llama3_3_quantize_example.py](./quantization_attention/llama3_3_quantize_example.py) | `meta-llama/Llama-3.3-70B-Instruct`, per-tensor FP8 attention |
 | `W8A8-FP8` Static   | [llama4_example](./quantization_w8a8_fp8/llama4_static_quant_example.py) |                                       |
 | `W8A8-FP8` Dynamic  | [llama4_example](./quantization_w8a8_fp8/llama4_dynamic_quant_example.py)  |                                       |
 | `W8A8-FP8` Block    | [llama3.1_example](./quantization_w8a8_fp8/llama3.1_block_quant_example.py) |                                     |
@@ -76,6 +77,18 @@ The accuracy of the quantized model is configured by tuning-related parameters. 
 | `MXFP4`  | [example](./quantization_w4a4_mxfp4/autoround_example.py)  | Usage: `python autoround_example.py ${model_id}` |
 | `NVFP4`  | [llama3.1_example](./quantization_w4a4_fp4/llama3.1_example.py)  |                                       |
 
+
+### Llama 3.3 70B with MXFP8 and FP8 Attention
+
+The [Llama 3.3 example](./quantization_attention/llama3_3_quantize_example.py) combines per-tensor FP8 attention quantization with AutoRound MXFP8 quantization for Linear layers, excluding `lm_head`. Attention quantization also applies KV cache quantization. It uses AutoRound's `get_dataset()` calibration data with 128 samples, a sequence length of 1024, and 200 tuning iterations.
+
+After installing LLM Compressor, run from the repository root on a machine with enough memory and disk space for the 70B model. Access to the gated Hugging Face model is required; alternatively, set `model_id` in the script to a local checkpoint directory.
+
+```bash
+python examples/autoround/quantization_attention/llama3_3_quantize_example.py
+```
+
+The script runs a sample generation and saves the compressed model and tokenizer to `Llama-3.3-70B-Instruct-FP8Attention-MXFP8-AutoRound` (or a directory based on the local checkpoint's name). For vLLM evaluation, use `kv_cache_dtype="fp8"` to enable the calibrated KV cache scales, and select a hardware/backend combination that supports the exported quantization schemes. See the [KV cache example](../quantization_kv_cache/README.md#evaluating-accuracy) for evaluation guidance.
 
 ### Known Issues
 `llm-compressor` supports AutoRound on weight-only integer schemes `W2A16` through `W7A16`, `W8A8`/FP8 variants, `MXFP8`, `MXFP4`, and `NVFP4`. `W7A16` is handled through the `llm-compressor` compatibility mapping because upstream `auto_round` does not currently ship a native `W7A16` preset. You can follow broader scheme work in the [RFC](https://github.com/vllm-project/llm-compressor/issues/2706).

--- a/examples/autoround/quantization_attention/llama3_3_quantize_example.py
+++ b/examples/autoround/quantization_attention/llama3_3_quantize_example.py
@@ -1,0 +1,66 @@
+from auto_round.calib_dataset import get_dataset
+from compressed_tensors.offload import dispatch_model
+from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.autoround import AutoRoundModifier
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.utils import load_context
+
+model_id = "meta-llama/Llama-3.3-70B-Instruct"
+with load_context():
+    model = AutoModelForCausalLM.from_pretrained(model_id, dtype="auto")
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+NUM_CALIBRATION_SAMPLES = 128
+MAX_SEQUENCE_LENGTH = 1024
+ITERS = 200
+
+# Get aligned calibration dataset.
+ds = get_dataset(
+    tokenizer=tokenizer,
+    seqlen=MAX_SEQUENCE_LENGTH,
+    nsamples=NUM_CALIBRATION_SAMPLES,
+)
+
+recipe = [
+    QuantizationModifier(
+        config_groups={
+            "attention": QuantizationScheme(
+                targets=["LlamaAttention"],
+                input_activations=QuantizationArgs(
+                    num_bits=8, type="float", strategy="tensor"
+                ),
+            ),
+        },
+    ),
+    AutoRoundModifier(
+        targets="Linear",
+        scheme="MXFP8",
+        ignore=["lm_head"],
+        iters=ITERS,
+    ),
+]
+
+oneshot(
+    model=model,
+    dataset=ds,
+    recipe=recipe,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    shuffle_calibration_samples=False,
+)
+
+print("\n\n========== SAMPLE GENERATION ==============")
+dispatch_model(model)
+sample = tokenizer("Hello my name is", return_tensors="pt")
+sample = {key: value.to(model.device) for key, value in sample.items()}
+output = model.generate(**sample, max_new_tokens=50)
+print(tokenizer.decode(output[0]))
+print("==========================================\n\n")
+
+SAVE_DIR = model_id.rstrip("/").split("/")[-1] + "-FP8Attention-MXFP8-AutoRound"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)
+print("Saved to", SAVE_DIR)

--- a/examples/autoround/quantization_attention/llama3_3_quantize_example.py
+++ b/examples/autoround/quantization_attention/llama3_3_quantize_example.py
@@ -9,6 +9,7 @@ from llmcompressor.modifiers.quantization import QuantizationModifier
 from llmcompressor.utils import load_context
 
 model_id = "meta-llama/Llama-3.3-70B-Instruct"
+# Use LLM Compressor's offloaded loading context for the 70B model.
 with load_context():
     model = AutoModelForCausalLM.from_pretrained(model_id, dtype="auto")
 tokenizer = AutoTokenizer.from_pretrained(model_id)
@@ -25,9 +26,11 @@ ds = get_dataset(
 )
 
 recipe = [
+    # Attention input quantization calibrates Q, K, and V, including the KV cache.
     QuantizationModifier(
         config_groups={
             "attention": QuantizationScheme(
+                # Transformers 5 uses LlamaAttention across attention backends.
                 targets=["LlamaAttention"],
                 input_activations=QuantizationArgs(
                     num_bits=8, type="float", strategy="tensor"


### PR DESCRIPTION
SUMMARY:
  - Add a Llama 3.3 70B Instruct example using AutoRound MXFP8 weight quantization.
  - Add per-tensor FP8 attention quantization, including calibrated Q/K/V and KV-cache quantization.
  - Document calibration settings and usage in the AutoRound README.
  - Relate this example to #2905.


TEST:
bf16 
```
CUDA_VISIBLE_DEVICES=2 lm_eval --model vllm --model_args "pretrained=/home/changwa1/llm-c
ompressor/examples/autoround/quantization_attention/Llama-3.3-70B-Instruct,dtype=bfloat16,tensor_parallel_size=1,kv_cache_dtype=a
uto,attention_backend=FLASHINFER,add_bos_token=True,max_model_len=8192,max_num_seqs=16,gpu_memory_utilization=0.9"  --tasks gsm8k
 --num_fewshot 5 --batch_size auto --seed 42 --log_samples --output_path ~/results/llama33_bf16_gsm8k
```
```
2026-09-10:08:03:22 INFO     [loggers.evaluation_tracker:119] Saving per-task samples to /home/changwa1/results/llama33_bf16_gsm8
k/__home__changwa1__llm-compressor__examples__autoround__quantization_attention__Llama-3.3-70B-Instruct/*.jsonl
vllm ({'pretrained': '/home/changwa1/llm-compressor/examples/autoround/quantization_attention/Llama-3.3-70B-Instruct', 'dtype': '
bfloat16', 'tensor_parallel_size': 1, 'kv_cache_dtype': 'auto', 'attention_backend': 'FLASHINFER', 'add_bos_token': True, 'max_mo
del_len': 8192, 'max_num_seqs': 16, 'gpu_memory_utilization': 0.9}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: a
uto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9416|±  |0.0065|
|     |       |strict-match    |     5|exact_match|↑  |0.7741|±  |0.0115|
```
mxfp8 + fp8attn
```
CUDA_VISIBLE_DEVICES=5 lm_eval --model vllm --model_args "pretrained=/home/changwa1/llm-c
ompressor/examples/autoround/quantization_attention/Llama-3.3-70B-Instruct-FP8Attention-MXFP8-AutoRound,dtype=bfloat16,tensor_parallel_size=1,kv_cache_dtype=fp8,attention_backend=FLASHINFER,add_bos_token=True,max_model_len=8192,max_num_seqs=16,gpu_memory_utilization=0.9"  --tasks gsm8k
 --num_fewshot 5 --batch_size auto --seed 42 --log_samples --output_path ~/results/llama33_mxfp8_fp8attn_gsm8k
```
```
2026-09-10:17:53:25 INFO     [loggers.evaluation_tracker:119] Saving per-task samples to /home/changwa1/results/llama33_mxfp8_fp8attn_gsm8k/__home__changwa1__llm-compressor__examples__autoround__quantization_attention__Llama-3.3-70B-Instruct-FP8Attention-MXFP8-AutoRound/*.jsonl
vllm ({'pretrained': '/home/changwa1/llm-compressor/examples/autoround/quantization_attention/Llama-3.3-70B-Instruct-FP8Attention-MXFP8-AutoRound', 'dtype': 'bfloat16', 'tensor_parallel_size': 1, 'kv_cache_dtype': 'fp8', 'attention_backend': 'FLASHINFER', 'add_bos_token': True, 'max_model_len': 8192, 'max_num_seqs': 16, 'gpu_memory_utilization': 0.9}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9416|±  |0.0065|
|     |       |strict-match    |     5|exact_match|↑  |0.7544|±  |0.0119|

```