### PR TITLE
Add GLM 5.3 MXFp4 example

### DIFF
--- a/examples/model_free_ptq/glm_5_3_mxfp4.py
+++ b/examples/model_free_ptq/glm_5_3_mxfp4.py
@@ -1,0 +1,28 @@
+from compressed_tensors.entrypoints.convert import FP8BlockDequantizer
+
+from llmcompressor import model_free_ptq
+
+
+MODEL_ID = "zai-org/GLM-5.3"
+SAVE_DIR = "/mnt/nvme_stripe/playground/dsikka/" + MODEL_ID.rstrip("/").split("/")[-1] + "-MXFP4"
+
+ignore = [
+    "re:.*mlp.gate$",
+    "re:.*lm_head",
+    "re:.*embed_tokens$",
+    # not fp8-block quantized in the source checkpoint
+    "re:.*eh_proj$",
+    "re:.*self_attn.indexer.weights_proj$",
+]
+
+model_free_ptq(
+    model_stub=MODEL_ID,
+    save_directory=SAVE_DIR,
+    scheme="MXFP4",
+    ignore=ignore,
+    converter=FP8BlockDequantizer(
+        ignore=ignore,
+    ),
+    max_workers=2,
+    device="cuda:0",
+)

--- a/examples/model_free_ptq/glm_5_3_mxfp4.py
+++ b/examples/model_free_ptq/glm_5_3_mxfp4.py
@@ -2,15 +2,14 @@ from compressed_tensors.entrypoints.convert import FP8BlockDequantizer
 
 from llmcompressor import model_free_ptq
 
-
 MODEL_ID = "zai-org/GLM-5.3"
-SAVE_DIR = "/mnt/nvme_stripe/playground/dsikka/" + MODEL_ID.rstrip("/").split("/")[-1] + "-MXFP4"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1] + "-MXFP4"
 
+# modules that were not fp8-block quantized in the source checkpoint
 ignore = [
     "re:.*mlp.gate$",
     "re:.*lm_head",
     "re:.*embed_tokens$",
-    # not fp8-block quantized in the source checkpoint
     "re:.*eh_proj$",
     "re:.*self_attn.indexer.weights_proj$",
 ]
@@ -19,10 +18,11 @@ model_free_ptq(
     model_stub=MODEL_ID,
     save_directory=SAVE_DIR,
     scheme="MXFP4",
-    ignore=ignore,
-    converter=FP8BlockDequantizer(
-        ignore=ignore,
-    ),
+    # wk IS fp8 in the source (dequantizer dequantizes it), but vLLM fuses
+    # wk + weights_proj into a dense (quant_config=None) layer whose fp8-only
+    # load path can't unpack mxfp4 weights — keep wk in bf16 instead
+    ignore=ignore + ["re:.*self_attn.indexer.wk$"],
+    converter=FP8BlockDequantizer(ignore=ignore),
     max_workers=2,
     device="cuda:0",
 )


### PR DESCRIPTION
SUMMARY:
- The example first dequantizes from FP8 and then quantizes to MXFP4
 

Produces: https://huggingface.co/RedHatAI/GLM-5.3-MXFP4