### PR TITLE
[Tests] [Bugfix] Expose vLLM environment variables in test config

### DIFF
--- a/tests/e2e/configs/fp8_weight_only_channel.yaml
+++ b/tests/e2e/configs/fp8_weight_only_channel.yaml
@@ -4,3 +4,6 @@ recipe: tests/e2e/recipes/FP8/recipe_fp8_weight_only_channel.yaml
 scheme: FP8A16_channel
 # vLLM produces gibberish after this quantization scheme
 skip_sanity_check: true
+# FP8A16 requires marlin
+vllm_env_variables:
+  VLLM_TEST_FORCE_FP8_MARLIN: "1"

--- a/tests/e2e/configs/fp8_weight_only_tensor.yaml
+++ b/tests/e2e/configs/fp8_weight_only_tensor.yaml
@@ -4,3 +4,6 @@ recipe: tests/e2e/recipes/FP8/recipe_fp8_weight_only_per_tensor.yaml
 scheme: FP8A16_tensor
 # vLLM produces gibberish after this quantization scheme
 skip_sanity_check: true
+# FP8A16 requires marlin
+vllm_env_variables:
+  VLLM_TEST_FORCE_FP8_MARLIN: "1"

--- a/tests/e2e/test_vllm.py
+++ b/tests/e2e/test_vllm.py
@@ -194,14 +194,6 @@ class TestvLLM:
         import subprocess
 
         llm_kwargs = {"model": self.config.save_dir}
-
-        # if FP8A16 scheme, must set VLLM_TEST_FORCE_FP8_MARLIN=1
-        # to force usage of marlin kernel
-        if self.config.scheme and "FP8A16" in self.config.scheme.upper():
-            os.environ["VLLM_TEST_FORCE_FP8_MARLIN"] = "1"
-        else:
-            os.environ.pop("VLLM_TEST_FORCE_FP8_MARLIN", None)
-
         llm_kwargs["gpu_memory_utilization"] = self.config.gpu_memory_utilization
 
         json_scheme = json.dumps(self.config.scheme)
@@ -210,6 +202,12 @@ class TestvLLM:
         json_prompts = json.dumps(prompts)
 
         test_file_dir = os.path.dirname(os.path.abspath(__file__))
+
+        # vLLM-specific environment variables from the test config
+        vllm_env_variables = {
+            str(key): str(value)
+            for key, value in self.config.vllm_env_variables.items()
+        }
 
         if IS_VLLM_IMAGE:
             # generate python command to run in the vllm image
@@ -228,14 +226,12 @@ class TestvLLM:
             ]
             vllm_cmd = " ".join(cmds)
             vllm_bash = os.path.join(RUN_SAVE_DIR, "run-vllm.bash")
+            vllm_env_vars = "\n".join(
+                f'export {key}="{value}"\n'
+                for key, value in vllm_env_variables.items()
+            )
             with open(vllm_bash, "w") as cf:
-                cf.write(
-                    f"""#!/bin/bash
-                    export HF_HUB_OFFLINE=0
-                    export VLLM_NO_USAGE_STATS=1
-                    {vllm_cmd}
-                    """
-                )
+                cf.write(f"#!/bin/bash\n{vllm_env_vars}\n{vllm_cmd}")
             os.chmod(vllm_bash, 0o755)
             logger.info(f"Wrote vllm cmd into {vllm_bash}:")
             logger.info("vllm image. Run vllm cmd with kubectl.")
@@ -263,6 +259,7 @@ class TestvLLM:
             env = os.environ.copy()
             venv_bin = os.path.dirname(self.vllm_env)
             env["PATH"] = venv_bin + os.pathsep + env.get("PATH", "")
