### PR TITLE
Layerwise decompression and compression

### DIFF
--- a/examples/layerwise_decompression/glm_5_3_layerwise_example.py
+++ b/examples/layerwise_decompression/glm_5_3_layerwise_example.py
@@ -1,0 +1,69 @@
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.utils import load_context
+
+# Already compressed
+MODEL_ID = "RedHatAI/GLM-5.3-MXFP4"
+SAVE_DIR = (
+    "/data-tier-1/machine/Roderick-Wu/"
+    + MODEL_ID.rstrip("/").split("/")[-1]
+    + "-NVFP4-Layerwise"
+)
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+IGNORE = [
+    "re:.*mlp.gate$",
+    "re:.*lm_head",
+    "re:.*embed_tokens$",
+    "re:.*eh_proj$",
+    "re:.*self_attn.indexer.weights_proj$",
+]
+
+config = AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=True)
+config.quantization_config["ignore"] = [
+    *config.quantization_config.get("ignore", []),
+    *IGNORE,
+]
+
+with load_context():
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_ID,
+        config=config,
+        device_map="auto_offload",
+        offload_folder="./offload_folder",
+        dtype="auto",
+        trust_remote_code=True,
+    )
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
+if tokenizer.pad_token is None:
+    tokenizer.pad_token = tokenizer.eos_token
+
+recipe = QuantizationModifier(
+    targets="Linear",
+    scheme="NVFP4",
+    ignore=IGNORE,
+)
+
+oneshot(
+    model=model,
+    tokenizer=tokenizer,
+    dataset="perfectblend",
+    splits=f"train[:{NUM_CALIBRATION_SAMPLES}]",
+    batch_size=4,
+    recipe=recipe,
+    trust_remote_code_model=True,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    shuffle_calibration_samples=False,
+    pipeline="sequential",
+    sequential_targets=["GlmMoeDsaAttention", "GlmMoeDsaMoE"],
+    layerwise_decompression=True,
+    layerwise_compression=True,
+)
+
+model.generation_config.top_p = None
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/examples/layerwise_decompression/kimi_k3_layerwise_example.py
+++ b/examples/layerwise_decompression/kimi_k3_layerwise_example.py
@@ -41,7 +41,7 @@ with load_context(KimiK3ForConditionalGeneration):
         MODEL_ID,
         config=config,
         device_map="auto_offload",
-        #max_memory={"cpu": "500GiB"}, 
+        # max_memory={"cpu": "500GiB"},
         offload_folder="/mnt/nfs-preprod-1/machine/Roderick-Wu/offload_folder",
         dtype="auto",
         trust_remote_code=True,
@@ -93,12 +93,16 @@ oneshot(
     pipeline="sequential",
     sequential_targets=[
         "KimiDecoderLayer",
-    ], # Determines what is selected for subgraphs
-    sequential_targets_per_subgraph=1, # Number of targets for subgraph
+    ],  # Determines what is selected for subgraphs
+    sequential_targets_per_subgraph=1,  # Number of targets for subgraph
     layerwise_decompression=True,
     layerwise_compression=True,
 )
 
-SAVE_DIR = "/mnt/nfs-preprod-1/machine/Roderick-Wu/offload_folder/" + MODEL_ID.rstrip("/").split("/")[-1] + "-NVFP4-Layerwise"
+SAVE_DIR = (
+    "/mnt/nfs-preprod-1/machine/Roderick-Wu/offload_folder/"
+    + MODEL_ID.rstrip("/").split("/")[-1]
+    + "-NVFP4-Layerwise"
+)
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)

