### PR TITLE
[Tests] [Bugfix] Default to unset max_model_len

### DIFF
--- a/tests/lmeval/run_lmeval.py
+++ b/tests/lmeval/run_lmeval.py
@@ -34,13 +34,15 @@ def main():
         f"dtype={lmeval_config['dtype']},"
         f"add_bos_token={lmeval_config['add_bos_token']},"
         f"trust_remote_code={lmeval_config['trust_remote_code']},"
-        f"max_model_len={config['max_model_len']},"
         f"seed={seed},"
         f"gpu_memory_utilization={config['gpu_memory_utilization']},"
         f"max_num_seqs={config['max_num_seqs']},"
         f"pipeline_parallel_size="
         f"{config.get('num_gpus', 1) if config.get('pipeline_parallel', False) else 1},"
     )
+
+    if config["max_model_len"] is not None:
+        model_args += f"max_model_len={config['max_model_len']},"
 
     gen_kwargs = None
     if lmeval_config.get("max_gen_toks") is not None:

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -282,7 +282,7 @@ class BaseTestConfig(BaseModel):
     )
     max_model_len: Optional[int] = Field(
         default=None,
-        description="Maximum sequence length for the model. Not used by e2e tests."
+        description="Maximum sequence length for the model. Not used by e2e tests.",
     )
     pipeline_parallel: bool = Field(
         False,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -280,8 +280,9 @@ class BaseTestConfig(BaseModel):
     max_num_seqs: int = Field(
         128, description="Maximum number of sequences to process in parallel."
     )
-    max_model_len: int = Field(
-        10000, description="Maximum sequence length for the model."
+    max_model_len: Optional[int] = Field(
+        default=None,
+        description="Maximum sequence length for the model. Not used by e2e tests."
     )
     pipeline_parallel: bool = Field(
         False,


### PR DESCRIPTION
## Purpose

Make `max_model_len` an optional test config field that defaults to unset (`None`).

- The e2e tests do not use `max_model_len` at all.
- The lm-eval harness now only passes `max_model_len` to vLLM when it is explicitly set in the config. When unset, vLLM infers the model's maximum sequence length instead of being pinned to the previous hardcoded `10000`.

## Changes

- `tests/testing_utils.py`: `max_model_len` is now `Optional[int]` defaulting to `None`.
- `tests/lmeval/run_lmeval.py`: only append `max_model_len=...` to the vLLM `model_args` when it is set.

## Testing

- https://github.com/neuralmagic/llm-compressor-testing/actions/runs/34717218286