### PR TITLE
[AWQ] Fix Qwen2.5-VL mapping registry entry (vision tower collapses MLP mapping)

### DIFF
--- a/src/llmcompressor/modifiers/transform/awq/mappings.py
+++ b/src/llmcompressor/modifiers/transform/awq/mappings.py
@@ -349,6 +349,27 @@ _example_parallel_transformer_block_mappings = [
     )
 ]
 
+_qwen2_5_vl_mappings = [
+    # Attention: same as default_mappings, these do not collide with the vision tower.
+    AWQMapping(
+        "re:.*input_layernorm$",
+        ["re:.*q_proj$", "re:.*k_proj$", "re:.*v_proj$"],
+    ),
+    AWQMapping("re:.*v_proj$", ["re:.*o_proj$"]),
+    # MLP: scoped to the language model, because the vision tower's gate/up/down
+    # projections otherwise collapse the resolution.
+    AWQMapping(
+        r"re:.*language_model\.layers\.\d+\.post_attention_layernorm$",
+        [
+            r"re:.*language_model\.layers\.\d+\.mlp\.gate_proj$",
+            r"re:.*language_model\.layers\.\d+\.mlp\.up_proj$",
+        ],
+    ),
+    AWQMapping(
+        r"re:.*language_model\.layers\.\d+\.mlp\.up_proj$",
+        [r"re:.*language_model\.layers\.\d+\.mlp\.down_proj$"],
+    ),
+]
 AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "AfmoeForCausalLM": _afmoe_mappings,
     "BloomForCausalLM": _bloom_mappings,