--- a/examples/layerwise_decompression/kimi_k3_layerwise_example.py
+++ b/examples/layerwise_decompression/kimi_k3_layerwise_example.py
@@ -1,0 +1,104 @@
+from datasets import load_dataset
+from transformers import AutoConfig, AutoTokenizer
+
+from llmcompressor import oneshot
+from llmcompressor.modeling.kimi_k3 import KimiK3ForConditionalGeneration
+from llmcompressor.modifiers.quantization import QuantizationModifier
+from llmcompressor.utils import load_context
+
+MODEL_ID = "moonshotai/Kimi-K3"
+DATASET_ID = "HuggingFaceH4/ultrachat_200k"
+DATASET_SPLIT = "train_sft"
+NUM_CALIBRATION_SAMPLES = 512
+MAX_SEQUENCE_LENGTH = 2048
+
+LOAD_IGNORE = [
+    "re:.*mlp_res_proj.*",
+    "re:.*self_attention_res_proj.*",
+    "re:.*routed_expert.*",
+    "re:.*output_attn_res_proj.*",
+]
+
+RECIPE_IGNORE = [
+    "lm_head",
+    *LOAD_IGNORE,
+    r"re:.*block_sparse_moe\.gate",
+    "re:.*vision_tower.*",
+]
+
+
+config = AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=True)
+quant_config = getattr(config, "quantization_config", None) or getattr(
+    config.text_config, "quantization_config", None
+)
+quant_config["ignore"] = [*quant_config.get("ignore", []), *LOAD_IGNORE]
+config.quantization_config = quant_config
+config.text_config.quantization_config = quant_config
+
+MAX_GPU_MEMORY = "60GiB"
+with load_context(KimiK3ForConditionalGeneration):
+    model = KimiK3ForConditionalGeneration.from_pretrained(
+        MODEL_ID,
+        config=config,
+        device_map="auto_offload",
+        #max_memory={"cpu": "500GiB"}, 
+        offload_folder="/mnt/nfs-preprod-1/machine/Roderick-Wu/offload_folder",
+        dtype="auto",
+        trust_remote_code=True,
+    )
+tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
+
+ds = load_dataset(DATASET_ID, split=f"{DATASET_SPLIT}[:{NUM_CALIBRATION_SAMPLES}]")
+ds = ds.shuffle(seed=42)
+
+
+def preprocess(example):
+    return {
+        "text": tokenizer.apply_chat_template(
+            example["messages"],
+            tokenize=False,
+        )
+    }
+
+
+ds = ds.map(preprocess)
+
+
+def tokenize(sample):
+    return tokenizer(
+        sample["text"],
+        padding=False,
+        max_length=MAX_SEQUENCE_LENGTH,
+        truncation=True,
+        add_special_tokens=False,
+    )
+
+
+ds = ds.map(tokenize, remove_columns=ds.column_names)
+
+recipe = QuantizationModifier(
+    targets="Linear",
+    scheme="NVFP4",
+    ignore=RECIPE_IGNORE,
+)
+
+oneshot(
+    model=model,
+    tokenizer=tokenizer,
+    dataset=ds,
+    recipe=recipe,
+    trust_remote_code_model=True,
+    max_seq_length=MAX_SEQUENCE_LENGTH,
+    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
+    pipeline="sequential",
+    sequential_targets=[
+        "KimiDecoderLayer",
+    ], # Determines what is selected for subgraphs
+    sequential_targets_per_subgraph=1, # Number of targets for subgraph
+    layerwise_decompression=True,
+    layerwise_compression=True,
+)
+
+SAVE_DIR = "/mnt/nfs-preprod-1/machine/Roderick-Wu/offload_folder/" + MODEL_ID.rstrip("/").split("/")[-1] + "-NVFP4-Layerwise"
+model.save_pretrained(SAVE_DIR, save_compressed=True)
+tokenizer.save_pretrained(SAVE_DIR)

--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -304,6 +304,22 @@ class DatasetArguments(CustomDatasetArguments):
             "calibration. Default False."
         },
     )
+    layerwise_decompression: bool = field(
+        default=False,
+        metadata={
+            "help": "When True, each layer is decompressed before calibrating in "
+            "the sequential pipeline. Use when loading a pre-compressed model "
+            "that needs recalibration. Default False."
+        },
+    )
+    layerwise_compression: bool = field(
+        default=False,
+        metadata={
+            "help": "When True, each layer is compressed after propagation in the "
+            "sequential pipeline. Reduces peak memory by keeping only the "
+            "active layer decompressed. Default False."
+        },
+    )
 
     def is_dataset_provided(self) -> bool:
         return self.dataset is not None or self.dataset_path is not None

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -249,6 +249,13 @@ class Oneshot:
             if self.dataset_args.moe_calibrate_all_experts:
                 stack.enter_context(moe_calibration_context())
 
