### PR TITLE
Add log_sequential_error option for layerwise SQNR-based error reporting

### DIFF
--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -272,6 +272,15 @@ class DatasetArguments(CustomDatasetArguments):
             "Default is True"
         },
     )
+    log_sequential_error: bool = field(
+        default=False,
+        metadata={
+            "help": "Only relevant for the sequential pipeline. If True, compute and "
+            "log the KL divergence between each subgraph's pre-compression and "
+            "post-compression outputs. Automatically enables propagate_error. "
+            "Default is False."
+        },
+    )
     use_loss_mask: bool = field(
         default=False,
         metadata={

--- a/src/llmcompressor/args/dataset_arguments.py
+++ b/src/llmcompressor/args/dataset_arguments.py
@@ -276,7 +276,7 @@ class DatasetArguments(CustomDatasetArguments):
         default=False,
         metadata={
             "help": "Only relevant for the sequential pipeline. If True, compute and "
-            "log the KL divergence between each subgraph's pre-compression and "
+            "log the SQNR between each subgraph's pre-compression and "
             "post-compression outputs. Automatically enables propagate_error. "
             "Default is False."
         },

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -367,6 +367,7 @@ def oneshot(
     sequential_offload_device: str = "cpu",
     quantization_aware_calibration: bool = True,
     sequential_prefetch: bool = False,
+    log_sequential_error: bool = False,
     # Miscellaneous arguments
     output_dir: str | None = None,
     log_dir: str | None = None,
@@ -460,6 +461,10 @@ def oneshot(
     :param sequential_prefetch: When using the sequential pipeline, prefetch the
         next batch in a background thread to overlap onload with forward. Default
         False; set True for faster calibration when GPU memory allows.
+    :param log_sequential_error: Only relevant for the sequential pipeline. If True,
+        compute and log the KL divergence between each subgraph's pre-compression
+        and post-compression outputs. Automatically enables propagate_error.
+        Default is False.
     # Miscellaneous arguments
     :param output_dir: Path to save the output model after calibration.
         Nothing is saved if None.

--- a/src/llmcompressor/entrypoints/oneshot.py
+++ b/src/llmcompressor/entrypoints/oneshot.py
@@ -462,7 +462,7 @@ def oneshot(
         next batch in a background thread to overlap onload with forward. Default
         False; set True for faster calibration when GPU memory allows.
     :param log_sequential_error: Only relevant for the sequential pipeline. If True,
-        compute and log the KL divergence between each subgraph's pre-compression
+        compute and log the SQNR between each subgraph's pre-compression
         and post-compression outputs. Automatically enables propagate_error.
         Default is False.
     # Miscellaneous arguments

--- a/src/llmcompressor/pipelines/sequential/error_logging.py
+++ b/src/llmcompressor/pipelines/sequential/error_logging.py
@@ -1,0 +1,101 @@
+import math
+from typing import Any
+
+import torch
+
+from llmcompressor.pipelines.cache import IntermediatesCache
+
+__all__ = ["compute_sqnr", "cache_pre_compression_output", "accumulate_batch_power"]
+
+_PRE_ERROR_KEY = "__pre_error__"
+
+
+def _get_largest_tensor(outputs: dict[str, Any]) -> torch.Tensor | None:
+    """
+    Select the largest tensor (by number of elements) from a subgraph output dict.
+    This is used as a heuristic to identify the "main activation" (e.g. hidden
+    states) among a subgraph's outputs, which may also include pass-through values
+    such as attention masks or position ids.
+
+    :param outputs: dictionary of subgraph output values
+    :return: the largest tensor value, or None if no tensor values are present
+    """
+    largest = None
+    largest_numel = 0
+    for value in outputs.values():
+        if isinstance(value, torch.Tensor) and value.numel() > largest_numel:
+            largest = value
+            largest_numel = value.numel()
+    return largest
+
+
+def compute_sqnr(signal_power_sum: float, noise_power_sum: float) -> float:
+    """
+    Compute the Signal-to-Quantization-Noise Ratio (SQNR), in decibels, from
+    accumulated signal and noise power sums; higher values indicate less
+    distortion. Callers should sum power across every batch in a subgraph
+    (see :func:`accumulate_batch_power`) and call this once on the totals,
+    since SQNR is a logarithmic ratio and cannot be meaningfully averaged
+    batch-by-batch.
+
+    :param signal_power_sum: sum of squared pre-compression activation values
+    :param noise_power_sum: sum of squared compression noise values
+    :return: SQNR in dB, or ``inf`` if there is no noise
+    """
+    if noise_power_sum == 0:
+        return float("inf")
+    return 10 * math.log10(signal_power_sum / noise_power_sum)
+
+
+def cache_pre_compression_output(
+    activations: IntermediatesCache,
+    batch_idx: int,
+    outputs: dict[str, Any],
+) -> None:
+    """
+    Save the main activation tensor from a subgraph's pre-compression output
+    into the intermediates cache for later error comparison.
+
+    :param activations: intermediates cache shared across the pipeline
+    :param batch_idx: index of the current calibration batch
+    :param outputs: subgraph output dict from the calibration (pre-compression) pass
+    """
+    main_tensor = _get_largest_tensor(outputs)
+    if main_tensor is not None:
+        activations.update(batch_idx, {_PRE_ERROR_KEY: main_tensor})
+
+
+def accumulate_batch_power(
+    activations: IntermediatesCache,
+    batch_idx: int,
+    output: dict[str, Any],
+) -> tuple[float, float] | None:
+    """
+    Compute the signal and noise power sums for a single batch by comparing
+    the saved pre-compression activation against the post-compression output,
+    then remove the cached pre-compression tensor to free memory. Power is
+    summed (not averaged) so callers can add it across batches and compute a
+    single SQNR from the totals via :func:`compute_sqnr`.
+
+    :param activations: intermediates cache holding the pre-compression tensor
+    :param batch_idx: index of the current propagation batch
+    :param output: subgraph output dict from the propagation (post-compression) pass
+    :return: (signal power sum, noise power sum) for this batch, or None if
+        either tensor is unavailable
+    """
+    pre_data = activations.fetch(batch_idx, [_PRE_ERROR_KEY])
+    pre_tensor = pre_data.get(_PRE_ERROR_KEY)
+    if pre_tensor is None:
+        return None
+    # clean up cached tensor; delete only after confirming the key exists,
+    # since IntermediatesCache.delete raises KeyError for missing keys
+    activations.delete(batch_idx, [_PRE_ERROR_KEY])
+
+    post_tensor = _get_largest_tensor(output)
+    if post_tensor is None:
+        return None
+
+    noise = post_tensor.float() - pre_tensor.float()
+    signal_power_sum = (pre_tensor.float() ** 2).sum().item()
+    noise_power_sum = (noise**2).sum().item()
+    return signal_power_sum, noise_power_sum

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -119,6 +119,8 @@ class SequentialPipeline(CalibrationPipeline):
         :param dataloader: loads data for calibration
         :param dataset_args: dataset arguments relevant to pipelines
         """
+        _logger = logger.patch(lambda r: r.update(function="SequentialPipeline"))
+
         session = active_session()
 
         # prepare model for sequential onloading
@@ -260,7 +262,7 @@ class SequentialPipeline(CalibrationPipeline):
 
                         if dataset_args.log_sequential_error and batch_kls:
                             avg_kl = sum(batch_kls) / len(batch_kls)
-                            logger.log(
+                            _logger.log(
                                 "METRIC",
                                 f"subgraph {subgraph_index + 1}/{num_subgraphs} | "
                                 f"sequential error (KL): {avg_kl:.6f}",

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -185,8 +185,11 @@ class SequentialPipeline(CalibrationPipeline):
                 prop_desc = f"({subgraph_index + 1}/{num_subgraphs}): Propagating"
 
                 # per-batch largest tensor captured before compression, used by
-                # log_sequential_error to compare against post-compression outputs
-                pre_compression_outputs: list[torch.Tensor] = []
+                # log_sequential_error to compare against post-compression outputs.
+                # keyed by batch_idx (rather than appended to a list) so that a
+                # batch skipped in pass 1 (e.g. _get_largest_tensor returns None)
+                # cannot desynchronize the alignment with pass 2
+                pre_compression_outputs: dict[int, torch.Tensor] = {}
 
                 # reduce memory movement by keeping modules onloaded
                 num_batches = len(dataloader)
@@ -213,7 +216,7 @@ class SequentialPipeline(CalibrationPipeline):
                         ):
                             main_tensor = _get_largest_tensor(outputs)
                             if main_tensor is not None:
-                                pre_compression_outputs.append(
+                                pre_compression_outputs[batch_idx] = (
                                     main_tensor.detach().clone().cpu()
                                 )
 
@@ -242,7 +245,7 @@ class SequentialPipeline(CalibrationPipeline):
                                 if (
                                     dataset_args.log_sequential_error
                                     and subgraph_index < num_subgraphs - 1
-                                    and batch_idx < len(pre_compression_outputs)
+                                    and batch_idx in pre_compression_outputs
                                 ):
                                     post_tensor = _get_largest_tensor(output)
                                     if post_tensor is not None:

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -1,8 +1,9 @@
 import contextlib
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
 
 import torch
 from compressed_tensors.offload import disable_offloading, set_onload_device
+from loguru import logger
 from torch.utils.data.dataloader import DataLoader
 from tqdm import tqdm
 
@@ -46,6 +47,45 @@ def _get_batches(
         enumerate(batch_source), total=num_batches, desc=desc
     ):
         yield batch_idx, inputs
+
+
+def _get_largest_tensor(outputs: dict[str, Any]) -> torch.Tensor | None:
+    """
+    Select the largest tensor (by number of elements) from a subgraph output dict.
+    This is used as a heuristic to identify the "main activation" (e.g. hidden
+    states) among a subgraph's outputs, which may also include pass-through values
+    such as attention masks or position ids.
+
+    :param outputs: dictionary of subgraph output values
+    :return: the largest tensor value, or None if no tensor values are present
+    """
+    largest = None
+    largest_numel = 0
+    for value in outputs.values():
+        if isinstance(value, torch.Tensor) and value.numel() > largest_numel:
+            largest = value
+            largest_numel = value.numel()
+    return largest
+
+
+def _compute_kl_divergence(
+    pre_tensor: torch.Tensor, post_tensor: torch.Tensor
+) -> float:
+    """
+    Compute the KL divergence between pre-compression and post-compression
+    activation tensors. Both tensors are cast to float32 and converted to
+    log-probability distributions via ``log_softmax`` along the last dimension
+    before computing the divergence.
+
+    :param pre_tensor: activation tensor captured before compression
+    :param post_tensor: activation tensor captured after compression
+    :return: scalar KL divergence value
+    """
+    pre_log_probs = torch.nn.functional.log_softmax(pre_tensor.float(), dim=-1)
+    post_log_probs = torch.nn.functional.log_softmax(post_tensor.float(), dim=-1)
+    return torch.nn.functional.kl_div(
+        post_log_probs, pre_log_probs, log_target=True, reduction="batchmean"
+    ).item()
 
 
 @CalibrationPipeline.register("sequential")
@@ -93,6 +133,12 @@ class SequentialPipeline(CalibrationPipeline):
         if any(type(m).__name__ == "AutoRoundModifier" for m in modifiers):
             dataset_args.propagate_error = False
 
+        # log_sequential_error requires comparing unquantized (pass 1) and quantized
+        # (pass 2) outputs, so propagate_error must be enabled. This takes precedence
+        # over the AutoRoundModifier override above since it was explicitly requested
+        if dataset_args.log_sequential_error:
+            dataset_args.propagate_error = True
+
         # prepare to trace subgraphs
         sequential_targets = infer_sequential_targets(
             model, dataset_args.sequential_targets
@@ -138,6 +184,10 @@ class SequentialPipeline(CalibrationPipeline):
                 calib_desc = f"({subgraph_index + 1}/{num_subgraphs}): Calibrating"
                 prop_desc = f"({subgraph_index + 1}/{num_subgraphs}): Propagating"
 
+                # per-batch largest tensor captured before compression, used by
+                # log_sequential_error to compare against post-compression outputs
+                pre_compression_outputs: list[torch.Tensor] = []
+
                 # reduce memory movement by keeping modules onloaded
                 num_batches = len(dataloader)
                 with disable_offloading():
@@ -157,11 +207,22 @@ class SequentialPipeline(CalibrationPipeline):
                                 activations.update(batch_idx, outputs)
                                 activations.delete(batch_idx, subgraph.consumed_names)
 
+                        if (
+                            dataset_args.log_sequential_error
+                            and subgraph_index < num_subgraphs - 1
+                        ):
+                            main_tensor = _get_largest_tensor(outputs)
+                            if main_tensor is not None:
+                                pre_compression_outputs.append(
+                                    main_tensor.detach().clone().cpu()
+                                )
+
                     LifecycleCallbacks.sequential_epoch_end(subgraph.submodules(model))
 
                     if dataset_args.propagate_error:
                         # this pass does not trigger modifier hooks
                         # and is only used for capturing outputs of compressed modules
+                        batch_kls: list[float] = []
                         with HooksMixin.disable_hooks():
                             for batch_idx, inputs in _get_batches(
                                 activations,
@@ -176,6 +237,33 @@ class SequentialPipeline(CalibrationPipeline):
                                     activations.delete(
                                         batch_idx, subgraph.consumed_names
                                     )
+
+                                # compare pre/post-compression activations
+                                if (
+                                    dataset_args.log_sequential_error
+                                    and subgraph_index < num_subgraphs - 1
+                                    and batch_idx < len(pre_compression_outputs)
+                                ):
+                                    post_tensor = _get_largest_tensor(output)
+                                    if post_tensor is not None:
+                                        pre_tensor = pre_compression_outputs[
+                                            batch_idx
+                                        ].to(post_tensor.device)
+                                        batch_kls.append(
+                                            _compute_kl_divergence(
+                                                pre_tensor, post_tensor
+                                            )
+                                        )
+
+                        if dataset_args.log_sequential_error and batch_kls:
+                            avg_kl = sum(batch_kls) / len(batch_kls)
+                            logger.log(
+                                "METRIC",
+                                f"subgraph {subgraph_index + 1}/{num_subgraphs} | "
+                                f"sequential error (KL): {avg_kl:.6f}",
+                            )
+
+                pre_compression_outputs.clear()
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_end()

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -1,5 +1,5 @@
 import contextlib
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Iterator
 
 import torch
 from compressed_tensors.offload import disable_offloading, set_onload_device
@@ -11,6 +11,11 @@ from llmcompressor.core import LifecycleCallbacks, active_session
 from llmcompressor.modifiers.utils.hooks import HooksMixin
 from llmcompressor.pipelines.cache import IntermediatesCache
 from llmcompressor.pipelines.registry import CalibrationPipeline
+from llmcompressor.pipelines.sequential.error_logging import (
+    accumulate_batch_power,
+    cache_pre_compression_output,
+    compute_sqnr,
+)
 from llmcompressor.pipelines.sequential.helpers import (
     handle_sequential_oom,
     trace_subgraphs,
@@ -47,96 +52,6 @@ def _get_batches(
         enumerate(batch_source), total=num_batches, desc=desc
     ):
         yield batch_idx, inputs
-
-
-def _get_largest_tensor(outputs: dict[str, Any]) -> torch.Tensor | None:
-    """
-    Select the largest tensor (by number of elements) from a subgraph output dict.
-    This is used as a heuristic to identify the "main activation" (e.g. hidden
-    states) among a subgraph's outputs, which may also include pass-through values
-    such as attention masks or position ids.
-
-    :param outputs: dictionary of subgraph output values
-    :return: the largest tensor value, or None if no tensor values are present
-    """
-    largest = None
-    largest_numel = 0
-    for value in outputs.values():
-        if isinstance(value, torch.Tensor) and value.numel() > largest_numel:
-            largest = value
-            largest_numel = value.numel()
-    return largest
-
-
-def _compute_kl_divergence(
-    pre_tensor: torch.Tensor, post_tensor: torch.Tensor
-) -> float:
-    """
-    Compute the KL divergence between pre-compression and post-compression
-    activation tensors. Both tensors are cast to float32 and converted to
-    log-probability distributions via ``log_softmax`` along the last dimension
-    before computing the divergence.
-
-    :param pre_tensor: activation tensor captured before compression
-    :param post_tensor: activation tensor captured after compression
-    :return: scalar KL divergence value
-    """
-    pre_log_probs = torch.nn.functional.log_softmax(pre_tensor.float(), dim=-1)
-    post_log_probs = torch.nn.functional.log_softmax(post_tensor.float(), dim=-1)
-    return torch.nn.functional.kl_div(
-        post_log_probs, pre_log_probs, log_target=True, reduction="batchmean"
-    ).item()
-
-
-_PRE_KL_KEY = "__pre_kl__"
-
-
-def _cache_pre_compression_output(
-    activations: IntermediatesCache,
-    batch_idx: int,
-    outputs: dict[str, Any],
-) -> None:
-    """
-    Save the main activation tensor from a subgraph's pre-compression output
-    into the intermediates cache for later KL divergence comparison.
-
-    :param activations: intermediates cache shared across the pipeline
-    :param batch_idx: index of the current calibration batch
-    :param outputs: subgraph output dict from the calibration (pre-compression) pass
-    """
-    main_tensor = _get_largest_tensor(outputs)
-    if main_tensor is not None:
-        activations.update(batch_idx, {_PRE_KL_KEY: main_tensor})
-
-
-def _compute_batch_kl_divergence(
-    activations: IntermediatesCache,
-    batch_idx: int,
-    output: dict[str, Any],
-) -> float | None:
-    """
-    Compute the KL divergence for a single batch by comparing the saved
-    pre-compression activation against the post-compression output, then
-    remove the cached pre-compression tensor to free memory.
-
-    :param activations: intermediates cache holding the pre-compression tensor
-    :param batch_idx: index of the current propagation batch
-    :param output: subgraph output dict from the propagation (post-compression) pass
-    :return: scalar KL divergence, or None if either tensor is unavailable
-    """
-    pre_data = activations.fetch(batch_idx, [_PRE_KL_KEY])
-    pre_tensor = pre_data.get(_PRE_KL_KEY)
-    if pre_tensor is None:
-        return None
-    # clean up cached tensor; delete only after confirming the key exists,
-    # since IntermediatesCache.delete raises KeyError for missing keys
-    activations.delete(batch_idx, [_PRE_KL_KEY])
-
-    post_tensor = _get_largest_tensor(output)
-    if post_tensor is None:
-        return None
-
-    return _compute_kl_divergence(pre_tensor, post_tensor)
 
 
 @CalibrationPipeline.register("sequential")
@@ -260,7 +175,7 @@ class SequentialPipeline(CalibrationPipeline):
                             dataset_args.log_sequential_error
                             and subgraph_index < num_subgraphs - 1
                         ):
-                            _cache_pre_compression_output(
+                            cache_pre_compression_output(
                                 activations, batch_idx, outputs
                             )
 
@@ -269,7 +184,12 @@ class SequentialPipeline(CalibrationPipeline):
                     if dataset_args.propagate_error:
                         # this pass does not trigger modifier hooks
                         # and is only used for capturing outputs of compressed modules
-                        batch_kls: list[float] = []
+                        # signal/noise power sums are accumulated across all batches
+                        # (rather than averaging a per-batch SQNR) so that the final
+                        # ratio correctly weights each batch by its element count
+                        signal_power_sum = 0.0
+                        noise_power_sum = 0.0
+                        num_batches_measured = 0
                         with HooksMixin.disable_hooks():
                             for batch_idx, inputs in _get_batches(
                                 activations,
@@ -290,18 +210,20 @@ class SequentialPipeline(CalibrationPipeline):
                                     dataset_args.log_sequential_error
                                     and subgraph_index < num_subgraphs - 1
                                 ):
-                                    kl = _compute_batch_kl_divergence(
+                                    batch_power = accumulate_batch_power(
                                         activations, batch_idx, output
                                     )
-                                    if kl is not None:
-                                        batch_kls.append(kl)
+                                    if batch_power is not None:
+                                        signal_power_sum += batch_power[0]
+                                        noise_power_sum += batch_power[1]
+                                        num_batches_measured += 1
 
-                        if dataset_args.log_sequential_error and batch_kls:
-                            avg_kl = sum(batch_kls) / len(batch_kls)
+                        if dataset_args.log_sequential_error and num_batches_measured:
+                            sqnr = compute_sqnr(signal_power_sum, noise_power_sum)
                             _logger.log(
                                 "METRIC",
                                 f"subgraph {subgraph_index + 1}/{num_subgraphs} | "
-                                f"sequential error (KL): {avg_kl:.6f}",
+                                f"sequential error (SQNR dB): {sqnr:.2f}",
                             )
 
             # redundant, finish any remaining compression

--- a/src/llmcompressor/pipelines/sequential/pipeline.py
+++ b/src/llmcompressor/pipelines/sequential/pipeline.py
@@ -88,6 +88,57 @@ def _compute_kl_divergence(
     ).item()
 
 
+_PRE_KL_KEY = "__pre_kl__"
+
+
+def _cache_pre_compression_output(
+    activations: IntermediatesCache,
+    batch_idx: int,
+    outputs: dict[str, Any],
+) -> None:
+    """
+    Save the main activation tensor from a subgraph's pre-compression output
+    into the intermediates cache for later KL divergence comparison.
+
+    :param activations: intermediates cache shared across the pipeline
+    :param batch_idx: index of the current calibration batch
+    :param outputs: subgraph output dict from the calibration (pre-compression) pass
+    """
+    main_tensor = _get_largest_tensor(outputs)
+    if main_tensor is not None:
+        activations.update(batch_idx, {_PRE_KL_KEY: main_tensor})
+
+
+def _compute_batch_kl_divergence(
+    activations: IntermediatesCache,
+    batch_idx: int,
+    output: dict[str, Any],
+) -> float | None:
+    """
+    Compute the KL divergence for a single batch by comparing the saved
+    pre-compression activation against the post-compression output, then
+    remove the cached pre-compression tensor to free memory.
+
+    :param activations: intermediates cache holding the pre-compression tensor
+    :param batch_idx: index of the current propagation batch
+    :param output: subgraph output dict from the propagation (post-compression) pass
+    :return: scalar KL divergence, or None if either tensor is unavailable
+    """
+    pre_data = activations.fetch(batch_idx, [_PRE_KL_KEY])
+    pre_tensor = pre_data.get(_PRE_KL_KEY)
+    if pre_tensor is None:
+        return None
+    # clean up cached tensor; delete only after confirming the key exists,
+    # since IntermediatesCache.delete raises KeyError for missing keys
+    activations.delete(batch_idx, [_PRE_KL_KEY])
+
+    post_tensor = _get_largest_tensor(output)
+    if post_tensor is None:
+        return None
+
+    return _compute_kl_divergence(pre_tensor, post_tensor)
+
+
 @CalibrationPipeline.register("sequential")
 class SequentialPipeline(CalibrationPipeline):
     @staticmethod
@@ -186,13 +237,6 @@ class SequentialPipeline(CalibrationPipeline):
                 calib_desc = f"({subgraph_index + 1}/{num_subgraphs}): Calibrating"
                 prop_desc = f"({subgraph_index + 1}/{num_subgraphs}): Propagating"
 
-                # per-batch largest tensor captured before compression, used by
-                # log_sequential_error to compare against post-compression outputs.
-                # keyed by batch_idx (rather than appended to a list) so that a
-                # batch skipped in pass 1 (e.g. _get_largest_tensor returns None)
-                # cannot desynchronize the alignment with pass 2
-                pre_compression_outputs: dict[int, torch.Tensor] = {}
-
                 # reduce memory movement by keeping modules onloaded
                 num_batches = len(dataloader)
                 with disable_offloading():
@@ -216,11 +260,9 @@ class SequentialPipeline(CalibrationPipeline):
                             dataset_args.log_sequential_error
                             and subgraph_index < num_subgraphs - 1
                         ):
-                            main_tensor = _get_largest_tensor(outputs)
-                            if main_tensor is not None:
-                                pre_compression_outputs[batch_idx] = (
-                                    main_tensor.detach().clone().cpu()
-                                )
+                            _cache_pre_compression_output(
+                                activations, batch_idx, outputs
+                            )
 
                     LifecycleCallbacks.sequential_epoch_end(subgraph.submodules(model))
 
@@ -247,18 +289,12 @@ class SequentialPipeline(CalibrationPipeline):
                                 if (
                                     dataset_args.log_sequential_error
                                     and subgraph_index < num_subgraphs - 1
-                                    and batch_idx in pre_compression_outputs
                                 ):
-                                    post_tensor = _get_largest_tensor(output)
-                                    if post_tensor is not None:
-                                        pre_tensor = pre_compression_outputs[
-                                            batch_idx
-                                        ].to(post_tensor.device)
-                                        batch_kls.append(
-                                            _compute_kl_divergence(
-                                                pre_tensor, post_tensor
-                                            )
-                                        )
+                                    kl = _compute_batch_kl_divergence(
+                                        activations, batch_idx, output
+                                    )
+                                    if kl is not None:
+                                        batch_kls.append(kl)
 
                         if dataset_args.log_sequential_error and batch_kls:
                             avg_kl = sum(batch_kls) / len(batch_kls)
@@ -267,8 +303,6 @@ class SequentialPipeline(CalibrationPipeline):
                                 f"subgraph {subgraph_index + 1}/{num_subgraphs} | "
                                 f"sequential error (KL): {avg_kl:.6f}",
                             )
-
-                pre_compression_outputs.clear()
 
             # redundant, finish any remaining compression
             LifecycleCallbacks.calibration_end()

--- a/tests/llmcompressor/pipelines/sequential/test_log_sequential_error.py
+++ b/tests/llmcompressor/pipelines/sequential/test_log_sequential_error.py
@@ -10,43 +10,19 @@ MODEL = "nm-testing/tinysmokellama-3.2"
 NUM_SAMPLES = 8
 MAX_SEQ_LENGTH = 128
 
-# Matches the METRIC message logged by SequentialPipeline once per subgraph when
-# log_sequential_error=True, e.g. (as captured via `format="{message}"`, which
-# strips the leading timestamp/function/level fields loguru normally adds):
-#
-#   subgraph 2/7 | sequential error (KL): 0.022716
-#
-# The first group is the 1-indexed subgraph number, the second is the total
-# number of subgraphs, and the third is the mean KL divergence for that subgraph.
-_KL_LINE_PATTERN = re.compile(
-    r"subgraph (\d+)/(\d+) \| sequential error \(KL\): (-?[\d.eE+-]+)"
+# e.g. "subgraph 2/7 | sequential error (SQNR dB): 84.91" (or "... : inf")
+_SQNR_LINE_PATTERN = re.compile(
+    r"subgraph (\d+)/(\d+) \| sequential error \(SQNR dB\): (\S+)"
 )
 
 
 def _run_oneshot_and_capture_metrics(log_sequential_error: bool) -> list[str]:
     """
-    Run GPTQ oneshot calibration on the smoke model and capture all METRIC-level
-    log messages emitted during the run.
+    Run GPTQ oneshot calibration and capture all METRIC-level log messages.
 
-    A temporary loguru sink is used (rather than capsys/capfd) since
-    `llmcompressor` binds its console sink to `sys.stdout` once at import
-    time, before any per-test stdout capturing fixture is installed.
-
-    Example return value (tinysmokellama-3.2 has 6 decoder layers, so 7
-    subgraphs total; the last subgraph has no downstream consumer and is
-    therefore never logged). Values are near-zero since this smoke model's
-    randomly-initialized weights barely change under W8A8 quantization; note
-    subgraph 5 below, whose value is a small negative floating point rounding
-    artifact rather than a true (impossible) negative KL divergence:
-
-        [
-            "subgraph 1/7 | sequential error (KL): 0.000000",
-            "subgraph 2/7 | sequential error (KL): 0.000001",
-            "subgraph 3/7 | sequential error (KL): 0.000000",
-            "subgraph 4/7 | sequential error (KL): 0.000002",
-            "subgraph 5/7 | sequential error (KL): -0.000001",
-            "subgraph 6/7 | sequential error (KL): 0.000000",
-        ]
+    Uses a temporary loguru sink (rather than capsys/capfd) since
+    `llmcompressor` binds its console sink to `sys.stdout` at import time,
+    before any per-test stdout capturing fixture is installed.
     """
     messages = []
     handler_id = logger.add(messages.append, level="METRIC", format="{message}")
@@ -55,9 +31,9 @@ def _run_oneshot_and_capture_metrics(log_sequential_error: bool) -> list[str]:
             model=MODEL,
             dataset="open_platypus",
             splits=f"train[:{NUM_SAMPLES}]",
-            # W8A8 uses per-channel weights (no group_size). tinysmokellama-3.2 has
-            # hidden_size=64, which is not divisible by the default W4A16 group_size
-            # (128) and would raise a RuntimeError in the weight observer.
+            # W8A8 (per-channel weights) avoids a group_size divisibility
+            # error: this model's hidden_size=64 isn't divisible by W4A16's
+            # default group_size of 128
             recipe=GPTQModifier(targets="Linear", scheme="W8A8", ignore=["lm_head"]),
             num_calibration_samples=NUM_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,
@@ -70,73 +46,43 @@ def _run_oneshot_and_capture_metrics(log_sequential_error: bool) -> list[str]:
     return messages
 
 
-def _parse_kl_lines(messages: list[str]) -> list[tuple[int, int, float]]:
-    """
-    Extract (subgraph_index, num_subgraphs, kl_value) tuples from METRIC lines.
-
-    Example:
-        >>> _parse_kl_lines(["subgraph 2/7 | sequential error (KL): 0.022716"])
-        [(2, 7, 0.022716)]
-    """
+def _parse_sqnr_lines(messages: list[str]) -> list[tuple[int, int, float]]:
+    """Extract (subgraph_index, num_subgraphs, sqnr_value) from METRIC lines."""
     parsed = []
     for message in messages:
-        match = _KL_LINE_PATTERN.search(message)
+        match = _SQNR_LINE_PATTERN.search(message)
         if match:
-            subgraph_index, num_subgraphs, kl_value = match.groups()
-            parsed.append((int(subgraph_index), int(num_subgraphs), float(kl_value)))
+            subgraph_index, num_subgraphs, sqnr_value = match.groups()
+            parsed.append((int(subgraph_index), int(num_subgraphs), float(sqnr_value)))
     return parsed
 
 
-def test_log_sequential_error_reports_kl_divergence():
+def test_log_sequential_error_reports_sqnr():
     """
-    Enabling log_sequential_error (see #3154) should emit one KL divergence
-    METRIC line per subgraph, except for the last subgraph (which has no
-    downstream consumer and is therefore skipped). Every reported value
-    should be finite and non-negative, consistent with the definition of KL
-    divergence.
+    Enabling log_sequential_error should log one SQNR value per subgraph,
+    except the last (which has no downstream consumer to compare against).
     """
     messages = _run_oneshot_and_capture_metrics(log_sequential_error=True)
-    kl_lines = _parse_kl_lines(messages)
+    sqnr_lines = _parse_sqnr_lines(messages)
+    assert sqnr_lines, "Expected at least one SQNR METRIC line"
 
-    assert kl_lines, "Expected at least one 'sequential error (KL)' METRIC line"
-
-    # every line should report the same subgraph total
-    subgraph_totals = {num_subgraphs for _, num_subgraphs, _ in kl_lines}
-    assert (
-        len(subgraph_totals) == 1
-    ), f"Expected a single consistent subgraph total, got {subgraph_totals}"
-    num_subgraphs = subgraph_totals.pop()
-    reported_indices = {subgraph_index for subgraph_index, _, _ in kl_lines}
-
-    # every subgraph except the last should report a KL value
+    num_subgraphs = sqnr_lines[0][1]
+    reported_indices = {subgraph_index for subgraph_index, _, _ in sqnr_lines}
     assert reported_indices == set(range(1, num_subgraphs)), (
-        f"Expected KL divergence reported for subgraphs 1..{num_subgraphs - 1}, "
+        f"Expected SQNR for subgraphs 1..{num_subgraphs - 1}, "
         f"got {sorted(reported_indices)}"
     )
 
-    # KL divergence is mathematically non-negative, but floating point rounding
-    # in log_softmax/kl_div can produce values that are negative by a tiny amount
-    # when the compared tensors are (near) identical
-    floating_point_tolerance = -1e-4
-    for subgraph_index, _, kl_value in kl_lines:
-        assert math.isfinite(
-            kl_value
-        ), f"subgraph {subgraph_index} KL divergence is not finite: {kl_value}"
-        assert (
-            kl_value >= floating_point_tolerance
-        ), f"subgraph {subgraph_index} KL divergence is negative: {kl_value}"
+    # SQNR has no lower bound (unlike KL divergence): a negative value is
+    # valid if compression noise exceeds the signal. Only NaN is a bug.
+    for subgraph_index, _, sqnr in sqnr_lines:
+        assert not math.isnan(sqnr), f"subgraph {subgraph_index} SQNR is NaN"
 
 
 def test_log_sequential_error_disabled_by_default():
     """
-    With log_sequential_error left at its default (False), no 'sequential error
-    (KL)' METRIC lines should be emitted, and calibration should otherwise
-    complete normally.
+    With log_sequential_error at its default (False), no SQNR METRIC lines
+    should be emitted.
     """
     messages = _run_oneshot_and_capture_metrics(log_sequential_error=False)
-    kl_lines = _parse_kl_lines(messages)
-
-    assert not kl_lines, (
-        "Expected no 'sequential error (KL)' METRIC lines when "
-        f"log_sequential_error is disabled, got {len(kl_lines)}"
-    )
+    assert not _parse_sqnr_lines(messages), "Expected no SQNR METRIC lines"

--- a/tests/llmcompressor/pipelines/sequential/test_log_sequential_error.py
+++ b/tests/llmcompressor/pipelines/sequential/test_log_sequential_error.py
@@ -55,6 +55,9 @@ def _run_oneshot_and_capture_metrics(log_sequential_error: bool) -> list[str]:
             model=MODEL,
             dataset="open_platypus",
             splits=f"train[:{NUM_SAMPLES}]",
+            # W8A8 uses per-channel weights (no group_size). tinysmokellama-3.2 has
+            # hidden_size=64, which is not divisible by the default W4A16 group_size
+            # (128) and would raise a RuntimeError in the weight observer.
             recipe=GPTQModifier(targets="Linear", scheme="W8A8", ignore=["lm_head"]),
             num_calibration_samples=NUM_SAMPLES,
             max_seq_length=MAX_SEQ_LENGTH,
@@ -97,7 +100,12 @@ def test_log_sequential_error_reports_kl_divergence():
 
     assert kl_lines, "Expected at least one 'sequential error (KL)' METRIC line"
 
-    num_subgraphs = kl_lines[0][1]
+    # every line should report the same subgraph total
+    subgraph_totals = {num_subgraphs for _, num_subgraphs, _ in kl_lines}
+    assert (
+        len(subgraph_totals) == 1
+    ), f"Expected a single consistent subgraph total, got {subgraph_totals}"
+    num_subgraphs = subgraph_totals.pop()
     reported_indices = {subgraph_index for subgraph_index, _, _ in kl_lines}
 
     # every subgraph except the last should report a KL value

--- a/tests/llmcompressor/pipelines/sequential/test_log_sequential_error.py
+++ b/tests/llmcompressor/pipelines/sequential/test_log_sequential_error.py
@@ -1,0 +1,134 @@
+import math
+import re
+
+from loguru import logger
+
+from llmcompressor import oneshot
+from llmcompressor.modifiers.gptq import GPTQModifier
+
+MODEL = "nm-testing/tinysmokellama-3.2"
+NUM_SAMPLES = 8
+MAX_SEQ_LENGTH = 128
+
+# Matches the METRIC message logged by SequentialPipeline once per subgraph when
+# log_sequential_error=True, e.g. (as captured via `format="{message}"`, which
+# strips the leading timestamp/function/level fields loguru normally adds):
+#
+#   subgraph 2/7 | sequential error (KL): 0.022716
+#
+# The first group is the 1-indexed subgraph number, the second is the total
+# number of subgraphs, and the third is the mean KL divergence for that subgraph.
+_KL_LINE_PATTERN = re.compile(
+    r"subgraph (\d+)/(\d+) \| sequential error \(KL\): (-?[\d.eE+-]+)"
+)
+
+
+def _run_oneshot_and_capture_metrics(log_sequential_error: bool) -> list[str]:
+    """
+    Run GPTQ oneshot calibration on the smoke model and capture all METRIC-level
+    log messages emitted during the run.
+
+    A temporary loguru sink is used (rather than capsys/capfd) since
+    `llmcompressor` binds its console sink to `sys.stdout` once at import
+    time, before any per-test stdout capturing fixture is installed.
+
+    Example return value (tinysmokellama-3.2 has 6 decoder layers, so 7
+    subgraphs total; the last subgraph has no downstream consumer and is
+    therefore never logged). Values are near-zero since this smoke model's
+    randomly-initialized weights barely change under W8A8 quantization; note
+    subgraph 5 below, whose value is a small negative floating point rounding
+    artifact rather than a true (impossible) negative KL divergence:
+
+        [
+            "subgraph 1/7 | sequential error (KL): 0.000000",
+            "subgraph 2/7 | sequential error (KL): 0.000001",
+            "subgraph 3/7 | sequential error (KL): 0.000000",
+            "subgraph 4/7 | sequential error (KL): 0.000002",
+            "subgraph 5/7 | sequential error (KL): -0.000001",
+            "subgraph 6/7 | sequential error (KL): 0.000000",
+        ]
+    """
+    messages = []
+    handler_id = logger.add(messages.append, level="METRIC", format="{message}")
+    try:
+        oneshot(
+            model=MODEL,
+            dataset="open_platypus",
+            splits=f"train[:{NUM_SAMPLES}]",
+            recipe=GPTQModifier(targets="Linear", scheme="W8A8", ignore=["lm_head"]),
+            num_calibration_samples=NUM_SAMPLES,
+            max_seq_length=MAX_SEQ_LENGTH,
+            pipeline="sequential",
+            log_sequential_error=log_sequential_error,
+        )
+    finally:
+        logger.remove(handler_id)
+
+    return messages
+
+
+def _parse_kl_lines(messages: list[str]) -> list[tuple[int, int, float]]:
+    """
+    Extract (subgraph_index, num_subgraphs, kl_value) tuples from METRIC lines.
+
+    Example:
+        >>> _parse_kl_lines(["subgraph 2/7 | sequential error (KL): 0.022716"])
+        [(2, 7, 0.022716)]
+    """
+    parsed = []
+    for message in messages:
+        match = _KL_LINE_PATTERN.search(message)
+        if match:
+            subgraph_index, num_subgraphs, kl_value = match.groups()
+            parsed.append((int(subgraph_index), int(num_subgraphs), float(kl_value)))
+    return parsed
+
+
+def test_log_sequential_error_reports_kl_divergence():
+    """
+    Enabling log_sequential_error (see #3154) should emit one KL divergence
+    METRIC line per subgraph, except for the last subgraph (which has no
+    downstream consumer and is therefore skipped). Every reported value
+    should be finite and non-negative, consistent with the definition of KL
+    divergence.
+    """
+    messages = _run_oneshot_and_capture_metrics(log_sequential_error=True)
+    kl_lines = _parse_kl_lines(messages)
+
+    assert kl_lines, "Expected at least one 'sequential error (KL)' METRIC line"
+
+    num_subgraphs = kl_lines[0][1]
+    reported_indices = {subgraph_index for subgraph_index, _, _ in kl_lines}
+
+    # every subgraph except the last should report a KL value
+    assert reported_indices == set(range(1, num_subgraphs)), (
+        f"Expected KL divergence reported for subgraphs 1..{num_subgraphs - 1}, "
+        f"got {sorted(reported_indices)}"
+    )
+
+    # KL divergence is mathematically non-negative, but floating point rounding
+    # in log_softmax/kl_div can produce values that are negative by a tiny amount
+    # when the compared tensors are (near) identical
+    floating_point_tolerance = -1e-4
+    for subgraph_index, _, kl_value in kl_lines:
+        assert math.isfinite(kl_value), (
+            f"subgraph {subgraph_index} KL divergence is not finite: {kl_value}"
+        )
+        assert kl_value >= floating_point_tolerance, (
+            f"subgraph {subgraph_index} KL divergence is negative: {kl_value}"
+        )
+
+
+def test_log_sequential_error_disabled_by_default():
+    """
+    With log_sequential_error left at its default (False), no 'sequential error
+    (KL)' METRIC lines should be emitted, and calibration should otherwise
+    complete normally.
+    """
+    messages = _run_oneshot_and_capture_metrics(log_sequential_error=False)
+    kl_lines = _parse_kl_lines(messages)
+
+    assert not kl_lines, (
+        "Expected no 'sequential error (KL)' METRIC lines when "
+        f"log_sequential_error is disabled, got {len(kl_lines)}"
+    )

--- a/tests/llmcompressor/pipelines/sequential/test_log_sequential_error.py
+++ b/tests/llmcompressor/pipelines/sequential/test_log_sequential_error.py
@@ -111,12 +111,12 @@ def test_log_sequential_error_reports_kl_divergence():
     # when the compared tensors are (near) identical
     floating_point_tolerance = -1e-4
     for subgraph_index, _, kl_value in kl_lines:
-        assert math.isfinite(kl_value), (
-            f"subgraph {subgraph_index} KL divergence is not finite: {kl_value}"
-        )
-        assert kl_value >= floating_point_tolerance, (
-            f"subgraph {subgraph_index} KL divergence is negative: {kl_value}"
-        )
+        assert math.isfinite(
+            kl_value
+        ), f"subgraph {subgraph_index} KL divergence is not finite: {kl_value}"
+        assert (
+            kl_value >= floating_point_tolerance
+        ), f"subgraph {subgraph_index} KL divergence is negative: {kl_value}"
 
 
 def test_log_sequential_error_disabled_by_default():


### PR DESCRIPTION
## Purpose

Reports the Signal-to-Quantization-Noise Ratio (SQNR) between each sequential subgraph's pre- and post compression outputs during oneshot calibration, using the largest output tensor as a proxy for the subgraph's main activation.

SQNR (not KL divergence — the issue was updated after discussion, since KL divergence is for comparing probability distributions, whereas here we're comparing differences in raw activation values) is computed directly from accumulated signal/noise power sums:

    SQNR = 10 * log10(signal_power_sum / noise_power_sum)

Enabling this option forces `propagate_error=True` since both unquantized and quantized outputs are needed for comparison.

## Changes

* Add `log_sequential_error` option to `DatasetArguments` and the `oneshot()` entrypoint (default `False`)
* New module `pipelines/sequential/error_logging.py` holds all SQNR logic, keeping `pipeline.py`'s original loop structure intact:
  * `cache_pre_compression_output()` — selects a subgraph's main activation (largest tensor in its output dict) and stashes it in the shared `IntermediatesCache` under a reserved key, so it inherits the pipeline's existing CPU/disk offloading instead of accumulating in a raw Python list/dict (avoids OOM on large calibration datasets)
  * `accumulate_batch_power()` — compares the cached pre-compression tensor against the post-compression output for a batch, returning `(signal_power_sum, noise_power_sum)`, then frees the cached tensor
  * `compute_sqnr()` — computes one SQNR value from accumulated power sums across all batches in a subgraph, rather than averaging a per-batch SQNR (dB is a logarithmic ratio, so arithmetic-averaging it is not meaningful, and would let a single zero-noise batch skew the whole subgraph's result to `inf`); mirrors the accumulate-then-normalize pattern already used by `AWQModifier._compute_loss`
* In `SequentialPipeline`, force `propagate_error=True` when `log_sequential_error` is enabled, taking precedence over the existing `AutoRoundModifier` override, and log the per-subgraph SQNR via a `SequentialPipeline`-named logger patch (matching `IndependentPipeline`'s existing convention)
* Add unit tests (`test_log_sequential_error.py`) covering both the enabled and disabled paths using the `nm-testing/tinysmokellama-3.2` smoke model

## Test Plan

```python
from llmcompressor import oneshot
from llmcompressor.modifiers.gptq import GPTQModifier

recipe = GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"])

oneshot(
    model="Qwen/Qwen3-0.6B",
    dataset="open_platypus",
    splits="train[:64]",
    max_seq_length=256,
    num_calibration_samples=64,
    pipeline="sequential",
    log_sequential_error=True,            # For #3154
    recipe=recipe,
)