@@ -383,7 +404,7 @@ AWQ_MAPPING_REGISTRY: dict[str, list[AWQMapping]] = {
     "Qwen2ForCausalLM": default_mappings,
     "Qwen2_5OmniModel": default_mappings,
     "Qwen2_5OmniThinkerForConditionalGeneration": default_mappings,
-    "Qwen2_5_VLForConditionalGeneration": default_mappings,
+    "Qwen2_5_VLForConditionalGeneration": _qwen2_5_vl_mappings,
     "Qwen2MoeForCausalLM": _moe_default_mappings,
     "Qwen3ForCausalLM": default_mappings,
     "Qwen3MoeForCausalLM": _moe_default_mappings,

--- a/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
+++ b/tests/llmcompressor/modifiers/transform/awq/test_dynamic_mappings.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 from compressed_tensors.quantization import apply_quantization_config
+from compressed_tensors.utils import match_modules_set
 from torch.nn import Linear
 
 from llmcompressor.modifiers.quantization import QuantizationModifier
@@ -15,6 +16,7 @@ from llmcompressor.modifiers.transform.awq.dynamic_mappings import (
 )
 from llmcompressor.modifiers.transform.awq.mappings import (
     AWQ_MAPPING_REGISTRY,
+    _qwen2_5_vl_mappings,
     default_mappings,
 )
 from llmcompressor.modifiers.transform.utils.hybrid_attention import (
@@ -493,3 +495,169 @@ class TestGetLayerMappingsFromModel:
         mappings = get_layer_mappings_from_model(model)
         assert mappings is not None
         assert len(mappings) == 4
+
+
+QWEN2_5_VL_TEXT_LAYERS = 2  # tiny model, only for resolution checks -- not accuracy
+QWEN2_5_VL_VISION_BLOCKS = 2
+
+
+def _make_tiny_qwen2_5_vl():
+    """Build a tiny Qwen2.5-VL on the meta device -- no hub download, no weights.
+
+    Both the text layers and the vision blocks are >1: the vision blocks are what
+    make the MLP mapping collapse, so a single-block config would not reproduce it.
+    """
+    import torch
+    from transformers import Qwen2_5_VLConfig, Qwen2_5_VLForConditionalGeneration
+
+    config = Qwen2_5_VLConfig(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=QWEN2_5_VL_TEXT_LAYERS,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=64,
+        vision_config={
+            "depth": QWEN2_5_VL_VISION_BLOCKS,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_heads": 2,
+            "in_chans": 3,
+            "patch_size": 14,
+            "spatial_merge_size": 2,
+            "temporal_patch_size": 2,
+            "out_hidden_size": 64,
+        },
+    )
+    with torch.device("meta"):
+        model = Qwen2_5_VLForConditionalGeneration(config)
+    return model
+
+
+def _mlp_mapping(mappings):
+    """The `post_attention_layernorm -> gate/up` entry, which is the one that breaks."""
+    return next(
+        mapping
+        for mapping in mappings
+        if "post_attention_layernorm" in mapping.smooth_layer
+        and any("gate_proj" in layer for layer in mapping.balance_layers)
+    )
+
+
+class TestQwen2_5_VLMappings:
+    def test_registry_points_to_vl_specific_mappings(self):
+        from llmcompressor.modifiers.transform.awq.mappings import (
+            AWQ_MAPPING_REGISTRY,
+            default_mappings,
+        )
+
+        entry = AWQ_MAPPING_REGISTRY["Qwen2_5_VLForConditionalGeneration"]
+        assert entry is _qwen2_5_vl_mappings
+        assert entry is not default_mappings
+
+    def test_vision_tower_collides_only_on_mlp_names(self):
+        """Only the MLP projections collide; the attention names do not.
+
+        This is why the attention mappings can stay unscoped while the MLP ones
+        must be scoped -- and it is the property that makes the fix minimal.
+        """
+        import re
+
+        model = _make_tiny_qwen2_5_vl()
+        names = [name for name, _ in model.named_modules()]
+
+        def prefixes(pattern):
+            hits = [n for n in names if re.search(pattern, n)]
+            return {n.split(".blocks")[0].split(".layers")[0] for n in hits}
+
+        # MLP projections exist in both the language model and the vision tower
+        for pattern in (r"gate_proj$", r"up_proj$", r"down_proj$"):
+            hits = [n for n in names if re.search(pattern, n)]
+            assert any("visual." in n for n in hits), f"{pattern} should hit vision"
+            assert any(
+                "language_model." in n for n in hits
+            ), f"{pattern} should hit text"
+
+        # Attention projections only exist in the language model
+        for pattern in (
+            r"input_layernorm$",
+            r"q_proj$",
+            r"k_proj$",
+            r"v_proj$",
+            r"o_proj$",
+        ):
+            hits = [n for n in names if re.search(pattern, n)]
+            assert hits, f"{pattern} matched nothing"
+            assert not any(
+                "visual." in n for n in hits
+            ), f"{pattern} unexpectedly hits vision"
+
+    def test_default_mappings_collapse_on_vl_tree(self):
+        """Pin the bug: default_mappings' MLP entry collapses into a single group.
+
+        If upstream ever fixes this another way (e.g. by threading the ignore list
+        into match_modules_set), this test fails and the registry entry added here
+        can be dropped.
+        """
+        from llmcompressor.modifiers.transform.awq.mappings import default_mappings
+
+        model = _make_tiny_qwen2_5_vl()
+        mapping = _mlp_mapping(default_mappings)
+
+        groups = list(
+            match_modules_set(model, (mapping.smooth_layer, *mapping.balance_layers))
+        )
+        assert groups, "default_mappings should match something"
+        assert len(groups) == 1 and len(groups[0][0]) > 1, (
+            "default_mappings did not collapse on this tree -- upstream may have fixed "
+            "the underlying issue another way, making this mapping entry unnecessary"
+        )
+
+        # The collapse is caused by the vision tower being pulled into the balance set
+        module_to_name = {module: name for name, module in model.named_modules()}
+        balance_names = [
+            module_to_name[module] for sub in groups[0][1:] for module in sub
+        ]
+        assert any("visual." in name for name in balance_names)
+
+    def test_vl_mappings_resolve_one_group_per_layer(self):
+        """The fix: every mapping resolves to one group of one module per target."""
+        from llmcompressor.modifiers.transform.awq.mappings import _qwen2_5_vl_mappings
+
+        model = _make_tiny_qwen2_5_vl()
+        assert len(_qwen2_5_vl_mappings) == 4
+
+        for mapping in _qwen2_5_vl_mappings:
+            groups = list(
+                match_modules_set(
+                    model, (mapping.smooth_layer, *mapping.balance_layers)
+                )
+            )
+            assert len(groups) == QWEN2_5_VL_TEXT_LAYERS, (
+                f"{mapping.smooth_layer}: expected one group per decoder layer, "
+                f"got {len(groups)} (1 means the resolution collapsed)"
+            )
+            for smooth, *balances in groups:
+                assert len(smooth) == 1, "each mapping needs exactly one smooth layer"
+                assert all(len(balance) == 1 for balance in balances)
+
+    def test_vision_tower_is_untouched_by_vl_mappings(self):
+        """No vision module may end up in any resolved group."""
+        import re
+
+        from llmcompressor.modifiers.transform.awq.mappings import _qwen2_5_vl_mappings
+
+        model = _make_tiny_qwen2_5_vl()
+        module_to_name = {module: name for name, module in model.named_modules()}
+
+        for mapping in _qwen2_5_vl_mappings:
+            for group in match_modules_set(
+                model, (mapping.smooth_layer, *mapping.balance_layers)
+            ):
+                for sub in group:
+                    for module in sub:
+                        name = module_to_name[module]
+                        assert not re.search(
+                            r"visual\.", name
+                        ), f"vision module was included: {name}"


### PR DESCRIPTION
## Summary

`AWQ_MAPPING_REGISTRY` maps `Qwen2_5_VLForConditionalGeneration` to `default_mappings`,
but those mappings do not resolve on this architecture — AWQ quantization fails outright:

```
ValueError: AWQ needs to match a single smoothlayer for each mapping but got
['model.language_model.layers.0.post_attention_layernorm',
 ...
 'model.language_model.layers.35.post_attention_layernorm']
for mapping: AWQMapping(smooth_layer='re:.*post_attention_layernorm$',
                        balance_layers=['re:.*gate_proj$', 're:.*up_proj$'])
```

This PR adds a VL-specific entry that keeps the two attention mappings unchanged and
scopes only the MLP mappings to the language model.

## Root cause

Qwen2.5-VL's vision tower (`model.visual.blocks.*`) names its MLP layers
`gate_proj` / `up_proj` / `down_proj` — the same names as the language model — but has
no `post_attention_layernorm`.

Measured on the real `Qwen/Qwen2.5-VL-3B-Instruct` module tree (839 modules):

| pattern | matches | where |
|---|---|---|
| `input_layernorm$` | 36 | language only |
| `post_attention_layernorm$` | 36 | language only |
| `q_proj$` / `k_proj$` / `v_proj$` / `o_proj$` | 36 each | language only |
| **`gate_proj$`** | **68** | **32 vision + 36 language** |
| **`up_proj$`** | **68** | **32 vision + 36 language** |
| **`down_proj$`** | **68** | **32 vision + 36 language** |

**Only the MLP names collide.** `default_mappings` balances
`re:.*post_attention_layernorm$` (36 language) against `re:.*gate_proj$` +
`re:.*up_proj$` (68 = 32 vision + 36 language). `match_modules_set` groups by shared
parent context, so the 32 vision blocks never close against a norm and the whole
resolution collapses into a **single group** instead of one group per decoder layer:

```
default_mappings' MLP entry → 1 group, sizes = [36, 68, 68]   # collapsed
```

AWQ's `_set_resolved_mappings` then sees 36 smooth layers for one mapping and raises.

Minimal reproduction: a 2-text-layer / 2-vision-block config is enough (`[2, 4, 4]`,
collapsed). A single-text-layer config does **not** collapse, because the smooth set has
one element and AWQ's guard is `len(smooth) > 1`.

## Fix

`_qwen2_5_vl_mappings` keeps all four `default_mappings` entries. The two attention
entries are byte-identical to `default_mappings` — they do not collide, so there is no
reason to touch them — and only the two MLP entries are scoped to the language model:

```
_qwen2_5_vl_mappings  →  4 mappings
  re:.*input_layernorm$                                          (unchanged)
  re:.*v_proj$                                                   (unchanged)
  re:.*language_model\.layers\.\d+\.post_attention_layernorm$     (scoped)
  re:.*language_model\.layers\.\d+\.mlp\.up_proj$                 (scoped)

→ 36 groups of [1, 1, 1] (and [1, 1] for the v_proj→o_proj entry)
```

The vision tower is excluded entirely rather than merely scoped out of the smooth set:
it is also excluded from quantization via the `ignore` list (keeping the vision encoder
in BF16 is the default for VLMs), so there is nothing for AWQ's balancing to compensate
for there.

### Why the patterns are not anchored at `model.`

The prefix is `re:.*language_model\.layers\.\d+\.`, not `re:model\.language_model\.…`.
transformers recently moved Qwen2.5-VL from `model.layers` + `model.visual` to
`model.language_model.layers` + `model.visual`, and llm-compressor supports a wider
transformers range than the one this was developed against. Anchoring at `.*` keeps the
pattern working across that rename. **Verified on transformers 5.14.1** — if the
supported floor is lower, the pattern may need adjusting there.

### Why a per-architecture mapping rather than a general fix

`match_modules_set` already accepts an `ignore` argument and `_set_resolved_mappings`
does not pass one. Threading AWQ's ignore list through would be the more general fix —
but `AWQTransformModifier` has no `ignore` field today (`mappings` / `duo_scaling` /
`n_grid` / `offload_device` only), so it means adding a field, wiring it through the
modifier lifecycle, and changing resolution behavior for **every** architecture.

**This PR is intended as the narrow fix; I'm happy to follow up with the general one.**
It is worth noting the same class of collision is not specific to Qwen2.5-VL: any VLM
whose vision tower uses SwiGLU-style MLP names is exposed (`Pixtral` /
`Mistral3` use `feed_forward.gate_proj`; Qwen3-VL is likely the same shape as 2.5-VL).
A general fix would cover those without a registry entry each.

## Testing

Added to `tests/…/awq/test_dynamic_mappings.py`, building a tiny
`Qwen2_5_VLForConditionalGeneration` on the **meta device** (no hub download, no weight
allocation):

- `test_vision_tower_collides_only_on_mlp_names` — asserts the property that makes the
  fix minimal: `gate_proj`/`up_proj`/`down_proj` hit both towers, while
  `input_layernorm` and the attention projections hit only the language model.
- `test_default_mappings_collapse_on_vl_tree` — pins the *bug*: asserts
  `default_mappings`' MLP entry collapses to one group and that the vision tower is what
  got pulled into the balance set. Fails if upstream fixes this another way, signalling
  that the registry entry can be dropped.
- `test_vl_mappings_resolve_one_group_per_layer` — asserts all **four** mappings resolve
  to one group per decoder layer, each target contributing exactly one module.
- `test_vision_tower_is_untouched_by_vl_mappings` — no `visual.*` module appears in any
  resolved group.
- `test_registry_points_to_vl_specific_mappings` — the registry entry is the new mapping,
  not `default_mappings`.

`make style` and `make quality` are clean on both changed files (with the repo's pinned
`ruff~=0.4.8`).

## End-to-end

On `Qwen/Qwen2.5-VL-3B-Instruct`, AWQ W4A16:

| | before | after |
|---|---|---|
| quantization | `ValueError` (collapsed) | completes (141 s) |
| checkpoint | — | 3.39 GB |
| loads in vLLM 0.29 | — | yes |

### Accuracy: does keeping the attention mappings matter?

DocVQA validation set, all 200 items, ANLS / exact-match:

| calibration | attention mappings | ANLS | exact |
|---|---|---|---|
| `n_calib=128`, `n_grid=8` | dropped (earlier revision) | 0.9172 | 0.8350 |
| `n_calib=48`, `n_grid=6` | dropped | 0.8946 | 0.7600 |
| `n_calib=48`, `n_grid=6` | **kept (this revision)** | 0.8942 | 0.7550 |
| BF16 reference | — | 0.9217 | 0.8500 |

**At a matched calibration budget the two are indistinguishable** (ΔANLS 0.0004, Δexact 0.005).
On this benchmark I cannot measure a quality delta from the attention mappings in either
direction. The drop between the first two rows is the calibration budget, not the
mappings — the first comparison I ran changed both variables at once, and the controlled
row exists to correct that.

Keeping them is the right call regardless: silently dropping entries that
`default_mappings` prescribes changes how attention layers are smoothed, and that is not a
decision this PR should make implicitly.

### A note on calibration size

With all four mappings AWQ caches more activation statistics. `n_calib=128` thrashed this
16 GB card (stalled mid-grid-search at ~16.0 / 16.4 GiB with no progress); the runs above
use `n_calib=48`. Worth knowing if the mapping is validated on a small GPU.

## Related

- #2514 — same class of failure (`default_mappings` matching every layer's norm at once)
  on Qwen3.5 MoE, fixed by a per-architecture entry.

## Environment

```
llmcompressor 0.13.0 · compressed-tensors 0.18.0 · transformers 5.14.1
torch 2.13.0+cu130 · vLLM 0.29.0 · RTX 4080 SUPER (sm89)
```