+            session.state.layerwise_decompression = (
+                self.dataset_args.layerwise_decompression
+            )
+            session.state.layerwise_compression = (
+                self.dataset_args.layerwise_compression
+            )
+
             session.initialize(
                 model=self.model,
                 start=-1,

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -187,7 +187,9 @@ class Oneshot:
         self.processor = self.model_args.processor
         self.recipe = self.recipe_args.recipe
 
-        self.validate_model(self.model)
+        # Skip model validation if using layerwise decompression for pre-quantized models
+        if not getattr(self.dataset_args, "layerwise_decompression", False):
+            self.validate_model(self.model)
 
     def __call__(self):
         """

--- a/src/llmcompressor/modeling/moe/linearize.py
+++ b/src/llmcompressor/modeling/moe/linearize.py
@@ -15,7 +15,6 @@ from transformers.conversion_mapping import (
     register_checkpoint_conversion_mapping,
 )
 from transformers.monkey_patching import clear_patch_mapping, register_patch_mapping
-from transformers.integrations.finegrained_fp8 import replace_with_fp8_linear
 
 from llmcompressor.modeling.moe.helpers import FusedExpertsProtocol
 
@@ -27,42 +26,26 @@ from .conversion_mappings import (
 from .linear_experts import LinearExperts2D
 
 
-def _patch_fp8_quantizer_for_moe():
-    """Patch transformers' FP8 quantizer to skip expert modules."""
-    original_replace_with_fp8_linear = replace_with_fp8_linear
 
-    def patched_replace_with_fp8_linear(*args, **kwargs):
-        # Skip FP8Experts and similar expert container modules
-        modules_to_not_convert = kwargs.get("modules_to_not_convert") or []
-        if not isinstance(modules_to_not_convert, list):
-            modules_to_not_convert = list(modules_to_not_convert) if modules_to_not_convert else []
 
-        # Extract model from args (first positional argument)
-        model = args[0] if args else kwargs.get("model")
+def _patch_replace_with_fp8_linear_for_moe():
+    """Make replace_with_fp8_linear a no-op for MoE models.
 
-        # Add FP8Experts and related MoE expert modules to skip list
-        skip_module_names = {
-            "FP8Experts",
-            "FP8MoEExperts",
-            "Experts",
-            "MoEExperts",
-        }
+    MoE models with pre-quantized experts don't need FP8 linear replacement.
+    The quantized weights are already in the checkpoint and our layerwise
+    decompression code handles dequantization.
+    """
+    try:
+        import transformers.integrations.finegrained_fp8
 
-        if model is not None:
-            for name, module in model.named_modules():
-                if any(skip_name in module.__class__.__name__ for skip_name in skip_module_names):
-                    if name not in modules_to_not_convert:
-                        modules_to_not_convert.append(name)
+        def patched_replace_with_fp8_linear(model, *args, **kwargs):
+            # Return model unchanged. Quantized weights are already loaded.
+            logger.info("Skipping FP8 linear replacement for MoE model")
+            return model
 
-        kwargs["modules_to_not_convert"] = modules_to_not_convert
-        return original_replace_with_fp8_linear(*args, **kwargs)
-
-    # Monkey patch the function
-    import transformers.integrations.finegrained_fp8
-
-    transformers.integrations.finegrained_fp8.replace_with_fp8_linear = (
-        patched_replace_with_fp8_linear
-    )
+        transformers.integrations.finegrained_fp8.replace_with_fp8_linear = patched_replace_with_fp8_linear
+    except Exception as e:
+        logger.warning(f"Could not patch replace_with_fp8_linear: {e}")
 
 
 @contextlib.contextmanager
@@ -85,8 +68,8 @@ def load_quantizable_moe(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM
 
     :param model_cls: The model class to patch, defaults to AutoModelForCausalLM
     """
-    # Patch FP8 quantizer to skip expert modules
-    _patch_fp8_quantizer_for_moe()
+    # Patch replace_with_fp8_linear to skip expert modules
+    _patch_replace_with_fp8_linear_for_moe()
 
     original_from_pretrained = model_cls.from_pretrained
     patched_fn_called = False

--- a/src/llmcompressor/modeling/moe/linearize.py
+++ b/src/llmcompressor/modeling/moe/linearize.py
@@ -15,6 +15,7 @@ from transformers.conversion_mapping import (
     register_checkpoint_conversion_mapping,
 )
 from transformers.monkey_patching import clear_patch_mapping, register_patch_mapping
+from transformers.integrations.finegrained_fp8 import replace_with_fp8_linear
 
 from llmcompressor.modeling.moe.helpers import FusedExpertsProtocol
 
@@ -24,6 +25,44 @@ from .conversion_mappings import (
     set_save_conversion_mapping,
 )
 from .linear_experts import LinearExperts2D
+
+
+def _patch_fp8_quantizer_for_moe():
+    """Patch transformers' FP8 quantizer to skip expert modules."""
+    original_replace_with_fp8_linear = replace_with_fp8_linear
+
+    def patched_replace_with_fp8_linear(*args, **kwargs):
+        # Skip FP8Experts and similar expert container modules
+        modules_to_not_convert = kwargs.get("modules_to_not_convert") or []
+        if not isinstance(modules_to_not_convert, list):
+            modules_to_not_convert = list(modules_to_not_convert) if modules_to_not_convert else []
+
+        # Extract model from args (first positional argument)
+        model = args[0] if args else kwargs.get("model")
+
+        # Add FP8Experts and related MoE expert modules to skip list
+        skip_module_names = {
+            "FP8Experts",
+            "FP8MoEExperts",
+            "Experts",
+            "MoEExperts",
+        }
+
+        if model is not None:
+            for name, module in model.named_modules():
+                if any(skip_name in module.__class__.__name__ for skip_name in skip_module_names):
+                    if name not in modules_to_not_convert:
+                        modules_to_not_convert.append(name)
+
+        kwargs["modules_to_not_convert"] = modules_to_not_convert
+        return original_replace_with_fp8_linear(*args, **kwargs)
+
+    # Monkey patch the function
+    import transformers.integrations.finegrained_fp8
+
+    transformers.integrations.finegrained_fp8.replace_with_fp8_linear = (
+        patched_replace_with_fp8_linear
+    )
 
 
 @contextlib.contextmanager
@@ -46,6 +85,9 @@ def load_quantizable_moe(model_cls: Type[PreTrainedModel] = AutoModelForCausalLM
 
     :param model_cls: The model class to patch, defaults to AutoModelForCausalLM
     """
+    # Patch FP8 quantizer to skip expert modules
+    _patch_fp8_quantizer_for_moe()
+
     original_from_pretrained = model_cls.from_pretrained
     patched_fn_called = False
 

--- a/src/llmcompressor/modifiers/quantization/calibration.py
+++ b/src/llmcompressor/modifiers/quantization/calibration.py
@@ -222,8 +222,10 @@ def freeze_module_quantization(module: Module):
         # no quantization scheme nothing to do
         return
 
-    if module.quantization_status == QuantizationStatus.FROZEN:
-        # nothing to do, already frozen
+    if module.quantization_status in (
+        QuantizationStatus.FROZEN,
+        QuantizationStatus.COMPRESSED,
+    ):
         return
 
     # remove observers

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -4,11 +4,13 @@ from compressed_tensors.distributed import (
     greedy_bin_packing,
     is_distributed,
 )
+from compressed_tensors.quantization import enable_quantization
 from compressed_tensors.quantization.utils import is_module_quantized
 
 from llmcompressor.core import Event, State
 from llmcompressor.modifiers import Modifier
 from llmcompressor.modifiers.quantization.calibration import (
+    freeze_module_quantization,
     observe,
     update_qparams,
 )
@@ -65,20 +67,28 @@ class QuantizationModifier(Modifier, QuantizationMixin):
 
         Then, according to the module's quantization scheme, observers and calibration
         hooks are added. These hooks are disabled until the modifier starts.
+
+        Skipped when layerwise_decompression is enabled because modules are still
+        compressed; per-layer setup happens in start_layerwise_calibration instead.
         """
         if not QuantizationMixin.has_config(self):
             raise ValueError(
                 "QuantizationModifier requires that quantization fields be specified"
             )
-        QuantizationMixin.initialize_quantization(self, state.model)
+        if not getattr(state, "layerwise_decompression", False):
+            QuantizationMixin.initialize_quantization(self, state.model)
 
         return True
 
     def on_calibration_start(self, state: State, event: Event, **kwargs):
         """
         Begin calibrating activations.
+
+        Skipped when layerwise_decompression is enabled; per-layer calibration
+        setup is handled by start_layerwise_calibration in the pipeline.
         """
-        QuantizationMixin.start_calibration(self, state.model)
+        if not getattr(state, "layerwise_decompression", False):
+            QuantizationMixin.start_calibration(self, state.model)
 
     def on_sequential_epoch_end(
         self, state: State, event: Event, modules: list[torch.nn.Module], **kwargs
@@ -91,24 +101,35 @@ class QuantizationModifier(Modifier, QuantizationMixin):
         if not is_distributed():
             observe(modules, "weight")
             update_qparams(modules, "weight")
-            return
+        else:
+            ### Distributed
+            rank = dist.get_rank()
+            world_size = dist.get_world_size()
 
-        ### Distributed
-        rank = dist.get_rank()
-        world_size = dist.get_world_size()
+            module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
+                modules,
+                world_size,
+                item_weight_fn=lambda mod: mod.weight.numel(),
+            )
 
-        module_list, rank_to_modules, module_to_rank = greedy_bin_packing(
-            modules,
-            world_size,
-            item_weight_fn=lambda mod: mod.weight.numel(),
-        )
+            observe(rank_to_modules[rank], "weight")
+            update_qparams(rank_to_modules[rank], "weight")
+            broadcast_qparams_and_cleanup(
+                module_list, module_to_rank, _WEIGHT_Q_PARAMS
+            )
 
-        observe(rank_to_modules[rank], "weight")
-        update_qparams(rank_to_modules[rank], "weight")
-        broadcast_qparams_and_cleanup(module_list, module_to_rank, _WEIGHT_Q_PARAMS)
+        if getattr(state, "layerwise_decompression", False):
+            self.remove_hooks(self._calibration_hooks)
+            for module in modules:
+                freeze_module_quantization(module)
+                enable_quantization(module)
 
     def on_calibration_end(self, state: State, event: Event, **kwargs):
         """
-        Finish calibrating by removing observers and calibration hooks
+        Finish calibrating by removing observers and calibration hooks.
+
+        Skipped when layerwise_decompression is enabled; per-layer cleanup
+        is handled in on_sequential_epoch_end.
         """
-        QuantizationMixin.end_calibration(self, state.model)
+        if not getattr(state, "layerwise_decompression", False):
+            QuantizationMixin.end_calibration(self, state.model)

--- a/src/llmcompressor/modifiers/quantization/quantization/base.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/base.py
@@ -114,9 +114,7 @@ class QuantizationModifier(Modifier, QuantizationMixin):
 
             observe(rank_to_modules[rank], "weight")
             update_qparams(rank_to_modules[rank], "weight")
-            broadcast_qparams_and_cleanup(
-                module_list, module_to_rank, _WEIGHT_Q_PARAMS
-            )
+            broadcast_qparams_and_cleanup(module_list, module_to_rank, _WEIGHT_Q_PARAMS)
 
         if getattr(state, "layerwise_decompression", False):
             self.remove_hooks(self._calibration_hooks)

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -24,6 +24,7 @@ from compressed_tensors.quantization import (
     preset_name_to_scheme,
 )
 from compressed_tensors.quantization.utils import KV_CACHE_TARGETS
+from compressed_tensors.quantization.utils.helpers import is_module_quantized
 from compressed_tensors.utils import match_named_modules
 from pydantic import Field, PrivateAttr, field_validator, model_validator
 from torch.utils.hooks import RemovableHandle
@@ -270,6 +271,28 @@ class QuantizationMixin(HooksMixin):
             freeze_module_quantization(module)  # remove observers
 
         model.apply(enable_quantization)  # keep quantization enabled
+
+    def start_layerwise_calibration(
+        self, model: torch.nn.Module, modules: list[torch.nn.Module]
+    ):
+        """
+        Set up quantization for a subset of modules after layerwise
+        decompression. Applies quantization config scoped to the given
+        modules, then initializes observers, calibration hooks, and fuses
+        weight observers.
+
+        :param model: the full model (needed for config application)
+        :param modules: modules in the current subgraph to prepare
+        """
+        apply_quantization_config(
+            model, self.resolved_config, allowed_modules=modules
+        )
+        for module in modules:
+            if is_module_quantized(module):
+                self._initialize_observers(module)
+                self._calibration_hooks |= self._initialize_hooks(module)
+                apply_calibration_status(module)
+        fuse_weight_observers(model)
 
     def sync_obs_act_stats(self, modules: Iterator[torch.nn.Module]):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -1,4 +1,6 @@
+import inspect
 from collections.abc import Iterator
+from copy import deepcopy
 from typing import Any
 
 import torch
@@ -284,15 +286,36 @@ class QuantizationMixin(HooksMixin):
         :param model: the full model (needed for config application)
         :param modules: modules in the current subgraph to prepare
         """
-        apply_quantization_config(
-            model, self.resolved_config, allowed_modules=modules
-        )
+        self._apply_layerwise_quantization_config(model, modules)
         for module in modules:
             if is_module_quantized(module):
                 self._initialize_observers(module)
                 self._calibration_hooks |= self._initialize_hooks(module)
                 apply_calibration_status(module)
         fuse_weight_observers(model, modules)
+
+    def _apply_layerwise_quantization_config(
+        self, model: torch.nn.Module, modules: list[torch.nn.Module]
+    ):
+        if "allowed_modules" in inspect.signature(apply_quantization_config).parameters:
+            apply_quantization_config(
+                model, self.resolved_config, allowed_modules=modules
+            )
+            return
+
+        scoped_config = deepcopy(self.resolved_config)
+        allowed_module_ids = {id(module) for module in modules}
+        scoped_config.ignore = [
+            *scoped_config.ignore,
+            *(
+                name
+                for name, module in match_named_modules(
+                    model, self.resolved_targets, self.ignore
+                )
+                if id(module) not in allowed_module_ids
+            ),
+        ]
+        apply_quantization_config(model, scoped_config)
 
     def sync_obs_act_stats(self, modules: Iterator[torch.nn.Module]):
         """

--- a/src/llmcompressor/modifiers/quantization/quantization/mixin.py
+++ b/src/llmcompressor/modifiers/quantization/quantization/mixin.py
@@ -292,7 +292,7 @@ class QuantizationMixin(HooksMixin):
                 self._initialize_observers(module)
                 self._calibration_hooks |= self._initialize_hooks(module)
                 apply_calibration_status(module)
-        fuse_weight_observers(model)
+        fuse_weight_observers(model, modules)
 
     def sync_obs_act_stats(self, modules: Iterator[torch.nn.Module]):
         """

--- a/src/llmcompressor/observers/helpers.py
+++ b/src/llmcompressor/observers/helpers.py
@@ -183,8 +183,8 @@ def _fusion_search_modules(model: Module, modules: list[Module] | None):
         return model.modules()
 
     search_modules = []
-    seen = set() # isn't completely necessary, but
-    # in case we pass something like 
+    seen = set()  # isn't completely necessary, but
+    # in case we pass something like
     # [parent_module, parent_module.q_proj, parent_module.k_proj]
     for module in modules:
         if module in seen or not _has_fused_layer_group(module):

--- a/src/llmcompressor/observers/helpers.py
+++ b/src/llmcompressor/observers/helpers.py
@@ -171,7 +171,33 @@ FUSED_LAYER_NAMES = [
 ]
 
 
-def fuse_weight_observers(model: Module):
+def _has_fused_layer_group(module: Module) -> bool:
+    return any(
+        all(hasattr(module, name) for name in fusion_name_group)
+        for fusion_name_group in FUSED_LAYER_NAMES
+    )
+
+
+def _fusion_search_modules(model: Module, modules: list[Module] | None):
+    if modules is None:
+        return model.modules()
+
+    search_modules = []
+    seen = set() # isn't completely necessary, but
+    # in case we pass something like 
+    # [parent_module, parent_module.q_proj, parent_module.k_proj]
+    for module in modules:
+        if module in seen or not _has_fused_layer_group(module):
+            continue
+        search_modules.append(module)
+        seen.add(module)
+
+    # When sequential targets are child modules such as `Linear`, the subgraph
+    # module list may not contain the parent module that owns q/k/v or gate/up.
+    return search_modules or model.modules()
+
+
+def fuse_weight_observers(model: Module, modules: list[Module] | None = None):
     """
     Link weight observers across fused layer groups for shared global_scale.
 
@@ -181,10 +207,11 @@ def fuse_weight_observers(model: Module):
     global_scale from the combined statistics of all observers in the group.
 
     :param model: model whose weight observers should be linked
+    :param modules: optional subset of modules to search for fused layer groups
     """
     from llmcompressor.observers.fusion import FusionHandler
 
-    for submodule in model.modules():
+    for submodule in _fusion_search_modules(model, modules):
         for fusion_name_group in FUSED_LAYER_NAMES:
             if not all(hasattr(submodule, name) for name in fusion_name_group):
                 continue

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Iterator
 import torch
 from compressed_tensors.compressors import compress_module, decompress_module
 from compressed_tensors.offload import disable_offloading, set_onload_device
+from compressed_tensors.distributed import is_distributed, replace_module_parallel
 from compressed_tensors.quantization.utils import is_module_quantized
 from torch.utils.data.dataloader import DataLoader
 from tqdm import tqdm
@@ -201,8 +202,11 @@ class SequentialPipeline(CalibrationPipeline):
                         quantized = [
                             m for m in modules if is_module_quantized(m)
                         ]
-                        for module in quantized:
-                            compress_module(module)
+                        if not is_distributed():
+                           for module in tqdm(quantized, desc="Compressing modules"):
+                                compress_module(module)
+                        else:
+                            replace_module_parallel(quantized, compress_module, desc="Compressing modules")
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -2,7 +2,9 @@ import contextlib
 from typing import TYPE_CHECKING, Iterator
 
 import torch
+from compressed_tensors.compressors import compress_module, decompress_module
 from compressed_tensors.offload import disable_offloading, set_onload_device
+from compressed_tensors.quantization.utils import is_module_quantized
 from torch.utils.data.dataloader import DataLoader
 from tqdm import tqdm
 
@@ -141,6 +143,22 @@ class SequentialPipeline(CalibrationPipeline):
                 # reduce memory movement by keeping modules onloaded
                 num_batches = len(dataloader)
                 with disable_offloading():
+                    modules = subgraph.submodules(model)
+
+                    # layerwise decompression: strip compression and
+                    # re-apply quantization config for this subgraph
+                    if dataset_args.layerwise_decompression:
+                        compressed = [
+                            m for m in modules if is_module_quantized(m)
+                        ]
+                        for module in compressed:
+                            decompress_module(module, leave_decompressed=False)
+                        for modifier in modifiers:
+                            if hasattr(modifier, "start_layerwise_calibration"):
+                                modifier.start_layerwise_calibration(
+                                    model, modules
+                                )
+
                     # do a preliminary pass to trigger modifier hooks
                     for batch_idx, inputs in _get_batches(
                         activations,
@@ -157,7 +175,7 @@ class SequentialPipeline(CalibrationPipeline):
                                 activations.update(batch_idx, outputs)
                                 activations.delete(batch_idx, subgraph.consumed_names)
 
-                    LifecycleCallbacks.sequential_epoch_end(subgraph.submodules(model))
+                    LifecycleCallbacks.sequential_epoch_end(modules)
 
                     if dataset_args.propagate_error:
                         # this pass does not trigger modifier hooks
@@ -176,6 +194,15 @@ class SequentialPipeline(CalibrationPipeline):
                                     activations.delete(
                                         batch_idx, subgraph.consumed_names
                                     )
+
+                    # layerwise compression: pack weights back after
+                    # calibration and error propagation
+                    if dataset_args.layerwise_compression:
+                        quantized = [
+                            m for m in modules if is_module_quantized(m)
+                        ]
+                        for module in quantized:
+                            compress_module(module)
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -149,16 +149,12 @@ class SequentialPipeline(CalibrationPipeline):
                     # layerwise decompression: strip compression and
                     # re-apply quantization config for this subgraph
                     if dataset_args.layerwise_decompression:
-                        compressed = [
-                            m for m in modules if is_module_quantized(m)
-                        ]
+                        compressed = [m for m in modules if is_module_quantized(m)]
                         for module in compressed:
                             decompress_module(module, leave_decompressed=False)
                         for modifier in modifiers:
                             if hasattr(modifier, "start_layerwise_calibration"):
-                                modifier.start_layerwise_calibration(
-                                    model, modules
-                                )
+                                modifier.start_layerwise_calibration(model, modules)
 
                     # do a preliminary pass to trigger modifier hooks
                     for batch_idx, inputs in _get_batches(
@@ -199,9 +195,7 @@ class SequentialPipeline(CalibrationPipeline):
                     # layerwise compression: pack weights back after
                     # calibration and error propagation
                     if dataset_args.layerwise_compression:
-                        quantized = [
-                            m for m in modules if is_module_quantized(m)
-                        ]
+                        quantized = [m for m in modules if is_module_quantized(m)]
                         if not is_distributed():
                             for module in tqdm(quantized, desc="Compressing modules"):
                                 compress_module(module)

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -3,8 +3,8 @@ from typing import TYPE_CHECKING, Iterator
 
 import torch
 from compressed_tensors.compressors import compress_module, decompress_module
-from compressed_tensors.offload import disable_offloading, set_onload_device
 from compressed_tensors.distributed import is_distributed, replace_module_parallel
+from compressed_tensors.offload import disable_offloading, set_onload_device
 from compressed_tensors.quantization.utils import is_module_quantized
 from torch.utils.data.dataloader import DataLoader
 from tqdm import tqdm
@@ -203,10 +203,12 @@ class SequentialPipeline(CalibrationPipeline):
                             m for m in modules if is_module_quantized(m)
                         ]
                         if not is_distributed():
-                           for module in tqdm(quantized, desc="Compressing modules"):
+                            for module in tqdm(quantized, desc="Compressing modules"):
                                 compress_module(module)
                         else:
-                            replace_module_parallel(quantized, compress_module, desc="Compressing modules")
+                            replace_module_parallel(
+                                quantized, compress_module, desc="Compressing modules"
+                            )
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -149,8 +149,10 @@ class SequentialPipeline(CalibrationPipeline):
                     # layerwise decompression: strip compression and
                     # re-apply quantization config for this subgraph
                     if dataset_args.layerwise_decompression:
-                        compressed = [m for m in modules if is_module_quantized(m)]
-                        for module in compressed:
+                        compressed = [
+                            m for m in modules if is_module_quantized(m)
+                        ]
+                        for module in tqdm(compressed, desc="Decompressing modules"):
                             decompress_module(module, leave_decompressed=False)
                         for modifier in modifiers:
                             if hasattr(modifier, "start_layerwise_calibration"):

--- a/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
+++ b/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
@@ -176,7 +176,13 @@ def test_layerwise_quantization_only_initializes_and_freezes_passed_modules():
     assert not hasattr(model[0], "quantization_scheme")
     assert not hasattr(model[1], "quantization_scheme")
 
-    modifier.start_layerwise_calibration(model, list(model[0].modules()))
+    modules = list(model[0].modules())
+    with patch(
+        "llmcompressor.modifiers.quantization.quantization.mixin.fuse_weight_observers"
+    ) as fuse_weight_observers:
+        modifier.start_layerwise_calibration(model, modules)
+
+    fuse_weight_observers.assert_called_once_with(model, modules)
 
     assert model[0].quantization_status == QuantizationStatus.CALIBRATION
     assert hasattr(model[0], "weight_observer")

--- a/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
+++ b/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
@@ -4,6 +4,7 @@ import torch
 from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationScheme,
+    QuantizationStatus,
     initialize_module_for_quantization,
 )
 from torch import nn
@@ -161,3 +162,32 @@ def test_nested_parent_modules_produce_valid_global_scale():
             assert (
                 torch.isfinite(param).all() and param.item() > 0
             ), f"{name} not valid: {param.item()}"
+
+
+def test_layerwise_quantization_only_initializes_and_freezes_passed_modules():
+    model = nn.Sequential(nn.Linear(256, 256), nn.Linear(256, 256))
+    modifier = QuantizationModifier(targets="Linear", scheme="W8A16")
+    state = State(model=model)
+    state.layerwise_decompression = True
+
+    modifier.on_initialize(state)
+    modifier.on_calibration_start(state, None)
+
+    assert not hasattr(model[0], "quantization_scheme")
+    assert not hasattr(model[1], "quantization_scheme")
+
+    modifier.start_layerwise_calibration(model, list(model[0].modules()))
+
+    assert model[0].quantization_status == QuantizationStatus.CALIBRATION
+    assert hasattr(model[0], "weight_observer")
+    assert not hasattr(model[1], "quantization_scheme")
+
+    modifier.on_sequential_epoch_end(
+        state,
+        Event(type_=EventType.SEQUENTIAL_EPOCH_END),
+        modules=list(model[0].modules()),
+    )
+
+    assert model[0].quantization_status == QuantizationStatus.FROZEN
+    assert not hasattr(model[0], "weight_observer")
+    assert not hasattr(model[1], "quantization_scheme")

--- a/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
+++ b/tests/llmcompressor/modifiers/quantization/test_sequential_observation.py
@@ -197,3 +197,22 @@ def test_layerwise_quantization_only_initializes_and_freezes_passed_modules():
     assert model[0].quantization_status == QuantizationStatus.FROZEN
     assert not hasattr(model[0], "weight_observer")
     assert not hasattr(model[1], "quantization_scheme")
+
+
+def test_layerwise_quantization_supports_old_compressed_tensors_apply_api():
+    model = nn.Sequential(nn.Linear(256, 256), nn.Linear(256, 256))
+    modifier = QuantizationModifier(targets="Linear", scheme="W8A16")
+
+    from compressed_tensors.quantization import apply_quantization_config
+
+    def old_apply_quantization_config(model, config):
+        return apply_quantization_config(model, config)
+
+    with patch(
+        "llmcompressor.modifiers.quantization.quantization.mixin.apply_quantization_config",
+        old_apply_quantization_config,
+    ):
+        modifier.start_layerwise_calibration(model, list(model[0].modules()))
+
+    assert model[0].quantization_status == QuantizationStatus.CALIBRATION
+    assert not hasattr(model[1], "quantization_scheme")

--- a/tests/llmcompressor/observers/test_helpers.py
+++ b/tests/llmcompressor/observers/test_helpers.py
@@ -69,10 +69,24 @@ class _SlidingAttention(nn.Module):
         self.v_proj = None
 
 
+class _Attention(nn.Module):
+    def __init__(self, hidden_size):
+        super().__init__()
+        self.q_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.v_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+
+
 class _DecoderLayer(nn.Module):
     def __init__(self, hidden_size, num_heads):
         super().__init__()
         self.self_attn = _SlidingAttention(hidden_size, num_heads)
+
+
+class _FullDecoderLayer(nn.Module):
+    def __init__(self, hidden_size):
+        super().__init__()
+        self.self_attn = _Attention(hidden_size)
 
 
 class _ToyGemma4(nn.Module):
@@ -80,6 +94,14 @@ class _ToyGemma4(nn.Module):
         super().__init__()
         self.layers = nn.ModuleList(
             [_DecoderLayer(hidden_size, num_heads) for _ in range(num_layers)]
+        )
+
+
+class _ToyAttentionModel(nn.Module):
+    def __init__(self, hidden_size=64, num_layers=2):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [_FullDecoderLayer(hidden_size) for _ in range(num_layers)]
         )
 
 
@@ -117,3 +139,19 @@ def test_fuse_weight_observers_with_none_v_proj():
         k_obs = layer.self_attn.k_proj.weight_observer
         assert q_obs.fusion_handler.is_fused, "q_proj observer should be fused"
         assert k_obs.fusion_handler.is_fused, "k_proj observer should be fused"
+
+
+def test_fuse_weight_observers_can_scope_to_subgraph_modules():
+    model = _ToyAttentionModel()
+    scoped_attn = model.layers[0].self_attn
+    unrelated_attn = model.layers[1].self_attn
+
+    for layer in (scoped_attn.q_proj, scoped_attn.k_proj, scoped_attn.v_proj):
+        _attach_tensor_group_scheme(layer)
+    _attach_tensor_group_scheme(unrelated_attn.q_proj)
+
+    fuse_weight_observers(model, modules=list(scoped_attn.modules()))
+
+    for layer in (scoped_attn.q_proj, scoped_attn.k_proj, scoped_attn.v_proj):
+        assert layer.weight_observer.fusion_handler.is_fused
+    assert not unrelated_attn.q_proj.weight_observer.fusion_handler.is_fused

--- a/tests/llmcompressor/pipelines/sequential/test_layerwise_pipeline.py
+++ b/tests/llmcompressor/pipelines/sequential/test_layerwise_pipeline.py
@@ -70,7 +70,9 @@ def test_sequential_pipeline_decompresses_and_recompresses_current_subgraph(
     monkeypatch.setattr(pipeline_module, "set_onload_device", lambda *args: None)
     monkeypatch.setattr(pipeline_module, "disable_offloading", contextlib.nullcontext)
     monkeypatch.setattr(
-        pipeline_module, "calibration_forward_context", lambda model: contextlib.nullcontext()
+        pipeline_module,
+        "calibration_forward_context",
+        lambda model: contextlib.nullcontext(),
     )
     monkeypatch.setattr(
         pipeline_module, "DisableQuantization", lambda model: contextlib.nullcontext()

--- a/tests/llmcompressor/pipelines/sequential/test_layerwise_pipeline.py
+++ b/tests/llmcompressor/pipelines/sequential/test_layerwise_pipeline.py
@@ -1,0 +1,132 @@
+import contextlib
+from types import SimpleNamespace
+
+import torch
+
+import llmcompressor.pipelines.sequential.pipeline as pipeline_module
+from llmcompressor.pipelines.sequential.pipeline import SequentialPipeline
+
+
+class _FakeActivations:
+    def iter(self, input_names):
+        yield {}
+
+    def update(self, batch_idx, outputs):
+        pass
+
+    def delete(self, batch_idx, consumed_names):
+        pass
+
+
+class _FakeSubgraph:
+    input_names = []
+    consumed_names = []
+
+    def __init__(self, module, events):
+        self.module = module
+        self.events = events
+
+    def submodules(self, model):
+        return [self.module]
+
+    def forward(self, model, **inputs):
+        self.events.append("forward")
+        return {}
+
+
+class _FakeModifier:
+    def __init__(self, events):
+        self.events = events
+
+    def start_layerwise_calibration(self, model, modules):
+        self.events.append(("start_layerwise_calibration", modules))
+
+
+def test_sequential_pipeline_decompresses_and_recompresses_current_subgraph(
+    monkeypatch,
+):
+    model = torch.nn.Sequential(torch.nn.Linear(4, 4))
+    module = model[0]
+    events = []
+
+    modifier = _FakeModifier(events)
+    session = SimpleNamespace(
+        lifecycle=SimpleNamespace(recipe=SimpleNamespace(modifiers=[modifier])),
+        state=SimpleNamespace(),
+    )
+    dataset_args = SimpleNamespace(
+        layerwise_decompression=True,
+        layerwise_compression=True,
+        propagate_error=False,
+        sequential_offload_device="cpu",
+        sequential_targets=None,
+        sequential_targets_per_subgraph=1,
+        tracing_ignore=[],
+        use_loss_mask=False,
+    )
+
+    monkeypatch.setattr(pipeline_module, "active_session", lambda: session)
+    monkeypatch.setattr(pipeline_module, "get_main_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(pipeline_module, "set_onload_device", lambda *args: None)
+    monkeypatch.setattr(pipeline_module, "disable_offloading", contextlib.nullcontext)
+    monkeypatch.setattr(
+        pipeline_module, "calibration_forward_context", lambda model: contextlib.nullcontext()
+    )
+    monkeypatch.setattr(
+        pipeline_module, "DisableQuantization", lambda model: contextlib.nullcontext()
+    )
+    monkeypatch.setattr(pipeline_module, "infer_sequential_targets", lambda *args: [])
+    monkeypatch.setattr(
+        pipeline_module,
+        "trace_subgraphs",
+        lambda *args: [_FakeSubgraph(module, events)],
+    )
+    monkeypatch.setattr(
+        pipeline_module.IntermediatesCache,
+        "from_dataloader",
+        lambda *args: _FakeActivations(),
+    )
+    monkeypatch.setattr(
+        pipeline_module.LifecycleCallbacks,
+        "calibration_start",
+        lambda: events.append("calibration_start"),
+    )
+    monkeypatch.setattr(
+        pipeline_module.LifecycleCallbacks,
+        "sequential_epoch_end",
+        lambda modules: events.append(("sequential_epoch_end", modules)),
+    )
+    monkeypatch.setattr(
+        pipeline_module.LifecycleCallbacks,
+        "calibration_end",
+        lambda: events.append("calibration_end"),
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "is_module_quantized",
+        lambda candidate: candidate is module,
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "decompress_module",
+        lambda candidate, leave_decompressed=True: events.append(
+            ("decompress_module", candidate, leave_decompressed)
+        ),
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "compress_module",
+        lambda candidate: events.append(("compress_module", candidate)),
+    )
+
+    SequentialPipeline.__call__(model, [{}], dataset_args)
+
+    assert events == [
+        "calibration_start",
+        ("decompress_module", module, False),
+        ("start_layerwise_calibration", [module]),
+        "forward",
+        ("sequential_epoch_end", [module]),
+        ("compress_module", module),
+        "calibration_end",
+    ]


### PR DESCRIPTION
*marking as ready to trigger ci

Implements layer wise compression and decompression for sequential pipeline. Mostly taken from Kyle's branch main:layerwise-decompression-compression. Avoids having to do it upfront for large models. Under llm-c, add oneshot args for each layerwise decompression and layerwise compression. When enabled, quantization modifier skips initialization/calibration on the whole model. Separate function for doing this for each subgraph instead. 

Considering removing the layerwise weight observer fusion for simplicity. 

Goes along with:
https://github.com/vllm-project/compressed-tensors/pull/867