+            env.update(vllm_env_variables)
             result = subprocess.Popen(
                 [
                     self.vllm_env,

--- a/tests/lmeval/run_lmeval.py
+++ b/tests/lmeval/run_lmeval.py
@@ -34,13 +34,15 @@ def main():
         f"dtype={lmeval_config['dtype']},"
         f"add_bos_token={lmeval_config['add_bos_token']},"
         f"trust_remote_code={lmeval_config['trust_remote_code']},"
-        f"max_model_len={config['max_model_len']},"
         f"seed={seed},"
         f"gpu_memory_utilization={config['gpu_memory_utilization']},"
         f"max_num_seqs={config['max_num_seqs']},"
         f"pipeline_parallel_size="
         f"{config.get('num_gpus', 1) if config.get('pipeline_parallel', False) else 1},"
     )
+
+    if config["max_model_len"] is not None:
+        model_args += f"max_model_len={config['max_model_len']},"
 
     gen_kwargs = None
     if lmeval_config.get("max_gen_toks") is not None:

--- a/tests/lmeval/test_lmeval.py
+++ b/tests/lmeval/test_lmeval.py
@@ -240,6 +240,11 @@ class TestLMEval:
         env = os.environ.copy()
         venv_bin = os.path.dirname(VLLM_PYTHON_ENV)
         env["PATH"] = venv_bin + os.pathsep + env.get("PATH", "")
+
+        # apply vLLM-specific environment variables from the test config
+        for key, value in self.config.vllm_env_variables.items():
+            env[str(key)] = str(value)
+
         result = subprocess.Popen(
             [
                 VLLM_PYTHON_ENV,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -280,8 +280,9 @@ class BaseTestConfig(BaseModel):
     max_num_seqs: int = Field(
         128, description="Maximum number of sequences to process in parallel."
     )
-    max_model_len: int = Field(
-        10000, description="Maximum sequence length for the model."
+    max_model_len: Optional[int] = Field(
+        default=None,
+        description="Maximum sequence length for the model. Not used by e2e tests."
     )
     pipeline_parallel: bool = Field(
         False,

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -25,6 +25,13 @@ DISABLE_LMEVAL_CACHE = os.environ.get("DISABLE_LMEVAL_CACHE", "").lower() in (
 LMEVAL_CACHE_DIR = Path(os.environ.get("LMEVAL_CACHE_DIR", ".lmeval_cache"))
 LMEVAL_CACHE_FILE = LMEVAL_CACHE_DIR / "cache.csv"
 
+# Environment variables always applied when running vLLM. Configs may add to or
+# override individual entries via the `vllm_env_variables` field.
+DEFAULT_VLLM_ENV_VARIABLES = {
+    "HF_HUB_OFFLINE": "0",
+    "VLLM_NO_USAGE_STATS": "1",
+}
+
 
 class BaseTestConfig(BaseModel):
     """
@@ -115,6 +122,11 @@ class BaseTestConfig(BaseModel):
 
     Test infrastructure
     -------------------
+    vllm_env_variables: dict
+        Environment variables set when running vLLM. Values provided here are
+        merged over (and take precedence over) the always-applied defaults:
+            HF_HUB_OFFLINE=0
+            VLLM_NO_USAGE_STATS=1
     gpu_memory_utilization : float | None
         Fraction of GPU memory for vLLM to use (default: 0.70).
         Valid range is typically 0.0-1.0. Lower values leave memory for other processes.
@@ -298,6 +310,19 @@ class BaseTestConfig(BaseModel):
         False,
         description="Skip the sanity check that verifies vLLM generates coherent text",
     )
+    vllm_env_variables: dict = Field(
+        default_factory=lambda: dict(DEFAULT_VLLM_ENV_VARIABLES),
+        description="Environment variables to run vLLM with",
+    )
+
+    @model_validator(mode="after")
+    def merge_vllm_env_variable_defaults(self) -> "BaseTestConfig":
+        # config-provided values take precedence over, but do not drop, defaults
+        self.vllm_env_variables = {
+            **DEFAULT_VLLM_ENV_VARIABLES,
+            **self.vllm_env_variables,
+        }
+        return self
 
     @model_validator(mode="after")
     def require_scheme_or_recipe(self) -> "BaseTestConfig":


### PR DESCRIPTION
## Purpose

Allow test configs to declare arbitrary environment variables to set when spinning up vLLM, and propagate them consistently across both the e2e and lm-eval test paths.

This fixes a bug where `VLLM_NO_USAGE_STATS` (and `HF_HUB_OFFLINE`) were only exported in the e2e RHAIIS image bash script and were **never** propagated to the lm-eval tests.

> [!NOTE]
> Stacked on top of #3170 — review/merge that first. This PR targets `kylesayrs/fix-model-len`.

## Changes

- `tests/testing_utils.py`: add `vllm_env_variables` field to `BaseTestConfig`. Config-provided values are **merged over** the always-applied defaults (`HF_HUB_OFFLINE=0`, `VLLM_NO_USAGE_STATS=1`) via a model validator, so a config can override or add individual variables without dropping the defaults.
- `tests/e2e/test_vllm.py`: propagate `vllm_env_variables` to the vLLM subprocess (both the RHAIIS image bash path and the local venv path). Removes the FP8A16-specific `VLLM_TEST_FORCE_FP8_MARLIN` special-casing.
- `tests/lmeval/test_lmeval.py`: apply `vllm_env_variables` to the lm-eval subprocess environment.
- `tests/e2e/configs/fp8_weight_only_{channel,tensor}.yaml`: set `VLLM_TEST_FORCE_FP8_MARLIN=1` via the new field (replacing the removed special-casing). These configs still get the defaults thanks to the merge behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)